### PR TITLE
fix/175 Adding `bond` dependency that is being used

### DIFF
--- a/packages/shared/lib/src/lib.rs
+++ b/packages/shared/lib/src/lib.rs
@@ -3,6 +3,7 @@
 //! A library of functions to integrate shared functionality from the Anoma ecosystem
 
 pub mod account;
+pub mod bond;
 pub mod ibc_transfer;
 pub mod query;
 pub mod reveal_pk;


### PR DESCRIPTION
# What does this PR do
Adds back a dependency that had gone missing. It prevented building the extension as `Bond` is being used.