### PR TITLE
Keplr Integration - Display All Accounts

### DIFF
--- a/apps/namada-interface/src/App/AccountOverview/DerivedAccounts/DerivedAccounts.components.ts
+++ b/apps/namada-interface/src/App/AccountOverview/DerivedAccounts/DerivedAccounts.components.ts
@@ -197,7 +197,7 @@ export const TokenBalance = styled.li`
   width: 100%;
   list-style: none;
   list-style-type: none;
-  padding: 10px 0;
+  padding: 10px 0 10px 12px;
   color: ${(props) => props.theme.colors.utility2.main};
 `;
 

--- a/apps/namada-interface/src/App/AccountOverview/DerivedAccounts/DerivedAccounts.components.ts
+++ b/apps/namada-interface/src/App/AccountOverview/DerivedAccounts/DerivedAccounts.components.ts
@@ -103,6 +103,7 @@ export const DerivedAccountInfo = styled.div`
   display: flex;
   justify-content: flex-start;
   flex-direction: column;
+  padding 0 8px;
 `;
 
 export const DerivedAccountAlias = styled.div`
@@ -120,7 +121,7 @@ export const DerivedAccountType = styled.div`
 `;
 
 export const DerivedAccountBalance = styled.div`
-  padding: 8px 0;
+  padding: 8px 8px 8px 0;
   font-weight: bold;
   margin-bottom: 0;
   width: 200px;

--- a/apps/namada-interface/src/App/AccountOverview/DerivedAccounts/DerivedAccounts.components.ts
+++ b/apps/namada-interface/src/App/AccountOverview/DerivedAccounts/DerivedAccounts.components.ts
@@ -96,6 +96,7 @@ export const DerivedAccountItem = styled.li`
 export const DerivedAccountInfo = styled.div`
   display: flex;
   justify-content: flex-start;
+  flex-direction: column;
 `;
 
 export const DerivedAccountAlias = styled.div`
@@ -167,6 +168,23 @@ export const TokenIcon = styled.img`
   height: 36px;
   cursor: pointer;
   margin-right: 12px;
+`;
+
+export const TokenTotals = styled.div``;
+
+export const TokenBalances = styled.ul`
+  padding: 0;
+  margin: 0;
+`;
+export const TokenBalance = styled.li`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 100%;
+  list-style: none;
+  list-style-type: none;
+  padding: 10px 0;
+  color: ${(props) => props.theme.colors.utility2.main};
 `;
 
 export const ShieldedLabel = styled.div`

--- a/apps/namada-interface/src/App/AccountOverview/DerivedAccounts/DerivedAccounts.components.ts
+++ b/apps/namada-interface/src/App/AccountOverview/DerivedAccounts/DerivedAccounts.components.ts
@@ -176,12 +176,19 @@ export const TokenIcon = styled.img`
   margin-right: 12px;
 `;
 
-export const TokenTotals = styled.div``;
+export const TokenTotals = styled.div`
+  display: none;
+
+  &.active {
+    display: flex;
+  }
+`;
 
 export const TokenBalances = styled.ul`
   padding: 0;
   margin: 0;
 `;
+
 export const TokenBalance = styled.li`
   display: flex;
   flex-direction: row;

--- a/apps/namada-interface/src/App/AccountOverview/DerivedAccounts/DerivedAccounts.components.ts
+++ b/apps/namada-interface/src/App/AccountOverview/DerivedAccounts/DerivedAccounts.components.ts
@@ -64,19 +64,12 @@ export const DerivedAccountsList = styled.ul`
   max-height: 400px; /* TODO: Remove this - set a max height on a main container */
 `;
 
-export const DerivedAccountContainer = styled.div`
-  width: 100%;
-  display: flex;
-  justify-content: space-between;
-`;
-
 export const DerivedAccountItem = styled.li`
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   justify-content: space-between;
   align-items: flex-start;
   margin: 0;
-  padding: 20px 0;
   border-bottom: 1px solid ${(props) => props.theme.colors.utility2.main20};
 
   button {
@@ -90,6 +83,19 @@ export const DerivedAccountItem = styled.li`
 
   &:last-child {
     border-bottom: none;
+  }
+`;
+
+export const DerivedAccountContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  cursor: pointer;
+  padding: 20px 0;
+
+  &:hover {
+    background-color: ${(props) => props.theme.colors.utility2.main20};
   }
 `;
 
