### PR TITLE
feat: increase memory param of argon2

### DIFF
--- a/apps/extension/src/config/argon2.ts
+++ b/apps/extension/src/config/argon2.ts
@@ -1,8 +1,9 @@
 export const Argon2Config = {
-  // Number of memory blocks
+  // Number of memory blocks in kibibytes
   // Max: 268_435_455
   // Min: 8
-  m_cost: 4096,
+  // https://www.rfc-editor.org/rfc/rfc9106.html#name-recommendations
+  m_cost: 65536, // 65536 KiB equals 64MiB
   // Number of iterations (time)
   // Max: 4_294_967_29
   // Min: 1


### PR DESCRIPTION
Based on `Issue A: Memory Parameter of Argon2 Is Too Low`

The Namada Interface uses an Argon2 memory parameter of 4 MiB, which is far below the
recommendations prescribed in [[BDK+21]](https://www.rfc-editor.org/rfc/rfc9106.html#name-recommendations).

> The Argon2id variant with t=1 and 2 GiB memory is the FIRST RECOMMENDED option and is suggested as a default setting for all environments. This setting is secure against side-channel attacks and maximizes adversarial costs on dedicated brute-force hardware. The Argon2id variant with t=3 and 64 MiB memory is the SECOND RECOMMENDED option and is suggested as a default setting for memory-constrained environments.
