### PR TITLE
WIP: #13 Unifying MASP implementations between CLI and Web

### DIFF
--- a/packages/shared/lib/Cargo.lock
+++ b/packages/shared/lib/Cargo.lock
@@ -1602,6 +1602,39 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "namada"
+version = "0.10.1"
+source = "git+https://github.com/anoma/namada.git?branch=murisi/shared_masp2#dcbc058747a6ae9875658f4fbb9465001096dc47"
+dependencies = [
+ "async-trait",
+ "bellman",
+ "bls12_381",
+ "borsh",
+ "circular-queue",
+ "clru",
+ "data-encoding",
+ "derivative",
+ "ibc",
+ "ibc-proto",
+ "itertools",
+ "masp_primitives",
+ "masp_proofs",
+ "namada_core 0.9.0",
+ "namada_proof_of_stake 0.10.1",
+ "paste",
+ "prost",
+ "rust_decimal",
+ "serde_json",
+ "sha2 0.9.9",
+ "tendermint",
+ "tendermint-proto",
+ "thiserror",
+ "tracing",
+ "wasmparser",
+ "zeroize",
+]
+
+[[package]]
+name = "namada"
 version = "0.11.0"
 source = "git+https://github.com/anoma/namada?tag=v0.11.0#7ed315a96cd5bfc8e0e2bef37e065746eada6622"
 dependencies = [
@@ -1617,8 +1650,8 @@ dependencies = [
  "itertools",
  "masp_primitives",
  "masp_proofs",
- "namada_core",
- "namada_proof_of_stake",
+ "namada_core 0.11.0",
+ "namada_proof_of_stake 0.11.0",
  "paste",
  "prost",
  "rust_decimal",
@@ -1629,6 +1662,44 @@ dependencies = [
  "thiserror",
  "tracing",
  "wasmparser",
+ "zeroize",
+]
+
+[[package]]
+name = "namada_core"
+version = "0.9.0"
+source = "git+https://github.com/anoma/namada.git?branch=murisi/shared_masp2#dcbc058747a6ae9875658f4fbb9465001096dc47"
+dependencies = [
+ "ark-bls12-381",
+ "ark-serialize",
+ "bech32",
+ "bellman",
+ "bit-vec",
+ "borsh",
+ "chrono",
+ "data-encoding",
+ "derivative",
+ "ed25519-consensus",
+ "ferveo-common",
+ "ibc",
+ "ibc-proto",
+ "ics23",
+ "itertools",
+ "libsecp256k1",
+ "masp_primitives",
+ "prost",
+ "prost-types",
+ "rust_decimal",
+ "rust_decimal_macros",
+ "serde",
+ "serde_json",
+ "sha2 0.9.9",
+ "sparse-merkle-tree",
+ "tendermint",
+ "tendermint-proto",
+ "thiserror",
+ "tonic-build",
+ "tracing",
  "zeroize",
 ]
 
@@ -1677,12 +1748,26 @@ dependencies = [
 
 [[package]]
 name = "namada_proof_of_stake"
+version = "0.10.1"
+source = "git+https://github.com/anoma/namada.git?branch=murisi/shared_masp2#dcbc058747a6ae9875658f4fbb9465001096dc47"
+dependencies = [
+ "borsh",
+ "derivative",
+ "namada_core 0.9.0",
+ "rust_decimal",
+ "rust_decimal_macros",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "namada_proof_of_stake"
 version = "0.11.0"
 source = "git+https://github.com/anoma/namada?tag=v0.11.0#7ed315a96cd5bfc8e0e2bef37e065746eada6622"
 dependencies = [
  "borsh",
  "derivative",
- "namada_core",
+ "namada_core 0.11.0",
  "rust_decimal",
  "rust_decimal_macros",
  "thiserror",
@@ -2463,13 +2548,16 @@ dependencies = [
 name = "shared"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "borsh",
  "chrono",
  "getrandom 0.2.8",
  "gloo-utils",
  "js-sys",
  "masp_primitives",
- "namada",
+ "masp_proofs",
+ "namada 0.10.1",
+ "namada 0.11.0",
  "prost",
  "prost-types",
  "rand 0.8.5",
@@ -2477,6 +2565,7 @@ dependencies = [
  "serde",
  "thiserror",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "wasm-bindgen-test",
 ]
 

--- a/packages/shared/lib/Cargo.toml
+++ b/packages/shared/lib/Cargo.toml
@@ -17,7 +17,11 @@ getrandom = { version = "0.2.7", features = ["js"] }
 gloo-utils = { version = "0.1.5", features = ["serde"] }
 js-sys = "0.3.60"
 masp_primitives = { git = "https://github.com/anoma/masp", rev = "bee40fc465f6afbd10558d12fe96eb1742eee45c" }
+masp_proofs = { git = "https://github.com/anoma/masp", rev = "bee40fc465f6afbd10558d12fe96eb1742eee45c" }
 namada = {git = "https://github.com/anoma/namada", tag = "v0.11.0", features = ["ferveo-tpke"]}
+namada_for_masp = { package = "namada", git = "https://github.com/anoma/namada.git", branch = "murisi/shared_masp2", features = [
+    "async-client",
+] }
 prost = "0.9.0"
 prost-types = "0.9.0"
 rand = "0.8.5"
@@ -25,6 +29,8 @@ rayon = "=1.5.1"
 serde = "1.0.144"
 thiserror = "^1"
 wasm-bindgen = "0.2.83"
+wasm-bindgen-futures = "0.4.33"
+async-trait = "0.1.51"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"

--- a/packages/shared/lib/src/lib.rs
+++ b/packages/shared/lib/src/lib.rs
@@ -7,5 +7,6 @@ pub mod reveal_pk;
 pub mod ibc_transfer;
 pub mod signer;
 pub mod transfer;
+pub mod masp_transfer;
 pub mod types;
 mod utils;

--- a/packages/shared/lib/src/masp_transfer/mod.rs
+++ b/packages/shared/lib/src/masp_transfer/mod.rs
@@ -1,0 +1,166 @@
+use async_trait::async_trait;
+use borsh::{BorshDeserialize, BorshSerialize};
+use js_sys::JsString;
+use masp_primitives::asset_type::AssetType;
+use masp_primitives::merkle_tree::MerklePath;
+use masp_primitives::sapling::Node;
+use masp_primitives::transaction::components::Amount;
+use masp_proofs::prover::LocalTxProver;
+use namada_for_masp as namada;
+use namada_for_masp::ledger::masp::ShieldedUtils;
+use namada_for_masp::types::storage::Key;
+use wasm_bindgen::prelude::*;
+
+
+// required as a supertrait by ShieldedUtils
+impl Default for WebShieldedUtils {
+    fn default() -> Self {
+        WebShieldedUtils {}
+    }
+}
+
+// This is being passed to MASP creating util. This mostly contains callsbacks
+// that are specific to the platform (MacOS, Linux, Web(WAMS), ...) where the
+// MASP transactiosn are being created
+#[derive(Debug, BorshSerialize, BorshDeserialize, Clone)]
+struct WebShieldedUtils {}
+
+// for documentation for this trait refer to
+// namada::ledger::masp::ShieldedUtils trait from
+// https://github.com/anoma/namada repo
+//
+// the js implementations of these callbacks are in folder indicated by the
+// raw_module statement connected with the  extern block below
+#[async_trait]
+impl ShieldedUtils for WebShieldedUtils {
+    fn local_tx_prover(&self) -> LocalTxProver {
+        let web_shielded_utils_js_callbacks = WebShieldedUtilsJsCallbacks::new();
+        let local_tx_prover = web_shielded_utils_js_callbacks.local_tx_prover_callback(0);
+        let local_tx_prover_as_str = local_tx_prover.as_string().unwrap();
+        console_log(&local_tx_prover_as_str);
+        !unimplemented!("returns a prover that was constructed with the parameter files")
+    }
+
+    fn save(&self, ctx: &namada::ledger::masp::ShieldedContext<Self>) -> std::io::Result<()> {
+        let web_shielded_utils_js_callbacks = WebShieldedUtilsJsCallbacks::new();
+        let shielded_context = web_shielded_utils_js_callbacks.save(0);
+        let shielded_context_as_str = shielded_context.as_string().unwrap();
+        console_log(&shielded_context_as_str);
+        !unimplemented!("this func does not do anything for now")
+    }
+
+    fn load(self) -> std::io::Result<namada::ledger::masp::ShieldedContext<Self>> {
+        let web_shielded_utils_js_callbacks = WebShieldedUtilsJsCallbacks::new();
+        let shielded_context = web_shielded_utils_js_callbacks.load(0);
+        let shielded_context_as_str = shielded_context.as_string().unwrap();
+        console_log(&shielded_context_as_str);
+        !unimplemented!("this func returns the shielded notes that were fetched in js for now")
+    }
+
+    async fn query_conversion(
+        &self,
+        asset_type: AssetType,
+    ) -> Option<(
+        namada::types::address::Address,
+        namada::types::storage::Epoch,
+        Amount,
+        MerklePath<Node>,
+    )> {
+        let web_shielded_utils_js_callbacks = WebShieldedUtilsJsCallbacks::new();
+        let conversion = web_shielded_utils_js_callbacks.query_conversion(0);
+        let conversion_as_str = conversion.as_string().unwrap();
+        console_log(&conversion_as_str);
+        !unimplemented!("this will have to query the endpoint for a specific path, but it does not have to do anything except return the data")
+    }
+
+    async fn query_epoch(&self) -> namada::types::storage::Epoch {
+        let web_shielded_utils_js_callbacks = WebShieldedUtilsJsCallbacks::new();
+        let epoch = web_shielded_utils_js_callbacks.query_epoch(0);
+        let epoch_as_str = epoch.as_string().unwrap();
+        console_log(&epoch_as_str);
+        !unimplemented!("returns the epoch, use the existing code for this")
+    }
+
+    async fn query_storage_value<T: Send>(&self, key: &namada::types::storage::Key) -> Option<T>
+    where
+        T: BorshDeserialize,
+    {
+        let web_shielded_utils_js_callbacks = WebShieldedUtilsJsCallbacks::new();
+        let storage_value_byte_array = web_shielded_utils_js_callbacks.query_storage_value(0);
+        let storage_value_byte_arrayh_as_str = storage_value_byte_array.as_string().unwrap();
+        console_log(&storage_value_byte_arrayh_as_str);
+        !unimplemented!("returns an encrypted value that was fetched by storage path")
+    }
+}
+
+#[wasm_bindgen]
+pub fn create_masp_transfer() -> u8 {
+    0
+}
+
+// - this maps callbacks from js to Rust signatures
+// - they live in WebShieldedUtilsJsCallbacks that contains a class of the same name
+// - the path defined below at raw_module refers to the location of the destination of
+//   where the resulting glue code gets copied to by by the script. The script is at
+//   ./scripts/build.sh at the root of this module
+#[wasm_bindgen(raw_module = "../callbacksForWasm/WebShieldedUtilsJsCallbacks")]
+extern "C" {
+
+    // this is the js class containing all the callbacks and utils
+    #[wasm_bindgen(js_class = "WebShieldedUtilsJsCallbacks")]
+    type WebShieldedUtilsJsCallbacks;
+
+    // constructor for the class so we get the ::new method
+    #[wasm_bindgen(constructor)]
+    fn new() -> WebShieldedUtilsJsCallbacks;
+
+    // returns the local transaction prover
+    #[wasm_bindgen(
+        method,
+        js_class = "WebShieldedUtilsJsCallbacks",
+        js_name = "localTxProverCallback"
+    )]
+    fn local_tx_prover_callback(this: &WebShieldedUtilsJsCallbacks, placeholder: u32) -> JsString;
+
+    // this saves the shielded context. This is an optimization, that helps to
+    // prevent the client having to fetch all the shielded notes again and again.
+    #[wasm_bindgen(method, js_class = "WebShieldedUtilsJsCallbacks", js_name = "save")]
+    fn save(this: &WebShieldedUtilsJsCallbacks, placeholder: u32) -> JsString;
+
+    // this loads the persisted context. This is an optimization, that helps to
+    // prevent the client having to fetch all the shielded notes again and again.
+    // this loads what WebShieldedUtilsJsCallbacks.save saves
+    #[wasm_bindgen(method, js_class = "WebShieldedUtilsJsCallbacks", js_name = "load")]
+    fn load(this: &WebShieldedUtilsJsCallbacks, placeholder: u32) -> JsString;
+
+    // queries the conversion from the chain
+    #[wasm_bindgen(
+        method,
+        js_class = "WebShieldedUtilsJsCallbacks",
+        js_name = "queryConversion"
+    )]
+    fn query_conversion(this: &WebShieldedUtilsJsCallbacks, placeholder: u32) -> JsString;
+
+    // queries the epoch from the chain
+    #[wasm_bindgen(
+        method,
+        js_class = "WebShieldedUtilsJsCallbacks",
+        js_name = "queryEpoch"
+    )]
+    fn query_epoch(this: &WebShieldedUtilsJsCallbacks, placeholder: u32) -> JsString;
+
+    // queries a storage value from the chain based on the storage path being passed in
+    #[wasm_bindgen(
+        method,
+        js_class = "WebShieldedUtilsJsCallbacks",
+        js_name = "queryStorageValue"
+    )]
+    fn query_storage_value(this: &WebShieldedUtilsJsCallbacks, placeholder: u32) -> JsString;
+}
+
+// maps js console.log() for debugging
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console)]
+    fn console_log(s: &str);
+}

