### PR TITLE
feat: keep track of the transfer using msgId

### DIFF
--- a/apps/extension/src/background/content/handler.ts
+++ b/apps/extension/src/background/content/handler.ts
@@ -1,14 +1,14 @@
 import { Env, Handler, InternalHandler, Message } from "router";
-import { TransferCompletedMsg } from "./messages";
+import { TransferCompletedEvent } from "./messages";
 import { ContentService } from "./service";
 
 export const getHandler: (service: ContentService) => Handler = (service) => {
   return (env: Env, msg: Message<unknown>) => {
     switch (msg.constructor) {
-      case TransferCompletedMsg:
+      case TransferCompletedEvent:
         return handleTransferCompletedMsg(service)(
           env,
-          msg as TransferCompletedMsg
+          msg as TransferCompletedEvent
         );
     }
   };
@@ -16,9 +16,9 @@ export const getHandler: (service: ContentService) => Handler = (service) => {
 
 const handleTransferCompletedMsg: (
   service: ContentService
-) => InternalHandler<TransferCompletedMsg> = (service) => {
+) => InternalHandler<TransferCompletedEvent> = (service) => {
   return async (_, msg) => {
-    const { success } = msg;
-    return service.handleTransferCompleted(success);
+    const { success, msgId } = msg;
+    return service.handleTransferCompleted(success, msgId);
   };
 };

--- a/apps/extension/src/background/content/init.ts
+++ b/apps/extension/src/background/content/init.ts
@@ -1,11 +1,11 @@
 import { Router } from "router";
 import { ROUTE } from "./constants";
 import { getHandler } from "./handler";
-import { TransferCompletedMsg } from "./messages";
+import { TransferCompletedEvent } from "./messages";
 import { ContentService } from "./service";
 
 export function init(router: Router, service: ContentService): void {
-  router.registerMessage(TransferCompletedMsg);
+  router.registerMessage(TransferCompletedEvent);
 
   router.addHandler(ROUTE, getHandler(service));
 }

--- a/apps/extension/src/background/content/messages.ts
+++ b/apps/extension/src/background/content/messages.ts
@@ -2,15 +2,15 @@ import { Message } from "router";
 import { ROUTE } from "./constants";
 
 enum MessageType {
-  TransferCompletedMsg = "transfer-completed-msg",
+  TransferCompletedEvent = "transfer-completed-event",
 }
 
-export class TransferCompletedMsg extends Message<void> {
+export class TransferCompletedEvent extends Message<void> {
   public static type(): MessageType {
-    return MessageType.TransferCompletedMsg;
+    return MessageType.TransferCompletedEvent;
   }
 
-  constructor(public readonly success: boolean) {
+  constructor(public readonly success: boolean, public readonly msgId: string) {
     super();
   }
 
@@ -25,6 +25,6 @@ export class TransferCompletedMsg extends Message<void> {
   }
 
   type(): string {
-    return TransferCompletedMsg.type();
+    return TransferCompletedEvent.type();
   }
 }

--- a/apps/extension/src/background/content/service.ts
+++ b/apps/extension/src/background/content/service.ts
@@ -1,16 +1,19 @@
-import { TransferCompletedMsg } from "content/events";
+import { TransferCompletedEvent } from "content/events";
 import { ExtensionRequester } from "extension";
 import { Ports } from "router";
 
 export class ContentService {
   constructor(private readonly requester: ExtensionRequester) {}
 
-  async handleTransferCompleted(success: boolean): Promise<void> {
+  async handleTransferCompleted(
+    success: boolean,
+    msgId: string
+  ): Promise<void> {
     // TODO: most likely we want to send this back to the sender.
     // We can get sender's tabId from the onMessage listener.
     return this.requester.sendMessageToCurrentTab(
       Ports.WebBrowser,
-      new TransferCompletedMsg(success)
+      new TransferCompletedEvent(success, msgId)
     );
   }
 }

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -62,7 +62,8 @@ const extensionStore = new ExtensionKVStore(KVPrefix.LocalStorage, {
     sdkStore,
     extensionStore,
     defaultChainId,
-    sdk
+    sdk,
+    requester
   );
   const contentService = new ContentService(requester);
 

--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -399,6 +399,7 @@ export class KeyRing {
 
   private async submitTransferChrome(
     txMsg: Uint8Array,
+    msgId: string,
     password: string
   ): Promise<void> {
     const offscreenDocumentPath = "offscreen.html";
@@ -412,12 +413,13 @@ export class KeyRing {
       type: SUBMIT_TRANSFER_MSG_TYPE,
       target: OFFSCREEN_TARGET,
       routerId,
-      data: { txMsg: toBase64(txMsg), password },
+      data: { txMsg: toBase64(txMsg), msgId, password },
     });
   }
 
   private async submitTransferFirefox(
     txMsg: Uint8Array,
+    msgId: string,
     password: string
   ): Promise<void> {
     const routerId = await getAnomaRouterId(this.extensionStore);
@@ -425,22 +427,23 @@ export class KeyRing {
     initSubmitTransferWebWorker(
       {
         txMsg: toBase64(txMsg),
+        msgId,
         password,
       },
       routerId
     );
   }
 
-  async submitTransfer(txMsg: Uint8Array): Promise<void> {
+  async submitTransfer(txMsg: Uint8Array, msgId: string): Promise<void> {
     if (!this._password) {
       throw new Error("Not authenticated!");
     }
 
     const { TARGET } = process.env;
     if (TARGET === "chrome") {
-      this.submitTransferChrome(txMsg, this._password);
+      this.submitTransferChrome(txMsg, msgId, this._password);
     } else if (TARGET === "firefox") {
-      this.submitTransferFirefox(txMsg, this._password);
+      this.submitTransferFirefox(txMsg, msgId, this._password);
     } else {
       console.warn("Submitting transfers is not supported with your browser.");
     }

--- a/apps/extension/src/background/keyring/messages.ts
+++ b/apps/extension/src/background/keyring/messages.ts
@@ -13,7 +13,6 @@ enum MessageType {
   GenerateMnemonic = "generate-mnemonic",
   LockKeyRing = "lock-keyring",
   SaveMnemonic = "save-mnemonic",
-  TransferCompletedMsg = "transfer-completed-msg",
   UnlockKeyRing = "unlock-keyring",
 }
 

--- a/apps/extension/src/background/web-workers/types.ts
+++ b/apps/extension/src/background/web-workers/types.ts
@@ -7,6 +7,7 @@ export type SubmitTransferMessage = {
 
 export type SubmitTransferMessageData = {
   txMsg: string;
+  msgId: string;
   password: string;
 };
 

--- a/apps/extension/src/content/events.ts
+++ b/apps/extension/src/content/events.ts
@@ -1,11 +1,11 @@
 import { Message, Router, Events, Routes } from "../router";
 
-export class TransferCompletedMsg extends Message<void> {
+export class TransferCompletedEvent extends Message<void> {
   public static type(): Events {
     return Events.TransferCompleted;
   }
 
-  constructor(readonly success: boolean) {
+  constructor(readonly success: boolean, readonly msgId: string) {
     super();
   }
 
@@ -20,22 +20,56 @@ export class TransferCompletedMsg extends Message<void> {
   }
 
   type(): string {
-    return TransferCompletedMsg.type();
+    return TransferCompletedEvent.type();
+  }
+}
+
+export class TransferStartedEvent extends Message<void> {
+  public static type(): Events {
+    return Events.TransferStarted;
+  }
+
+  constructor(readonly msgId: string) {
+    super();
+  }
+
+  validate(): void {
+    if (!this.msgId) {
+      throw new Error("msgId should not be empty");
+    }
+  }
+
+  route(): string {
+    return Routes.InteractionForeground;
+  }
+
+  type(): string {
+    return TransferStartedEvent.type();
   }
 }
 
 export function initEvents(router: Router): void {
-  router.registerMessage(TransferCompletedMsg);
+  router.registerMessage(TransferCompletedEvent);
+  router.registerMessage(TransferStartedEvent);
 
   router.addHandler(Routes.InteractionForeground, (_, msg) => {
     switch (msg.constructor) {
-      case TransferCompletedMsg:
-        if ((msg as TransferCompletedMsg).success) {
-          window.dispatchEvent(new Event("anoma_transfer_completed"));
+      case TransferCompletedEvent:
+        if ((msg as TransferCompletedEvent).success) {
+          window.dispatchEvent(
+            new CustomEvent("anoma_transfer_completed", { detail: msg })
+          );
         } else {
-          window.dispatchEvent(new Event("anoma_transfer_failed"));
+          window.dispatchEvent(
+            new CustomEvent("anoma_transfer_failed", { detail: msg })
+          );
         }
-        return;
+        break;
+      case TransferStartedEvent:
+        window.dispatchEvent(
+          new CustomEvent("anoma_transfer_started", { detail: msg })
+        );
+        break;
       default:
         throw new Error("Unknown msg type");
     }

--- a/apps/extension/src/router/types/enums.ts
+++ b/apps/extension/src/router/types/enums.ts
@@ -7,6 +7,7 @@ export enum Ports {
 export enum Events {
   KeystoreChanged = "anoma-keystore-changed",
   TransferCompleted = "anoma-transfer-completed",
+  TransferStarted = "anoma-transfer-started",
 }
 
 export enum Routes {

--- a/apps/extension/src/test/init.ts
+++ b/apps/extension/src/test/init.ts
@@ -69,7 +69,8 @@ export const init = (): {
     sdkStore,
     extStore,
     "namada-test.XXXXXXXX",
-    sdk
+    sdk,
+    requester
   );
 
   // Initialize messages and handlers

--- a/apps/namada-interface/src/App/App.tsx
+++ b/apps/namada-interface/src/App/App.tsx
@@ -57,13 +57,6 @@ function App(): JSX.Element {
   const [colorMode, setColorMode] = useState<ColorMode>(initialColorMode);
   const theme = getTheme(colorMode);
 
-  useEffect(() => {
-    window.addEventListener("anoma_transfer_completed", (event) => {
-      // TODO: remove when we have proper event handling.
-      console.log("anoma_transfer_completed", event);
-    });
-  }, []);
-
   const toggleColorMode = (): void => {
     setColorMode((currentMode) => (currentMode === "dark" ? "light" : "dark"));
   };

--- a/apps/namada-interface/src/hooks/index.ts
+++ b/apps/namada-interface/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from "./useEvent";
+export * from "./useUntil";

--- a/apps/namada-interface/src/hooks/useEvent.ts
+++ b/apps/namada-interface/src/hooks/useEvent.ts
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+
+export const useEventListener = (
+  event: string,
+  handler: (e: CustomEventInit) => void,
+  deps?: React.DependencyList,
+  useCapture = false
+): void => {
+  useEffect(() => {
+    window.addEventListener(event, handler, useCapture);
+
+    return () => {
+      window.removeEventListener(event, handler);
+    };
+  }, deps);
+};
+
+export const useEventListenerOnce = (
+  event: string,
+  handler: (e: CustomEventInit) => void,
+  useCapture = false
+): void => {
+  useEventListener(event, handler, [], useCapture);
+};

--- a/apps/namada-interface/src/index.tsx
+++ b/apps/namada-interface/src/index.tsx
@@ -6,14 +6,16 @@ import { init as initShared } from "@anoma/shared/src/init";
 import "./index.css";
 import { store } from "store/store";
 import { getRouter } from "./App/AppRoutes";
-import { IntegrationsProvider } from "services";
+import { ExtensionEventsProvider, IntegrationsProvider } from "services";
 import { Provider } from "react-redux";
 
 ReactDOM.render(
   <React.StrictMode>
     <IntegrationsProvider>
       <Provider store={store}>
-        <RouterProvider router={getRouter()} />
+        <ExtensionEventsProvider>
+          <RouterProvider router={getRouter()} />
+        </ExtensionEventsProvider>
       </Provider>
     </IntegrationsProvider>
   </React.StrictMode>,

--- a/apps/namada-interface/src/services/extension-events.tsx
+++ b/apps/namada-interface/src/services/extension-events.tsx
@@ -1,0 +1,43 @@
+import { createContext, Dispatch } from "react";
+
+import { useEventListenerOnce } from "hooks";
+import { actions as notificationsActions } from "slices/notifications";
+import { getToast, Toasts } from "slices/transfers";
+import { useAppDispatch } from "store";
+
+const TransferCompletedHandler =
+  (dispatch: Dispatch<unknown>) => (event: CustomEventInit) => {
+    dispatch(
+      notificationsActions.createToast(
+        getToast(`${event.detail.msgId}-fullfilled`, Toasts.TransferCompleted)()
+      )
+    );
+  };
+
+const TransferStartedHandler =
+  (dispatch: Dispatch<unknown>) => (event: CustomEventInit) => {
+    dispatch(
+      notificationsActions.createToast(
+        getToast(`${event.detail.msgId}-pending`, Toasts.TransferStarted)()
+      )
+    );
+  };
+
+export const ExtensionEventsContext = createContext({});
+
+export const ExtensionEventsProvider: React.FC = (props): JSX.Element => {
+  const dispatch = useAppDispatch();
+  const transferStartedHandler = TransferStartedHandler(dispatch);
+  const transferCompletedHandler = TransferCompletedHandler(dispatch);
+
+  // Register event handlers
+  // TODO: Names and payloads should be defined in the content script
+  useEventListenerOnce("anoma_transfer_started", transferStartedHandler);
+  useEventListenerOnce("anoma_transfer_completed", transferCompletedHandler);
+
+  return (
+    <ExtensionEventsContext.Provider value={{}}>
+      {props.children}
+    </ExtensionEventsContext.Provider>
+  );
+};

--- a/apps/namada-interface/src/services/index.ts
+++ b/apps/namada-interface/src/services/index.ts
@@ -1,1 +1,2 @@
 export * from "./integrations";
+export * from "./extension-events";

--- a/apps/namada-interface/src/slices/transfers.ts
+++ b/apps/namada-interface/src/slices/transfers.ts
@@ -11,7 +11,7 @@ import {
 import { getIntegration } from "services";
 import { RootState } from "store";
 
-enum Toasts {
+export enum Toasts {
   TransferStarted,
   TransferCompleted,
 }
@@ -19,7 +19,7 @@ enum Toasts {
 type TransferCompletedToastProps = { gas: number };
 type GetToastProps = TransferCompletedToastProps | void;
 
-const getToast = (
+export const getToast = (
   toastId: ToastId,
   toast: Toasts
 ): ((props: GetToastProps) => CreateToastPayload) => {
@@ -134,19 +134,11 @@ export const submitTransferTransaction = createAsyncThunk<
   { state: RootState }
 >(
   actionTypes.SUBMIT_TRANSFER_ACTION_TYPE,
-  async (txTransferArgs, { getState, dispatch, requestId }) => {
+  async (txTransferArgs, { getState }) => {
     const { chainId } = getState().settings;
     const integration = getIntegration(chainId);
     const signer = integration.signer() as Signer;
 
-    dispatch(
-      notificationsActions.createToast(
-        getToast(`${requestId}-pending`, Toasts.TransferStarted)()
-      )
-    );
-
-    // TODO: because submitting transfer is async we have to keep track of the
-    // transfer id to know how when and how to handle it when it's completed.
     await signer.submitTransfer({
       tx: {
         token: Tokens.NAM.address || "",
@@ -161,12 +153,6 @@ export const submitTransferTransaction = createAsyncThunk<
       nativeToken: Tokens.NAM.address || "",
       txCode: await fetchWasmCode(TxWasm.Transfer),
     });
-
-    dispatch(
-      notificationsActions.createToast(
-        getToast(`${requestId}-fullfilled`, Toasts.TransferCompleted)()
-      )
-    );
   }
 );
 


### PR DESCRIPTION
Resolves [#251](https://github.com/anoma/namada-interface/issues/251)

- Added TransferStartedEvent - sent by the background script, that informs content script that stuff is happening :)- 
Added custom "anoma_transfer_completed" event, which is being send from content script to the interface via `window.dispatchEvent`
- Added service which listens to the window events and handles them accordingly. In this case by displaying correct toasts.