### PR TITLE
feat: send event to the correct browser tab

### DIFF
--- a/apps/extension/src/background/content/handler.ts
+++ b/apps/extension/src/background/content/handler.ts
@@ -18,7 +18,7 @@ const handleTransferCompletedMsg: (
   service: ContentService
 ) => InternalHandler<TransferCompletedEvent> = (service) => {
   return async (_, msg) => {
-    const { success, msgId } = msg;
-    return service.handleTransferCompleted(success, msgId);
+    const { success, msgId, senderTabId } = msg;
+    return service.handleTransferCompleted(success, msgId, senderTabId);
   };
 };

--- a/apps/extension/src/background/content/messages.ts
+++ b/apps/extension/src/background/content/messages.ts
@@ -10,7 +10,11 @@ export class TransferCompletedEvent extends Message<void> {
     return MessageType.TransferCompletedEvent;
   }
 
-  constructor(public readonly success: boolean, public readonly msgId: string) {
+  constructor(
+    public readonly success: boolean,
+    public readonly msgId: string,
+    public readonly senderTabId: number
+  ) {
     super();
   }
 

--- a/apps/extension/src/background/content/service.ts
+++ b/apps/extension/src/background/content/service.ts
@@ -7,11 +7,11 @@ export class ContentService {
 
   async handleTransferCompleted(
     success: boolean,
-    msgId: string
+    msgId: string,
+    senderTabId: number
   ): Promise<void> {
-    // TODO: most likely we want to send this back to the sender.
-    // We can get sender's tabId from the onMessage listener.
-    return this.requester.sendMessageToCurrentTab(
+    return this.requester.sendMessageToTab(
+      senderTabId,
       Ports.WebBrowser,
       new TransferCompletedEvent(success, msgId)
     );

--- a/apps/extension/src/background/keyring/handler.ts
+++ b/apps/extension/src/background/keyring/handler.ts
@@ -166,9 +166,9 @@ const handleSubmitUnbondMsg: (
 const handleSubmitTransferMsg: (
   service: KeyRingService
 ) => InternalHandler<SubmitTransferMsg> = (service) => {
-  return async (_, msg) => {
+  return async ({ senderTabId }, msg) => {
     const { txMsg } = msg;
-    return await service.submitTransfer(txMsg);
+    return await service.submitTransfer(txMsg, senderTabId);
   };
 };
 

--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -400,6 +400,7 @@ export class KeyRing {
   private async submitTransferChrome(
     txMsg: Uint8Array,
     msgId: string,
+    senderTabId: number,
     password: string
   ): Promise<void> {
     const offscreenDocumentPath = "offscreen.html";
@@ -413,13 +414,14 @@ export class KeyRing {
       type: SUBMIT_TRANSFER_MSG_TYPE,
       target: OFFSCREEN_TARGET,
       routerId,
-      data: { txMsg: toBase64(txMsg), msgId, password },
+      data: { txMsg: toBase64(txMsg), msgId, senderTabId, password },
     });
   }
 
   private async submitTransferFirefox(
     txMsg: Uint8Array,
     msgId: string,
+    senderTabId: number,
     password: string
   ): Promise<void> {
     const routerId = await getAnomaRouterId(this.extensionStore);
@@ -428,22 +430,27 @@ export class KeyRing {
       {
         txMsg: toBase64(txMsg),
         msgId,
+        senderTabId,
         password,
       },
       routerId
     );
   }
 
-  async submitTransfer(txMsg: Uint8Array, msgId: string): Promise<void> {
+  async submitTransfer(
+    txMsg: Uint8Array,
+    msgId: string,
+    senderTabId: number
+  ): Promise<void> {
     if (!this._password) {
       throw new Error("Not authenticated!");
     }
 
     const { TARGET } = process.env;
     if (TARGET === "chrome") {
-      this.submitTransferChrome(txMsg, msgId, this._password);
+      this.submitTransferChrome(txMsg, msgId, senderTabId, this._password);
     } else if (TARGET === "firefox") {
-      this.submitTransferFirefox(txMsg, msgId, this._password);
+      this.submitTransferFirefox(txMsg, msgId, senderTabId, this._password);
     } else {
       console.warn("Submitting transfers is not supported with your browser.");
     }

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -105,16 +105,17 @@ export class KeyRingService {
     }
   }
 
-  async submitTransfer(txMsg: string): Promise<void> {
+  async submitTransfer(txMsg: string, senderTabId: number): Promise<void> {
     const msgId = uuidv4();
 
-    this.requester.sendMessageToCurrentTab(
+    this.requester.sendMessageToTab(
+      senderTabId,
       Ports.WebBrowser,
       new TransferStartedEvent(msgId)
     );
 
     try {
-      await this._keyRing.submitTransfer(fromBase64(txMsg), msgId);
+      await this._keyRing.submitTransfer(fromBase64(txMsg), msgId, senderTabId);
     } catch (e) {
       console.warn(e);
       throw new Error(`Unable to encode transfer! ${e}`);

--- a/apps/extension/src/background/web-workers/types.ts
+++ b/apps/extension/src/background/web-workers/types.ts
@@ -8,6 +8,7 @@ export type SubmitTransferMessage = {
 export type SubmitTransferMessageData = {
   txMsg: string;
   msgId: string;
+  senderTabId: number;
   password: string;
 };
 

--- a/apps/extension/src/extension/utils.ts
+++ b/apps/extension/src/extension/utils.ts
@@ -3,6 +3,7 @@ import { KVStore } from "@anoma/storage";
 import { Env, MessageSender } from "router/types";
 
 const ROUTER_ID_KEY = "anomaExtensionRouterId";
+const NO_TAB_ID = -2;
 
 export const getAnomaRouterId = async (
   store: KVStore<number>
@@ -21,9 +22,11 @@ export const getAnomaRouterId = async (
 export class ContentScriptEnv {
   static readonly produceEnv = (sender: MessageSender): Env => {
     const isInternalMsg = sender.id === browser.runtime.id;
+    const senderTabId = sender.tab?.id || NO_TAB_ID;
 
     return {
       isInternalMsg,
+      senderTabId,
       requestInteraction: () => {
         throw new Error(
           "ContentScriptEnv doesn't support `requestInteraction`"

--- a/apps/extension/src/router/types/router.ts
+++ b/apps/extension/src/router/types/router.ts
@@ -5,6 +5,7 @@ export type MessageSender = Pick<Runtime.MessageSender, "id" | "url" | "tab">;
 
 export interface Env {
   readonly isInternalMsg: boolean;
+  readonly senderTabId: number;
   readonly requestInteraction: () => void;
 }
 

--- a/apps/extension/src/test/init.ts
+++ b/apps/extension/src/test/init.ts
@@ -49,6 +49,7 @@ export const init = (): {
 
   const router = new ExtensionRouter(
     () => ({
+      senderTabId: -1,
       isInternalMsg: true,
       requestInteraction: () => {
         throw new Error("Test env doesn't support `requestInteraction`");


### PR DESCRIPTION
Added `senderTabId` to identify to which tab we want to send message back. 
For now we only need it for a transfer msg. Maybe later on it will make more sense to store (msgId, tabId) pair in the DB so we do not have to pass it around everywhere. Also adding msgId to every kind of message might be some kind of abstraction :) Probably too soon to make that decision though.