### PR TITLE
feat/32 Remove WebSocket usage from checking when Tx gets applied

### DIFF
--- a/packages/rpc/src/RpcClient.ts
+++ b/packages/rpc/src/RpcClient.ts
@@ -40,7 +40,7 @@ class RpcClient extends RpcClientBase {
   public async getAppliedTx(hash: string): Promise<AbciResponse> {
     const path = `${ABCI_QUERY_PATH_PREFIX}applied/${hash}`;
     const request = createJsonRpcRequest("abci_query", [path, "", "0", false]);
-    let TRIES = 10;
+    let TRIES = 40;
 
     const executeRequest = async (): Promise<AbciResponse> => {
       try {


### PR DESCRIPTION
# What does this PR do
* uses polling instead of WebSocket to check whether a Tx got applied after broadcasting it
* Increased the timeout for the polling functionality to 40sec, this is as the time to get a response increases when the chain contains more blocks