### PR TITLE
feat: add linter to the ci

### DIFF
--- a/.github/workflows/deploy-wallet-at-pr.yml
+++ b/.github/workflows/deploy-wallet-at-pr.yml
@@ -18,7 +18,20 @@ on:
 env:
   CI: false
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Run ESLint
+        run: yarn lint:ci
+
   unit-tests-js:
+    needs: lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -54,6 +67,7 @@ jobs:
           ${{ secrets.SLACK_WEBHOOK_WALLET_PR }}
 
   unit-tests-wasm:
+    needs: lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -15,6 +15,7 @@
     "build:firefox": "yarn clean:firefox && NODE_ENV=production TARGET=firefox webpack && web-ext build --s ./build/firefox -a ./build/firefox",
     "lint": "npx eslint src --ext .ts",
     "lint:fix": "yarn lint -- --fix",
+    "lint:ci": "yarn lint --max-warnings 0",
     "start": "yarn start:chrome",
     "start:chrome": "yarn clean:chrome && export NODE_ENV=development; export TARGET=chrome && webpack --watch",
     "start:firefox": "yarn clean:firefox && export NODE_ENV=development; export TARGET=firefox webpack --watch",

--- a/apps/namada-interface/package.json
+++ b/apps/namada-interface/package.json
@@ -39,6 +39,7 @@
     "build": "export NODE_ENV=production && yarn wasm:build && webpack",
     "lint": "npx eslint src --ext .ts,.tsx",
     "lint:fix": "yarn lint -- --fix",
+    "lint:ci": "yarn lint --max-warnings 0",
     "test": "yarn wasm:build-node && yarn jest",
     "test:watch": "yarn wasm:build-node && yarn jest --watchAll=true",
     "test:coverage": "yarn wasm:build-node && yarn test --coverage",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test:ci": "wsrun --serial --exclude-missing -c test:ci",
     "test-wasm:ci": "wsrun --serial --exclude-missing -c test-wasm:ci",
     "lint": "wsrun --serial --exclude-missing -c lint",
-    "lint:fix": "wsrun --serial --exclude-missing -c lint:fix"
+    "lint:fix": "wsrun --serial --exclude-missing -c lint:fix",
+    "lint:ci": "wsrun --serial --exclude-missing -c lint:ci"
   },
   "dependencies": {
     "@cosmjs/encoding": "^0.27.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -9,7 +9,8 @@
   "private": false,
   "scripts": {
     "lint": "npx eslint src --ext .ts,.tsx",
-    "lint:fix": "yarn lint -- --fix"
+    "lint:fix": "yarn lint -- --fix",
+    "lint:ci": "yarn lint --max-warnings 0"
   },
   "dependencies": {
     "@anoma/utils": "0.1.0",

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -13,7 +13,8 @@
     "test:watch": "yarn wasm:build && jest --watchAll",
     "test:ci": "jest",
     "lint": "npx eslint src --ext .ts",
-    "lint:fix": "yarn lint -- --fix"
+    "lint:fix": "yarn lint -- --fix",
+    "lint:ci": "yarn lint --max-warnings 0"
   },
   "devDependencies": {
     "@types/jest": "^28.1.8",

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -9,7 +9,8 @@
   "private": false,
   "scripts": {
     "lint": "npx eslint src --ext .ts",
-    "lint:fix": "yarn lint -- --fix"
+    "lint:fix": "yarn lint -- --fix",
+    "lint:ci": "yarn lint --max-warnings 0"
   },
   "dependencies": {
     "@anoma/utils": "0.1.0",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -9,7 +9,8 @@
   "private": false,
   "scripts": {
     "lint": "npx eslint src --ext .ts",
-    "lint:fix": "yarn lint -- --fix"
+    "lint:fix": "yarn lint -- --fix",
+    "lint:ci": "yarn lint --max-warnings 0"
   },
   "dependencies": {
     "typescript": "^4.8.2"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -9,7 +9,8 @@
   "private": false,
   "scripts": {
     "lint": "npx eslint src --ext .ts",
-    "lint:fix": "yarn lint -- --fix"
+    "lint:fix": "yarn lint -- --fix",
+    "lint:ci": "yarn lint --max-warnings 0"
   },
   "dependencies": {
     "bn.js": "^5.2.1",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -9,7 +9,8 @@
   "private": false,
   "scripts": {
     "lint": "npx eslint src --ext .ts",
-    "lint:fix": "yarn lint -- --fix"
+    "lint:fix": "yarn lint -- --fix",
+    "lint:ci": "yarn lint --max-warnings 0"
   },
   "dependencies": {
     "@cosmjs/json-rpc": "^0.27.1",


### PR DESCRIPTION
Resolves #245 
We run linter with `max-warnings 0`.
Unit tests depend on a lint action to succeed.
Build does not depend on lint as we might want to showcase some builds without linter or unit tests passing.