### PR TITLE
feat/216 - Remove placeholder theme on Staking

### DIFF
--- a/apps/namada-interface/src/App/App.tsx
+++ b/apps/namada-interface/src/App/App.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable max-len */
 import { useState, useEffect } from "react";
-import { useLocation, Location } from "react-router-dom";
 import { Provider } from "react-redux";
 import { createBrowserHistory } from "history";
 import { AnimatePresence } from "framer-motion";
@@ -13,7 +12,6 @@ import {
   ColorMode,
 } from "@anoma/utils";
 
-import { TopLevelRoute, locationToTopLevelRoute } from "./types";
 import { TopNavigation } from "./TopNavigation";
 import {
   AppContainer,
@@ -47,19 +45,10 @@ export const AnimatedTransition = (props: {
   );
 };
 
-// based on location we decide whether to use placeholder theme
-const getShouldUsePlaceholderTheme = (location: Location): boolean => {
-  const topLevelRoute = locationToTopLevelRoute(location);
-  const isStaking = topLevelRoute === TopLevelRoute.StakingAndGovernance;
-  return isStaking;
-};
-
 function App(): JSX.Element {
   const initialColorMode = loadColorMode();
   const [colorMode, setColorMode] = useState<ColorMode>(initialColorMode);
-  const location = useLocation();
-  const ShouldUsePlaceholderTheme = getShouldUsePlaceholderTheme(location);
-  const theme = getTheme(colorMode, ShouldUsePlaceholderTheme);
+  const theme = getTheme(colorMode);
 
   const toggleColorMode = (): void => {
     setColorMode((currentMode) => (currentMode === "dark" ? "light" : "dark"));

--- a/apps/namada-interface/src/App/TopNavigation/topNavigation.tsx
+++ b/apps/namada-interface/src/App/TopNavigation/topNavigation.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useEffect } from "react";
+import React, { useState, useContext } from "react";
 import { ThemeContext } from "styled-components";
 import {
   useNavigate,
@@ -118,19 +118,13 @@ type SecondMenuRowProps = {
 
 const SecondMenuRow = (props: SecondMenuRowProps): React.ReactElement => {
   const dispatch = useAppDispatch();
-  const { navigate, location, setColorMode } = props;
+  const { navigate, location } = props;
   const topLevelRoute = locationToTopLevelRoute(location);
   const stakingAndGovernanceSubRoute =
     locationToStakingAndGovernanceSubRoute(location);
   const isSubMenuContentVisible =
     topLevelRoute === TopLevelRoute.StakingAndGovernance;
   const { chainId } = useAppSelector<SettingsState>((state) => state.settings);
-
-  useEffect(() => {
-    if (topLevelRoute === TopLevelRoute.StakingAndGovernance) {
-      setColorMode("light");
-    }
-  });
 
   // callback func for select component
   const handleNetworkSelect = (
@@ -257,7 +251,6 @@ function TopNavigation(props: TopNavigationProps): JSX.Element {
                 <TopNavigationLoggedIn
                   colorMode={colorMode}
                   toggleColorMode={toggleColorMode}
-                  topLevelRoute={topLevelRoute}
                 ></TopNavigationLoggedIn>
               </>
             )}

--- a/apps/namada-interface/src/App/TopNavigation/topNavigationLoggedIn.tsx
+++ b/apps/namada-interface/src/App/TopNavigation/topNavigationLoggedIn.tsx
@@ -14,11 +14,10 @@ import {
 type Props = {
   colorMode: ColorMode;
   toggleColorMode: () => void;
-  topLevelRoute?: TopLevelRoute;
 };
 
 const TopNavigationLoggedIn = (props: Props): JSX.Element => {
-  const { colorMode, toggleColorMode, topLevelRoute } = props;
+  const { colorMode, toggleColorMode } = props;
   const navigate = useNavigate();
 
   return (
@@ -33,14 +32,12 @@ const TopNavigationLoggedIn = (props: Props): JSX.Element => {
             <Icon iconName={IconName.Settings} />
           </SettingsButton>
           <ColorModeContainer>
-            {topLevelRoute !== TopLevelRoute.StakingAndGovernance && (
-              <Toggle
-                checked={colorMode === "dark"}
-                onClick={() => {
-                  toggleColorMode();
-                }}
-              />
-            )}
+            <Toggle
+              checked={colorMode === "dark"}
+              onClick={() => {
+                toggleColorMode();
+              }}
+            />
           </ColorModeContainer>
         </TopNavigationLoggedInControlsContainer>
       </OnlyInMedium>


### PR DESCRIPTION
See #216 

This PR removes the placeholder theme from the Staking page, and re-enables the theme toggle. This will now match the rest of the interface.