### PR TITLE
Interface: Bug - Fix for useLocation hook error

### DIFF
--- a/apps/namada-interface/src/App/Staking/Staking.tsx
+++ b/apps/namada-interface/src/App/Staking/Staking.tsx
@@ -18,7 +18,7 @@ import {
 import { NewBondingPosition } from "./NewBondingPosition";
 import { UnbondPosition } from "./UnbondPosition";
 import { Account } from "slices/accounts";
-import { useSanitizedLocation } from "@anoma/hooks";
+import { useLocation } from "react-router-dom";
 
 const initialTitle = "Staking";
 
@@ -96,7 +96,7 @@ export enum ModalOnRequestCloseType {
 export const Staking = (props: Props): JSX.Element => {
   const [breadcrumb, setBreadcrumb] = useState([initialTitle]);
   const [modalState, setModalState] = useState(ModalState.None);
-  const location = useSanitizedLocation();
+  const location = useLocation();
   const navigate = useNavigate();
 
   const {

--- a/apps/namada-interface/src/App/StakingAndGovernance/StakingAndGovernance.tsx
+++ b/apps/namada-interface/src/App/StakingAndGovernance/StakingAndGovernance.tsx
@@ -12,7 +12,6 @@ import {
   StakingAndGovernanceSubRoute,
   locationToStakingAndGovernanceSubRoute,
 } from "App/types";
-import { useSanitizedLocation } from "@anoma/hooks";
 
 import {
   fetchValidators,
@@ -23,6 +22,7 @@ import {
 } from "slices/StakingAndGovernance";
 import { SettingsState } from "slices/settings";
 import { AccountsState } from "slices/accounts";
+import { useLocation } from "react-router-dom";
 
 export type { ChangeInStakingPosition };
 // This is just rendering the actual Staking/Governance/PGF screens
@@ -30,7 +30,7 @@ export type { ChangeInStakingPosition };
 // the user clicks the top level Staking & Governance menu
 //
 export const StakingAndGovernance = (): JSX.Element => {
-  const location = useSanitizedLocation();
+  const location = useLocation();
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const stakingAndGovernance = useAppSelector(

--- a/apps/namada-interface/src/App/TopNavigation/topNavigation.tsx
+++ b/apps/namada-interface/src/App/TopNavigation/topNavigation.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useContext } from "react";
 import { ThemeContext } from "styled-components";
 import {
+  useLocation,
   useNavigate,
   NavigateFunction,
   Location,
@@ -52,17 +53,16 @@ import {
 } from "./topNavigation.components";
 import { setChainId, SettingsState } from "slices/settings";
 import TopNavigationLoggedIn from "./topNavigationLoggedIn";
-import { useSanitizedLocation } from "@anoma/hooks";
 
 /**
  * this is rendered in one of 2 places depending of the screen size
  */
 const TopNavigationMenuItems = (props: {
   navigate: NavigateFunction;
+  location: Location;
   setColorMode: (mode: ColorMode) => void;
 }): React.ReactElement => {
   const { navigate } = props;
-  const location = useSanitizedLocation();
   const topLevelPath = `/${location.pathname.split("/")[1]}`;
   return (
     <>
@@ -214,7 +214,7 @@ function TopNavigation(props: TopNavigationProps): JSX.Element {
   const navigate = useNavigate();
   const themeContext = useContext(ThemeContext);
   const [showMenu, setShowMenu] = useState(false);
-  const location = useSanitizedLocation();
+  const location = useLocation();
   const topLevelRoute = locationToTopLevelRoute(location);
   const stakingAndGovernanceSubRoute =
     locationToStakingAndGovernanceSubRoute(location);
@@ -240,6 +240,7 @@ function TopNavigation(props: TopNavigationProps): JSX.Element {
 
           <MiddleSection>
             <TopNavigationMenuItems
+              location={location}
               navigate={navigate}
               setColorMode={setColorMode}
             />


### PR DESCRIPTION
This is a temporary fix for the introduction of `useSanitizedLocation` where its use is breaking on `namada-interface`, which was added as a part of #222. This PR reverts its usage in three areas as it is breaking the interface.

__TODO__ We need to figure out why that hook breaks in certain contexts. _Note:_ It does not have any issues on the extension as far as I can tell, but within `TopNavigation/topNavigation`, `Staking`, and `StakingAndGovernance`, it complains that `useLocation` must be used in the context of a `Router`, which it appears to be, but still breaks for some reason. 