### PR TITLE
feat: initialize masp params load from the extension

### DIFF
--- a/apps/extension/src/App/Loading/Loading.components.ts
+++ b/apps/extension/src/App/Loading/Loading.components.ts
@@ -1,5 +1,33 @@
 import styled from "styled-components";
 
+export const LoadingContainer = styled.div`
+  &.is-loading::after {
+    content: "";
+    position: absolute;
+    width: 32px;
+    height: 32px;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    margin: auto;
+    border: 4px solid transparent;
+    border-top-color: ${(props) => props.theme.colors.primary.main};
+    border-radius: 50%;
+    animation: button-loading-spinner 1s ease infinite;
+
+    @keyframes button-loading-spinner {
+      from {
+        transform: rotate(0turn);
+      }
+
+      to {
+        transform: rotate(1turn);
+      }
+    }
+  }
+`;
+
 export const LoadingError = styled.div`
   color: ${(props) => props.theme.colors.utility3.highAttention};
 `;

--- a/apps/extension/src/App/Loading/Loading.tsx
+++ b/apps/extension/src/App/Loading/Loading.tsx
@@ -1,19 +1,20 @@
 import { Status } from "App/App";
 import React from "react";
-import { LoadingError } from "./Loading.components";
+import { LoadingContainer, LoadingError } from "./Loading.components";
 
 type Props = {
   status?: Status;
+  info?: string;
   error?: string;
 };
 
-const Loading: React.FC<Props> = ({ error, status }) => {
+const Loading: React.FC<Props> = ({ error, status, info }) => {
   return (
-    <div>
+    <LoadingContainer className={error ? "" : "is-loading"}>
       {(status === Status.Failed && (
         <LoadingError>Error: {error}</LoadingError>
-      )) || <p>Loading...</p>}
-    </div>
+      )) || <p>{info ?? "Loading..."}</p>}
+    </LoadingContainer>
   );
 };
 

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -64,7 +64,6 @@ const { REACT_APP_NAMADA_URL = DEFAULT_URL } = process.env;
   //TODO: Most likely sdk and query should be a one thing
   const sdk = new Sdk(REACT_APP_NAMADA_URL);
   const query = new Query(REACT_APP_NAMADA_URL);
