### PR TITLE
bug/282 - Fix all service worker-related errors in Create Account

### DIFF
--- a/apps/extension/src/App/Accounts/AccountListing.tsx
+++ b/apps/extension/src/App/Accounts/AccountListing.tsx
@@ -1,6 +1,10 @@
 import { useNavigate } from "react-router-dom";
+
 import { Icon, IconName } from "@anoma/components";
 import { AccountType, Bip44Path, DerivedAccount } from "@anoma/types";
+import { shortenAddress } from "@anoma/utils";
+
+import { TopLevelRoute } from "App/types";
 import {
   AccountListingContainer,
   Address,
@@ -12,9 +16,6 @@ import {
   ParentAlias,
   DerivationPathContainer,
 } from "./AccountListing.components";
-import { shortenAddress } from "@anoma/utils";
-
-import { TopLevelRoute } from "App/types";
 
 type Props = {
   // The parent BIP44/ZIP32 "account"

--- a/packages/hooks/src/useUntil.ts
+++ b/packages/hooks/src/useUntil.ts
@@ -1,6 +1,12 @@
 import { useEffect } from "react";
 
-import { executeUntil, Config, Options } from "@anoma/utils";
+import { executeUntil, Config } from "@anoma/utils";
+
+type Options = {
+  predFn: () => Promise<boolean>;
+  onSuccess: () => unknown;
+  onFail: () => unknown;
+};
 
 /**
  * Hook that wait until predicate is met
@@ -15,6 +21,11 @@ export const useUntil = (
   deps?: React.DependencyList
 ): void => {
   useEffect(() => {
-    executeUntil(config, options);
+    const { predFn, onSuccess, onFail } = options;
+    (async () => {
+      const succ = await executeUntil(predFn, config);
+      const fn = succ ? onSuccess : onFail;
+      fn();
+    })();
   }, deps);
 };

--- a/packages/hooks/src/useUntil.ts
+++ b/packages/hooks/src/useUntil.ts
@@ -1,15 +1,6 @@
 import { useEffect } from "react";
 
-type Options = {
-  predFn: () => Promise<boolean>;
-  onSuccess: () => unknown;
-  onFail: () => unknown;
-};
-
-type Config = {
-  tries: number;
-  ms: number;
-};
+import { executeUntil, Config, Options } from "@anoma/utils";
 
 /**
  * Hook that wait until predicate is met
@@ -23,28 +14,7 @@ export const useUntil = (
   config: Config,
   deps?: React.DependencyList
 ): void => {
-  const { predFn, onSuccess, onFail } = options;
-  let { tries } = config;
-
-  const wait = async (ms: number): Promise<unknown> => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, ms);
-    });
-  };
-
   useEffect(() => {
-    const execute = async (): Promise<void> => {
-      let succ = false;
-      while (!succ && tries > 0) {
-        succ = await predFn();
-        tries--;
-        await wait(config.ms);
-      }
-
-      const fn = succ ? onSuccess : onFail;
-      fn();
-    };
-
-    execute();
+    executeUntil(config, options);
   }, deps);
 };

--- a/packages/utils/src/async/executeUntil.ts
+++ b/packages/utils/src/async/executeUntil.ts
@@ -3,12 +3,6 @@ export type Config = {
   ms: number;
 };
 
-export type Options = {
-  predFn: () => Promise<boolean>;
-  onSuccess: () => unknown;
-  onFail: () => unknown;
-};
-
 export const wait = async (ms: number): Promise<unknown> => {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
@@ -17,12 +11,14 @@ export const wait = async (ms: number): Promise<unknown> => {
 
 /**
  * Execute attempts until predicate is satisfied
+ *
+ * @param {Function} predFn
+ * @param {Config} config - number of tries and ms before failing
  */
 export const executeUntil = async (
-  config: Config,
-  options: Options
-): Promise<void> => {
-  const { predFn, onSuccess, onFail } = options;
+  predFn: () => Promise<boolean>,
+  config: Config
+): Promise<boolean> => {
   let succ = false;
   let { tries } = config;
 
@@ -32,6 +28,5 @@ export const executeUntil = async (
     await wait(config.ms);
   }
 
-  const fn = succ ? onSuccess : onFail;
-  fn();
+  return succ;
 };

--- a/packages/utils/src/async/executeUntil.ts
+++ b/packages/utils/src/async/executeUntil.ts
@@ -1,0 +1,37 @@
+export type Config = {
+  tries: number;
+  ms: number;
+};
+
+export type Options = {
+  predFn: () => Promise<boolean>;
+  onSuccess: () => unknown;
+  onFail: () => unknown;
+};
+
+export const wait = async (ms: number): Promise<unknown> => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+};
+
+/**
+ * Execute attempts until predicate is satisfied
+ */
+export const executeUntil = async (
+  config: Config,
+  options: Options
+): Promise<void> => {
+  const { predFn, onSuccess, onFail } = options;
+  let succ = false;
+  let { tries } = config;
+
+  while (!succ && tries > 0) {
+    succ = await predFn();
+    tries--;
+    await wait(config.ms);
+  }
+
+  const fn = succ ? onSuccess : onFail;
+  fn();
+};

--- a/packages/utils/src/async/index.ts
+++ b/packages/utils/src/async/index.ts
@@ -42,3 +42,5 @@ export const debounce = <ArgumentsType extends unknown[], ReturnType>(
     }
   };
 };
+
+export * from "./executeUntil";


### PR DESCRIPTION
Partially resolves #282 

This PR adds the functionality from `useUntil` in several key places throughout the Account Creation setup process, where the app will break due to the service worker being inactive when the user request an action requiring the background scripts.

