### PR TITLE
feat: non blocking masp transfers in chrome

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.20.11",
     "@svgr/webpack": "^6.3.1",
-    "@types/chrome": "^0.0.196",
+    "@types/chrome": "^0.0.224",
     "@types/firefox-webext-browser": "^94.0.1",
     "@types/jest": "^29.0.0",
     "@types/node": "^18.7.14",

--- a/apps/extension/src/App/App.tsx
+++ b/apps/extension/src/App/App.tsx
@@ -7,7 +7,11 @@ import { AccountType, DerivedAccount } from "@anoma/types";
 import { getTheme } from "@anoma/utils";
 import { ExtensionKVStore } from "@anoma/storage";
 
-import { ExtensionMessenger, ExtensionRequester } from "extension";
+import {
+  ExtensionMessenger,
+  ExtensionRequester,
+  getAnomaRouterId,
+} from "extension";
 import { KVPrefix, Ports } from "router";
 import { QueryAccountsMsg } from "provider/messages";
 import { useQuery } from "hooks";
@@ -26,12 +30,14 @@ import { Setup } from "./Setup";
 import { Loading } from "./Loading";
 import { ApproveConnection, ApproveTx } from "./Approvals";
 
+const getRouterId = async (): Promise<number | undefined> =>
+  getAnomaRouterId(store);
 const store = new ExtensionKVStore(KVPrefix.LocalStorage, {
   get: browser.storage.local.get,
   set: browser.storage.local.set,
 });
 const messenger = new ExtensionMessenger();
