### PR TITLE
feat: zeroize secrets in WASM memory

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -18,7 +18,7 @@
     "lint:ci": "yarn lint --max-warnings 0",
     "start": "yarn start:chrome",
     "start:chrome": "yarn clean:chrome && export NODE_ENV=development; export TARGET=chrome && webpack --watch",
-    "start:firefox": "yarn clean:firefox && export NODE_ENV=development; export TARGET=firefox webpack --watch",
+    "start:firefox": "yarn clean:firefox && export NODE_ENV=development; export TARGET=firefox && webpack --watch",
     "test": "./scripts/build-node.sh && yarn jest",
     "test:watch": "./scripts/build-node.sh && yarn jest --watchAll=true",
     "test:ci": "jest",

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -27,7 +27,8 @@ const DEFAULT_URL =
 const { REACT_APP_NAMADA_URL = DEFAULT_URL } = process.env;
 
 (async function init() {
-  await initCrypto();
+  const { memory: cryptoMemory } = await initCrypto();
+
   await initShared();
 
   const extensionStore = new ExtensionKVStore(KVPrefix.LocalStorage, {
@@ -57,7 +58,8 @@ const { REACT_APP_NAMADA_URL = DEFAULT_URL } = process.env;
     sdkStore,
     activeAccountStore,
     defaultChainId,
-    sdk
+    sdk,
+    cryptoMemory
   );
 
   // Initialize messages and handlers

--- a/apps/extension/src/background/keyring/crypto.ts
+++ b/apps/extension/src/background/keyring/crypto.ts
@@ -2,6 +2,7 @@ import { AES, Argon2, Argon2Params, ByteSize, Rng, Salt } from "@anoma/crypto";
 import { AccountType, Bip44Path } from "@anoma/types";
 import { Argon2Config } from "config";
 import { KdfType, KeyStore } from "./types";
+import { readVecU8Pointer } from "@anoma/crypto/src/utils";
 
 type CryptoArgs = {
   alias: string;
@@ -28,15 +29,20 @@ export class Crypto {
       text,
       type,
     } = args;
-    const salt = Salt.generate().as_string();
+    const saltInstance = Salt.generate();
+    const salt = saltInstance.as_string();
     const { m_cost, t_cost, p_cost } = Argon2Config;
     const argon2Params = new Argon2Params(m_cost, t_cost, p_cost);
     const argon2 = new Argon2(password, salt, argon2Params);
-    const { params, key } = argon2.to_serialized();
+    const params = argon2.params();
+    const key = argon2.key();
 
     const iv = Rng.generate_bytes(ByteSize.N12);
     const aes = new AES(key, iv);
     const encrypted = aes.encrypt(text);
+
+    saltInstance.free();
+    argon2.free();
     aes.free();
 
     return {
@@ -54,30 +60,34 @@ export class Crypto {
         },
         kdf: {
           type: KdfType.Argon2,
-          params: { ...params, salt },
+          params: { m_cost: params.m_cost, t_cost: params.t_cost, p_cost: params.p_cost, salt },
         },
       },
       type,
     };
   }
 
-  public decrypt(store: KeyStore, password: string): string {
+  public decrypt(store: KeyStore, password: string, cryptoMemory: WebAssembly.Memory): string {
     const { crypto } = store;
     const { cipher, kdf } = crypto;
     const { m_cost, t_cost, p_cost, salt } = kdf.params;
 
     const argon2Params = new Argon2Params(m_cost, t_cost, p_cost);
 
-    const { key: newKey } = new Argon2(
+    const newKey = new Argon2(
       password,
       salt,
       argon2Params
-    ).to_serialized();
+    ).key();
 
     const aes = new AES(newKey, cipher.iv);
-    const decrypted = aes.decrypt(cipher.text);
-    aes.free();
+    const vecU8Pointer = aes.decrypt(cipher.text);
+    const decrypted = readVecU8Pointer(vecU8Pointer, cryptoMemory);
+    const phrase = new TextDecoder().decode(decrypted);
 
-    return new TextDecoder().decode(decrypted);
+    aes.free();
+    vecU8Pointer.free();
+
+    return phrase;
   }
 }

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -15,14 +15,16 @@ export class KeyRingService {
     protected readonly sdkStore: KVStore<string>,
     protected readonly accountAccountStore: KVStore<string>,
     protected readonly chainId: string,
-    protected readonly sdk: Sdk
+    protected readonly sdk: Sdk,
+    protected readonly cryptoMemory: WebAssembly.Memory
   ) {
     this._keyRing = new KeyRing(
       kvStore,
       sdkStore,
       accountAccountStore,
       chainId,
-      sdk
+      sdk,
+      cryptoMemory
     );
   }
 

--- a/apps/extension/src/test/init.ts
+++ b/apps/extension/src/test/init.ts
@@ -17,6 +17,10 @@ import { Anoma } from "provider";
 import { Chain } from "@anoma/types";
 import { Sdk } from "@anoma/shared";
 
+// __wasm is not exported in crypto.d.ts so need to use require instead of import
+/* eslint-disable @typescript-eslint/no-var-requires */
+const cryptoMemory = (require("@anoma/crypto")).__wasm.memory;
+
 class KVStoreMock<T> implements KVStore<T> {
   private storage: { [key: string]: T | null } = {};
 
@@ -71,7 +75,8 @@ export const init = (): {
     sdkStore,
     activeAccountStore,
     "namada-75a7e12.69483d59a9fb174",
-    sdk
+    sdk,
+    cryptoMemory
   );
 
   // Initialize messages and handlers

--- a/packages/crypto/lib/Cargo.lock
+++ b/packages/crypto/lib/Cargo.lock
@@ -498,6 +498,7 @@ dependencies = [
  "thiserror",
  "wasm-bindgen",
  "wasm-bindgen-test",
+ "zeroize",
 ]
 
 [[package]]
@@ -1793,9 +1794,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 dependencies = [
  "zeroize_derive",
 ]

--- a/packages/crypto/lib/Cargo.toml
+++ b/packages/crypto/lib/Cargo.toml
@@ -29,6 +29,7 @@ serde = { version = "1.0.145", features = ["derive"] }
 thiserror = "1.0.30"
 rand = {version = "0.7", features = ["wasm-bindgen"]}
 wasm-bindgen = "0.2.84"
+zeroize = "1.6.0"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"

--- a/packages/crypto/lib/src/crypto/aes.rs
+++ b/packages/crypto/lib/src/crypto/aes.rs
@@ -4,6 +4,8 @@ use aes_gcm::{
 };
 use thiserror::Error;
 use wasm_bindgen::prelude::*;
+use zeroize::Zeroize;
+use crate::crypto::pointer_types::VecU8Pointer;
 
 #[derive(Debug, Error)]
 pub enum AESError {
@@ -22,35 +24,41 @@ pub struct AES {
 #[wasm_bindgen]
 impl AES {
     #[wasm_bindgen(constructor)]
-    pub fn new(key: Vec<u8>, iv: Vec<u8>) -> Result<AES, String> {
-        if key.len() < 32 {
-            return Err(format!("{} Received {}", AESError::KeyLengthError, key.len()));
+    pub fn new(key: VecU8Pointer, iv: Vec<u8>) -> Result<AES, String> {
+        if key.length < 32 {
+            return Err(format!("{} Received {}", AESError::KeyLengthError, key.length));
         }
-        let key = GenericArray::from_iter(key.into_iter());
+        let mut key = GenericArray::from_iter(key.vec.clone().into_iter());
         let iv: [u8; 12] = match iv.try_into() {
             Ok(iv) => iv,
-            Err(_) => return Err(AESError::IVSizeError.to_string()),
+            Err(_) => {
+                key.zeroize();
+                return Err(AESError::IVSizeError.to_string())
+            }
         };
 
-        Ok(AES {
+        let aes = AES {
             cipher: Aes256Gcm::new(&key),
             iv,
-        })
+        };
+        key.zeroize();
+        Ok(aes)
     }
 
-    pub fn encrypt(&self, text: &str) -> Result<Vec<u8>, String> {
+    pub fn encrypt(&self, mut text: String) -> Result<Vec<u8>, String> {
         let nonce = Nonce::from_slice(&self.iv);
-        let ciphertext = self.cipher.encrypt(nonce, text.as_ref())
-            .map_err(|err| err.to_string())?;
-
-        Ok(ciphertext)
+        let result = self.cipher.encrypt(nonce, text.as_ref())
+            .map_err(|err| err.to_string());
+        text.zeroize();
+        result
     }
 
-    pub fn decrypt(&self, ciphertext: Vec<u8>) -> Result<Vec<u8>, String> {
+    pub fn decrypt(&self, ciphertext: Vec<u8>) -> Result<VecU8Pointer, String> {
         let nonce = Nonce::from_slice(&self.iv);
         let plaintext = self.cipher.decrypt(nonce, ciphertext.as_ref())
             .map_err(|err| err.to_string())?;
-        Ok(plaintext)
+
+        Ok(VecU8Pointer::new(plaintext))
     }
 }
 
@@ -65,13 +73,14 @@ mod tests {
             .expect("Generating random bytes should not fail");
         let iv = Rng::generate_bytes(Some(ByteSize::N12))
             .expect("Generating random bytes should not fail");
-        let aes = AES::new(key, iv).unwrap();
+        let aes = AES::new(VecU8Pointer::new(key), iv).unwrap();
         let plaintext = "my secret message";
-        let encrypted = aes.encrypt(plaintext)
+        let encrypted = aes.encrypt(String::from(plaintext))
             .expect("AES should not fail encrypting plaintext");
 
         let decrypted: &[u8] = &aes.decrypt(encrypted)
-            .expect("AES should not fail decrypting ciphertext");
+            .expect("AES should not fail decrypting ciphertext")
+            .vec;
         let decrypted = std::str::from_utf8(decrypted)
             .expect("Should parse as string");
 

--- a/packages/crypto/lib/src/crypto/bip39.rs
+++ b/packages/crypto/lib/src/crypto/bip39.rs
@@ -46,8 +46,9 @@ impl Mnemonic {
         Ok(())
     }
 
-    pub fn from_phrase(phrase: String) -> Result<Mnemonic, String> {
+    pub fn from_phrase(mut phrase: String) -> Result<Mnemonic, String> {
         if let Err(e) = Mnemonic::validate(&phrase) {
+            phrase.zeroize();
             return Err(e)
         }
 

--- a/packages/crypto/lib/src/crypto/mod.rs
+++ b/packages/crypto/lib/src/crypto/mod.rs
@@ -5,3 +5,4 @@ pub mod bip39;
 pub mod rng;
 pub mod salt;
 pub mod zip32;
+pub mod pointer_types;

--- a/packages/crypto/lib/src/crypto/pointer_types.rs
+++ b/packages/crypto/lib/src/crypto/pointer_types.rs
@@ -1,0 +1,90 @@
+//! Types for wrapping sensitive data.
+//!
+//! Wrapped values will not automatically be accessible to JavaScript, so we can
+//! avoid loading sensitive data into browser memory. However, values can be
+//! accessed in JavaScript by using the pointer and length fields to read
+//! directly from WASM memory if required.
+//!
+//! These types will also zeroize sensitive data when dropped.
+use wasm_bindgen::prelude::*;
+use zeroize::ZeroizeOnDrop;
+
+#[wasm_bindgen]
+#[derive(ZeroizeOnDrop)]
+pub struct VecU8Pointer {
+    #[zeroize(skip)]
+    pub pointer: *const u8,
+    #[zeroize(skip)]
+    pub length: usize,
+    #[wasm_bindgen(skip)]
+    pub vec: Vec<u8>
+}
+
+#[wasm_bindgen]
+impl VecU8Pointer {
+    #[wasm_bindgen(constructor)]
+    pub fn new(vec: Vec<u8>) -> VecU8Pointer {
+        VecU8Pointer {
+            pointer: vec.as_ptr(),
+            length: vec.len(),
+            vec
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(ZeroizeOnDrop)]
+pub struct StringPointer {
+    #[zeroize(skip)]
+    pub pointer: *const u8,
+    #[zeroize(skip)]
+    pub length: usize,
+    #[wasm_bindgen(skip)]
+    pub string: String
+}
+
+#[wasm_bindgen]
+impl StringPointer {
+    #[wasm_bindgen(constructor)]
+    pub fn new(string: String) -> StringPointer {
+        StringPointer {
+            pointer: string.as_ptr(),
+            length: string.len(),
+            string
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(ZeroizeOnDrop)]
+pub struct VecStringPointer {
+    #[zeroize(skip)]
+    pointers: Vec<usize>,
+    #[zeroize(skip)]
+    lengths: Vec<usize>,
+    #[wasm_bindgen(skip)]
+    pub strings: Vec<String>
+}
+
+#[wasm_bindgen]
+impl VecStringPointer {
+    #[wasm_bindgen(getter)]
+    pub fn pointers(&self) -> Vec<usize> {
+      self.pointers.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn lengths(&self) -> Vec<usize> {
+      self.lengths.clone()
+    }
+}
+
+pub fn new_vec_string_pointer(strings: Vec<String>) -> VecStringPointer {
+    let pointers = strings.iter()
+        .map(|str| str.as_ptr() as usize)
+        .collect();
+    let lengths = strings.iter()
+        .map(|str| str.len())
+        .collect();
+    VecStringPointer { pointers, lengths, strings }
+}

--- a/packages/crypto/lib/src/crypto/zip32.rs
+++ b/packages/crypto/lib/src/crypto/zip32.rs
@@ -10,8 +10,9 @@ use masp_primitives::zip32::{
 use borsh::BorshSerialize;
 use thiserror::Error;
 use wasm_bindgen::prelude::*;
+use crate::crypto::pointer_types::VecU8Pointer;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
-const KEY_SIZE: usize = 96;
 const SEED_SIZE: usize = 64;
 
 #[derive(Debug, Error)]
@@ -50,6 +51,7 @@ impl ExtendedKeys {
 }
 
 #[wasm_bindgen]
+#[derive(ZeroizeOnDrop)]
 pub struct Serialized {
     payment_address: Vec<u8>,
     xsk: Vec<u8>,
@@ -72,48 +74,7 @@ impl Serialized {
 }
 
 #[wasm_bindgen]
-pub struct Keys {
-    expsk: [u8; KEY_SIZE],
-    fvk: [u8; KEY_SIZE],
-}
-
-#[wasm_bindgen]
-impl Keys {
-    #[wasm_bindgen(constructor)]
-    pub fn new(expsk: &[u8], fvk: &[u8]) -> Result<Keys, String> {
-        let expsk: [u8; KEY_SIZE] = match expsk.try_into() {
-            Ok(bytes) => bytes,
-            Err(err) => return Err(
-                format!("{}, {:?}", Zip32Error::InvalidKeySize, err),
-            ),
-        };
-        let fvk: [u8; KEY_SIZE] = match fvk.try_into() {
-            Ok(bytes) => bytes,
-            Err(err) => return Err(
-                format!("{}: {:?}", Zip32Error::InvalidKeySize, err),
-            ),
-        };
-
-        Ok(Keys {
-            expsk,
-            fvk
-        })
-    }
-
-    pub fn expsk(&self) -> Vec<u8> {
-        let expsk: &[u8] = &self.expsk;
-        Vec::from(expsk)
-    }
-
-    pub fn fvk(&self) -> Vec<u8> {
-        let fvk: &[u8] = &self.fvk;
-        Vec::from(fvk)
-    }
-}
-
-#[wasm_bindgen]
 pub struct ShieldedHDWallet {
-    seed: [u8; SEED_SIZE],
     xsk_m: ExtendedSpendingKey,
     xfvk_m: ExtendedFullViewingKey,
 }
@@ -121,11 +82,11 @@ pub struct ShieldedHDWallet {
 #[wasm_bindgen]
 impl ShieldedHDWallet {
     #[wasm_bindgen(constructor)]
-    pub fn new(seed: Vec<u8>) -> Result<ShieldedHDWallet, String> {
+    pub fn new(seed: VecU8Pointer) -> Result<ShieldedHDWallet, String> {
         // zip-0032 requires seed to be at least 32 and at most 252 bytes,
         // but the seed generated from our mnemonic will be 64, so let's
         // enforce it here:
-        let seed: [u8; SEED_SIZE] = match seed.try_into() {
+        let mut seed: [u8; SEED_SIZE] = match seed.vec.clone().try_into() {
             Ok(bytes) => bytes,
             Err(err) => return Err(
                 format!("{}: {:?}", Zip32Error::InvalidSeedSize, err),
@@ -133,54 +94,13 @@ impl ShieldedHDWallet {
         };
 
         let xsk_m = ExtendedSpendingKey::master(&seed);
+        seed.zeroize();
         let xfvk_m = ExtendedFullViewingKey::from(&xsk_m);
 
         Ok(ShieldedHDWallet {
-            seed,
             xsk_m,
             xfvk_m,
         })
-    }
-
-    pub fn derive(&self, index: u32) -> Result<Keys, String> {
-        let c_index = ChildIndex::NonHardened(index);
-        let child_sk = self.xsk_m.derive_child(c_index);
-        let child_fvk = self.xfvk_m.derive_child(c_index)
-            .map_err(|err| format!("{}: {:?}", Zip32Error::ChildDerivationError, err))?;
-
-        Ok(ShieldedHDWallet::derived_to_keys(
-            ExtSpendingKey(child_sk),
-            ExtFullViewingKey(child_fvk),
-        ))
-    }
-
-    pub fn derived_to_keys(
-        ext_sk: ExtSpendingKey,
-        ext_fvk: ExtFullViewingKey,
-    ) -> Keys {
-        let expsk = ext_sk.0.expsk.to_bytes();
-        let fvk = ext_fvk.0.fvk.to_bytes();
-
-        Keys {
-            expsk,
-            fvk,
-        }
-    }
-
-    pub fn derive_from_ext(
-        ext_sk: ExtSpendingKey,
-        ext_fvk: ExtFullViewingKey,
-        index: u32,
-    ) -> Result<Keys, String> {
-        let c_index = ChildIndex::NonHardened(index);
-        let child_sk = ext_sk.0.derive_child(c_index);
-        let child_fvk = ext_fvk.0.derive_child(c_index)
-            .map_err(|err| format!("{}: {:?}", Zip32Error::ChildDerivationError, err))?;
-
-        Ok(ShieldedHDWallet::derived_to_keys(
-            ExtSpendingKey(child_sk),
-            ExtFullViewingKey(child_fvk),
-        ))
     }
 
     pub fn derive_to_serialized_keys(
@@ -207,47 +127,6 @@ impl ShieldedHDWallet {
             xsk: child_sk,
             xfvk: child_fvk,
         })
-    }
-
-    pub fn master_keys_serialized(&self) -> Result<Serialized, String> {
-        // BorshSerialize the payment address and master keys
-        let (_, address) = &self.xsk_m.default_address();
-
-        let payment_address = address.try_to_vec()
-            .map_err(|err| format!("{}: {:?}", Zip32Error::BorshSerialize, err))?;
-
-        let xsk = self.xsk_m.try_to_vec()
-            .map_err(|err| format!("{}: {:?}", Zip32Error::BorshSerialize, err))?;
-        let xfvk = self.xfvk_m.try_to_vec()
-            .map_err(|err| format!("{}: {:?}", Zip32Error::BorshSerialize, err))?;
-
-        Ok(Serialized {
-            payment_address,
-            xsk,
-            xfvk,
-        })
-    }
-
-    pub fn seed(&self) -> Vec<u8> {
-        let seed: &[u8] = &self.seed;
-        Vec::from(seed)
-    }
-
-    pub fn extended_master_keys(&self) -> ExtendedKeys {
-        ExtendedKeys {
-            xsk: ExtSpendingKey(self.xsk_m),
-            xfvk: ExtFullViewingKey(self.xfvk_m),
-        }
-    }
-
-    pub fn master_keys(&self) -> Keys {
-        let expsk = self.xsk_m.expsk.to_bytes();
-        let fvk = self.xfvk_m.fvk.to_bytes();
-
-        Keys {
-            expsk,
-            fvk,
-        }
     }
 
     // TODO
@@ -278,96 +157,29 @@ mod tests {
     use super::*;
     use masp_primitives::primitives::PaymentAddress;
 
+    const KEY_SIZE: usize = 96;
+
     #[test]
     #[should_panic]
     fn invalid_seed_should_panic() {
-        let _zip32 = ShieldedHDWallet::new(vec![0, 1, 2, 3, 4]).unwrap();
+        let _zip32 = ShieldedHDWallet::new(VecU8Pointer::new(vec![0, 1, 2, 3, 4])).unwrap();
     }
 
     #[test]
     fn can_instantiate_from_seed() {
         let seed: &[u8] = &[0; 64];
-        let shielded_wallet = ShieldedHDWallet::new(Vec::from(seed));
+        let shielded_wallet = ShieldedHDWallet::new(VecU8Pointer::new(Vec::from(seed)));
 
         assert!(shielded_wallet.is_ok());
     }
 
     #[test]
-    fn can_serialize_master_keys() {
-        let seed: &[u8] = &[0; 64];
-        let shielded_wallet = ShieldedHDWallet::new(Vec::from(seed))
-            .expect("ShieldedHDWallet should instantiate");
-        let Serialized { payment_address, xsk, xfvk } = shielded_wallet.master_keys_serialized()
-            .expect("Master keys should serialize");
-
-        let payment_address: PaymentAddress = borsh::BorshDeserialize::try_from_slice(&payment_address)
-            .expect("Should be able to deserialize payment address!");
-        let xsk: ExtendedSpendingKey = borsh::BorshDeserialize::try_from_slice(&xsk)
-            .expect("BorshDeserialize should not fail");
-        let xfvk: ExtendedFullViewingKey = borsh::BorshDeserialize::try_from_slice(&xfvk)
-            .expect("BorshDeserialize should not fail");
-
-        assert_eq!(payment_address.to_bytes().len(), 43);
-        assert_eq!(xsk.expsk.to_bytes().len(), KEY_SIZE);
-        assert_eq!(xfvk.fvk.to_bytes().len(), KEY_SIZE);
-    }
-
-    #[test]
-    fn can_derive_child_keys() {
-        let seed: &[u8] = &[0; SEED_SIZE];
-        let shielded_wallet = ShieldedHDWallet::new(Vec::from(seed))
-            .expect("Should be able to instantiate ShieldedHDWallet");
-
-        let Keys { expsk, fvk } = shielded_wallet.derive(1)
-            .expect("Should derive child extended keys!");
-
-        // ExpandedSpendingKey
-        // ask + nsk + ovk - 96 bytes
-        let expsk_expected = [71, 230, 226, 2, 146, 75, 94, 233, 234, 254, 128, 142,
-                              209, 73, 65, 180, 64, 235, 159, 125, 24, 77, 12, 246,
-                              113, 174, 41, 217, 5, 190, 215, 6, 76, 189, 55, 31, 96,
-                              85, 114, 22, 215, 250, 140, 98, 162, 95, 203, 154, 180,
-                              0, 231, 40, 172, 36, 137, 30, 142, 181, 225, 143, 180,
-                              110, 135, 2, 213, 181, 237, 102, 55, 178, 202, 2, 123,
-                              161, 104, 49, 91, 37, 62, 52, 132, 72, 103, 7, 60, 110,
-                              171, 49, 22, 100, 146, 44, 79, 205, 112, 25];
-        // FullViewingKey
-        // vk + ovk - 96 bytes
-        let fvk_expected = [231, 141, 253, 33, 141, 45, 47, 253, 94, 99, 2, 58, 233, 84,
-                            152, 142, 60, 45, 175, 100, 10, 5, 32, 126, 133, 46, 214, 50,
-                            136, 235, 250, 73, 125, 112, 103, 142, 119, 204, 205, 75, 30,
-                            208, 119, 223, 218, 19, 88, 206, 173, 185, 244, 228, 224, 32,
-                            104, 193, 189, 255, 9, 147, 22, 21, 240, 191, 213, 181, 237,
-                            102, 55, 178, 202, 2, 123, 161, 104, 49, 91, 37, 62, 52, 132,
-                            72, 103, 7, 60, 110, 171, 49, 22, 100, 146, 44, 79, 205, 112, 25];
-
-        assert_eq!(expsk, expsk_expected);
-        assert_eq!(expsk.len(), KEY_SIZE);
-        assert_eq!(fvk, fvk_expected);
-        assert_eq!(fvk.len(), KEY_SIZE);
-    }
-
-    #[test]
-    fn can_derive_child_from_extended_keys() {
-        let seed: &[u8] = &[0; SEED_SIZE];
-        let shielded_wallet = ShieldedHDWallet::new(Vec::from(seed))
-            .expect("Instantiating ShieldedHDWallet should not fail");
-
-        let ExtendedKeys { xsk, xfvk } = shielded_wallet.extended_master_keys();
-        let Keys { expsk, fvk } = ShieldedHDWallet::derive_from_ext(xsk, xfvk, 1)
-            .expect("Deriving from ExtendedKeys should not fail");
-
-        assert_eq!(expsk.len(), KEY_SIZE);
-        assert_eq!(fvk.len(), KEY_SIZE);
-    }
-
-     #[test]
     fn can_derive_child_to_serialized() {
         let seed: &[u8] = &[0; SEED_SIZE];
-        let shielded_wallet = ShieldedHDWallet::new(Vec::from(seed))
+        let shielded_wallet = ShieldedHDWallet::new(VecU8Pointer::new(Vec::from(seed)))
             .expect("Instantiating ShieldedHDWallet should not fail");
 
-        let Serialized { payment_address, xsk, xfvk } = shielded_wallet.derive_to_serialized_keys(1)
+        let Serialized { ref payment_address, ref xsk, ref xfvk } = shielded_wallet.derive_to_serialized_keys(1)
             .expect("Deriving from ExtendedKeys should not fail");
 
         let payment_address: PaymentAddress = borsh::BorshDeserialize::try_from_slice(&payment_address)
@@ -380,27 +192,5 @@ mod tests {
         assert_eq!(payment_address.to_bytes().len(), 43);
         assert_eq!(xsk.expsk.to_bytes().len(), KEY_SIZE);
         assert_eq!(xfvk.fvk.to_bytes().len(), KEY_SIZE);
-    }
-
-    #[test]
-    fn can_recover_native_spending_key_from_child() {
-        let seed: &[u8] = &[0; SEED_SIZE];
-        let shielded_wallet = ShieldedHDWallet::new(Vec::from(seed))
-            .expect("Instantiating ShieldedHDWallet should not fail");
-        let ext_keys = shielded_wallet.extended_master_keys();
-
-        // recover masp_primitive for zip32 ExtendedSpendingKey from instance
-        let xsk = ext_keys.xsk.0;
-        let child_index = ChildIndex::NonHardened(1);
-
-        let child = xsk.derive_child(child_index);
-        let (diversifier_index, address) = child.default_address();
-
-        assert_eq!(address.to_bytes().len(), 43);
-        assert_eq!(diversifier_index.0, [3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
-        assert_eq!(
-            address.diversifier().0,
-            [100, 199, 34, 96, 93, 67, 18, 95, 86, 139, 123],
-        );
     }
 }

--- a/packages/crypto/src/utils.ts
+++ b/packages/crypto/src/utils.ts
@@ -1,0 +1,24 @@
+import { VecU8Pointer, VecStringPointer, StringPointer } from ".";
+
+const decoder = new TextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+
+const getUint8Memory = (memory: WebAssembly.Memory): Uint8Array =>
+  new Uint8Array(memory.buffer);
+
+const readVecU8Pointer = ({ pointer, length }: VecU8Pointer, memory: WebAssembly.Memory): Uint8Array =>
+  getUint8Memory(memory).subarray(pointer, pointer + length);
+
+const readStringPointer = (stringPointer: StringPointer, memory: WebAssembly.Memory): string =>
+  decoder.decode(readVecU8Pointer(stringPointer, memory));
+
+const readVecStringPointer = ({ pointers, lengths }: VecStringPointer, memory: WebAssembly.Memory): string[] => {
+  const memoryBuffer = getUint8Memory(memory);
+  return Array.from(pointers)
+    .map((p, i) => decoder.decode(memoryBuffer.subarray(p, p + lengths[i])));
+}
+
+export {
+  readVecU8Pointer,
+  readStringPointer,
+  readVecStringPointer
+};

--- a/specs/browser-extension/security.md
+++ b/specs/browser-extension/security.md
@@ -22,6 +22,31 @@ when communicating between the web client and the content scripts. This requires
 When the extension is installed, the content and background scripts establish a shared state variable, `anomaExtensionRouterId`, stored in the extension's `localStorage`, which allows
 us to validate messages between the two before performing any actions in the background scripts.
 
+## Handling sensitive data in WASM memory
+
+Values that should be kept secret are handled specially in order to
+prevent them from being read from memory by an attacker. The measures
+we take are:
+
+1. Temporary sensitive values used in Rust code are zeroized in memory
+   after they are done being used.
+
+2. Sensitive values are wrapped in structs. (See ./packages/crypto/lib/src/crypto/pointer_types.rs.)
+
+   a. These structs have the ZeroizeOnDrop trait, so sensitive values
+   will automatically be zeroized when the struct is dropped.
+
+   b. Passing a struct between JavaScript and WASM does not reveal the
+   contents of the struct. This lets us avoid putting sensitive values
+   in JavaScript memory, where we cannot ensure they are zeroized.
+
+   c. If a sensitive value is needed in JavaScript, it can be
+   optionally read directly from WASM memory by using the pointer and
+   length fields of the struct. (See ./packages/crypto/src/utils.ts.)
+
+3. Methods that handle sensitive data and are not needed in JavaScript
+   are hidden using `#[wasm_bindgen(skip_typescript)]`.
+
 ## Resources
 
 - [https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#connection-based_messaging](Connection-Based Messaging)


### PR DESCRIPTION
This PR adds more careful handling of sensitive data to try to guard against sensitive data being left in memory.

The strategy is:

1. Wrap sensitive values in structs.
a. Wrapped values will be automatically zeroized in memory when dropped.
b. Wrapped values can be passed to JS without loading the sensitive value into JS memory.
c. If required, the value can be read from JS by reading directly from WASM memory, which gets around wasm-bindgen making a temporary value in memory that we can't zeroize.
2. Local variables in Rust are zeroized after use if they hold sensitive data.
3. Use `#[wasm_bindgen(skip_typescript)]` to hide methods from JS that don't wrap sensitive data. (Ideally I would use `#[wasm_bindgen(skip)]` but it [doesn't currently support](https://github.com/rustwasm/wasm-bindgen/pull/1410#issuecomment-1517584716) skipping methods.)

I've added some comments for the review at parts I wasn't sure about.

Fixes #243.