### PR TITLE
feat/21 - Fiat conversion rates

### DIFF
--- a/packages/anoma-wallet/.env.sample
+++ b/packages/anoma-wallet/.env.sample
@@ -27,3 +27,15 @@ REACT_APP_CHAIN_B_URL=http://10.7.1.162 # OPTIONAL - Defaults to 127.0.0.1
 REACT_APP_CHAIN_B_PORT=28657 # OPTIONAL - Appends to URL if specified
 REACT_APP_CHAIN_B_FAUCET=atest1v4ehgw36xscyvdpcxgenvdf3x5c523j98pqnz3fjgfq5yvp4xpqnvv69x5erzvjzgse5yd3suq5pd0
 REACT_APP_CHAIN_B_PORT_ID=transfer # OPTIONAL - Defaults to transfer
+
+# Optional variables for overriding CoinGecko API settings
+
+# The default URL is set to "https://api.coingecko.com/api/v3/", but if we needed to point to a proxy of
+# this API that we host, we could specify the appropriate settings below:
+REACT_APP_API_URL=http://proxy.namada.me/api/v1 # OPTIONAL - Defaults to CoinGecko's API
+
+# The following is only needed with a proxy API requiring an x-api-key header
+REACT_APP_API_KEY=XXXXXXXXXXXXXXXXXXXX # OPTIONAL - Defaults to undefined
+
+# Set an alternative TTL for caching API queries (in seconds):
+REACT_APP_API_TTL=120 # OPTIONAL - Defaults to 60

