### PR TITLE
feat: add zxcvbn validation

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -41,7 +41,8 @@
     "styled-components": "^5.3.5",
     "typescript": "^4.8.2",
     "uuid": "^9.0.0",
-    "webextension-polyfill": "^0.10.0"
+    "webextension-polyfill": "^0.10.0",
+    "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.20.11",
@@ -55,6 +56,7 @@
     "@types/styled-components": "^5.1.26",
     "@types/uuid": "^8.3.4",
     "@types/webextension-polyfill": "^0.9.0",
+    "@types/zxcvbn": "^4.4.1",
     "copy-webpack-plugin": "^11.0.0",
     "dotenv": "^16.0.3",
     "eslint": "^8.23.0",

--- a/apps/extension/src/Setup/AccountCreation/Steps/Password/Password.components.ts
+++ b/apps/extension/src/Setup/AccountCreation/Steps/Password/Password.components.ts
@@ -63,12 +63,16 @@ export const Input = styled.input`
 
 export const InputContainer = styled.div`
   width: 100%;
-  height: 92px;
+  min-height: 92px;
   color: ${(props) => props.theme.colors.utility2.main80};
 `;
 
-export const InputFeedback = styled.span`
+export const InputFeedback = styled.div`
   font-size: 12px;
+  margin-top: 4px;
+  &.warning {
+    color: ${(props) => props.theme.colors.primary.main};
+  }
 `;
 
 export const RecoveryPhraseLengthRadioButton = styled.input`

--- a/yarn.lock
+++ b/yarn.lock
@@ -5476,6 +5476,11 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/zxcvbn@^4.4.1":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@types/zxcvbn/-/zxcvbn-4.4.1.tgz#46e42cbdcee681b22181478feaf4af2bc4c1abd2"
+  integrity sha512-3NoqvZC2W5gAC5DZbTpCeJ251vGQmgcWIHQJGq2J240HY6ErQ9aWKkwfoKJlHLx+A83WPNTZ9+3cd2ILxbvr1w==
+
 "@typescript-eslint/eslint-plugin@^5.5.0":
   version "5.15.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.15.0.tgz#c28ef7f2e688066db0b6a9d95fb74185c114fb9a"
@@ -17606,3 +17611,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zxcvbn@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/zxcvbn/-/zxcvbn-4.4.2.tgz#28ec17cf09743edcab056ddd8b1b06262cc73c30"
+  integrity sha512-Bq0B+ixT/DMyG8kgX2xWcI5jUvCwqrMxSFam7m0lAf78nf04hv6lNCsyLYdyYTrCVMqNDY/206K7eExYCeSyUQ==


### PR DESCRIPTION
Based on the Audit report:
Issue D: Usage of Strong Passwords Not Enforced

Added `zxcvbn` validation which allows passwords with strength of 3 or more, which usually means password at least 11 characters long. It also checks for other properties like most common passwords and usage of recursive words.

Validation is disabled for `NODE_ENV=development`, although feedback messages are still present.