-const requester = new ExtensionRequester(messenger, store);
+const requester = new ExtensionRequester(messenger, getRouterId);
 
 export enum Status {
   Completed,

--- a/apps/extension/src/Setup/Setup.tsx
+++ b/apps/extension/src/Setup/Setup.tsx
@@ -4,7 +4,11 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { ThemeProvider } from "styled-components";
 
 import { getTheme } from "@anoma/utils";
-import { ExtensionMessenger, ExtensionRequester } from "extension";
+import {
+  ExtensionMessenger,
+  ExtensionRequester,
+  getAnomaRouterId,
+} from "extension";
 
 import { AccountCreation } from "./AccountCreation";
 import {
@@ -22,7 +26,9 @@ const store = new ExtensionKVStore(KVPrefix.LocalStorage, {
   set: browser.storage.local.set,
 });
 const messenger = new ExtensionMessenger();
-const requester = new ExtensionRequester(messenger, store);
+const getRouterId = async (): Promise<number | undefined> =>
+  getAnomaRouterId(store);
+const requester = new ExtensionRequester(messenger, getRouterId);
 
 export const Setup: React.FC = () => {
   const theme = getTheme("dark");

--- a/apps/extension/src/background/content/constants.ts
+++ b/apps/extension/src/background/content/constants.ts
@@ -1,0 +1,1 @@
+export const ROUTE = "contents-route";

--- a/apps/extension/src/background/content/handler.ts
+++ b/apps/extension/src/background/content/handler.ts
@@ -1,0 +1,24 @@
+import { Env, Handler, InternalHandler, Message } from "router";
+import { TransferCompletedMsg } from "./messages";
+import { ContentService } from "./service";
+
+export const getHandler: (service: ContentService) => Handler = (service) => {
+  return (env: Env, msg: Message<unknown>) => {
+    switch (msg.constructor) {
+      case TransferCompletedMsg:
+        return handleTransferCompletedMsg(service)(
+          env,
+          msg as TransferCompletedMsg
+        );
+    }
+  };
+};
+
+const handleTransferCompletedMsg: (
+  service: ContentService
+) => InternalHandler<TransferCompletedMsg> = (service) => {
+  return async (_, msg) => {
+    const { success } = msg;
+    return service.handleTransferCompleted(success);
+  };
+};

--- a/apps/extension/src/background/content/index.ts
+++ b/apps/extension/src/background/content/index.ts
@@ -1,0 +1,4 @@
+export * from "./constants";
+export * from "./init";
+export * from "./messages";
+export * from "./service";

--- a/apps/extension/src/background/content/init.ts
+++ b/apps/extension/src/background/content/init.ts
@@ -1,0 +1,11 @@
+import { Router } from "router";
+import { ROUTE } from "./constants";
+import { getHandler } from "./handler";
+import { TransferCompletedMsg } from "./messages";
+import { ContentService } from "./service";
+
+export function init(router: Router, service: ContentService): void {
+  router.registerMessage(TransferCompletedMsg);
+
+  router.addHandler(ROUTE, getHandler(service));
+}

--- a/apps/extension/src/background/content/messages.ts
+++ b/apps/extension/src/background/content/messages.ts
@@ -1,0 +1,30 @@
+import { Message } from "router";
+import { ROUTE } from "./constants";
+
+enum MessageType {
+  TransferCompletedMsg = "transfer-completed-msg",
+}
+
+export class TransferCompletedMsg extends Message<void> {
+  public static type(): MessageType {
+    return MessageType.TransferCompletedMsg;
+  }
+
+  constructor(public readonly success: boolean) {
+    super();
+  }
+
+  validate(): void {
+    if (this.success === undefined) {
+      throw new Error("Success is undefined");
+    }
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return TransferCompletedMsg.type();
+  }
+}

--- a/apps/extension/src/background/content/service.ts
+++ b/apps/extension/src/background/content/service.ts
@@ -1,0 +1,16 @@
+import { TransferCompletedMsg } from "content/events";
+import { ExtensionRequester } from "extension";
+import { Ports } from "router";
+
+export class ContentService {
+  constructor(private readonly requester: ExtensionRequester) {}
+
+  async handleTransferCompleted(success: boolean): Promise<void> {
+    // TODO: most likely we want to send this back to the sender.
+    // We can get sender's tabId from the onMessage listener.
+    return this.requester.sendMessageToCurrentTab(
+      Ports.WebBrowser,
+      new TransferCompletedMsg(success)
+    );
+  }
+}

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -45,7 +45,7 @@ const { REACT_APP_NAMADA_URL = DEFAULT_URL } = process.env;
 
   const sdk = new Sdk(REACT_APP_NAMADA_URL);
   //TODO: should not be here most likely :)
-  sdk.fetch_masp_params();
+  await sdk.fetch_masp_params();
 
   if (sdkDataStr) {
     const sdkData = new TextEncoder().encode(sdkDataStr);

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -56,6 +56,7 @@ const { REACT_APP_NAMADA_URL = DEFAULT_URL } = process.env;
   const keyRingService = new KeyRingService(
     store,
     sdkStore,
+    extensionStore,
     defaultChainId,
     sdk
   );

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -45,7 +45,7 @@ const { REACT_APP_NAMADA_URL = DEFAULT_URL } = process.env;
 
   const sdk = new Sdk(REACT_APP_NAMADA_URL);
   //TODO: should not be here most likely :)
-  await sdk.fetch_masp_params();
+  sdk.fetch_masp_params();
 
   if (sdkDataStr) {
     const sdkData = new TextEncoder().encode(sdkDataStr);

--- a/apps/extension/src/background/keyring/handler.ts
+++ b/apps/extension/src/background/keyring/handler.ts
@@ -5,6 +5,7 @@ import {
   CheckPasswordMsg,
   DeriveAccountMsg,
   GenerateMnemonicMsg,
+  CloseOffscreenDocumentMsg,
   LockKeyRingMsg,
   SaveMnemonicMsg,
   UnlockKeyRingMsg,
@@ -33,6 +34,11 @@ export const getHandler: (service: KeyRingService) => Handler = (service) => {
         return handleGenerateMnemonicMsg(service)(
           env,
           msg as GenerateMnemonicMsg
+        );
+      case CloseOffscreenDocumentMsg:
+        return handleCloseOffscreenDocumentMsg(service)(
+          env,
+          msg as CloseOffscreenDocumentMsg
         );
       case SaveMnemonicMsg:
         return handleSaveMnemonicMsg(service)(env, msg as SaveMnemonicMsg);
@@ -99,6 +105,14 @@ const handleGenerateMnemonicMsg: (
 ) => InternalHandler<GenerateMnemonicMsg> = (service) => {
   return async (_, msg) => {
     return await service.generateMnemonic(msg.size);
+  };
+};
+
+const handleCloseOffscreenDocumentMsg: (
+  service: KeyRingService
+) => InternalHandler<CloseOffscreenDocumentMsg> = (service) => {
+  return async () => {
+    return await service.closeOffscreenDocument();
   };
 };
 

--- a/apps/extension/src/background/keyring/init.ts
+++ b/apps/extension/src/background/keyring/init.ts
@@ -6,6 +6,7 @@ import {
   UnlockKeyRingMsg,
   CheckPasswordMsg,
   GenerateMnemonicMsg,
+  CloseOffscreenDocumentMsg,
   SaveMnemonicMsg,
 } from "./messages";
 import {
@@ -29,6 +30,7 @@ export function init(router: Router, service: KeyRingService): void {
   router.registerMessage(UnlockKeyRingMsg);
   router.registerMessage(CheckPasswordMsg);
   router.registerMessage(GenerateMnemonicMsg);
+  router.registerMessage(CloseOffscreenDocumentMsg);
   router.registerMessage(SaveMnemonicMsg);
   router.registerMessage(SubmitBondMsg);
   router.registerMessage(SubmitUnbondMsg);

--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -404,6 +404,7 @@ export class KeyRing {
     if (!(await hasOffscreenDocument(offscreenDocumentPath))) {
       await createOffscreenWithTxWorker(offscreenDocumentPath);
     }
+
     await chrome.runtime.sendMessage({
       type: SUBMIT_TRANSFER_MSG_TYPE,
       target: OFFSCREEN_TARGET,

--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -420,10 +420,15 @@ export class KeyRing {
     txMsg: Uint8Array,
     password: string
   ): Promise<void> {
-    initSubmitTransferWebWorker({
-      txMsg: toBase64(txMsg),
-      password,
-    });
+    const routerId = await getAnomaRouterId(this.extensionStore);
+
+    initSubmitTransferWebWorker(
+      {
+        txMsg: toBase64(txMsg),
+        password,
+      },
+      routerId
+    );
   }
 
   async submitTransfer(txMsg: Uint8Array): Promise<void> {

--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -28,6 +28,7 @@ import {
   SUBMIT_TRANSFER_MSG_TYPE,
 } from "../offscreen";
 import { init as initSubmitTransferWebWorker } from "background/web-workers";
+import { getAnomaRouterId } from "extension";
 
 // Generated UUID namespace for uuid v5
 const UUID_NAMESPACE = "9bfceade-37fe-11ed-acc0-a3da3461b38c";
@@ -78,6 +79,7 @@ export class KeyRing {
   constructor(
     protected readonly kvStore: KVStore<KeyStore[]>,
     protected readonly sdkStore: KVStore<string>,
+    protected readonly extensionStore: KVStore<number>,
     protected readonly chainId: string,
     protected readonly sdk: Sdk
   ) {
@@ -400,6 +402,7 @@ export class KeyRing {
     password: string
   ): Promise<void> {
     const offscreenDocumentPath = "offscreen.html";
+    const routerId = await getAnomaRouterId(this.extensionStore);
 
     if (!(await hasOffscreenDocument(offscreenDocumentPath))) {
       await createOffscreenWithTxWorker(offscreenDocumentPath);
@@ -408,6 +411,7 @@ export class KeyRing {
     await chrome.runtime.sendMessage({
       type: SUBMIT_TRANSFER_MSG_TYPE,
       target: OFFSCREEN_TARGET,
+      routerId,
       data: { txMsg: toBase64(txMsg), password },
     });
   }

--- a/apps/extension/src/background/keyring/messages.ts
+++ b/apps/extension/src/background/keyring/messages.ts
@@ -6,13 +6,14 @@ import { KeyRingStatus } from "./types";
 
 enum MessageType {
   CheckIsLocked = "check-is-locked",
-  LockKeyRing = "lock-keyring",
-  UnlockKeyRing = "unlock-keyring",
   CheckPassword = "check-password",
-  GenerateMnemonic = "generate-mnemonic",
-  SaveMnemonic = "save-mnemonic",
+  CloseOffscreenDocument = "close-offscreen-document",
   DeriveAccount = "derive-account",
   DeriveShieldedAccount = "derive-shielded-account",
+  GenerateMnemonic = "generate-mnemonic",
+  LockKeyRing = "lock-keyring",
+  SaveMnemonic = "save-mnemonic",
+  UnlockKeyRing = "unlock-keyring",
 }
 
 export class CheckIsLockedMsg extends Message<boolean> {
@@ -126,6 +127,28 @@ export class GenerateMnemonicMsg extends Message<string[]> {
 
   type(): string {
     return GenerateMnemonicMsg.type();
+  }
+}
+
+export class CloseOffscreenDocumentMsg extends Message<void> {
+  public static type(): MessageType {
+    return MessageType.CloseOffscreenDocument;
+  }
+
+  constructor() {
+    super();
+  }
+
+  validate(): void {
+    return;
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return CloseOffscreenDocumentMsg.type();
   }
 }
 

--- a/apps/extension/src/background/keyring/messages.ts
+++ b/apps/extension/src/background/keyring/messages.ts
@@ -13,6 +13,7 @@ enum MessageType {
   GenerateMnemonic = "generate-mnemonic",
   LockKeyRing = "lock-keyring",
   SaveMnemonic = "save-mnemonic",
+  TransferCompletedMsg = "transfer-completed-msg",
   UnlockKeyRing = "unlock-keyring",
 }
 

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -12,10 +12,17 @@ export class KeyRingService {
   constructor(
     protected readonly kvStore: KVStore<KeyStore[]>,
     protected readonly sdkStore: KVStore<string>,
+    protected readonly extensionStore: KVStore<number>,
     protected readonly chainId: string,
     protected readonly sdk: Sdk
   ) {
-    this._keyRing = new KeyRing(kvStore, sdkStore, chainId, sdk);
+    this._keyRing = new KeyRing(
+      kvStore,
+      sdkStore,
+      extensionStore,
+      chainId,
+      sdk
+    );
   }
 
   lock(): { status: KeyRingStatus } {
@@ -37,6 +44,16 @@ export class KeyRingService {
 
   async checkPassword(password: string): Promise<boolean> {
     return await this._keyRing.checkPassword(password);
+  }
+
+  closeOffscreenDocument(): Promise<void> {
+    if (chrome) {
+      return chrome.offscreen.closeDocument();
+    } else {
+      return Promise.reject(
+        "Trying to close offscreen document for nor supported browser"
+      );
+    }
   }
 
   async generateMnemonic(size?: PhraseSize): Promise<string[]> {

--- a/apps/extension/src/background/offscreen/index.ts
+++ b/apps/extension/src/background/offscreen/index.ts
@@ -1,0 +1,1 @@
+export * from "./utils";

--- a/apps/extension/src/background/offscreen/offscreen.html
+++ b/apps/extension/src/background/offscreen/offscreen.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<script src="offscreen.anoma.js"></script>

--- a/apps/extension/src/background/offscreen/offscreen.ts
+++ b/apps/extension/src/background/offscreen/offscreen.ts
@@ -1,5 +1,3 @@
-import browser from "webextension-polyfill";
-import { ExtensionKVStore } from "@anoma/storage";
 import { CloseOffscreenDocumentMsg } from "background/keyring";
 import { init as initSubmitTransferWebWorker } from "background/web-workers";
 import {
@@ -52,7 +50,7 @@ const SW_TTL = 20000;
     };
 
     if (type == SUBMIT_TRANSFER_MSG_TYPE) {
-      initSubmitTransferWebWorker(data, onmessage);
+      initSubmitTransferWebWorker(data, routerId, onmessage);
       ww_count++;
     } else {
       console.warn(`Unexpected message type received: '${type}'.`);

--- a/apps/extension/src/background/offscreen/offscreen.ts
+++ b/apps/extension/src/background/offscreen/offscreen.ts
@@ -1,13 +1,8 @@
-export {};
-
-type Message = {
-  type: string;
-  target: string;
-  data: {
-    txMsg: string;
-    password: string;
-  };
-};
+import {
+  SubmitTransferMessage,
+  init as initSubmitTransferWebWorker,
+} from "background/web-workers";
+import { OFFSCREEN_TARGET, SUBMIT_TRANSFER_MSG_TYPE } from "./utils";
 
 (async function init() {
   chrome.runtime.onMessage.addListener(handleMessages);
@@ -16,20 +11,14 @@ type Message = {
     data,
     type,
     target,
-  }: Message): Promise<boolean> {
-    if (target !== "offscreen.anoma") {
+  }: SubmitTransferMessage): Promise<boolean> {
+    if (target !== OFFSCREEN_TARGET) {
       return false;
     }
 
     switch (type) {
-      case "test_offscreen":
-        const w = new Worker("send_transfer_webworker.anoma.js");
-        w.onmessage = (e) => {
-          if (e.data === "initialized") {
-            w.postMessage(data);
-          }
-          console.log("WW done " + e.data);
-        };
+      case SUBMIT_TRANSFER_MSG_TYPE:
+        initSubmitTransferWebWorker(data);
         break;
       default:
         console.warn(`Unexpected message type received: '${type}'.`);

--- a/apps/extension/src/background/offscreen/offscreen.ts
+++ b/apps/extension/src/background/offscreen/offscreen.ts
@@ -1,11 +1,21 @@
+import { init as initSubmitTransferWebWorker } from "background/web-workers";
 import {
+  Msg,
   SubmitTransferMessage,
-  init as initSubmitTransferWebWorker,
-} from "background/web-workers";
+  TRANSFER_FAILED_MSG,
+  TRANSFER_SUCCESSFUL_MSG,
+} from "background/web-workers/types";
 import { OFFSCREEN_TARGET, SUBMIT_TRANSFER_MSG_TYPE } from "./utils";
 
+const SW_TTL = 20000;
+
 (async function init() {
+  let ww_count = 0;
   chrome.runtime.onMessage.addListener(handleMessages);
+
+  const pingSw = setInterval(() => {
+    chrome.runtime.sendMessage({ keepAlive: true });
+  }, SW_TTL);
 
   async function handleMessages({
     data,
@@ -16,13 +26,22 @@ import { OFFSCREEN_TARGET, SUBMIT_TRANSFER_MSG_TYPE } from "./utils";
       return false;
     }
 
-    switch (type) {
-      case SUBMIT_TRANSFER_MSG_TYPE:
-        initSubmitTransferWebWorker(data);
-        break;
-      default:
-        console.warn(`Unexpected message type received: '${type}'.`);
-        return false;
+    const onmessage = (e: MessageEvent<Msg>): void => {
+      if ([TRANSFER_SUCCESSFUL_MSG, TRANSFER_FAILED_MSG].includes(e.data)) {
+        ww_count--;
+      }
+
+      if (ww_count === 0) {
+        clearInterval(pingSw);
+      }
+    };
+
+    if (type == SUBMIT_TRANSFER_MSG_TYPE) {
+      initSubmitTransferWebWorker(data, onmessage);
+      ww_count++;
+    } else {
+      console.warn(`Unexpected message type received: '${type}'.`);
+      return false;
     }
 
     return false;

--- a/apps/extension/src/background/offscreen/offscreen.ts
+++ b/apps/extension/src/background/offscreen/offscreen.ts
@@ -1,0 +1,41 @@
+export {};
+
+type Message = {
+  type: string;
+  target: string;
+  data: {
+    txMsg: string;
+    password: string;
+  };
+};
+
+(async function init() {
+  chrome.runtime.onMessage.addListener(handleMessages);
+
+  async function handleMessages({
+    data,
+    type,
+    target,
+  }: Message): Promise<boolean> {
+    if (target !== "offscreen.anoma") {
+      return false;
+    }
+
+    switch (type) {
+      case "test_offscreen":
+        const w = new Worker("send_transfer_webworker.anoma.js");
+        w.onmessage = (e) => {
+          if (e.data === "initialized") {
+            w.postMessage(data);
+          }
+          console.log("WW done " + e.data);
+        };
+        break;
+      default:
+        console.warn(`Unexpected message type received: '${type}'.`);
+        return false;
+    }
+
+    return false;
+  }
+})();

--- a/apps/extension/src/background/offscreen/send_transfer_webworker.ts
+++ b/apps/extension/src/background/offscreen/send_transfer_webworker.ts
@@ -1,0 +1,36 @@
+import { Sdk } from "@anoma/shared";
+import { init as initShared } from "@anoma/shared/src/init";
+import { IndexedDBKVStore } from "@anoma/storage";
+import { fromBase64 } from "@cosmjs/encoding";
+import { KVPrefix } from "router";
+
+const DEFAULT_URL =
+  "https://d3brk13lbhxfdb.cloudfront.net/qc-testnet-5.1.025a61165acd05e";
+const { REACT_APP_NAMADA_URL = DEFAULT_URL } = process.env;
+
+(async function init() {
+  await initShared();
+  const sdkStore = new IndexedDBKVStore(KVPrefix.SDK);
+  const sdkDataStr: string | undefined = await sdkStore.get("sdk-store");
+  const sdk = new Sdk(REACT_APP_NAMADA_URL);
+  await sdk.fetch_masp_params();
+
+  if (sdkDataStr) {
+    const sdkData = new TextEncoder().encode(sdkDataStr);
+    sdk.decode(sdkData);
+  }
+
+  addEventListener(
+    "message",
+    function ({ data }) {
+      sdk
+        .submit_transfer(fromBase64(data.txMsg), data.password)
+        .then((v) => {
+          console.log("v", v);
+        })
+        .catch((e) => console.log("e", e));
+    },
+    false
+  );
+  postMessage("initialized");
+})();

--- a/apps/extension/src/background/offscreen/utils.ts
+++ b/apps/extension/src/background/offscreen/utils.ts
@@ -1,0 +1,27 @@
+declare let self: ServiceWorkerGlobalScope;
+
+export const hasOffscreenDocument = async (path: string): Promise<boolean> => {
+  const offscreenUrl = chrome.runtime.getURL(path);
+  const matchedClients = await self.clients.matchAll();
+  for (const client of matchedClients) {
+    if (client.url === offscreenUrl) {
+      return true;
+    }
+  }
+  return false;
+};
+
+export const createOffscreenWithTxWorker = async (
+  offscreenDocumentPath: string
+): Promise<void> => {
+  await chrome.offscreen.createDocument({
+    url: chrome.runtime.getURL(offscreenDocumentPath),
+    //TODO: change to WORKER with new version of chrome typings
+    reasons: [chrome.offscreen.Reason.IFRAME_SCRIPTING],
+    justification:
+      "We need to spawn WebWorkers to submit transfers in non-blocking way.",
+  });
+};
+
+export const SUBMIT_TRANSFER_MSG_TYPE = "submit-transfer-offscreen";
+export const OFFSCREEN_TARGET = "offscreen.anoma";

--- a/apps/extension/src/background/web-workers/index.ts
+++ b/apps/extension/src/background/web-workers/index.ts
@@ -1,3 +1,7 @@
+import { TransferCompletedMsg as BackgroundTransferCompletedMsg } from "background/content";
+import { TransferCompletedMsg as ContentTransferCompletedMsg } from "content/events";
+import { ExtensionMessenger, ExtensionRequester } from "extension";
+import { Ports } from "router";
 import {
   INIT_MSG,
   Msg,
@@ -6,11 +10,36 @@ import {
   TRANSFER_SUCCESSFUL_MSG,
 } from "./types";
 
+const sendTransferCompletedMsg = (
+  requester: ExtensionRequester,
+  success: boolean
+): Promise<void> => {
+  const { TARGET } = process.env;
+  if (TARGET === "chrome") {
+    return requester.sendMessage(
+      Ports.Background,
+      new BackgroundTransferCompletedMsg(success)
+    );
+  } else if (TARGET === "firefox") {
+    return requester.sendMessageToCurrentTab(
+      Ports.WebBrowser,
+      new ContentTransferCompletedMsg(success)
+    );
+  } else {
+    throw Error("Unsupported target.");
+  }
+};
+
 export const init = (
   data: SubmitTransferMessageData,
+  routerId: number,
   onMessage?: (e: MessageEvent<Msg>) => void
 ): void => {
   const w = new Worker("submit-transfer-web-worker.anoma.js");
+  const messenger = new ExtensionMessenger();
+  const requester = new ExtensionRequester(messenger, () =>
+    Promise.resolve(routerId)
+  );
 
   w.onmessage = (e: MessageEvent<Msg>) => {
     onMessage && onMessage(e);
@@ -18,11 +47,9 @@ export const init = (
     if (e.data === INIT_MSG) {
       w.postMessage(data);
     } else if (e.data === TRANSFER_SUCCESSFUL_MSG) {
-      // TODO: notify extension
-      w.terminate();
+      sendTransferCompletedMsg(requester, true).then(() => w.terminate());
     } else if (e.data === TRANSFER_FAILED_MSG) {
-      // TODO: notify extension
-      w.terminate();
+      sendTransferCompletedMsg(requester, false).then(() => w.terminate());
     } else {
       console.warn("Not supporeted msg type.");
     }

--- a/apps/extension/src/background/web-workers/index.ts
+++ b/apps/extension/src/background/web-workers/index.ts
@@ -1,22 +1,39 @@
-export type SubmitTransferMessage = {
-  type: string;
-  target: string;
-  data: SubmitTransferMessageData;
-};
+// import { ExtensionKVStore } from "@anoma/storage";
+// import { ExtensionMessenger, ExtensionRequester } from "extension";
+// import { KVPrefix } from "router";
+import {
+  INIT_MSG,
+  Msg,
+  SubmitTransferMessageData,
+  TRANSFER_FAILED_MSG,
+  TRANSFER_SUCCESSFUL_MSG,
+} from "./types";
 
-type SubmitTransferMessageData = {
-  txMsg: string;
-  password: string;
-};
-
-export const INIT_MSG = "init";
-
-export const init = (data: SubmitTransferMessageData): void => {
+export const init = (
+  data: SubmitTransferMessageData,
+  onMessage?: (e: MessageEvent<Msg>) => void
+): void => {
   const w = new Worker("submit-transfer-web-worker.anoma.js");
+  // const store = new ExtensionKVStore(KVPrefix.LocalStorage, {
+  //   get: browser.storage.local.get,
+  //   set: browser.storage.local.set,
+  // });
+  // const messenger = new ExtensionMessenger();
+  // const _requester = new ExtensionRequester(messenger, store);
 
-  w.onmessage = (e) => {
+  w.onmessage = (e: MessageEvent<Msg>) => {
+    onMessage && onMessage(e);
+
     if (e.data === INIT_MSG) {
       w.postMessage(data);
+    } else if (e.data === TRANSFER_SUCCESSFUL_MSG) {
+      // TODO: notify extension
+      w.terminate();
+    } else if (e.data === TRANSFER_FAILED_MSG) {
+      // TODO: notify extension
+      w.terminate();
+    } else {
+      console.warn("Not supporeted msg type.");
     }
   };
 };

--- a/apps/extension/src/background/web-workers/index.ts
+++ b/apps/extension/src/background/web-workers/index.ts
@@ -1,6 +1,3 @@
-// import { ExtensionKVStore } from "@anoma/storage";
-// import { ExtensionMessenger, ExtensionRequester } from "extension";
-// import { KVPrefix } from "router";
 import {
   INIT_MSG,
   Msg,
@@ -14,12 +11,6 @@ export const init = (
   onMessage?: (e: MessageEvent<Msg>) => void
 ): void => {
   const w = new Worker("submit-transfer-web-worker.anoma.js");
-  // const store = new ExtensionKVStore(KVPrefix.LocalStorage, {
-  //   get: browser.storage.local.get,
-  //   set: browser.storage.local.set,
-  // });
-  // const messenger = new ExtensionMessenger();
-  // const _requester = new ExtensionRequester(messenger, store);
 
   w.onmessage = (e: MessageEvent<Msg>) => {
     onMessage && onMessage(e);

--- a/apps/extension/src/background/web-workers/index.ts
+++ b/apps/extension/src/background/web-workers/index.ts
@@ -9,11 +9,13 @@ type SubmitTransferMessageData = {
   password: string;
 };
 
+export const INIT_MSG = "init";
+
 export const init = (data: SubmitTransferMessageData): void => {
   const w = new Worker("submit-transfer-web-worker.anoma.js");
 
   w.onmessage = (e) => {
-    if (e.data === "initialized") {
+    if (e.data === INIT_MSG) {
       w.postMessage(data);
     }
   };

--- a/apps/extension/src/background/web-workers/index.ts
+++ b/apps/extension/src/background/web-workers/index.ts
@@ -1,0 +1,20 @@
+export type SubmitTransferMessage = {
+  type: string;
+  target: string;
+  data: SubmitTransferMessageData;
+};
+
+type SubmitTransferMessageData = {
+  txMsg: string;
+  password: string;
+};
+
+export const init = (data: SubmitTransferMessageData): void => {
+  const w = new Worker("submit-transfer-web-worker.anoma.js");
+
+  w.onmessage = (e) => {
+    if (e.data === "initialized") {
+      w.postMessage(data);
+    }
+  };
+};

--- a/apps/extension/src/background/web-workers/submit-transfer-web-worker.ts
+++ b/apps/extension/src/background/web-workers/submit-transfer-web-worker.ts
@@ -2,9 +2,13 @@ import { Sdk } from "@anoma/shared";
 import { init as initShared } from "@anoma/shared/src/init";
 import { IndexedDBKVStore } from "@anoma/storage";
 import { fromBase64 } from "@cosmjs/encoding";
-import { SDK_KEY } from "background/keyring";
+// import { SDK_KEY } from "background/keyring";
 import { KVPrefix } from "router";
-import { INIT_MSG } from ".";
+import {
+  INIT_MSG,
+  TRANSFER_FAILED_MSG,
+  TRANSFER_SUCCESSFUL_MSG,
+} from "./types";
 
 const DEFAULT_URL =
   "https://d3brk13lbhxfdb.cloudfront.net/qc-testnet-5.1.025a61165acd05e";
@@ -13,7 +17,8 @@ const { REACT_APP_NAMADA_URL = DEFAULT_URL } = process.env;
 (async function init() {
   await initShared();
   const sdkStore = new IndexedDBKVStore(KVPrefix.SDK);
-  const sdkDataStr: string | undefined = await sdkStore.get(SDK_KEY);
+  //TODO: import sdk-store key
+  const sdkDataStr: string | undefined = await sdkStore.get("sdk-store");
   const sdk = new Sdk(REACT_APP_NAMADA_URL);
   await sdk.fetch_masp_params();
 
@@ -22,13 +27,14 @@ const { REACT_APP_NAMADA_URL = DEFAULT_URL } = process.env;
     sdk.decode(sdkData);
   }
 
+  //TODO: check for msg type
   addEventListener(
     "message",
     ({ data }) => {
       sdk
         .submit_transfer(fromBase64(data.txMsg), data.password)
-        .then(() => console.log("Transfer successfull."))
-        .catch(() => console.error("Transfer failed."));
+        .then(() => postMessage(TRANSFER_SUCCESSFUL_MSG))
+        .catch(() => postMessage(TRANSFER_FAILED_MSG));
     },
     false
   );

--- a/apps/extension/src/background/web-workers/submit-transfer-web-worker.ts
+++ b/apps/extension/src/background/web-workers/submit-transfer-web-worker.ts
@@ -2,6 +2,7 @@ import { Sdk } from "@anoma/shared";
 import { init as initShared } from "@anoma/shared/src/init";
 import { IndexedDBKVStore } from "@anoma/storage";
 import { fromBase64 } from "@cosmjs/encoding";
+import { SDK_KEY } from "background/keyring";
 import { KVPrefix } from "router";
 
 const DEFAULT_URL =
@@ -11,7 +12,7 @@ const { REACT_APP_NAMADA_URL = DEFAULT_URL } = process.env;
 (async function init() {
   await initShared();
   const sdkStore = new IndexedDBKVStore(KVPrefix.SDK);
-  const sdkDataStr: string | undefined = await sdkStore.get("sdk-store");
+  const sdkDataStr: string | undefined = await sdkStore.get(SDK_KEY);
   const sdk = new Sdk(REACT_APP_NAMADA_URL);
   await sdk.fetch_masp_params();
 
@@ -23,14 +24,10 @@ const { REACT_APP_NAMADA_URL = DEFAULT_URL } = process.env;
   addEventListener(
     "message",
     function ({ data }) {
-      sdk
-        .submit_transfer(fromBase64(data.txMsg), data.password)
-        .then((v) => {
-          console.log("v", v);
-        })
-        .catch((e) => console.log("e", e));
+      sdk.submit_transfer(fromBase64(data.txMsg), data.password);
     },
     false
   );
+  //TODO: add id to the msg
   postMessage("initialized");
 })();

--- a/apps/extension/src/background/web-workers/submit-transfer-web-worker.ts
+++ b/apps/extension/src/background/web-workers/submit-transfer-web-worker.ts
@@ -4,6 +4,7 @@ import { IndexedDBKVStore } from "@anoma/storage";
 import { fromBase64 } from "@cosmjs/encoding";
 import { SDK_KEY } from "background/keyring";
 import { KVPrefix } from "router";
+import { INIT_MSG } from ".";
 
 const DEFAULT_URL =
   "https://d3brk13lbhxfdb.cloudfront.net/qc-testnet-5.1.025a61165acd05e";
@@ -23,11 +24,14 @@ const { REACT_APP_NAMADA_URL = DEFAULT_URL } = process.env;
 
   addEventListener(
     "message",
-    function ({ data }) {
-      sdk.submit_transfer(fromBase64(data.txMsg), data.password);
+    ({ data }) => {
+      sdk
+        .submit_transfer(fromBase64(data.txMsg), data.password)
+        .then(() => console.log("Transfer successfull."))
+        .catch(() => console.error("Transfer failed."));
     },
     false
   );
-  //TODO: add id to the msg
-  postMessage("initialized");
+
+  postMessage(INIT_MSG);
 })();

--- a/apps/extension/src/background/web-workers/submit-transfer-web-worker.ts
+++ b/apps/extension/src/background/web-workers/submit-transfer-web-worker.ts
@@ -1,8 +1,8 @@
+import { defaultChainId, chains } from "@anoma/chains";
 import { Sdk } from "@anoma/shared";
 import { init as initShared } from "@anoma/shared/src/init";
 import { IndexedDBKVStore } from "@anoma/storage";
 import { fromBase64 } from "@cosmjs/encoding";
-// import { SDK_KEY } from "background/keyring";
 import { KVPrefix } from "router";
 import {
   INIT_MSG,
@@ -10,16 +10,12 @@ import {
   TRANSFER_SUCCESSFUL_MSG,
 } from "./types";
 
-const DEFAULT_URL =
-  "https://d3brk13lbhxfdb.cloudfront.net/qc-testnet-5.1.025a61165acd05e";
-const { REACT_APP_NAMADA_URL = DEFAULT_URL } = process.env;
-
 (async function init() {
   await initShared();
   const sdkStore = new IndexedDBKVStore(KVPrefix.SDK);
   //TODO: import sdk-store key
   const sdkDataStr: string | undefined = await sdkStore.get("sdk-store");
-  const sdk = new Sdk(REACT_APP_NAMADA_URL);
+  const sdk = new Sdk(chains[defaultChainId].rpc);
   await sdk.fetch_masp_params();
 
   if (sdkDataStr) {

--- a/apps/extension/src/background/web-workers/types.ts
+++ b/apps/extension/src/background/web-workers/types.ts
@@ -1,6 +1,7 @@
 export type SubmitTransferMessage = {
   type: string;
   target: string;
+  routerId: number;
   data: SubmitTransferMessageData;
 };
 

--- a/apps/extension/src/background/web-workers/types.ts
+++ b/apps/extension/src/background/web-workers/types.ts
@@ -1,0 +1,18 @@
+export type SubmitTransferMessage = {
+  type: string;
+  target: string;
+  data: SubmitTransferMessageData;
+};
+
+export type SubmitTransferMessageData = {
+  txMsg: string;
+  password: string;
+};
+
+export const INIT_MSG = "init";
+export const TRANSFER_SUCCESSFUL_MSG = "transfer-successful";
+export const TRANSFER_FAILED_MSG = "transfer-failed";
+export type Msg =
+  | typeof INIT_MSG
+  | typeof TRANSFER_FAILED_MSG
+  | typeof TRANSFER_SUCCESSFUL_MSG;

--- a/apps/extension/src/content/events.ts
+++ b/apps/extension/src/content/events.ts
@@ -1,21 +1,16 @@
 import { Message, Router, Events, Routes } from "../router";
 
-class PushEventDataMsg extends Message<void> {
+export class TransferCompletedMsg extends Message<void> {
   public static type(): Events {
-    return Events.PushEventData;
+    return Events.TransferCompleted;
   }
 
-  constructor(
-    public readonly data: {
-      type: string;
-      data: unknown;
-    }
-  ) {
+  constructor(readonly success: boolean) {
     super();
   }
 
   validate(): void {
-    if (!this.data.type) {
+    if (!this.success) {
       throw new Error("Type should not be empty");
     }
   }
@@ -25,18 +20,20 @@ class PushEventDataMsg extends Message<void> {
   }
 
   type(): string {
-    return PushEventDataMsg.type();
+    return TransferCompletedMsg.type();
   }
 }
 
 export function initEvents(router: Router): void {
-  router.registerMessage(PushEventDataMsg);
+  router.registerMessage(TransferCompletedMsg);
 
   router.addHandler(Routes.InteractionForeground, (_, msg) => {
     switch (msg.constructor) {
-      case PushEventDataMsg:
-        if ((msg as PushEventDataMsg).data.type === Events.KeystoreChanged) {
-          window.dispatchEvent(new Event("anoma_keystoreupdated"));
+      case TransferCompletedMsg:
+        if ((msg as TransferCompletedMsg).success) {
+          window.dispatchEvent(new Event("anoma_transfer_completed"));
+        } else {
+          window.dispatchEvent(new Event("anoma_transfer_failed"));
         }
         return;
       default:

--- a/apps/extension/src/content/index.ts
+++ b/apps/extension/src/content/index.ts
@@ -6,6 +6,7 @@ import {
   ContentScriptEnv,
   ContentScriptGuards,
   ExtensionMessenger,
+  getAnomaRouterId,
 } from "extension";
 import { KVPrefix, Ports } from "router/types";
 import { initEvents } from "./events";
@@ -18,9 +19,12 @@ const extensionStore = new ExtensionKVStore(KVPrefix.LocalStorage, {
   get: browser.storage.local.get,
   set: browser.storage.local.set,
 });
+
+const getRouterId = async (): Promise<number | undefined> =>
+  getAnomaRouterId(extensionStore);
 const messenger = new ExtensionMessenger();
 Proxy.start(
-  new Anoma(manifest.version, new ExtensionRequester(messenger, extensionStore))
+  new Anoma(manifest.version, new ExtensionRequester(messenger, getRouterId))
 );
 
 const router = new ExtensionRouter(

--- a/apps/extension/src/extension/ExtensionMessenger.ts
+++ b/apps/extension/src/extension/ExtensionMessenger.ts
@@ -19,7 +19,9 @@ export type Result<M> = {
 export interface Messenger {
   addListener(callback: Callback): void;
   removeListener(callback: Callback): void;
-  sendMessage<M extends Message<unknown>>(payload: RoutedMessage<M>): Promise<Result<M>>;
+  sendMessage<M extends Message<unknown>>(
+    payload: RoutedMessage<M>
+  ): Promise<Result<M>>;
 }
 
 export class ExtensionMessenger implements Messenger {

--- a/apps/extension/src/extension/ExtensionRequester.ts
+++ b/apps/extension/src/extension/ExtensionRequester.ts
@@ -1,3 +1,4 @@
+import browser from "webextension-polyfill";
 import { Message } from "../router";
 import { Messenger } from "./ExtensionMessenger";
 
@@ -12,7 +13,7 @@ export class ExtensionRequester {
     msg: M
   ): Promise<M extends Message<infer R> ? R : never> {
     msg.validate();
-    msg.origin = window.location.origin;
+    msg.origin = origin;
     msg.meta = {
       ...msg.meta,
       routerId: await this.getRouterId(),
@@ -43,7 +44,7 @@ export class ExtensionRequester {
     msg: M
   ): Promise<M extends Message<infer R> ? R : never> {
     msg.validate();
-    msg.origin = window.location.origin;
+    msg.origin = origin;
     msg.meta = {
       ...msg.meta,
       routerId: await this.getRouterId(),
@@ -64,5 +65,21 @@ export class ExtensionRequester {
     }
 
     return result.return;
+  }
+
+  async sendMessageToCurrentTab<M extends Message<unknown>>(
+    port: string,
+    msg: M
+  ): Promise<M extends Message<infer R> ? R : never> {
+    const tabs = await browser.tabs.query({
+      active: true,
+      currentWindow: true,
+    });
+
+    return this.sendMessageToTab(
+      tabs[0]?.id || browser.tabs.TAB_ID_NONE,
+      port,
+      msg
+    );
   }
 }

--- a/apps/extension/src/extension/ExtensionRequester.ts
+++ b/apps/extension/src/extension/ExtensionRequester.ts
@@ -1,12 +1,10 @@
-import { KVStore } from "@anoma/storage";
-import { getAnomaRouterId } from "../extension/utils";
 import { Message } from "../router";
 import { Messenger } from "./ExtensionMessenger";
 
 export class ExtensionRequester {
   constructor(
     private readonly messenger: Messenger,
-    private readonly store: KVStore<number>
+    private readonly getRouterId: () => Promise<number | undefined>
   ) {}
 
   async sendMessage<M extends Message<unknown>>(
@@ -17,7 +15,7 @@ export class ExtensionRequester {
     msg.origin = window.location.origin;
     msg.meta = {
       ...msg.meta,
-      routerId: await getAnomaRouterId(this.store),
+      routerId: await this.getRouterId(),
     };
 
     const payload = {
@@ -48,7 +46,7 @@ export class ExtensionRequester {
     msg.origin = window.location.origin;
     msg.meta = {
       ...msg.meta,
-      routerId: await getAnomaRouterId(this.store),
+      routerId: await this.getRouterId(),
     };
 
     const result = await browser.tabs.sendMessage(tabId, {

--- a/apps/extension/src/extension/utils.ts
+++ b/apps/extension/src/extension/utils.ts
@@ -6,13 +6,15 @@ const ROUTER_ID_KEY = "anomaExtensionRouterId";
 
 export const getAnomaRouterId = async (
   store: KVStore<number>
-): Promise<number | undefined> => {
+): Promise<number> => {
   const storedId = await store.get(ROUTER_ID_KEY);
   if (!storedId) {
     const id = Math.floor(Math.random() * 1000000);
     await store.set(ROUTER_ID_KEY, id);
+
+    return id;
   }
-  return store.get(ROUTER_ID_KEY) as Promise<number | undefined>;
+  return storedId;
 };
 
 // Determine if content-scripts can be executed in this environment

--- a/apps/extension/src/manifest/v3/_base.json
+++ b/apps/extension/src/manifest/v3/_base.json
@@ -13,7 +13,13 @@
   "action": {
     "default_popup": "popup.html"
   },
-  "permissions": ["storage", "notifications", "identity"],
+  "permissions": [
+    "storage",
+    "notifications",
+    "identity",
+    "offscreen",
+    "clipboardWrite"
+  ],
   "content_security_policy": {
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
   },

--- a/apps/extension/src/manifest/v3/_base.json
+++ b/apps/extension/src/manifest/v3/_base.json
@@ -13,13 +13,7 @@
   "action": {
     "default_popup": "popup.html"
   },
-  "permissions": [
-    "storage",
-    "notifications",
-    "identity",
-    "offscreen",
-    "clipboardWrite"
-  ],
+  "permissions": ["storage", "notifications", "identity", "offscreen"],
   "content_security_policy": {
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
   },

--- a/apps/extension/src/router/types/enums.ts
+++ b/apps/extension/src/router/types/enums.ts
@@ -6,7 +6,7 @@ export enum Ports {
 
 export enum Events {
   KeystoreChanged = "anoma-keystore-changed",
-  PushEventData = "anoma-push-event-data",
+  TransferCompleted = "anoma-transfer-completed",
 }
 
 export enum Routes {

--- a/apps/extension/src/test/init.ts
+++ b/apps/extension/src/test/init.ts
@@ -4,6 +4,7 @@ import {
   ExtensionRouter,
   ExtensionMessengerMock,
   ExtensionRequester,
+  getAnomaRouterId,
 } from "../extension";
 import { Ports, KVPrefix } from "../router";
 import { chains } from "@anoma/chains";
@@ -41,11 +42,13 @@ export const init = (): {
   chainsService: ChainsService;
   keyRingService: KeyRingService;
 } => {
+  const getRouterId = async (): Promise<number | undefined> =>
+    getAnomaRouterId(extStore);
   const messenger = new ExtensionMessengerMock();
   const iDBStore = new KVStoreMock<Chain[] | KeyStore[]>(KVPrefix.IndexedDB);
   const sdkStore = new KVStoreMock<string>(KVPrefix.SDK);
   const extStore = new KVStoreMock<number>(KVPrefix.IndexedDB);
-  const requester = new ExtensionRequester(messenger, extStore);
+  const requester = new ExtensionRequester(messenger, getRouterId);
 
   const router = new ExtensionRouter(
     () => ({
@@ -67,6 +70,7 @@ export const init = (): {
   const keyRingService = new KeyRingService(
     iDBStore as KVStore<KeyStore[]>,
     sdkStore,
+    extStore,
     "namada-test.XXXXXXXX",
     sdk
   );

--- a/apps/extension/tsconfig.json
+++ b/apps/extension/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": "./src",
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": ["dom", "dom.iterable", "esnext", "webworker"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,

--- a/apps/extension/webpack.config.js
+++ b/apps/extension/webpack.config.js
@@ -82,8 +82,8 @@ module.exports = {
     setup: "./src/Setup",
     injected: "./src/content/injected.ts",
     offscreen: "./src/background/offscreen/offscreen.ts",
-    send_transfer_webworker:
-      "./src/background/offscreen/send_transfer_webworker.ts",
+    ["submit-transfer-web-worker"]:
+      "./src/background/web-workers/submit-transfer-web-worker.ts",
   },
   output: {
     publicPath: "",

--- a/apps/extension/webpack.config.js
+++ b/apps/extension/webpack.config.js
@@ -25,6 +25,10 @@ const copyPatterns = [
     from: "./src/public/*.css",
     to: "./assets/[name].css",
   },
+  {
+    from: "./src/background/offscreen/offscreen.html",
+    to: "./offscreen.html",
+  },
   // browser-polyfill expects a source-map
   {
     from: "../../node_modules/webextension-polyfill/dist/browser-polyfill.js.map",
@@ -77,6 +81,9 @@ module.exports = {
     popup: "./src/App",
     setup: "./src/Setup",
     injected: "./src/content/injected.ts",
+    offscreen: "./src/background/offscreen/offscreen.ts",
+    send_transfer_webworker:
+      "./src/background/offscreen/send_transfer_webworker.ts",
   },
   output: {
     publicPath: "",

--- a/apps/namada-interface/src/App/App.tsx
+++ b/apps/namada-interface/src/App/App.tsx
@@ -57,6 +57,13 @@ function App(): JSX.Element {
   const [colorMode, setColorMode] = useState<ColorMode>(initialColorMode);
   const theme = getTheme(colorMode);
 
+  useEffect(() => {
+    window.addEventListener("anoma_transfer_completed", (event) => {
+      // TODO: remove when we have proper event handling.
+      console.log("anoma_transfer_completed", event);
+    });
+  }, []);
+
   const toggleColorMode = (): void => {
     setColorMode((currentMode) => (currentMode === "dark" ? "light" : "dark"));
   };

--- a/apps/namada-interface/src/App/Token/TokenSend/TokenSendForm.tsx
+++ b/apps/namada-interface/src/App/Token/TokenSend/TokenSendForm.tsx
@@ -420,7 +420,7 @@ const TokenSendForm = ({
         <Button
           loading={isTransferSubmitting}
           variant={ButtonVariant.Contained}
-          disabled={isFormInvalid}
+          // disabled={isFormInvalid}
           onClick={handleOnSendClick}
         >
           Continue

--- a/apps/namada-interface/src/App/Token/TokenSend/TokenSendForm.tsx
+++ b/apps/namada-interface/src/App/Token/TokenSend/TokenSendForm.tsx
@@ -420,7 +420,7 @@ const TokenSendForm = ({
         <Button
           loading={isTransferSubmitting}
           variant={ButtonVariant.Contained}
-          // disabled={isFormInvalid}
+          disabled={isFormInvalid}
           onClick={handleOnSendClick}
         >
           Continue

--- a/apps/namada-interface/src/App/Token/TokenSend/TokenSendForm.tsx
+++ b/apps/namada-interface/src/App/Token/TokenSend/TokenSendForm.tsx
@@ -259,7 +259,6 @@ const TokenSendForm = ({
           amount,
           token: tokenType,
           feeAmount: gasFee,
-          notify: true,
         })
       );
     }

--- a/apps/namada-interface/src/slices/transfers.ts
+++ b/apps/namada-interface/src/slices/transfers.ts
@@ -130,7 +130,7 @@ export const actionTypes = {
 // transparent -> transparent
 export const submitTransferTransaction = createAsyncThunk<
   void,
-  WithNotification<TxTransferArgs>,
+  TxTransferArgs,
   { state: RootState }
 >(
   actionTypes.SUBMIT_TRANSFER_ACTION_TYPE,
@@ -145,6 +145,8 @@ export const submitTransferTransaction = createAsyncThunk<
       )
     );
 
+    // TODO: because submitting transfer is async we have to keep track of the
+    // transfer id to know how when and how to handle it when it's completed.
     await signer.submitTransfer({
       tx: {
         token: Tokens.NAM.address || "",

--- a/packages/shared/lib/src/sdk/masp.rs
+++ b/packages/shared/lib/src/sdk/masp.rs
@@ -50,8 +50,6 @@ impl ShieldedUtils for WebShieldedUtils {
 
     //TODO: add async version
     fn local_tx_prover(&self) -> LocalTxProver {
-        crate::utils::console_log_any(&"local_tx_prover");
-        crate::utils::console_log_any(&self.convert_param_bytes);
         LocalTxProver::from_bytes(
             &self.spend_param_bytes,
             &self.output_param_bytes,

--- a/packages/shared/lib/src/sdk/mod.js
+++ b/packages/shared/lib/src/sdk/mod.js
@@ -3,8 +3,7 @@ export const PREFIX = "Anoma::SDK";
 async function fetchParams(params) {
   //TODO: pass env
   return fetch(`http://localhost:3000/assets/${params}`)
-    .then((response) => response.blob())
-    .then((blob) => blob.arrayBuffer())
+    .then((response) => response.arrayBuffer())
     .then((ab) => new Uint8Array(ab));
 }
 

--- a/packages/shared/lib/src/sdk/mod.js
+++ b/packages/shared/lib/src/sdk/mod.js
@@ -18,7 +18,6 @@ export async function fetchAndStore(params) {
     data = await get(params);
   }
 
-  console.log(params);
   return data;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4930,10 +4930,10 @@
     "@types/filesystem" "*"
     "@types/har-format" "*"
 
-"@types/chrome@^0.0.196":
-  version "0.0.196"
-  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.196.tgz#9e0196a6fcdf3c0e12cfbcd086cd28feb5206990"
-  integrity sha512-LAjGIQYC0wyiYu6lVT03dBrHBfYTMsM8EmNfQ+UdZipGZe8OUiir6weoa9oQoBw3T3RLzBCp9m904T+rFtpPAg==
+"@types/chrome@^0.0.224":
+  version "0.0.224"
+  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.0.224.tgz#0138497299eaaf261d61ece62d7d6af3868ce856"
+  integrity sha512-YkL7q3KDV7OAKgVCBNIfH73rnjNMbIzAYHzTa2DKhSK/2z0Wf/n8yJnK/UoW+lvuYJJR4LtAkG3YvsIZTy7BOA==
   dependencies:
     "@types/filesystem" "*"
     "@types/har-format" "*"
@@ -12142,7 +12142,7 @@ jest-snapshot@^29.4.1:
     pretty-format "^29.4.1"
     semver "^7.3.5"
 
-jest-util@^27.0.0, jest-util@^27.5.1:
+jest-util@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.5.1.tgz#3ba9771e8e31a0b85da48fe0b0891fb86c01c2f9"
   integrity sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw==
@@ -12458,7 +12458,7 @@ jest-worker@^29.4.1:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@^27.4.3, jest@^27.5.1:
+jest@^27.4.3:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest/-/jest-27.5.1.tgz#dadf33ba70a779be7a6fc33015843b51494f63fc"
   integrity sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==
@@ -12727,19 +12727,19 @@ json-stringify-safe@^5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@2.x, json5@^2.1.2, json5@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
-  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
-  dependencies:
-    minimist "^1.2.5"
-
 json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
+
+json5@^2.1.2, json5@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
+  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
+  dependencies:
+    minimist "^1.2.5"
 
 json5@^2.2.1:
   version "2.2.1"
@@ -16305,20 +16305,6 @@ tryer@^1.0.1:
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
-ts-jest@^27.1.3:
-  version "27.1.3"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.1.3.tgz#1f723e7e74027c4da92c0ffbd73287e8af2b2957"
-  integrity sha512-6Nlura7s6uM9BVUAoqLH7JHyMXjz8gluryjpPXxr3IxZdAXnU6FhjvVLHFtfd1vsE1p8zD1OJfskkc0jhTSnkA==
-  dependencies:
-    bs-logger "0.x"
-    fast-json-stable-stringify "2.x"
-    jest-util "^27.0.0"
-    json5 "2.x"
-    lodash.memoize "4.x"
-    make-error "1.x"
-    semver "7.x"
-    yargs-parser "20.x"
-
 ts-jest@^28.0.8:
   version "28.0.8"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-28.0.8.tgz#cd204b8e7a2f78da32cf6c95c9a6165c5b99cc73"
@@ -17514,11 +17500,6 @@ yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yargs-parser@20.x, yargs-parser@^20.2.2:
-  version "20.2.9"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
-  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
-
 yargs-parser@^13.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
@@ -17534,6 +17515,11 @@ yargs-parser@^18.1.2:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-parser@^20.2.2:
+  version "20.2.9"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
 yargs-parser@^21.0.0, yargs-parser@^21.0.1:
   version "21.1.1"


### PR DESCRIPTION
- [x] Send shielded transfer with WebWorker in Chrome
- [x] Send shielded transfer with WebWorker in FF
- [x] Keep service worker alive for the time transfers are going on
- [x] Clear offscreen document when not needed
- [x] Clear WebWorkers when not needed
- [x] Send message to the extension/interface with tx done info
- [ ] ~~Make sure that it works for MASP only~~ - Moved to the new issue
- [ ] ~~Fix transfer completed toasts~~ - Moved to the new issue