--- a/packages/anoma-wallet/src/App/AccountOverview/AccountOverview.tsx
+++ b/packages/anoma-wallet/src/App/AccountOverview/AccountOverview.tsx
@@ -32,6 +32,7 @@ import {
 import { ButtonsContainer } from "App/AccountCreation/Steps/Completion/Completion.components";
 import Config from "config";
 import { Session, Wallet } from "lib";
+import { formatCurrency } from "utils/helpers";
 
 type Props = {
   password: string;
@@ -48,11 +49,10 @@ export const AccountOverview = ({
   const { derived, shieldedAccounts } = useAppSelector<AccountsState>(
     (state) => state.accounts
   );
-  const currency = useAppSelector<SettingsState>(
-    (state) => state.settings.fiatCurrency
-  );
 
-  const { chainId } = useAppSelector<SettingsState>((state) => state.settings);
+  const { chainId, fiatCurrency } = useAppSelector<SettingsState>(
+    (state) => state.settings
+  );
   const { faucet, accountIndex } = Config.chain[chainId] || {};
 
   const [total, setTotal] = useState(0);
@@ -129,8 +129,10 @@ export const AccountOverview = ({
             <TotalContainer>
               {(derived[chainId] || shieldedAccounts[chainId]) && (
                 <TotalAmount>
-                  <TotalAmountFiat>{currency}</TotalAmountFiat>
-                  <TotalAmountValue>{total}</TotalAmountValue>
+                  <TotalAmountFiat>{fiatCurrency}</TotalAmountFiat>
+                  <TotalAmountValue>
+                    {formatCurrency(fiatCurrency, total)}
+                  </TotalAmountValue>
                 </TotalAmount>
               )}
             </TotalContainer>

--- a/packages/anoma-wallet/src/App/Settings/SettingsWalletSettings/SettingsWalletSettings.tsx
+++ b/packages/anoma-wallet/src/App/Settings/SettingsWalletSettings/SettingsWalletSettings.tsx
@@ -5,6 +5,7 @@ import { Chain } from "config/chain";
 import { setFiatCurrency, setChainId, SettingsState } from "slices/settings";
 import { useAppDispatch, useAppSelector } from "store";
 import { Session } from "lib";
+import { Currencies } from "constants/";
 
 import { NavigationContainer } from "components/NavigationContainer";
 import { Heading, HeadingLevel } from "components/Heading";
@@ -55,20 +56,10 @@ export const SettingsWalletSettings = ({ password }: Props): JSX.Element => {
     }
   };
 
-  const currencies: Option<string>[] = [
-    {
-      label: "USD - US dollar",
-      value: "USD",
-    },
-    {
-      label: "JPY - Japanese yen",
-      value: "JPY",
-    },
-    {
-      label: "EUR - Euro",
-      value: "EUR",
-    },
-  ];
+  const currencies: Option<string>[] = Currencies.map((currency) => ({
+    value: currency.currency,
+    label: `${currency.currency} - ${currency.label}`,
+  }));
 
   const currentCurrency = useAppSelector(
     (state) => state.settings.fiatCurrency

--- a/packages/anoma-wallet/src/config/api.ts
+++ b/packages/anoma-wallet/src/config/api.ts
@@ -1,0 +1,15 @@
+const {
+  REACT_APP_API_URL,
+  REACT_APP_API_KEY = "",
+  REACT_APP_API_TTL,
+} = process.env;
+
+const DEFAULT_TTL = 60; // One minute
+
+const ApiConfig = {
+  url: REACT_APP_API_URL || "https://api.coingecko.com/api/v3/",
+  key: REACT_APP_API_KEY,
+  cacheTTL: REACT_APP_API_TTL ? parseInt(REACT_APP_API_TTL) : DEFAULT_TTL,
+};
+
+export default ApiConfig;

--- a/packages/anoma-wallet/src/config/index.ts
+++ b/packages/anoma-wallet/src/config/index.ts
@@ -1,10 +1,12 @@
 import ChainConfig from "./chain";
+import ApiConfig from "./api";
 
 export { default as RPCConfig, type Network } from "./rpc";
 export { defaultChainId, type Protocol, type Chain } from "./chain";
 
 const Config = {
   chain: ChainConfig,
+  api: ApiConfig,
 };
 
 export default Config;

--- a/packages/anoma-wallet/src/constants/index.ts
+++ b/packages/anoma-wallet/src/constants/index.ts
@@ -1,3 +1,23 @@
 export { type TokenType, Tokens, Symbols } from "./tokens";
 export { TxResponse } from "./tx";
 export { TxWasm, VpWasm } from "./wasm";
+
+export type Currency = {
+  currency: string;
+  label: string;
+};
+
+export const Currencies: Currency[] = [
+  {
+    currency: "USD",
+    label: "US Dollar",
+  },
+  {
+    currency: "EUR",
+    label: "Euro",
+  },
+  {
+    currency: "JPY",
+    label: "Japanese Yen",
+  },
+];

--- a/packages/anoma-wallet/src/constants/tokens.ts
+++ b/packages/anoma-wallet/src/constants/tokens.ts
@@ -7,6 +7,7 @@ type TokenInfo = {
   coin: string;
   url: string;
   address?: string;
+  coinGeckoId?: string;
 };
 
 // Declare symbols for tokens we support:
@@ -46,9 +47,16 @@ Tokens["NAM"] = {
 
 Tokens["ATOM"].address =
   "atest1v4ehgw36gfryydj9g3p5zv3kg9znyd358ycnzsfcggc5gvecgc6ygs2rxv6ry3zpg4zrwdfeumqcz9";
+Tokens["ATOM"].coinGeckoId = "cosmos";
+
 Tokens["ETH"].address =
   "atest1v4ehgw36xqmr2d3nx3ryvd2xxgmrq33j8qcns33sxezrgv6zxdzrydjrxveygd2yxumrsdpsf9jc2p";
+Tokens["ETH"].coinGeckoId = "ethereum";
+
 Tokens["DOT"].address =
   "atest1v4ehgw36gg6nvs2zgfpyxsfjgc65yv6pxy6nwwfsxgungdzrggeyzv35gveyxsjyxymyz335hur2jn";
+Tokens["DOT"].coinGeckoId = "polkadot";
+
 Tokens["BTC"].address =
   "atest1v4ehgw36xdzryve5gsc52veeg5cnsv2yx5eygvp38qcrvd29xy6rys6p8yc5xvp4xfpy2v694wgwcp";
+Tokens["BTC"].coinGeckoId = "bitcoin";

--- a/packages/anoma-wallet/src/slices/coins.ts
+++ b/packages/anoma-wallet/src/slices/coins.ts
@@ -1,0 +1,124 @@
+import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { Symbols, Currencies, Tokens } from "constants/";
+import { getTimeStamp } from "utils/helpers";
+import Config from "config";
+
+const COINS_ACTIONS_BASE = "coins";
+
+export type ConversionRate = {
+  currency: string;
+  rate: number;
+};
+
+export type CoinGeckoIds = Record<string, { coinGeckoId: string }>;
+
+export type RateByToken = Record<string, ConversionRate>;
+export type CoinsState = {
+  rates: Record<string, RateByToken>;
+  timestamp?: number;
+};
+
+const initialState: CoinsState = {
+  rates: {},
+};
+
+type RatesResponse = {
+  data: {
+    [token: string]: {
+      [currency: string]: number;
+    };
+  };
+  timestamp: number;
+};
+
+enum CoinsThunkActions {
+  FetchRates = "fetchRates",
+}
+
+export const fetchConversionRates = createAsyncThunk(
+  `${COINS_ACTIONS_BASE}/${CoinsThunkActions.FetchRates}`,
+  async (): Promise<RatesResponse> => {
+    const { api } = Config;
+    const apiBase = api.url;
+    const apiKey = api.key;
+
+    const baseUrl = `${apiBase}/simple/price/`;
+
+    const coinsQuery = Symbols.filter((symbol) => Tokens[symbol]?.coinGeckoId)
+      .map((symbol) => {
+        const token = Tokens[symbol];
+        const { coinGeckoId } = token;
+        return coinGeckoId;
+      })
+      .join(",");
+    const currenciesQuery = Currencies.map(
+      (currency) => currency.currency
+    ).join(",");
+
+    const headers = apiKey
+      ? {
+          "X-Api-Key": apiKey,
+        }
+      : undefined;
+
+    const url = `${baseUrl}?ids=${coinsQuery}&vs_currencies=${currenciesQuery}`;
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers,
+    });
+
+    const json = await response.json();
+    const data = json;
+
+    return {
+      data,
+      timestamp: getTimeStamp(),
+    };
+  }
+);
+
+const coinsSlice = createSlice({
+  name: COINS_ACTIONS_BASE,
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(
+      fetchConversionRates.fulfilled,
+      (state, action: PayloadAction<RatesResponse>) => {
+        const { data, timestamp } = action.payload;
+        const keys = Object.keys(data);
+        state.rates = {};
+        state.timestamp = timestamp;
+
+        keys.forEach((key) => {
+          const token = Object.values(Tokens).find(
+            (token) => token?.coinGeckoId === key
+          );
+          const symbol = token?.symbol;
+
+          if (symbol) {
+            if (!state.rates[symbol]) {
+              state.rates[symbol] = {};
+            }
+            const currencies = Object.keys(data[key]);
+
+            currencies.forEach((currencyKey) => {
+              const currency = currencyKey.toUpperCase();
+              const rate = data[key][currencyKey] || 1;
+
+              state.rates[symbol][currency] = {
+                currency,
+                rate,
+              };
+            });
+          }
+        });
+      }
+    );
+  },
+});
+
+const { reducer } = coinsSlice;
+
+export default reducer;

--- a/packages/anoma-wallet/src/slices/index.ts
+++ b/packages/anoma-wallet/src/slices/index.ts
@@ -10,3 +10,4 @@ export { default as balancesReducer } from "./balances";
 export { default as transfersReducer } from "./transfers";
 export { default as channelsReducer } from "./channels";
 export { default as settingsReducer } from "./settings";
+export { default as coinsReducer } from "./coins";

--- a/packages/anoma-wallet/src/store/store.ts
+++ b/packages/anoma-wallet/src/store/store.ts
@@ -15,6 +15,7 @@ import {
   transfersReducer,
   settingsReducer,
   channelsReducer,
+  coinsReducer,
 } from "slices";
 import { LocalStorageKeys } from "App/types";
 import { hashPassword } from "utils/helpers";
@@ -25,6 +26,7 @@ const reducers = combineReducers({
   transfers: transfersReducer,
   channels: channelsReducer,
   settings: settingsReducer,
+  coins: coinsReducer,
 });
 
 type StoreFactory = (secretKey: string) => EnhancedStore;
@@ -40,7 +42,14 @@ const makeStore: StoreFactory = (secret) => {
     key: `${LocalStorageKeys.Persist}${POSTFIX}`,
     storage,
     // Only persist data in whitelist:
-    whitelist: ["accounts", "balances", "transfers", "settings", "channels"],
+    whitelist: [
+      "accounts",
+      "balances",
+      "transfers",
+      "settings",
+      "channels",
+      "coins",
+    ],
     transforms: [
       encryptTransform({
         secretKey: hash,

--- a/packages/anoma-wallet/src/utils/helpers/index.ts
+++ b/packages/anoma-wallet/src/utils/helpers/index.ts
@@ -145,3 +145,25 @@ export const getParams = (
   const params = Object.fromEntries(urlSearchParams.entries());
   return prop ? params[prop] : params;
 };
+
+/**
+ * Format by currency using the user's locale
+ * @param currency
+ * @param value
+ * @returns {string}
+ */
+export const formatCurrency = (currency = "USD", value = 0): string => {
+  const formatter = Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency,
+  });
+
+  return formatter.format(value);
+};
+
+/**
+ * Get timestamp
+ *
+ * @returns {number}
+ */
+export const getTimeStamp = (): number => Math.floor(Date.now() / 1000);


### PR DESCRIPTION
See https://github.com/anoma/namada-interface/issues/21

This PR is to connect the interface to an API (CoinGecko) serving fiat conversion rates for each token & currency we support.

By default, we connect directly to CoinGecko's API. The following values can be overridden if needed (if, for example, at some point we want to point to a proxy that may require an auth header), but by default it will work without these:
```bash
REACT_APP_API_URL=http://127.0.0.1:5000/api/v1 # OPTIONAL
REACT_APP_API_KEY=XXXXXXXXXXXXXXXXXXXX # OPTIONAL
# Set an alternative TTL for caching API queries (e.g., fiat conversion rates) in seconds:
REACT_APP_API_TTL=3600 # OPTIONAL
```

In this PR, the API data is added to the store, and only re-fetched after the TTL has been reached. The TTL is defined in seconds. Also, I created an additional `coins` slice (currently only supporting `rates`), where we can add additional functionality. The CoinGecko coin IDs are hard-coded for now, as it is a bit overkill to make a separate request for all tokens, so these are appended to the `Tokens` definitions. It may make sense in the future to periodically sync to their `/coins/list` results to gather new token IDs, but even then it may not make sense for each client to make this request when it's easy enough to add.

Total balance calculated from fiat conversion-rates:
![image](https://user-images.githubusercontent.com/330911/180191153-41160d5c-7705-4acd-9053-23904c79d523.png)

This value is calculated and formatted based on the wallet's `fiatCurrency` setting:
![image](https://user-images.githubusercontent.com/330911/180191360-d3535e60-7ae8-4b8b-b387-6f2d4a64b08f.png)

![image](https://user-images.githubusercontent.com/330911/180194272-eef7025c-10cc-4509-b6b2-c0d965841cd6.png)

Fiat conversion rates applied to Gas Fees:
![image](https://user-images.githubusercontent.com/330911/181199827-2db52c47-bbf9-4c19-a576-0039f248fab0.png)
