### PR TITLE
bug/263 - Fix for extension popup error

### DIFF
--- a/apps/extension/src/App/App.tsx
+++ b/apps/extension/src/App/App.tsx
@@ -75,7 +75,7 @@ export const App: React.FC = () => {
   };
 
   const fetchParentAccountId = async (): Promise<void> => {
-    setStatus(Status.Pending); // or "error"
+    setStatus(Status.Pending);
 
     try {
       const parentId = await requester.sendMessage(
@@ -130,6 +130,7 @@ export const App: React.FC = () => {
     { tries: 10, ms: 100 },
     []
   );
+
   useEffect(() => {
     if (redirect) {
       // Provide a redirect in the case of transaction/connection approvals

--- a/apps/extension/src/App/App.tsx
+++ b/apps/extension/src/App/App.tsx
@@ -12,7 +12,7 @@ import { useUntil } from "@anoma/hooks";
 import { ExtensionMessenger, ExtensionRequester } from "extension";
 import { KVPrefix, Ports } from "router";
 import { QueryAccountsMsg } from "provider/messages";
-import { GetActiveAccountMsg, CheckIsLockedMsg } from "background/keyring";
+import { GetActiveAccountMsg } from "background/keyring";
 import { useQuery } from "hooks";
 import {
   AppContainer,
@@ -98,7 +98,11 @@ export const App: React.FC = () => {
       predFn: async () => {
         setStatus(Status.Pending);
         try {
-          await requester.sendMessage(Ports.Background, new CheckIsLockedMsg());
+          const accounts = await requester.sendMessage(
+            Ports.Background,
+            new QueryAccountsMsg()
+          );
+          setAccounts(accounts);
           return true;
         } catch (e) {
           console.warn(e);
@@ -106,21 +110,7 @@ export const App: React.FC = () => {
         }
       },
       onSuccess: () => {
-        (async () => {
-          // Fetch accounts
-          try {
-            const accounts = await requester.sendMessage(
-              Ports.Background,
-              new QueryAccountsMsg()
-            );
-            setAccounts(accounts);
-          } catch (e) {
-            console.error(e);
-            setError(`An error occurred while loading extension: ${e}`);
-            setStatus(Status.Failed);
-            return;
-          }
-        })();
+        setStatus(Status.Completed);
       },
       onFail: () => {
         setError("An error occurred connecting to extension");

--- a/apps/extension/src/App/Loading/Loading.tsx
+++ b/apps/extension/src/App/Loading/Loading.tsx
@@ -1,12 +1,20 @@
+import { Status } from "App/App";
 import React from "react";
 import { LoadingError } from "./Loading.components";
 
 type Props = {
+  status?: Status;
   error?: string;
 };
 
-const Loading: React.FC<Props> = ({ error }) => {
-  return !!error ? <div>Loading...</div> : <LoadingError>{error}</LoadingError>;
+const Loading: React.FC<Props> = ({ error, status }) => {
+  return (
+    <div>
+      {(status === Status.Failed && (
+        <LoadingError>Error: {error}</LoadingError>
+      )) || <p>Loading...</p>}
+    </div>
+  );
 };
 
 export default Loading;

--- a/packages/hooks/src/useIntegration.ts
+++ b/packages/hooks/src/useIntegration.ts
@@ -117,7 +117,7 @@ export const useUntilIntegrationAttached = (chain: Chain): AttachStatusMap => {
 
   useUntil(
     {
-      predFn: () => integration.detect(),
+      predFn: () => Promise.resolve(integration.detect()),
       onSuccess: () => {
         setAttachStatus((v) => ({ ...v, [extension.id]: "attached" }));
       },

--- a/packages/hooks/src/useUntil.ts
+++ b/packages/hooks/src/useUntil.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 
 type Options = {
-  predFn: () => boolean;
+  predFn: () => Promise<boolean>;
   onSuccess: () => unknown;
   onFail: () => unknown;
 };
@@ -36,7 +36,7 @@ export const useUntil = (
     const execute = async (): Promise<void> => {
       let succ = false;
       while (!succ && tries > 0) {
-        succ = predFn();
+        succ = await predFn();
         tries--;
         await wait(config.ms);
       }


### PR DESCRIPTION
Resolve #263 

This PR makes use of `useUntil`, where the predicate will return `true` when the requester is able to resolve a "fetch accounts" `sendMessage` promise to the extension, and once successful, will load those accounts into state.

__NOTE__ This method will cause many errors to be logged, and I have some ideas on how to address that in #271. The idea is to introduce better and more useful error handling within the messaging of the extension. Currently, we throw an exception in any case that the requester is unable to resolve a promise, and it would perhaps be much more useful to reject the promise and return data to whichever method requested it for better handling on the client end.