### PR TITLE
chore: fix wasm-bindgen-cli version to v0.2.84 in CI

### DIFF
--- a/.github/workflows/deploy-wallet-at-pr.yml
+++ b/.github/workflows/deploy-wallet-at-pr.yml
@@ -118,7 +118,7 @@ jobs:
         run: rustup target add wasm32-unknown-unknown
 
       - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli
+        run: cargo install wasm-bindgen-cli@0.2.84
 
       - name: build the site
         working-directory: ./apps/namada-interface


### PR DESCRIPTION
When v0.2.85 was released, it broke the CI build because wasm-bindgen-cli versions are required to match, so this commit fixes the globally installed version to v0.2.84 as a temporary measure until we upgrade our packages to use v0.2.85.