-  await sdk.fetch_masp_params();
 
   if (sdkDataStr) {
     const sdkData = new TextEncoder().encode(sdkDataStr);

--- a/apps/extension/src/background/keyring/handler.ts
+++ b/apps/extension/src/background/keyring/handler.ts
@@ -24,6 +24,8 @@ import {
   SubmitBondMsg,
   SubmitUnbondMsg,
   SubmitIbcTransferMsg,
+  LoadMaspParamsMsg,
+  HasMaspParamsMsg,
 } from "provider/messages";
 
 export const getHandler: (service: KeyRingService) => Handler = (service) => {
@@ -98,6 +100,13 @@ export const getHandler: (service: KeyRingService) => Handler = (service) => {
         );
       case DeleteAccountMsg:
         return handleDeleteAccountMsg(service)(env, msg as DeleteAccountMsg);
+      case LoadMaspParamsMsg:
+        return handleLoadMaspParamsMsg(service)(
+          env,
+          msg as LoadMaspParamsMsg
+        );
+      case HasMaspParamsMsg:
+        return handleHasMaspParamsMsg(service)(env, msg as HasMaspParamsMsg);
       default:
         throw new Error("Unknown msg type");
     }
@@ -148,8 +157,11 @@ const handleResetPasswordMsg: (
   service: KeyRingService
 ) => InternalHandler<ResetPasswordMsg> = (service) => {
   return async (_, msg) => {
-    return await service.resetPassword(msg.currentPassword, msg.newPassword,
-      msg.accountId);
+    return await service.resetPassword(
+      msg.currentPassword,
+      msg.newPassword,
+      msg.accountId
+    );
   };
 };
 
@@ -281,5 +293,21 @@ const handleDeleteAccountMsg: (
 ) => InternalHandler<DeleteAccountMsg> = (service) => {
   return async (_, msg) => {
     return await service.deleteAccount(msg.accountId, msg.password);
+  };
+};
+
+const handleLoadMaspParamsMsg: (
+  service: KeyRingService
+) => InternalHandler<LoadMaspParamsMsg> = (service) => {
+  return async (_, _msg) => {
+    return await service.loadMaspParams();
+  };
+};
+
+const handleHasMaspParamsMsg: (
+  service: KeyRingService
+) => InternalHandler<HasMaspParamsMsg> = (service) => {
+  return async (_, _msg) => {
+    return await service.hasMaspParams();
   };
 };

--- a/apps/extension/src/background/keyring/init.ts
+++ b/apps/extension/src/background/keyring/init.ts
@@ -24,6 +24,8 @@ import {
   SubmitBondMsg,
   SubmitUnbondMsg,
   SubmitIbcTransferMsg,
+  LoadMaspParamsMsg,
+  HasMaspParamsMsg,
 } from "provider/messages";
 import { ROUTE } from "./constants";
 import { getHandler } from "./handler";
@@ -52,6 +54,8 @@ export function init(router: Router, service: KeyRingService): void {
   router.registerMessage(TransferCompletedEvent);
   router.registerMessage(UnlockKeyRingMsg);
   router.registerMessage(DeleteAccountMsg);
+  router.registerMessage(LoadMaspParamsMsg);
+  router.registerMessage(HasMaspParamsMsg);
 
   router.addHandler(ROUTE, getHandler(service));
 }

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -344,6 +344,14 @@ export class KeyRingService {
     return;
   }
 
+  async loadMaspParams(): Promise<void> {
+    await this.sdk.load_masp_params();
+  }
+
+  async hasMaspParams(): Promise<boolean> {
+    return this.sdk.has_masp_params();
+  }
+
   private async broadcastUpdateBalance(): Promise<void> {
     const tabs = await syncTabs(
       this.connectedTabsStore,

--- a/apps/extension/src/background/web-workers/submit-transfer-web-worker.ts
+++ b/apps/extension/src/background/web-workers/submit-transfer-web-worker.ts
@@ -17,7 +17,7 @@ import {
   //TODO: import sdk-store key - can't import from the keyring
   const sdkDataStr: string | undefined = await sdkStore.get("sdk-store");
   const sdk = new Sdk(chains[defaultChainId].rpc);
-  await sdk.fetch_masp_params();
+  await sdk.load_masp_params();
 
   if (sdkDataStr) {
     const sdkData = new TextEncoder().encode(sdkDataStr);

--- a/apps/extension/src/provider/Anoma.ts
+++ b/apps/extension/src/provider/Anoma.ts
@@ -9,6 +9,8 @@ import {
   SuggestChainMsg,
   EncodeInitAccountMsg,
   QueryAccountsMsg,
+  LoadMaspParamsMsg,
+  HasMaspParamsMsg,
   QueryBalancesMsg,
   SubmitBondMsg,
   SubmitUnbondMsg,
@@ -19,7 +21,7 @@ export class Anoma implements IAnoma {
   constructor(
     private readonly _version: string,
     protected readonly requester?: MessageRequester
-  ) { }
+  ) {}
 
   public async connect(chainId: string): Promise<void> {
     return await this.requester?.sendMessage(
@@ -48,6 +50,20 @@ export class Anoma implements IAnoma {
     return await this.requester?.sendMessage(
       Ports.Background,
       new QueryAccountsMsg(chainId)
+    );
+  }
+
+  public async fetchMaspParams(): Promise<void> {
+    return await this.requester?.sendMessage(
+      Ports.Background,
+      new LoadMaspParamsMsg()
+    );
+  }
+
+  public async hasMaspParams(): Promise<boolean | undefined> {
+    return await this.requester?.sendMessage(
+      Ports.Background,
+      new HasMaspParamsMsg()
     );
   }
 

--- a/apps/extension/src/provider/messages.ts
+++ b/apps/extension/src/provider/messages.ts
@@ -26,6 +26,8 @@ enum MessageType {
   SuggestChain = "suggest-chain",
   SubmitBond = "submit-bond",
   SubmitUnbond = "submit-unbond",
+  LoadMaspParams = "load-masp-params",
+  HasMaspParams = "has-masp-params",
 }
 
 /**
@@ -328,5 +330,39 @@ export class ApproveTransferMsg extends Message<void> {
 
   type(): string {
     return ApproveTransferMsg.type();
+  }
+}
+
+export class LoadMaspParamsMsg extends Message<void> {
+  public static type(): MessageType {
+    return MessageType.LoadMaspParams;
+  }
+  validate(): void {
+    return;
+  }
+
+  route(): string {
+    return Route.KeyRing;
+  }
+
+  type(): string {
+    return LoadMaspParamsMsg.type();
+  }
+}
+
+export class HasMaspParamsMsg extends Message<boolean> {
+  public static type(): MessageType {
+    return MessageType.HasMaspParams;
+  }
+  validate(): void {
+    return;
+  }
+
+  route(): string {
+    return Route.KeyRing;
+  }
+
+  type(): string {
+    return HasMaspParamsMsg.type();
   }
 }

--- a/packages/shared/lib/src/sdk/mod.rs
+++ b/packages/shared/lib/src/sdk/mod.rs
@@ -32,10 +32,21 @@ impl Sdk {
         }
     }
 
-    pub async fn fetch_masp_params(&mut self) -> Result<(), JsValue> {
-        let spend = fetch_and_store("masp-spend.params").await?;
-        let output = fetch_and_store("masp-output.params").await?;
-        let convert = fetch_and_store("masp-convert.params").await?;
+    pub async fn has_masp_params(&mut self) -> Result<JsValue, JsValue> {
+        let spend = has_masp_params("masp-spend.params").await?;
+        let output = has_masp_params("masp-output.params").await?;
+        let convert = has_masp_params("masp-output.params").await?;
+
+        let has =
+            spend.as_bool().unwrap() && output.as_bool().unwrap() && convert.as_bool().unwrap();
+
+        Ok(js_sys::Boolean::from(has).into())
+    }
+
+    pub async fn load_masp_params(&mut self) -> Result<(), JsValue> {
+        let spend = get_masp_params("masp-spend.params").await?;
+        let output = get_masp_params("masp-output.params").await?;
+        let convert = get_masp_params("masp-convert.params").await?;
 
         self.shielded_ctx =
             WebShieldedUtils::new(to_bytes(spend), to_bytes(output), to_bytes(convert));
@@ -117,6 +128,8 @@ impl Sdk {
 
 #[wasm_bindgen(module = "/src/sdk/mod.js")]
 extern "C" {
-    #[wasm_bindgen(catch, js_name = "fetchAndStore")]
-    async fn fetch_and_store(params: &str) -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(catch, js_name = "getMaspParams")]
+    async fn get_masp_params(params: &str) -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(catch, js_name = "hasMaspParams")]
+    async fn has_masp_params(params: &str) -> Result<JsValue, JsValue>;
 }


### PR DESCRIPTION
Resolves #293
Moved initialization of the masp params download into the extension app.
It should fix service worker initialization errors.
- [x] add HasMaspParamsMsg to check if params are already loaded
- [x] add LoadMaspParamsMsg to load the params
- [x] add spinner and status messages

In the next PRs:
- [x] Make loading async - we need to refactor sdk first as it might lead to "multiple mutable references" error #304
- [x] Figure out how to invalidate stored masp.params #303

Preview:
![fetch masp](https://github.com/anoma/namada-interface/assets/11858303/0df4e8b0-f661-4723-85a7-af1b7ab21194)
