### PR TITLE
Extension: Update tab storage to account for closed tabs

### DIFF
--- a/apps/extension/src/background/keyring/index.ts
+++ b/apps/extension/src/background/keyring/index.ts
@@ -5,3 +5,4 @@ export * from "./keyring";
 export * from "./messages";
 export * from "./service";
 export * from "./types";
+export * from "./utils";

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -6,6 +6,7 @@ import { Sdk } from "@anoma/shared";
 
 import { KeyRing } from "./keyring";
 import { KeyRingStatus, KeyStore, TabStore } from "./types";
+import { syncTabs } from "./utils";
 import { ExtensionRequester } from "extension";
 import { Ports } from "router";
 import { AccountChangedEventMsg } from "content/events";
@@ -154,7 +155,11 @@ export class KeyRingService {
   }
 
   async setActiveAccountId(accountId: string): Promise<void> {
-    const tabs = await this.connectedTabsStore.get(this.chainId);
+    const tabs = await syncTabs(
+      this.connectedTabsStore,
+      this.requester,
+      this.chainId
+    );
     await this._keyRing.setActiveAccountId(accountId);
 
     try {

--- a/apps/extension/src/background/keyring/utils.ts
+++ b/apps/extension/src/background/keyring/utils.ts
@@ -18,15 +18,11 @@ export const syncTabs = async (
   chainId: string
 ): Promise<TabStore[]> => {
   const tabs = await requester.queryBrowserTabIds();
-  const storedTabs = await connectedTabsStore.get(chainId);
+  const storedTabs = (await connectedTabsStore.get(chainId)) || [];
   const currentTabs: TabStore[] = [];
 
-  if (storedTabs?.length === 0) {
-    return [];
-  }
-
   storedTabs?.forEach((tab: TabStore) => {
-    if (tabs.indexOf(tab.tabId) > -1) {
+    if (tabs.includes(tab.tabId)) {
       currentTabs.push(tab);
     }
   });

--- a/apps/extension/src/background/keyring/utils.ts
+++ b/apps/extension/src/background/keyring/utils.ts
@@ -3,13 +3,22 @@ import { KVStore } from "@anoma/storage";
 import { TabStore } from "./types";
 import { ExtensionRequester } from "extension";
 
+/**
+ * Utility to sync tabs in storage with currently available tabs in browser
+ *
+ * @param {TabStore[]} connectedTabsStore
+ * @param {ExtensionRequester} requester
+ * @param {string} chainId
+ *
+ * @return Promise<TabStore[]>
+ */
 export const syncTabs = async (
-  connectedTabStore: KVStore<TabStore[]>,
+  connectedTabsStore: KVStore<TabStore[]>,
   requester: ExtensionRequester,
   chainId: string
 ): Promise<TabStore[]> => {
   const tabs = await requester.queryBrowserTabIds();
-  const storedTabs = await connectedTabStore.get(chainId);
+  const storedTabs = await connectedTabsStore.get(chainId);
   const currentTabs: TabStore[] = [];
 
   if (storedTabs?.length === 0) {
@@ -21,6 +30,38 @@ export const syncTabs = async (
       currentTabs.push(tab);
     }
   });
-  await connectedTabStore.set(chainId, currentTabs);
+
+  await connectedTabsStore.set(chainId, currentTabs);
+
   return currentTabs;
+};
+
+/**
+ * Update tab storage: Either append to store, or update existing tab timestamp
+ *
+ * @param {number} senderTabId
+ * @param {TabStore[]} tabs
+ * @param {KVStore<TabStore[]>} connectedTabsStore
+ *
+ * @return Promise<void>
+ */
+export const updateTabStorage = async (
+  senderTabId: number,
+  tabs: TabStore[],
+  connectedTabsStore: KVStore<TabStore[]>,
+  chainId: string
+): Promise<void> => {
+  const tabIndex = tabs.findIndex((tab) => tab.tabId === senderTabId);
+
+  if (tabIndex > -1) {
+    // If tab exists, update timestamp
+    tabs[tabIndex].timestamp = Date.now();
+  } else {
+    // Add tab to storage
+    tabs.push({
+      tabId: senderTabId,
+      timestamp: Date.now(),
+    });
+  }
+  return await connectedTabsStore.set(chainId, tabs);
 };

--- a/apps/extension/src/background/keyring/utils.ts
+++ b/apps/extension/src/background/keyring/utils.ts
@@ -1,0 +1,26 @@
+import { KVStore } from "@anoma/storage";
+
+import { TabStore } from "./types";
+import { ExtensionRequester } from "extension";
+
+export const syncTabs = async (
+  connectedTabStore: KVStore<TabStore[]>,
+  requester: ExtensionRequester,
+  chainId: string
+): Promise<TabStore[]> => {
+  const tabs = await requester.queryBrowserTabIds();
+  const storedTabs = await connectedTabStore.get(chainId);
+  const currentTabs: TabStore[] = [];
+
+  if (storedTabs?.length === 0) {
+    return [];
+  }
+
+  storedTabs?.forEach((tab: TabStore) => {
+    if (tabs.indexOf(tab.tabId) > -1) {
+      currentTabs.push(tab);
+    }
+  });
+  await connectedTabStore.set(chainId, currentTabs);
+  return currentTabs;
+};

--- a/apps/extension/src/extension/ExtensionRequester.ts
+++ b/apps/extension/src/extension/ExtensionRequester.ts
@@ -89,6 +89,6 @@ export class ExtensionRequester {
   async queryBrowserTabIds(): Promise<number[]> {
     const tabs = await browser.tabs.query({});
 
-    return tabs?.map((tab) => tab.id || browser.tabs.TAB_ID_NONE);
+    return tabs.map((tab) => tab.id || browser.tabs.TAB_ID_NONE);
   }
 }

--- a/apps/extension/src/extension/ExtensionRequester.ts
+++ b/apps/extension/src/extension/ExtensionRequester.ts
@@ -85,4 +85,10 @@ export class ExtensionRequester {
       msg
     );
   }
+
+  async queryBrowserTabIds(): Promise<number[]> {
+    const tabs = await browser.tabs.query({});
+
+    return tabs?.map((tab) => tab.id || browser.tabs.TAB_ID_NONE);
+  }
 }


### PR DESCRIPTION
Resolves #269 

This PR adds a utility to synchronize the tabs tracked within the `KeyRingService`. It compares what is stored against what is available via `browser.tabs.query`, and updates the storage, returning the updated _current_ tabs before attempting to broadcast to them. This prevents errors that occur in the requester when an attempt is made to communicate with a non-existent tab.
