### PR TITLE
feat: display message about extenions connections status and

### DIFF
--- a/apps/namada-interface/src/components/Button/button.tsx
+++ b/apps/namada-interface/src/components/Button/button.tsx
@@ -28,13 +28,16 @@ export const Button: React.FC<ButtonProps> = (props): JSX.Element => {
     tooltip,
     loading,
   } = props;
+
+  const guardedClick = !loading ? onClick : undefined;
+
   switch (variant) {
     case ButtonVariant.Contained:
       return (
         <ContainedButton
           className={loading ? "loading" : ""}
           style={style}
-          onClick={onClick}
+          onClick={guardedClick}
           disabled={disabled}
           title={tooltip}
         >
@@ -45,7 +48,7 @@ export const Button: React.FC<ButtonProps> = (props): JSX.Element => {
       return (
         <ContainedAltButton
           style={style}
-          onClick={onClick}
+          onClick={guardedClick}
           disabled={disabled}
           title={tooltip}
           className={className ? className : ""}
@@ -57,7 +60,7 @@ export const Button: React.FC<ButtonProps> = (props): JSX.Element => {
       return (
         <OutlinedButton
           style={style}
-          onClick={onClick}
+          onClick={guardedClick}
           disabled={disabled}
           title={tooltip}
           className={className ? className : ""}
@@ -69,7 +72,7 @@ export const Button: React.FC<ButtonProps> = (props): JSX.Element => {
       return (
         <SmallButton
           style={style}
-          onClick={onClick}
+          onClick={guardedClick}
           disabled={disabled}
           title={tooltip}
         >

--- a/apps/namada-interface/src/hooks/useUntil.ts
+++ b/apps/namada-interface/src/hooks/useUntil.ts
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+
+type Options = {
+  predFn: () => boolean;
+  onSuccess: () => unknown;
+  onFail: () => unknown;
+};
+
+type Config = {
+  tries: number;
+  ms: number;
+};
+
+/**
+ * Hook that wait until predicate is met
+ *
+ * @param {Options} options - Predicate function, onSuccess and onFail callbacks
+ * @param {Config} config - Number of tries and time between tries before hook fails
+ * @param {React.DependencyList} [deps] - List of dependencies for hook to restart
+ */
+export const useUntil = (
+  options: Options,
+  config: Config,
+  deps?: React.DependencyList
+): void => {
+  const { predFn, onSuccess, onFail } = options;
+  let { tries } = config;
+
+  const wait = async (ms: number): Promise<unknown> => {
+    return new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
+  };
+
+  useEffect(() => {
+    const execute = async (): Promise<void> => {
+      let succ = false;
+      while (!succ && tries > 0) {
+        succ = predFn();
+        tries--;
+        await wait(config.ms);
+      }
+
+      const fn = succ ? onSuccess : onFail;
+      fn();
+    };
+
+    execute();
+  }, deps);
+};

--- a/packages/integrations/src/Keplr.ts
+++ b/packages/integrations/src/Keplr.ts
@@ -14,24 +14,27 @@ const IBC_FEATURE = "ibc-transfer";
 type OfflineSigner = ReturnType<IKeplr["getOfflineSigner"]>;
 
 class Keplr implements Integration<Account, OfflineSigner> {
+  private _keplr: IKeplr | undefined;
   private _offlineSigner: OfflineSigner | undefined;
   private _features: string[] = [];
   /**
    * Pass a chain config into constructor to instantiate, and optionally
    * override keplr instance for testing
    * @param chain
-   * @param _keplr
    */
-  constructor(
-    public readonly chain: Chain,
-    private readonly _keplr = (<KeplrWindow>window)?.keplr
-  ) {
+  constructor(public readonly chain: Chain) {
     // If chain is ibc-enabled, add relevant feature:
     const { ibc } = chain;
     this._features.push(...DEFAULT_FEATURES);
 
     if (ibc) {
       this._features.push(IBC_FEATURE);
+    }
+  }
+
+  private init(): void {
+    if (!this._keplr) {
+      this._keplr = (<KeplrWindow>window)?.keplr;
     }
   }
 
@@ -65,6 +68,7 @@ class Keplr implements Integration<Account, OfflineSigner> {
    * @returns {boolean}
    */
   public detect(): boolean {
+    this.init();
     return !!this._keplr;
   }
 


### PR DESCRIPTION
availability

Resolves #191

- I've changed the integrations so they are not looking for window[extension] in the constructor - because it is undefined most of the times :)
- Added a hook that waits until extension attaches itself so we can start using it
- Made sure that it is impossible to click button during loading phase