### PR TITLE
feat/141 - Prompt for password only when needed

### DIFF
--- a/apps/extension/src/App/Accounts/AddAccount.tsx
+++ b/apps/extension/src/App/Accounts/AddAccount.tsx
@@ -120,7 +120,7 @@ const AddAccount: React.FC<Props> = ({
         new CheckIsLockedMsg()
       );
       if (isKeyChainLocked) {
-        navigate(TopLevelRoute.Login);
+        navigate(`${TopLevelRoute.Login}?redirect=${TopLevelRoute.AddAccount}`);
       } else {
         setIsLocked(false);
       }
@@ -198,85 +198,94 @@ const AddAccount: React.FC<Props> = ({
 
   return (
     <AddAccountContainer>
-      <AddAccountForm
-        onKeyDown={(e) => {
-          if (e.key === "Enter" && isFormValid) {
-            handleAccountAdd();
-          }
-        }}
-      >
-        <InputContainer>
-          <Input
-            variant={InputVariant.Text}
-            label="Alias"
-            autoFocus={true}
-            value={alias}
-            onChange={(e) => setAlias(e.target.value)}
-          />
-        </InputContainer>
-        <InputContainer>
-          <Label>
-            <p>HD Derivation Path</p>
-            <Bip44PathContainer>
-              <Bip44PathDelimiter>{parentDerivationPath}</Bip44PathDelimiter>
-              {isTransparent && (
-                <>
+      {!isLocked && (
+        <>
+          <AddAccountForm
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && isFormValid) {
+                handleAccountAdd();
+              }
+            }}
+          >
+            <InputContainer>
+              <Input
+                variant={InputVariant.Text}
+                label="Alias"
+                autoFocus={true}
+                value={alias}
+                onChange={(e) => setAlias(e.target.value)}
+              />
+            </InputContainer>
+            <InputContainer>
+              <Label>
+                <p>HD Derivation Path</p>
+                <Bip44PathContainer>
+                  <Bip44PathDelimiter>
+                    {parentDerivationPath}
+                  </Bip44PathDelimiter>
+                  {isTransparent && (
+                    <>
+                      <Bip44Input
+                        type="number"
+                        min="0"
+                        max="1"
+                        value={change}
+                        onChange={(e) => handleNumericChange(e, setChange)}
+                        onFocus={handleFocus}
+                      />
+                      <Bip44PathDelimiter>/</Bip44PathDelimiter>
+                    </>
+                  )}
                   <Bip44Input
                     type="number"
                     min="0"
-                    max="1"
-                    value={change}
-                    onChange={(e) => handleNumericChange(e, setChange)}
+                    value={index}
+                    onChange={(e) => handleNumericChange(e, setIndex)}
                     onFocus={handleFocus}
                   />
-                  <Bip44PathDelimiter>/</Bip44PathDelimiter>
-                </>
-              )}
-              <Bip44Input
-                type="number"
-                min="0"
-                value={index}
-                onChange={(e) => handleNumericChange(e, setIndex)}
-                onFocus={handleFocus}
-              />
-            </Bip44PathContainer>
-          </Label>
-        </InputContainer>
-        <InputContainer>
-          <ShieldedToggleContainer>
-            <span>Transparent&nbsp;</span>
-            <Toggle
-              onClick={() => setIsTransparent(!isTransparent)}
-              checked={isTransparent}
-            />
-            <span>&nbsp;Shielded</span>
-          </ShieldedToggleContainer>
-        </InputContainer>
+                </Bip44PathContainer>
+              </Label>
+            </InputContainer>
+            <InputContainer>
+              <ShieldedToggleContainer>
+                <span>Transparent&nbsp;</span>
+                <Toggle
+                  onClick={() => setIsTransparent(!isTransparent)}
+                  checked={isTransparent}
+                />
+                <span>&nbsp;Shielded</span>
+              </ShieldedToggleContainer>
+            </InputContainer>
 
-        <Bip44Path>
-          Derivation path:{" "}
-          <span>{`${parentDerivationPath}${
-            isTransparent ? `${change}/` : ""
-          }${index}`}</span>
-        </Bip44Path>
-        <Bip44Error>{bip44Error}</Bip44Error>
-      </AddAccountForm>
-      {formStatus === Status.Pending && (
-        <FormStatus>Submitting new account...</FormStatus>
+            <Bip44Path>
+              Derivation path:{" "}
+              <span>{`${parentDerivationPath}${
+                isTransparent ? `${change}/` : ""
+              }${index}`}</span>
+            </Bip44Path>
+            <Bip44Error>{bip44Error}</Bip44Error>
+          </AddAccountForm>
+          {formStatus === Status.Pending && (
+            <FormStatus>Submitting new account...</FormStatus>
+          )}
+          {formStatus === Status.Failed && <FormError>{formError}</FormError>}
+          <ButtonsContainer>
+            <Button
+              variant={ButtonVariant.Contained}
+              onClick={() => navigate(TopLevelRoute.Accounts)}
+            >
+              Back
+            </Button>
+            <Button
+              variant={ButtonVariant.Contained}
+              disabled={!isFormValid || formStatus === Status.Pending}
+              onClick={handleAccountAdd}
+            >
+              Add
+            </Button>
+          </ButtonsContainer>
+        </>
       )}
-      {formStatus === Status.Failed && <FormError>{formError}</FormError>}
-      <ButtonsContainer>
-        <Button variant={ButtonVariant.Contained} onClick={() => navigate(-1)}>
-          Back
-        </Button>
-        <Button
-          variant={ButtonVariant.Contained}
-          disabled={!isFormValid || formStatus === Status.Pending}
-          onClick={handleAccountAdd}
-        >
-          Add
-        </Button>
-      </ButtonsContainer>
     </AddAccountContainer>
   );
 };

--- a/apps/extension/src/App/Accounts/AddAccount.tsx
+++ b/apps/extension/src/App/Accounts/AddAccount.tsx
@@ -37,6 +37,8 @@ type Props = {
   accounts: DerivedAccount[];
   requester: ExtensionRequester;
   setAccounts: (accounts: DerivedAccount[]) => void;
+  isLocked: boolean;
+  unlockKeyRing: () => void;
 };
 
 const validateAccount = (
@@ -93,9 +95,10 @@ const AddAccount: React.FC<Props> = ({
   accounts,
   requester,
   setAccounts,
+  isLocked,
+  unlockKeyRing,
 }) => {
   const navigate = useNavigate();
-  const [isLocked, setIsLocked] = useState(true);
   const [alias, setAlias] = useState("");
   const [change, setChange] = useState(0);
   const [bip44Error, setBip44Error] = useState("");
@@ -120,7 +123,7 @@ const AddAccount: React.FC<Props> = ({
     authorize(
       TopLevelRoute.AddAccount,
       "A password is required to add an account!",
-      () => setIsLocked(false)
+      unlockKeyRing
     );
   }, []);
 

--- a/apps/extension/src/App/Accounts/AddAccount.tsx
+++ b/apps/extension/src/App/Accounts/AddAccount.tsx
@@ -114,20 +114,22 @@ const AddAccount: React.FC<Props> = ({
   const { coinType } = chains[defaultChainId].bip44;
 
   const checkIsLocked = async (): Promise<void> => {
-    if (isLocked) {
-      const isKeyChainLocked = await requester.sendMessage(
-        Ports.Background,
-        new CheckIsLockedMsg()
+    const isKeyChainLocked = await requester.sendMessage(
+      Ports.Background,
+      new CheckIsLockedMsg()
+    );
+    if (isKeyChainLocked) {
+      navigate(
+        `${TopLevelRoute.Login}?redirect=${TopLevelRoute.AddAccount}&prompt=A password is required to derive an account`
       );
-      if (isKeyChainLocked) {
-        navigate(`${TopLevelRoute.Login}?redirect=${TopLevelRoute.AddAccount}`);
-      } else {
-        setIsLocked(false);
-      }
+    } else {
+      setIsLocked(false);
     }
   };
 
   useEffect(() => {
+    // Query the locked status of the Keyring before displaying the form,
+    // and redirect to Login if it is locked:
     checkIsLocked();
   }, []);
 

--- a/apps/extension/src/App/Accounts/AddAccount.tsx
+++ b/apps/extension/src/App/Accounts/AddAccount.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+
 import {
   Button,
   ButtonVariant,

--- a/apps/extension/src/App/Accounts/AddAccount.tsx
+++ b/apps/extension/src/App/Accounts/AddAccount.tsx
@@ -8,11 +8,11 @@ import {
   Toggle,
 } from "@anoma/components";
 import { AccountType, DerivedAccount } from "@anoma/types";
+import { chains, defaultChainId } from "@anoma/chains";
 
 import { ExtensionRequester } from "extension";
 import { Ports } from "router";
-import { CheckIsLockedMsg, DeriveAccountMsg } from "background/keyring";
-import { chains, defaultChainId } from "@anoma/chains";
+import { DeriveAccountMsg } from "background/keyring";
 import {
   AddAccountContainer,
   AddAccountForm,
@@ -29,6 +29,7 @@ import {
   ShieldedToggleContainer,
 } from "./AddAccount.components";
 import { TopLevelRoute } from "App/types";
+import { useAuth } from "hooks";
 
 type Props = {
   // The parent Bip44 "account"
@@ -113,24 +114,14 @@ const AddAccount: React.FC<Props> = ({
   const zip32Prefix = "m/32";
   const { coinType } = chains[defaultChainId].bip44;
 
-  const checkIsLocked = async (): Promise<void> => {
-    const isKeyChainLocked = await requester.sendMessage(
-      Ports.Background,
-      new CheckIsLockedMsg()
-    );
-    if (isKeyChainLocked) {
-      navigate(
-        `${TopLevelRoute.Login}?redirect=${TopLevelRoute.AddAccount}&prompt=A password is required to derive an account`
-      );
-    } else {
-      setIsLocked(false);
-    }
-  };
+  const authorize = useAuth(requester);
 
   useEffect(() => {
-    // Query the locked status of the Keyring before displaying the form,
-    // and redirect to Login if it is locked:
-    checkIsLocked();
+    authorize(
+      TopLevelRoute.AddAccount,
+      "A password is required to add an account!",
+      () => setIsLocked(false)
+    );
   }, []);
 
   useEffect(() => {

--- a/apps/extension/src/App/App.tsx
+++ b/apps/extension/src/App/App.tsx
@@ -22,6 +22,7 @@ import { Setup } from "./Setup";
 import { TopLevelRoute } from "./types";
 import { Loading } from "./Loading";
 import { ExtensionKVStore } from "@anoma/storage";
+import { ApproveConnection, ApproveTx } from "./Approvals";
 
 const store = new ExtensionKVStore(KVPrefix.LocalStorage, {
   get: browser.storage.local.get,
@@ -98,6 +99,14 @@ export const App: React.FC = () => {
               }
             />
             <Route path={TopLevelRoute.Setup} element={<Setup />} />
+            <Route
+              path={TopLevelRoute.ApproveConnection}
+              element={<ApproveConnection requester={requester} />}
+            />
+            <Route
+              path={TopLevelRoute.ApproveTx}
+              element={<ApproveTx requester={requester} />}
+            />
             <Route
               path={TopLevelRoute.Login}
               element={<Login requester={requester} />}

--- a/apps/extension/src/App/App.tsx
+++ b/apps/extension/src/App/App.tsx
@@ -7,7 +7,6 @@ import { AccountType, DerivedAccount } from "@anoma/types";
 import { getTheme } from "@anoma/utils";
 import { ExtensionMessenger, ExtensionRequester } from "extension";
 import { KVPrefix, Ports } from "router";
-import { CheckIsLockedMsg } from "background/keyring";
 import { QueryAccountsMsg } from "provider/messages";
 import {
   AppContainer,

--- a/apps/extension/src/App/App.tsx
+++ b/apps/extension/src/App/App.tsx
@@ -10,6 +10,7 @@ import { ExtensionKVStore } from "@anoma/storage";
 import { ExtensionMessenger, ExtensionRequester } from "extension";
 import { KVPrefix, Ports } from "router";
 import { QueryAccountsMsg } from "provider/messages";
+import { useQuery } from "hooks";
 import {
   AppContainer,
   BottomSection,
@@ -40,6 +41,8 @@ export enum Status {
 
 export const App: React.FC = () => {
   const theme = getTheme(true, false);
+  const query = useQuery();
+  const redirect = query.get("redirect");
   const navigate = useNavigate();
   const [isLocked, setIsLocked] = useState(true);
   const [status, setStatus] = useState<Status>();
@@ -64,7 +67,12 @@ export const App: React.FC = () => {
   };
 
   useEffect(() => {
-    fetchAccounts();
+    if (redirect) {
+      // Provide a redirect in the case of transaction/connection approvals
+      navigate(redirect);
+    } else {
+      fetchAccounts();
+    }
   }, []);
 
   useEffect(() => {

--- a/apps/extension/src/App/App.tsx
+++ b/apps/extension/src/App/App.tsx
@@ -24,7 +24,6 @@ import { TopLevelRoute } from "./types";
 import { Loading } from "./Loading";
 import { ExtensionKVStore } from "@anoma/storage";
 
-
 const store = new ExtensionKVStore(KVPrefix.LocalStorage, {
   get: browser.storage.local.get,
   set: browser.storage.local.set,
@@ -62,18 +61,6 @@ export const App: React.FC = () => {
     }
   };
 
-  const checkIsLocked = async (): Promise<void> => {
-    const isLocked = await requester.sendMessage(
-      Ports.Background,
-      new CheckIsLockedMsg()
-    );
-    if (isLocked) {
-      navigate(TopLevelRoute.Login);
-    } else {
-      navigate(TopLevelRoute.Accounts);
-    }
-  };
-
   useEffect(() => {
     fetchAccounts();
   }, []);
@@ -83,7 +70,7 @@ export const App: React.FC = () => {
       if (accounts.length === 0) {
         navigate(TopLevelRoute.Setup);
       } else {
-        checkIsLocked();
+        navigate(TopLevelRoute.Accounts);
       }
     }
   }, [status, accounts]);
@@ -114,7 +101,9 @@ export const App: React.FC = () => {
             <Route path={TopLevelRoute.Setup} element={<Setup />} />
             <Route
               path={TopLevelRoute.Login}
-              element={<Login requester={requester} />}
+              element={
+                <Login requester={requester} route={TopLevelRoute.AddAccount} />
+              }
             />
             <Route
               path={TopLevelRoute.AddAccount}

--- a/apps/extension/src/App/App.tsx
+++ b/apps/extension/src/App/App.tsx
@@ -40,6 +40,7 @@ export enum Status {
 export const App: React.FC = () => {
   const theme = getTheme(true, false);
   const navigate = useNavigate();
+  const [isLocked, setIsLocked] = useState(true);
   const [status, setStatus] = useState<Status>();
   const [accounts, setAccounts] = useState<DerivedAccount[]>([]);
   const [error, setError] = useState("");
@@ -92,20 +93,42 @@ export const App: React.FC = () => {
             <Route path="*" element={<Loading error={error} />} />
             <Route
               path={TopLevelRoute.Accounts}
-              element={
-                <LockWrapper requester={requester} setStatus={setStatus}>
-                  <Accounts accounts={accounts} requester={requester} />
-                </LockWrapper>
-              }
+              element={<Accounts accounts={accounts} requester={requester} />}
             />
             <Route path={TopLevelRoute.Setup} element={<Setup />} />
             <Route
               path={TopLevelRoute.ApproveConnection}
-              element={<ApproveConnection requester={requester} />}
+              element={
+                <LockWrapper
+                  requester={requester}
+                  setStatus={setStatus}
+                  isLocked={isLocked}
+                  lockKeyRing={() => setIsLocked(true)}
+                >
+                  <ApproveConnection
+                    requester={requester}
+                    isLocked={isLocked}
+                    unlockKeyRing={() => setIsLocked(false)}
+                  />
+                </LockWrapper>
+              }
             />
             <Route
               path={TopLevelRoute.ApproveTx}
-              element={<ApproveTx requester={requester} />}
+              element={
+                <LockWrapper
+                  requester={requester}
+                  setStatus={setStatus}
+                  isLocked={isLocked}
+                  lockKeyRing={() => setIsLocked(true)}
+                >
+                  <ApproveTx
+                    requester={requester}
+                    isLocked={isLocked}
+                    unlockKeyRing={() => setIsLocked(false)}
+                  />
+                </LockWrapper>
+              }
             />
             <Route
               path={TopLevelRoute.Login}
@@ -114,12 +137,19 @@ export const App: React.FC = () => {
             <Route
               path={TopLevelRoute.AddAccount}
               element={
-                <LockWrapper requester={requester} setStatus={setStatus}>
+                <LockWrapper
+                  requester={requester}
+                  setStatus={setStatus}
+                  isLocked={isLocked}
+                  lockKeyRing={() => setIsLocked(true)}
+                >
                   <AddAccount
                     parentAccount={parentAccount}
                     accounts={accounts}
                     requester={requester}
                     setAccounts={setAccounts}
+                    isLocked={isLocked}
+                    unlockKeyRing={() => setIsLocked(false)}
                   />
                 </LockWrapper>
               }

--- a/apps/extension/src/App/App.tsx
+++ b/apps/extension/src/App/App.tsx
@@ -5,6 +5,8 @@ import { Routes, Route, useNavigate } from "react-router-dom";
 
 import { AccountType, DerivedAccount } from "@anoma/types";
 import { getTheme } from "@anoma/utils";
+import { ExtensionKVStore } from "@anoma/storage";
+
 import { ExtensionMessenger, ExtensionRequester } from "extension";
 import { KVPrefix, Ports } from "router";
 import { QueryAccountsMsg } from "provider/messages";
@@ -15,13 +17,12 @@ import {
   GlobalStyles,
   TopSection,
 } from "./App.components";
+import { TopLevelRoute } from "./types";
 import { LockWrapper } from "./LockWrapper";
 import { Accounts, AddAccount } from "./Accounts";
 import { Login } from "./Login";
 import { Setup } from "./Setup";
-import { TopLevelRoute } from "./types";
 import { Loading } from "./Loading";
-import { ExtensionKVStore } from "@anoma/storage";
 import { ApproveConnection, ApproveTx } from "./Approvals";
 
 const store = new ExtensionKVStore(KVPrefix.LocalStorage, {

--- a/apps/extension/src/App/App.tsx
+++ b/apps/extension/src/App/App.tsx
@@ -100,9 +100,7 @@ export const App: React.FC = () => {
             <Route path={TopLevelRoute.Setup} element={<Setup />} />
             <Route
               path={TopLevelRoute.Login}
-              element={
-                <Login requester={requester} route={TopLevelRoute.AddAccount} />
-              }
+              element={<Login requester={requester} />}
             />
             <Route
               path={TopLevelRoute.AddAccount}

--- a/apps/extension/src/App/Approvals/ApproveConnection.components.tsx
+++ b/apps/extension/src/App/Approvals/ApproveConnection.components.tsx
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+
+export const ApproveConnectionContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const ApprovalButtonContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+`;

--- a/apps/extension/src/App/Approvals/ApproveConnection.tsx
+++ b/apps/extension/src/App/Approvals/ApproveConnection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { Button, ButtonVariant } from "@anoma/components";
 import { ExtensionRequester } from "extension";
 import {
@@ -10,17 +10,22 @@ import { useAuth } from "hooks";
 
 type Props = {
   requester: ExtensionRequester;
+  isLocked: boolean;
+  unlockKeyRing: () => void;
 };
 
-export const ApproveConnection: React.FC<Props> = ({ requester }) => {
-  const [isLocked, setIsLocked] = useState(true);
+export const ApproveConnection: React.FC<Props> = ({
+  requester,
+  isLocked,
+  unlockKeyRing,
+}) => {
   const authorize = useAuth(requester);
 
   useEffect(() => {
     authorize(
       TopLevelRoute.ApproveConnection,
       "A password is required to approve a connection!",
-      () => setIsLocked(false)
+      unlockKeyRing
     );
   }, []);
 

--- a/apps/extension/src/App/Approvals/ApproveConnection.tsx
+++ b/apps/extension/src/App/Approvals/ApproveConnection.tsx
@@ -1,0 +1,3 @@
+export const ApproveConnection: React.FC = () => {
+  return <div>ApproveConnection</div>;
+};

--- a/apps/extension/src/App/Approvals/ApproveConnection.tsx
+++ b/apps/extension/src/App/Approvals/ApproveConnection.tsx
@@ -1,5 +1,7 @@
 import { useEffect } from "react";
+
 import { Button, ButtonVariant } from "@anoma/components";
+
 import { ExtensionRequester } from "extension";
 import {
   ApproveConnectionContainer,

--- a/apps/extension/src/App/Approvals/ApproveConnection.tsx
+++ b/apps/extension/src/App/Approvals/ApproveConnection.tsx
@@ -1,3 +1,40 @@
-export const ApproveConnection: React.FC = () => {
-  return <div>ApproveConnection</div>;
+import { useEffect, useState } from "react";
+import { Button, ButtonVariant } from "@anoma/components";
+import { ExtensionRequester } from "extension";
+import {
+  ApproveConnectionContainer,
+  ApprovalButtonContainer,
+} from "./ApproveConnection.components";
+import { TopLevelRoute } from "App/types";
+import { useAuth } from "hooks";
+
+type Props = {
+  requester: ExtensionRequester;
+};
+
+export const ApproveConnection: React.FC<Props> = ({ requester }) => {
+  const [isLocked, setIsLocked] = useState(true);
+  const authorize = useAuth(requester);
+
+  useEffect(() => {
+    authorize(
+      TopLevelRoute.ApproveConnection,
+      "A password is required to approve a connection!",
+      () => setIsLocked(false)
+    );
+  }, []);
+
+  return (
+    <ApproveConnectionContainer>
+      {!isLocked && (
+        <>
+          <p>Approve connection?</p>
+          <ApprovalButtonContainer>
+            <Button variant={ButtonVariant.Contained}>Approve</Button>
+            <Button variant={ButtonVariant.Contained}>Reject</Button>
+          </ApprovalButtonContainer>
+        </>
+      )}
+    </ApproveConnectionContainer>
+  );
 };

--- a/apps/extension/src/App/Approvals/ApproveTx.components.tsx
+++ b/apps/extension/src/App/Approvals/ApproveTx.components.tsx
@@ -1,0 +1,6 @@
+import styled from "styled-components";
+
+export const ApproveTxContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;

--- a/apps/extension/src/App/Approvals/ApproveTx.tsx
+++ b/apps/extension/src/App/Approvals/ApproveTx.tsx
@@ -1,6 +1,8 @@
 import { useEffect } from "react";
+
 import { Button, ButtonVariant } from "@anoma/components";
 import { shortenAddress } from "@anoma/utils";
+
 import { useAuth } from "hooks";
 import { TopLevelRoute } from "App/types";
 import { ApproveTxContainer } from "./ApproveTx.components";

--- a/apps/extension/src/App/Approvals/ApproveTx.tsx
+++ b/apps/extension/src/App/Approvals/ApproveTx.tsx
@@ -1,3 +1,50 @@
-export const ApproveTx: React.FC = () => {
-  return <div>ApproveTx</div>;
+import { useEffect, useState } from "react";
+import { Button, ButtonVariant } from "@anoma/components";
+import { shortenAddress } from "@anoma/utils";
+import { useAuth } from "hooks";
+import { TopLevelRoute } from "App/types";
+import { ApproveTxContainer } from "./ApproveTx.components";
+import { ApprovalButtonContainer } from "./ApproveConnection.components";
+import { Address } from "App/Accounts/AccountListing.components";
+import { ExtensionRequester } from "extension";
+
+type Props = {
+  requester: ExtensionRequester;
+};
+
+export const ApproveTx: React.FC<Props> = ({ requester }) => {
+  const [isLocked, setIsLocked] = useState(true);
+  const authorize = useAuth(requester);
+
+  useEffect(() => {
+    authorize(
+      TopLevelRoute.ApproveTx,
+      "A password is required to approve a transaction!",
+      () => setIsLocked(false)
+    );
+  }, []);
+
+  // TODO: How to load tx details into this view?
+  return (
+    <ApproveTxContainer>
+      {!isLocked && (
+        <>
+          <p>Approve this Transaction?</p>
+          <p>
+            Target: <Address>{shortenAddress("xxxxxxxxxxxx")}</Address>
+          </p>
+          <p>
+            Source: <Address>{shortenAddress("xxxxxxxxxxxx")}</Address>
+          </p>
+          <p>Ammount: 1000</p>
+          <p>Token: NAM</p>
+
+          <ApprovalButtonContainer>
+            <Button variant={ButtonVariant.Contained}>Approve</Button>
+            <Button variant={ButtonVariant.Contained}>Reject</Button>
+          </ApprovalButtonContainer>
+        </>
+      )}
+    </ApproveTxContainer>
+  );
 };

--- a/apps/extension/src/App/Approvals/ApproveTx.tsx
+++ b/apps/extension/src/App/Approvals/ApproveTx.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { Button, ButtonVariant } from "@anoma/components";
 import { shortenAddress } from "@anoma/utils";
 import { useAuth } from "hooks";
@@ -10,17 +10,22 @@ import { ExtensionRequester } from "extension";
 
 type Props = {
   requester: ExtensionRequester;
+  isLocked: boolean;
+  unlockKeyRing: () => void;
 };
 
-export const ApproveTx: React.FC<Props> = ({ requester }) => {
-  const [isLocked, setIsLocked] = useState(true);
+export const ApproveTx: React.FC<Props> = ({
+  requester,
+  isLocked,
+  unlockKeyRing,
+}) => {
   const authorize = useAuth(requester);
 
   useEffect(() => {
     authorize(
       TopLevelRoute.ApproveTx,
       "A password is required to approve a transaction!",
-      () => setIsLocked(false)
+      unlockKeyRing
     );
   }, []);
 
@@ -31,10 +36,20 @@ export const ApproveTx: React.FC<Props> = ({ requester }) => {
         <>
           <p>Approve this Transaction?</p>
           <p>
-            Target: <Address>{shortenAddress("xxxxxxxxxxxx")}</Address>
+            Target:&nbsp;
+            <Address>
+              {shortenAddress(
+                "atest1d9khqw368ycrv3phxgcnwdzygdp5xd2yxyey2w2ygdpy23jxxgeyy3zp8ymnw3p5xyuyxwps5u3n2x"
+              )}
+            </Address>
           </p>
           <p>
-            Source: <Address>{shortenAddress("xxxxxxxxxxxx")}</Address>
+            Source:&nbsp;
+            <Address>
+              {shortenAddress(
+                "atest1d9khqw36xu65v3phgs6nvwz98q6rxvfnxaqnwv2rx4rrwsjxgezyvdpk8yervvjzgsu5vd34zrynzd"
+              )}
+            </Address>
           </p>
           <p>Ammount: 1000</p>
           <p>Token: NAM</p>

--- a/apps/extension/src/App/Approvals/ApproveTx.tsx
+++ b/apps/extension/src/App/Approvals/ApproveTx.tsx
@@ -1,0 +1,3 @@
+export const ApproveTx: React.FC = () => {
+  return <div>ApproveTx</div>;
+};

--- a/apps/extension/src/App/Approvals/ApproveTx.tsx
+++ b/apps/extension/src/App/Approvals/ApproveTx.tsx
@@ -31,7 +31,7 @@ export const ApproveTx: React.FC<Props> = ({
     );
   }, []);
 
-  // TODO: How to load tx details into this view?
+  // TODO: How to load tx details into this view? Via a query parameter?
   return (
     <ApproveTxContainer>
       {!isLocked && (

--- a/apps/extension/src/App/Approvals/index.ts
+++ b/apps/extension/src/App/Approvals/index.ts
@@ -1,2 +1,4 @@
 export * from "./ApproveConnection";
+export * from "./ApproveConnection.components";
 export * from "./ApproveTx";
+export * from "./ApproveTx.components";

--- a/apps/extension/src/App/Approvals/index.ts
+++ b/apps/extension/src/App/Approvals/index.ts
@@ -1,0 +1,2 @@
+export * from "./ApproveConnection";
+export * from "./ApproveTx";

--- a/apps/extension/src/App/LockWrapper/LockWrapper.tsx
+++ b/apps/extension/src/App/LockWrapper/LockWrapper.tsx
@@ -11,31 +11,42 @@ import { ExtensionRequester } from "extension";
 
 type Props = {
   requester: ExtensionRequester;
+  isLocked: boolean;
   setStatus: (status?: Status) => void;
+  lockKeyRing: () => void;
   children: JSX.Element;
 };
 
-const LockWrapper: React.FC<Props> = ({ requester, setStatus, children }) => {
+const LockWrapper: React.FC<Props> = ({
+  requester,
+  isLocked,
+  lockKeyRing,
+  setStatus,
+  children,
+}) => {
   const navigate = useNavigate();
 
   const handleLock = async (): Promise<void> => {
     try {
       await requester.sendMessage(Ports.Background, new LockKeyRingMsg());
       setStatus(undefined);
+      lockKeyRing();
     } catch (e) {
       console.error(e);
     } finally {
-      navigate(TopLevelRoute.Login);
+      navigate(TopLevelRoute.Accounts);
     }
   };
 
   return (
     <>
-      <ButtonContainer>
-        <LockExtensionButton onClick={handleLock}>
-          <span>Lock</span> <Icon iconName={IconName.Lock} />
-        </LockExtensionButton>
-      </ButtonContainer>
+      {!isLocked && (
+        <ButtonContainer>
+          <LockExtensionButton onClick={handleLock}>
+            <span>Lock</span> <Icon iconName={IconName.Lock} />
+          </LockExtensionButton>
+        </ButtonContainer>
+      )}
       {children}
     </>
   );

--- a/apps/extension/src/App/Login/Login.tsx
+++ b/apps/extension/src/App/Login/Login.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 
 import { TopLevelRoute } from "App/types";
 import { ExtensionRequester } from "extension";
@@ -17,16 +17,20 @@ enum Status {
 
 type Props = {
   requester: ExtensionRequester;
-  route?: TopLevelRoute;
 };
 
-const Login: React.FC<Props> = ({
-  requester,
-  route = TopLevelRoute.Accounts,
-}) => {
+const Login: React.FC<Props> = ({ requester }) => {
   const navigate = useNavigate();
   const [password, setPassword] = useState("");
   const [status, setStatus] = useState<Status>();
+
+  const useQuery = (): URLSearchParams => {
+    const { search } = useLocation();
+    return React.useMemo(() => new URLSearchParams(search), [search]);
+  };
+
+  const query = useQuery();
+  const redirect = query.get("redirect") || TopLevelRoute.Accounts;
 
   const handleSubmit = async (): Promise<void> => {
     setStatus(Status.Pending);
@@ -36,7 +40,7 @@ const Login: React.FC<Props> = ({
         new UnlockKeyRingMsg(password)
       );
       if (lockStatus === KeyRingStatus.Unlocked) {
-        navigate(route);
+        navigate(redirect);
       } else {
         setStatus(Status.InvalidPassword);
       }

--- a/apps/extension/src/App/Login/Login.tsx
+++ b/apps/extension/src/App/Login/Login.tsx
@@ -31,6 +31,7 @@ const Login: React.FC<Props> = ({ requester }) => {
 
   const query = useQuery();
   const redirect = query.get("redirect") || TopLevelRoute.Accounts;
+  const prompt = query.get("prompt");
 
   const handleSubmit = async (): Promise<void> => {
     setStatus(Status.Pending);
@@ -51,34 +52,37 @@ const Login: React.FC<Props> = ({ requester }) => {
   };
 
   return (
-    <LoginContainer
-      onKeyDown={(e) => {
-        if (e.key === "Enter" && password.length > 0) {
-          handleSubmit();
-        }
-      }}
-    >
-      <Input
-        label="Enter your password"
-        autoFocus={true}
-        variant={InputVariant.Password}
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-      />
-      <Button
-        variant={ButtonVariant.Contained}
-        disabled={status === Status.Pending || !(password.length > 0)}
-        onClick={handleSubmit}
+    <>
+      {prompt && <p>{prompt}</p>}
+      <LoginContainer
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && password.length > 0) {
+            handleSubmit();
+          }
+        }}
       >
-        Unlock
-      </Button>
-      {status === Status.Failed && (
-        <LoginError>An error has occured!</LoginError>
-      )}
-      {status === Status.InvalidPassword && (
-        <LoginError>Incorrect password!</LoginError>
-      )}
-    </LoginContainer>
+        <Input
+          label="Enter password"
+          autoFocus={true}
+          variant={InputVariant.Password}
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <Button
+          variant={ButtonVariant.Contained}
+          disabled={status === Status.Pending || !(password.length > 0)}
+          onClick={handleSubmit}
+        >
+          Unlock
+        </Button>
+        {status === Status.Failed && (
+          <LoginError>An error has occured!</LoginError>
+        )}
+        {status === Status.InvalidPassword && (
+          <LoginError>Incorrect password!</LoginError>
+        )}
+      </LoginContainer>
+    </>
   );
 };
 

--- a/apps/extension/src/App/Login/Login.tsx
+++ b/apps/extension/src/App/Login/Login.tsx
@@ -17,9 +17,13 @@ enum Status {
 
 type Props = {
   requester: ExtensionRequester;
+  route?: TopLevelRoute;
 };
 
-const Login: React.FC<Props> = ({ requester }) => {
+const Login: React.FC<Props> = ({
+  requester,
+  route = TopLevelRoute.Accounts,
+}) => {
   const navigate = useNavigate();
   const [password, setPassword] = useState("");
   const [status, setStatus] = useState<Status>();
@@ -32,7 +36,7 @@ const Login: React.FC<Props> = ({ requester }) => {
         new UnlockKeyRingMsg(password)
       );
       if (lockStatus === KeyRingStatus.Unlocked) {
-        navigate(TopLevelRoute.Accounts);
+        navigate(route);
       } else {
         setStatus(Status.InvalidPassword);
       }

--- a/apps/extension/src/App/Login/Login.tsx
+++ b/apps/extension/src/App/Login/Login.tsx
@@ -1,13 +1,14 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { Input, InputVariant } from "@anoma/components";
+import { Button, ButtonVariant } from "@anoma/components";
+
 import { TopLevelRoute } from "App/types";
 import { ExtensionRequester } from "extension";
 import { useQuery } from "hooks";
 import { Ports } from "router";
 import { UnlockKeyRingMsg, KeyRingStatus } from "background/keyring";
-import { Input, InputVariant } from "@anoma/components";
-import { Button, ButtonVariant } from "@anoma/components";
 import { LoginContainer, LoginError } from "./Login.components";
 
 enum Status {

--- a/apps/extension/src/App/Login/Login.tsx
+++ b/apps/extension/src/App/Login/Login.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import { TopLevelRoute } from "App/types";
 import { ExtensionRequester } from "extension";
+import { useQuery } from "hooks";
 import { Ports } from "router";
 import { UnlockKeyRingMsg, KeyRingStatus } from "background/keyring";
 import { Input, InputVariant } from "@anoma/components";
@@ -23,11 +24,6 @@ const Login: React.FC<Props> = ({ requester }) => {
   const navigate = useNavigate();
   const [password, setPassword] = useState("");
   const [status, setStatus] = useState<Status>();
-
-  const useQuery = (): URLSearchParams => {
-    const { search } = useLocation();
-    return React.useMemo(() => new URLSearchParams(search), [search]);
-  };
 
   const query = useQuery();
   const redirect = query.get("redirect") || TopLevelRoute.Accounts;

--- a/apps/extension/src/App/types.ts
+++ b/apps/extension/src/App/types.ts
@@ -1,5 +1,7 @@
 export enum TopLevelRoute {
   Default = "/",
+  ApproveConnection = "/connection",
+  ApproveTx = "/tx",
   Login = "/login",
   Setup = "/setup",
 

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -39,3 +39,16 @@ initChains(router, chainsService);
 initKeyRing(router, keyRingService);
 
 router.listen(Ports.Background);
+
+// The following is an example of launching an approval screen from the background:
+/*
+const url = browser.runtime.getURL("popup.html");
+console.log({ url });
+
+browser.windows.create({
+  url: `${url}?redirect=/tx`,
+  width: 415,
+  height: 510,
+  type: "popup",
+});
+*/

--- a/apps/extension/src/hooks/index.ts
+++ b/apps/extension/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export { default as useAuth } from "./useAuth";
+export { default as useQuery } from "./useQuery";

--- a/apps/extension/src/hooks/useAuth.tsx
+++ b/apps/extension/src/hooks/useAuth.tsx
@@ -1,0 +1,29 @@
+import { TopLevelRoute } from "App/types";
+import { ExtensionRequester } from "extension";
+import { useNavigate } from "react-router-dom";
+import { CheckIsLockedMsg } from "background/keyring";
+
+import { Ports } from "router";
+
+const useAuth = (
+  requester: ExtensionRequester
+): ((
+  route: TopLevelRoute,
+  prompt: string,
+  callback: () => void
+) => Promise<void>) => {
+  const navigate = useNavigate();
+  return async (route: TopLevelRoute, prompt: string, callback: () => void) => {
+    const isKeyChainLocked = await requester.sendMessage(
+      Ports.Background,
+      new CheckIsLockedMsg()
+    );
+    if (isKeyChainLocked) {
+      navigate(`${TopLevelRoute.Login}?redirect=${route}&prompt=${prompt}`);
+    } else {
+      callback();
+    }
+  };
+};
+
+export default useAuth;

--- a/apps/extension/src/hooks/useQuery.tsx
+++ b/apps/extension/src/hooks/useQuery.tsx
@@ -1,0 +1,9 @@
+import { useMemo } from "react";
+import { useLocation } from "react-router-dom";
+
+const useQuery = (): URLSearchParams => {
+  const { search } = useLocation();
+  return useMemo(() => new URLSearchParams(search), [search]);
+};
+
+export default useQuery;

--- a/packages/chains/src/chains/namada.ts
+++ b/packages/chains/src/chains/namada.ts
@@ -17,7 +17,10 @@ const namada: Chain = {
   alias,
   bech32Prefix,
   bip44: {
-    coinType: 118,
+    // TODO: Update this when coinType for NAM token is registered with a SLIP-0044 coin-type.
+    // For now, use coin-type for testnet (all coins).
+    // See: https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+    coinType: 1,
   },
   rpc,
   chainId,


### PR DESCRIPTION
See #141

This updates the extension web app with behavior similar to Polkadot extension, where public addresses are displayed by default, and features needing access to private keys in storage will first prompt for a password (if the keyring storage is locked - the issue here is that we currently require Chrome extension users to constantly authenticate due to Manifest 3 service workers)

- [x] Public addresses display by default (this process is simple in case we want to follow what Keplr does instead)
- [x] If adding an account, check to see if keyring is locked, if so, redirect to login first

 __NOTE__ I've added some preliminary code for handle Tx approvals, but to keep this PR smaller, I'm moving the rest of it to another PR.

*TODO* (separate PR for #200):

- [ ] Submitting a transfer should check if keyring is locked, and if so, prompt user for the password to unlock, prompt user to approve transaction. If keyring is unlocked, simply display the transfer approval form

__NOTE__ For approvals/unlocking from interface, we will need to trigger the opening of the extension web app from within `content-scripts` upon receiving the signing request from the interface, loading the app from the correct route. The password is needed here to decrypt the signing key from storage, and an approval will be needed to resolve the promise in the interface for completing the signing of a transaction.