@@ -119,9 +125,9 @@ export const DerivedAccountBalance = styled.div`
   margin-bottom: 0;
   width: 200px;
   color: ${(props) => props.theme.colors.utility2.main};
+  text-align: right;
 
   @media screen and (max-width: 860px) {
-    text-align: right;
     padding-right: 20px;
   }
 `;

--- a/apps/namada-interface/src/App/AccountOverview/DerivedAccounts/DerivedAccounts.tsx
+++ b/apps/namada-interface/src/App/AccountOverview/DerivedAccounts/DerivedAccounts.tsx
@@ -151,6 +151,8 @@ const DerivedAccounts = ({ setTotal }: Props): JSX.Element => {
 
   useEffect(() => {
     dispatch(fetchBalances(Object.values(derivedAccounts)));
+
+    setActiveAccountAddress(accountBalances[0]?.account?.address);
   }, [derivedAccounts]);
 
   const applyConversionRate = (balance: number, token: string): number => {

--- a/apps/namada-interface/src/App/AccountOverview/DerivedAccounts/DerivedAccounts.tsx
+++ b/apps/namada-interface/src/App/AccountOverview/DerivedAccounts/DerivedAccounts.tsx
@@ -201,29 +201,28 @@ const DerivedAccounts = ({ setTotal }: Props): JSX.Element => {
           const { alias, address, isShielded } = account;
 
           return (
-            <>
-              <DerivedAccountItem key={address}>
-                <DerivedAccountContainer>
-                  <DerivedAccountInfo>
-                    <DerivedAccountAlias>{alias}</DerivedAccountAlias>
-                    <DerivedAccountType>
-                      {isShielded ? (
-                        <ShieldedLabel>Shielded</ShieldedLabel>
-                      ) : (
-                        <TransparentLabel>Transparent</TransparentLabel>
-                      )}
-                    </DerivedAccountType>
-                  </DerivedAccountInfo>
+            <DerivedAccountItem key={address}>
+              <DerivedAccountContainer>
+                <DerivedAccountInfo>
+                  <DerivedAccountAlias>{alias}</DerivedAccountAlias>
+                  <DerivedAccountType>
+                    {isShielded ? (
+                      <ShieldedLabel>Shielded</ShieldedLabel>
+                    ) : (
+                      <TransparentLabel>Transparent</TransparentLabel>
+                    )}
+                  </DerivedAccountType>
+                </DerivedAccountInfo>
 
-                  <DerivedAccountBalance>
-                    {formatCurrency(fiatCurrency, 0)}
-                  </DerivedAccountBalance>
-                </DerivedAccountContainer>
-              </DerivedAccountItem>
+                <DerivedAccountBalance>
+                  {formatCurrency(fiatCurrency, 0)}
+                </DerivedAccountBalance>
+              </DerivedAccountContainer>
               <TokenTotals>
                 <TokenBalances>
                   {tokens.map((tokenBalance) => {
                     const { balance, token } = tokenBalance;
+                    console.log({ address, token });
 
                     return (
                       <TokenBalance key={`${address}-${token}`}>
@@ -244,7 +243,7 @@ const DerivedAccounts = ({ setTotal }: Props): JSX.Element => {
                   })}
                 </TokenBalances>
               </TokenTotals>
-            </>
+            </DerivedAccountItem>
           );
         })}
       </DerivedAccountsList>

--- a/apps/namada-interface/src/App/AccountOverview/DerivedAccounts/DerivedAccounts.tsx
+++ b/apps/namada-interface/src/App/AccountOverview/DerivedAccounts/DerivedAccounts.tsx
@@ -82,7 +82,7 @@ const DerivedAccounts = ({ setTotal }: Props): JSX.Element => {
   );
 
   const { api } = Config;
-  const { alias } = chains[chainId] || {};
+  const { alias, currency } = chains[chainId] || {};
 
   const transparentBalances = balancesByChainId[chainId] || {};
 
@@ -97,15 +97,27 @@ const DerivedAccounts = ({ setTotal }: Props): JSX.Element => {
   const derivedAccounts = derived[chainId] || {};
   const { colorMode } = themeContext.themeConfigurations;
 
-  const tokenBalances: TokenBalance[] = [];
+  const tokens: TokenBalance[] = [];
 
   Object.values(derivedAccounts).forEach((account) => {
     const { address, alias, isShielded } = account;
 
     const balances = transparentBalances[address] || {};
+    let tokenSymbols = [];
+    if (currency.symbol === "NAM") {
+      // TODO: It may be better to add to chain configs an array of all supported tokens,
+      // rather than use that logic here only for Namada:
+      // Show all supported tokens
+      tokenSymbols = Symbols.map((symbol) => symbol);
+    } else {
+      // Show token for this chain only
+      tokenSymbols.push(currency.symbol);
+    }
 
-    Symbols.forEach((symbol) => {
-      tokenBalances.push({
+    // TODO: Type this correctly
+    // eslint-disable-next-line
+    tokenSymbols.forEach((symbol: any) => {
+      tokens.push({
         address,
         balance: balances[symbol] || 0,
         label: `${alias}`,
@@ -114,10 +126,6 @@ const DerivedAccounts = ({ setTotal }: Props): JSX.Element => {
       });
     });
   });
-
-  const tokens = tokenBalances.filter(
-    (tokenBalance) => tokenBalance.balance > 0
-  );
 
   const getAssetIconByTheme = (symbol: TokenType): string => {
     return colorMode === "dark"

--- a/apps/namada-interface/src/App/AccountOverview/DerivedAccounts/DerivedAccounts.tsx
+++ b/apps/namada-interface/src/App/AccountOverview/DerivedAccounts/DerivedAccounts.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from "react";
+import { useContext, useEffect, useState } from "react";
 import { ThemeContext } from "styled-components";
 import { useNavigate } from "react-router-dom";
 
@@ -73,6 +73,7 @@ const DerivedAccounts = ({ setTotal }: Props): JSX.Element => {
   const dispatch = useAppDispatch();
   const themeContext = useContext(ThemeContext);
   const { derived } = useAppSelector<AccountsState>((state) => state.accounts);
+  const [activeAccountAddress, setActiveAccountAddress] = useState("");
 
   const { chainId, fiatCurrency } = useAppSelector<SettingsState>(
     (state) => state.settings
@@ -106,6 +107,7 @@ const DerivedAccounts = ({ setTotal }: Props): JSX.Element => {
 
     const balances = transparentBalances[address] || {};
     let tokenSymbols = [];
+
     if (currency.symbol === "NAM") {
       // TODO: It may be better to add to chain configs an array of all supported tokens,
       // rather than use that logic here only for Namada:
@@ -186,6 +188,10 @@ const DerivedAccounts = ({ setTotal }: Props): JSX.Element => {
     }
   }, [timestamp]);
 
+  const handleAccountClick = (address: string): void => {
+    setActiveAccountAddress(address === activeAccountAddress ? "" : address);
+  };
+
   return (
     <DerivedAccountsContainer>
       {accountBalances.length === 0 &&
@@ -202,7 +208,9 @@ const DerivedAccounts = ({ setTotal }: Props): JSX.Element => {
 
           return (
             <DerivedAccountItem key={address}>
-              <DerivedAccountContainer>
+              <DerivedAccountContainer
+                onClick={() => handleAccountClick(address)}
+              >
                 <DerivedAccountInfo>
                   <DerivedAccountAlias>{alias}</DerivedAccountAlias>
                   <DerivedAccountType>
@@ -213,16 +221,16 @@ const DerivedAccounts = ({ setTotal }: Props): JSX.Element => {
                     )}
                   </DerivedAccountType>
                 </DerivedAccountInfo>
-
                 <DerivedAccountBalance>
                   {formatCurrency(fiatCurrency, 0)}
                 </DerivedAccountBalance>
               </DerivedAccountContainer>
-              <TokenTotals>
+              <TokenTotals
+                className={(address === activeAccountAddress && "active") || ""}
+              >
                 <TokenBalances>
                   {tokens.map((tokenBalance) => {
                     const { balance, token } = tokenBalance;
-                    console.log({ address, token });
 
                     return (
                       <TokenBalance key={`${address}-${token}`}>

--- a/apps/namada-interface/webpack.config.js
+++ b/apps/namada-interface/webpack.config.js
@@ -55,12 +55,12 @@ const plugins = [
 module.exports = {
   mode: NODE_ENV,
   target: "web",
-  devtool: false,
+  devtool: "eval-source-map",
   entry: {
     interface: "./src",
   },
   output: {
-    publicPath: "",
+    publicPath: "/",
     path: resolve(__dirname, `./build/`),
     filename: "[name].bundle.js",
   },

--- a/apps/namada-interface/webpack.config.js
+++ b/apps/namada-interface/webpack.config.js
@@ -28,6 +28,10 @@ const copyPatterns = [
     from: "./public/manifest.json",
     to: "./manifest.json",
   },
+  {
+    from: "./public/_redirects",
+    to: "./_redirects",
+  },
 ];
 
 const plugins = [
@@ -155,5 +159,6 @@ module.exports = {
     },
     compress: false,
     port: 3000,
+    historyApiFallback: true,
   },
 };

--- a/packages/chains/src/chains/cosmos.ts
+++ b/packages/chains/src/chains/cosmos.ts
@@ -1,7 +1,7 @@
 import { Chain, Extensions } from "@anoma/types";
 
-const DEFAULT_ALIAS = "Cosmos Testnet";
-const DEFAULT_CHAIN_ID = "cosmos-75a7e12.69483d59a9fb174";
+const DEFAULT_ALIAS = "Cosmos Hub";
+const DEFAULT_CHAIN_ID = "cosmoshub-4";
 const DEFAULT_RPC = "https://api.cosmos.network/";
 
 const {

--- a/packages/chains/src/chains/osmosis.ts
+++ b/packages/chains/src/chains/osmosis.ts
@@ -1,7 +1,7 @@
 import { Chain, Extensions } from "@anoma/types";
 
 const DEFAULT_ALIAS = "Osmosis Testnet";
-const DEFAULT_CHAIN_ID = "osmosis-75a7e12.69483d59a9fb174";
+const DEFAULT_CHAIN_ID = "osmosis-1";
 const DEFAULT_RPC = "https://rpc.osmosis.zone/";
 
 const {

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@anoma/types": "0.1.0",
+    "@anoma/utils": "0.1.0",
     "@cosmjs/proto-signing": "^0.27.1",
     "@keplr-wallet/types": "^0.10.19",
     "@metamask/providers": "^10.2.1",

--- a/packages/integrations/src/Anoma.ts
+++ b/packages/integrations/src/Anoma.ts
@@ -2,13 +2,16 @@ import {
   Account,
   Anoma as IAnoma,
   Chain,
+  IbcTransferProps,
   Signer,
   WindowWithAnoma,
 } from "@anoma/types";
 
 import { Integration } from "./types/Integration";
 
-export default class Anoma implements Integration<Account, Signer> {
+export default class Anoma
+  implements Integration<Account, Signer, IbcTransferProps>
+{
   private _anoma: WindowWithAnoma["anoma"] | undefined;
 
   constructor(public readonly chain: Chain) {}
@@ -40,5 +43,22 @@ export default class Anoma implements Integration<Account, Signer> {
 
   public signer(): Signer | undefined {
     return this._anoma?.getSigner(this.chain.chainId);
+  }
+
+  public async submitBridgeTransfer({
+    sender,
+    receiver,
+    sourcePort,
+    sourceChannel,
+    amount,
+  }: IbcTransferProps): Promise<void> {
+    console.log("Anoma.submitBridgeTransfer", {
+      sender,
+      receiver,
+      sourcePort,
+      sourceChannel,
+      amount,
+    });
+    return;
   }
 }

--- a/packages/integrations/src/Anoma.ts
+++ b/packages/integrations/src/Anoma.ts
@@ -52,6 +52,7 @@ export default class Anoma
     sourceChannel,
     amount,
   }: IbcTransferProps): Promise<void> {
+    // TODO: Call method in Anoma extension
     console.log("Anoma.submitBridgeTransfer", {
       sender,
       receiver,

--- a/packages/integrations/src/Keplr.ts
+++ b/packages/integrations/src/Keplr.ts
@@ -115,6 +115,7 @@ class Keplr implements Integration<Account, OfflineSigner, IbcTransferProps> {
     sourceChannel,
     amount,
   }: IbcTransferProps): Promise<void> {
+    // TODO: Submit transfer via CosmJS RpcClient
     console.log("Keplr.submitBridgeTransfer", {
       sender,
       receiver,

--- a/packages/integrations/src/Keplr.ts
+++ b/packages/integrations/src/Keplr.ts
@@ -4,33 +4,22 @@ import {
   Window as KeplrWindow,
 } from "@keplr-wallet/types";
 import { AccountData } from "@cosmjs/proto-signing";
-import { Account, Chain } from "@anoma/types";
+import { Account, Chain, IbcTransferProps } from "@anoma/types";
 import { Integration } from "./types/Integration";
 
 const KEPLR_NOT_FOUND = "Keplr extension not found!";
-const DEFAULT_FEATURES: string[] = [];
-const IBC_FEATURE = "ibc-transfer";
 
 type OfflineSigner = ReturnType<IKeplr["getOfflineSigner"]>;
 
-class Keplr implements Integration<Account, OfflineSigner> {
+class Keplr implements Integration<Account, OfflineSigner, IbcTransferProps> {
   private _keplr: IKeplr | undefined;
   private _offlineSigner: OfflineSigner | undefined;
-  private _features: string[] = [];
   /**
    * Pass a chain config into constructor to instantiate, and optionally
    * override keplr instance for testing
    * @param chain
    */
-  constructor(public readonly chain: Chain) {
-    // If chain is ibc-enabled, add relevant feature:
-    const { ibc } = chain;
-    this._features.push(...DEFAULT_FEATURES);
-
-    if (ibc) {
-      this._features.push(IBC_FEATURE);
-    }
-  }
+  constructor(public readonly chain: Chain) {}
 
   private init(): void {
     if (!this._keplr) {
@@ -115,6 +104,23 @@ class Keplr implements Integration<Account, OfflineSigner> {
       );
     }
     return Promise.reject(KEPLR_NOT_FOUND);
+  }
+
+  public async submitBridgeTransfer({
+    sender,
+    receiver,
+    sourcePort,
+    sourceChannel,
+    amount,
+  }: IbcTransferProps): Promise<void> {
+    console.log("Keplr.submitBridgeTransfer", {
+      sender,
+      receiver,
+      sourcePort,
+      sourceChannel,
+      amount,
+    });
+    return;
   }
 }
 

--- a/packages/integrations/src/Keplr.ts
+++ b/packages/integrations/src/Keplr.ts
@@ -5,6 +5,7 @@ import {
 } from "@keplr-wallet/types";
 import { AccountData } from "@cosmjs/proto-signing";
 import { Account, Chain, IbcTransferProps } from "@anoma/types";
+import { shortenAddress } from "@anoma/utils";
 import { Integration } from "./types/Integration";
 
 const KEPLR_NOT_FOUND = "Keplr extension not found!";
@@ -97,7 +98,7 @@ class Keplr implements Integration<Account, OfflineSigner, IbcTransferProps> {
 
       return accounts?.map(
         (account: AccountData): Account => ({
-          alias: "keplr",
+          alias: shortenAddress(account.address, 16),
           chainId: this.chain.chainId,
           address: account.address,
           isShielded: false,

--- a/packages/integrations/src/Keplr.ts
+++ b/packages/integrations/src/Keplr.ts
@@ -69,7 +69,7 @@ class Keplr implements Integration<Account, OfflineSigner, IbcTransferProps> {
     if (this._keplr) {
       const { chainId } = this.chain;
 
-      await this._keplr.enable(chainId);
+      return await this._keplr.enable(chainId);
     }
     return Promise.reject(KEPLR_NOT_FOUND);
   }
@@ -92,7 +92,8 @@ class Keplr implements Integration<Account, OfflineSigner, IbcTransferProps> {
    */
   public async accounts(): Promise<readonly Account[] | undefined> {
     if (this._keplr) {
-      const accounts = await this._offlineSigner?.getAccounts();
+      const client = this.signer();
+      const accounts = await client?.getAccounts();
 
       return accounts?.map(
         (account: AccountData): Account => ({

--- a/packages/integrations/src/Metamask.ts
+++ b/packages/integrations/src/Metamask.ts
@@ -1,7 +1,7 @@
 import { type MetaMaskInpageProvider } from "@metamask/providers";
 import MetaMaskSDK from "@metamask/sdk";
 
-import { Account, Chain } from "@anoma/types";
+import { Account, BridgeTransferProps, Chain } from "@anoma/types";
 import { Integration } from "./types/Integration";
 
 const MULTIPLE_WALLETS = "Multiple wallets installed!";
@@ -12,7 +12,7 @@ type MetamaskWindow = Window &
     ethereum: MetaMaskInpageProvider;
   };
 
-class Metamask implements Integration<Account, unknown> {
+class Metamask implements Integration<Account, unknown, BridgeTransferProps> {
   private _ethereum: MetaMaskInpageProvider | undefined;
   constructor(public readonly chain: Chain) {}
 
@@ -71,6 +71,19 @@ class Metamask implements Integration<Account, unknown> {
       method: "wallet_switchEthereumChain",
       params: [{ chainId }],
     });
+  }
+
+  public async submitBridgeTransfer({
+    source,
+    target,
+    amount,
+  }: BridgeTransferProps): Promise<void> {
+    console.log("Metamask.submitBridgeTransfer", {
+      source,
+      target,
+      amount,
+    });
+    return;
   }
 }
 

--- a/packages/integrations/src/Metamask.ts
+++ b/packages/integrations/src/Metamask.ts
@@ -2,6 +2,7 @@ import { type MetaMaskInpageProvider } from "@metamask/providers";
 import MetaMaskSDK from "@metamask/sdk";
 
 import { Account, BridgeTransferProps, Chain } from "@anoma/types";
+import { shortenAddress } from "@anoma/utils";
 import { Integration } from "./types/Integration";
 
 const MULTIPLE_WALLETS = "Multiple wallets installed!";
@@ -45,7 +46,7 @@ class Metamask implements Integration<Account, unknown, BridgeTransferProps> {
 
     const accounts: Account[] = (addresses as string[]).map((address) => ({
       address,
-      alias: address.substring(0, 4),
+      alias: shortenAddress(address, 16),
       chainId: this.chain.chainId,
       isShielded: false,
     }));

--- a/packages/integrations/src/Metamask.ts
+++ b/packages/integrations/src/Metamask.ts
@@ -79,6 +79,7 @@ class Metamask implements Integration<Account, unknown, BridgeTransferProps> {
     target,
     amount,
   }: BridgeTransferProps): Promise<void> {
+    // TODO: Submit transfer via Ethereum Bridge
     console.log("Metamask.submitBridgeTransfer", {
       source,
       target,

--- a/packages/integrations/src/types/Integration.ts
+++ b/packages/integrations/src/types/Integration.ts
@@ -1,6 +1,9 @@
-export interface Integration<T, S> {
+import { BridgeTransferProps, IbcTransferProps } from "@anoma/types";
+
+export interface Integration<T, S, P = BridgeTransferProps | IbcTransferProps> {
   detect: () => boolean;
   connect: () => Promise<void>;
   accounts: () => Promise<readonly T[] | undefined>;
   signer: () => S | undefined;
+  submitBridgeTransfer: (props: P) => Promise<void>;
 }

--- a/packages/types/src/tx/types.ts
+++ b/packages/types/src/tx/types.ts
@@ -56,6 +56,13 @@ export type IbcTransferProps = {
   amount: number;
 };
 
+// TODO: This is a placeholder
+export type BridgeTransferProps = {
+  source: string;
+  target: string;
+  amount: number;
+};
+
 export type InitAccountProps = {
   vpCode: Uint8Array;
 };


### PR DESCRIPTION
This PR addresses parts of #205 

In this PR, we now show all accounts from the extension, even if it has a zero balance, and instead of listing by token balance, it lists all accounts, and the user can choose to view the breakdown of token balances underneath their account. An issue with loading accounts from Keplr has been resolved.

*NOTE* I've also patched up a couple small things in the `webpack.config` for `namada-interface`

- [x] Can view accounts loaded from Keplr extension
- [x] Can choose to submit IBC transfer to a chain in Cosmos ecosystem

TODO: Follow-up PR:
- [ ] Can sign IBC transfer with Keplr account

This PR introduces a `submitBridgeTransfer` function to `Integration` based classes, which can accept either `IbcTransferProps` or `BridgeTransferProps` (in the case of Metamask, which will use the Ethereum bridge). This will be implemented in a future PR.
