### PR TITLE
WIP: feat/254 - Support multiple top-level accounts

### DIFF
--- a/apps/extension/src/App/Accounts/AddAccount.tsx
+++ b/apps/extension/src/App/Accounts/AddAccount.tsx
@@ -33,8 +33,7 @@ import { TopLevelRoute } from "App/types";
 import { useAuth } from "hooks";
 
 type Props = {
-  // The parent Bip44 "account"
-  parentAccount: number;
+  accountIndex: number;
   accounts: DerivedAccount[];
   requester: ExtensionRequester;
   setAccounts: (accounts: DerivedAccount[]) => void;
@@ -43,12 +42,12 @@ type Props = {
 };
 
 const validatePath = (
-  account: number,
+  accountIndex: number,
   newAccount: { change: number; index: number },
   accounts: DerivedAccount[],
   accountType: AccountType
 ): boolean => {
-  const newPath = [account, newAccount.change, newAccount.index].join("/");
+  const newPath = [accountIndex, newAccount.change, newAccount.index].join("/");
   let isValid = true;
   accounts
     .filter((derivedAccount) => derivedAccount.type === accountType)
@@ -127,7 +126,7 @@ enum Validation {
 }
 
 const AddAccount: React.FC<Props> = ({
-  parentAccount,
+  accountIndex: parentAccount,
   accounts,
   requester,
   setAccounts,

--- a/apps/extension/src/App/App.tsx
+++ b/apps/extension/src/App/App.tsx
@@ -47,7 +47,7 @@ export const App: React.FC = () => {
   const [isLocked, setIsLocked] = useState(true);
   const [status, setStatus] = useState<Status>();
   const [accounts, setAccounts] = useState<DerivedAccount[]>([]);
-  const [parentAccount, setParentAccount] = useState(0);
+  const [parentAccount, setParentAccount] = useState<DerivedAccount>();
   const [error, setError] = useState("");
 
   const fetchAccounts = async (): Promise<void> => {
@@ -90,10 +90,12 @@ export const App: React.FC = () => {
     const parent = accounts.find(
       (account) => account.type === AccountType.Mnemonic
     );
-    if (parent?.path?.account) {
-      setParentAccount(parent.path.account);
+    if (parent) {
+      setParentAccount(parent);
     }
   }, []);
+
+  console.log({ parentAccount });
 
   return (
     <ThemeProvider theme={theme}>
@@ -158,7 +160,7 @@ export const App: React.FC = () => {
                   lockKeyRing={() => setIsLocked(true)}
                 >
                   <AddAccount
-                    parentAccount={parentAccount}
+                    accountIndex={parentAccount?.path?.account || 0}
                     accounts={accounts}
                     requester={requester}
                     setAccounts={setAccounts}

--- a/apps/extension/src/App/App.tsx
+++ b/apps/extension/src/App/App.tsx
@@ -91,9 +91,10 @@ export const App: React.FC = () => {
       (account) => account.type === AccountType.Mnemonic
     );
     if (parent) {
+      console.log({ parent, accounts });
       setParentAccount(parent);
     }
-  }, []);
+  }, [accounts]);
 
   return (
     <ThemeProvider theme={theme}>

--- a/apps/extension/src/App/App.tsx
+++ b/apps/extension/src/App/App.tsx
@@ -95,8 +95,6 @@ export const App: React.FC = () => {
     }
   }, []);
 
-  console.log({ parentAccount });
-
   return (
     <ThemeProvider theme={theme}>
       <AppContainer>

--- a/apps/extension/src/App/App.tsx
+++ b/apps/extension/src/App/App.tsx
@@ -47,6 +47,7 @@ export const App: React.FC = () => {
   const [isLocked, setIsLocked] = useState(true);
   const [status, setStatus] = useState<Status>();
   const [accounts, setAccounts] = useState<DerivedAccount[]>([]);
+  const [parentAccount, setParentAccount] = useState(0);
   const [error, setError] = useState("");
 
   const fetchAccounts = async (): Promise<void> => {
@@ -85,10 +86,14 @@ export const App: React.FC = () => {
     }
   }, [status, accounts]);
 
-  const parent = accounts.find(
-    (account) => account.type === AccountType.Mnemonic
-  );
-  const parentAccount = parent?.path?.account ?? 0;
+  useEffect(() => {
+    const parent = accounts.find(
+      (account) => account.type === AccountType.Mnemonic
+    );
+    if (parent?.path?.account) {
+      setParentAccount(parent.path.account);
+    }
+  }, []);
 
   return (
     <ThemeProvider theme={theme}>

--- a/apps/extension/src/background/keyring/crypto.ts
+++ b/apps/extension/src/background/keyring/crypto.ts
@@ -9,6 +9,7 @@ type CryptoArgs = {
   chainId: string;
   path: Bip44Path;
   id: string;
+  parentId?: string;
   password: string;
   text: string;
   type: AccountType;
@@ -16,7 +17,17 @@ type CryptoArgs = {
 
 export class Crypto {
   public encrypt(args: CryptoArgs): KeyStore {
-    const { address, alias, chainId, path, id, password, text, type } = args;
+    const {
+      address,
+      alias,
+      chainId,
+      path,
+      id,
+      parentId,
+      password,
+      text,
+      type,
+    } = args;
     const salt = Salt.generate().as_string();
     const { m_cost, t_cost, p_cost } = Argon2Config;
     const argon2Params = new Argon2Params(m_cost, t_cost, p_cost);
@@ -33,6 +44,7 @@ export class Crypto {
       address,
       chainId,
       id,
+      parentId,
       path,
       crypto: {
         cipher: {

--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -96,8 +96,7 @@ export class KeyRing {
   public async checkPassword(password: string): Promise<boolean> {
     const mnemonics = await this._keyStore.get();
 
-    // Note: We may support multiple top-level mnemonic seeds in the future,
-    // hence why we're storing these in an array. For now, we check for only one:
+    // TODO: Validate against stored mnemonic by mnemonic ID (using the selected mnemonic, instead of the first one!)
     if (mnemonics && mnemonics[0]) {
       try {
         crypto.decrypt(mnemonics[0], password);
@@ -240,8 +239,7 @@ export class KeyRing {
       throw new Error("No mnemonics have been stored!");
     }
 
-    // TODO: For now, we are assuming only one mnemonic is used, but in the future
-    // we may want to have multiple top-level accounts:
+    // TODO: Pull the stored mnemonic idenfitied by "id"
     const storedMnemonic = mnemonics[0];
 
     if (!storedMnemonic) {
@@ -290,6 +288,7 @@ export class KeyRing {
           address,
           chainId,
           id,
+          parentId,
           password: this._password,
           path,
           text,


### PR DESCRIPTION
Resolves #254 

In order to support a user flow where a user may connect and utilize accounts from their Ledger HW wallet, we need to _first_ support accessing multiple accounts from the extension. This has been previously implemented to a degree, where we can technically store any number of mnemonic seeds and the associated accounts, but this needs to be completed in this issue.