### PR TITLE
feat/280 - Implement events for new address & new mnemonics

### DIFF
--- a/apps/extension/src/App/Accounts/AccountListing.tsx
+++ b/apps/extension/src/App/Accounts/AccountListing.tsx
@@ -63,7 +63,8 @@ const AccountListing = ({ account, parentAlias }: Props): JSX.Element => {
           </Button>
         )}
         <Button
-          onClick={() => {
+          onClick={(e) => {
+            e.preventDefault();
             textToClipboard(address);
           }}
           href="#"

--- a/apps/extension/src/Setup/AccountCreation/Steps/SeedPhrase/SeedPhrase.tsx
+++ b/apps/extension/src/Setup/AccountCreation/Steps/SeedPhrase/SeedPhrase.tsx
@@ -94,7 +94,8 @@ const SeedPhrase: React.FC<Props> = (props) => {
         <ExportSeedPhraseButtonsContainer>
           {/* copy seed phrase */}
           <CopyToClipboard
-            onClick={() => {
+            onClick={(e) => {
+              e.preventDefault();
               textToClipboard(seedPhrase.join(" "));
             }}
             href="#"


### PR DESCRIPTION
Resolves #280 

__NOTE__ This still needs to be added to Ledger accounts once that service is implemented! This is simple enough to be handled in the PR that implements the Ledger service.

- [ ] Adding a new address reloads accounts in interface
- [ ] Adding a new mnemonic account reloads accounts in interface (sets it to the new top-level account)