--- a/packages/shared/src/callbacksForWasm/WebShieldedUtilsJsCallbacks.ts
+++ b/packages/shared/src/callbacksForWasm/WebShieldedUtilsJsCallbacks.ts
@@ -1,0 +1,45 @@
+// this class contains functions that are being used for the code
+// of creating MASP transfers
+// these are being passed to Rust(WASM) and used as a callback
+// this is supposed to be the smallest possible set where the
+// implementation between the desktop CLI and the web client differ
+// these callbacks (and this class) reflect the trait
+// namada::ledger::masp::ShieldedUtils from
+// https://github.com/anoma/namada repo
+export class WebShieldedUtilsJsCallbacks {
+  localTxProverCallback = (input: number): string => {
+    const returnValue = `localTxProverCallback called with ${input}`;
+    console.log(returnValue);
+    return returnValue;
+  };
+
+  save = (input: number): string => {
+    const returnValue = `save called with ${input}`;
+    console.log(returnValue);
+    return returnValue;
+  };
+
+  load = (input: number): string => {
+    const returnValue = `load called with ${input}`;
+    console.log(returnValue);
+    return returnValue;
+  };
+
+  queryConversion = (input: number): string => {
+    const returnValue = `queryConversion called with ${input}`;
+    console.log(returnValue);
+    return returnValue;
+  };
+
+  queryEpoch = (input: number): string => {
+    const returnValue = `queryEpoch called with ${input}`;
+    console.log(returnValue);
+    return returnValue;
+  };
+
+  queryStorageValue = (input: number): string => {
+    const returnValue = `queryStorageValue called with ${input}`;
+    console.log(returnValue);
+    return returnValue;
+  };
+}

--- a/packages/shared/src/callbacksForWasm/index.ts
+++ b/packages/shared/src/callbacksForWasm/index.ts
@@ -1,0 +1,1 @@
+export { WebShieldedUtilsJsCallbacks } from "./WebShieldedUtilsJsCallbacks";


### PR DESCRIPTION
# What does this PR do
It unifies the implementation of creating MASP transfers between CLI and Web client. The code in core `namada/shared` is refactored so that the only aspects that are different between those are contained in a trait called `ShieldedUtils` and are being implemented and passed to a common code.

The changes here are reflecting the refactoring that is being done at the core Namada codebase here https://github.com/anoma/namada/pull/848

# How to test it
The instructions will follow soon