### PR TITLE
use BigNumber for amounts + bug fixes

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -46,7 +46,7 @@
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.0.0",
     "styled-components": "^5.3.5",
-    "typescript": "^4.8.2",
+    "typescript": "^5.1.3",
     "uuid": "^9.0.0",
     "webextension-polyfill": "^0.10.0",
     "zxcvbn": "^4.4.2"

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -37,6 +37,7 @@
     "@ledgerhq/hw-transport-webhid": "^6.27.14",
     "@ledgerhq/hw-transport-webusb": "^6.27.14",
     "@zondax/ledger-namada": "^0.0.2",
+    "bignumber.js": "^9.1.1",
     "borsh": "^0.7.0",
     "buffer": "^6.0.3",
     "dompurify": "^3.0.2",

--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -2,6 +2,7 @@ import browser from "webextension-polyfill";
 import { fromBase64 } from "@cosmjs/encoding";
 import { deserialize } from "borsh";
 import { v4 as uuid } from "uuid";
+import BigNumber from "bignumber.js";
 
 import { SubmitTransferMsgSchema, TransferMsgValue } from "@anoma/types";
 import { amountFromMicro } from "@anoma/utils";
@@ -33,7 +34,7 @@ export class ApprovalsService {
       txMsgBuffer
     );
     const { source, target, token, amount: amountBN } = txDetails;
-    const amount = amountFromMicro(amountBN.toNumber());
+    const amount = amountFromMicro(new BigNumber(amountBN.toString()));
     const url = `${browser.runtime.getURL(
       "approvals.html"
     )}#/tx?id=${id}&source=${source}&target=${target}&token=${token}&amount=${amount}`;

--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -626,7 +626,7 @@ export class KeyRing {
 
   async queryBalances(
     address: string
-  ): Promise<{ token: string; amount: number }[]> {
+  ): Promise<{ token: string; amount: string }[]> {
     const account = await this._keyStore.getRecord("address", address);
     if (!account) {
       throw new Error(`Account not found.`);
@@ -636,7 +636,7 @@ export class KeyRing {
       ([token, amount]: [string, string]) => {
         return {
           token,
-          amount: Number.parseInt(amount),
+          amount,
         };
       }
     );

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -375,7 +375,7 @@ export class KeyRingService {
 
   async queryBalances(
     owner: string
-  ): Promise<{ token: string; amount: number }[]> {
+  ): Promise<{ token: string; amount: string }[]> {
     return this._keyRing.queryBalances(owner);
   }
 }

--- a/apps/extension/src/provider/Anoma.test.ts
+++ b/apps/extension/src/provider/Anoma.test.ts
@@ -2,6 +2,7 @@
 import { deepMock } from "mockzilla";
 import type { Browser } from "webextension-polyfill";
 import { toBase64 } from "@cosmjs/encoding";
+import BigNumber from "bignumber.js";
 
 import {
   AccountMsgSchema,
@@ -94,15 +95,15 @@ describe("Anoma", () => {
     const transferProps: TransferProps = {
       tx: {
         token,
-        feeAmount: 0,
-        gasLimit: 0,
+        feeAmount: new BigNumber(0),
+        gasLimit: new BigNumber(0),
         chainId: chain.chainId,
       },
       source: keyStore[0].address,
       target:
         "atest1d9khqw36gdz5ydzygvcnyvesxgcn2s6zxyung3zzgcmrjwzzgvmnyd3kxym52vzzg5unxve5cm87cr",
       token,
-      amount: 1000,
+      amount: new BigNumber(1000),
       nativeToken: token,
     };
 
@@ -130,15 +131,15 @@ describe("Anoma", () => {
     const transferProps: IbcTransferProps = {
       tx: {
         token,
-        feeAmount: 0,
-        gasLimit: 0,
+        feeAmount: new BigNumber(0),
+        gasLimit: new BigNumber(0),
         chainId: chain.chainId,
       },
       source: keyStore[0].address,
       receiver:
         "atest1d9khqw36gdz5ydzygvcnyvesxgcn2s6zxyung3zzgcmrjwzzgvmnyd3kxym52vzzg5unxve5cm87cr",
       token,
-      amount: 1000,
+      amount: new BigNumber(1000),
       portId: "transfer",
       channelId: "channel-0",
     };

--- a/apps/extension/src/provider/Anoma.ts
+++ b/apps/extension/src/provider/Anoma.ts
@@ -69,7 +69,7 @@ export class Anoma implements IAnoma {
 
   public async balances(
     owner: string
-  ): Promise<{ token: string; amount: number }[] | undefined> {
+  ): Promise<{ token: string; amount: string }[] | undefined> {
     return await this.requester?.sendMessage(
       Ports.Background,
       new QueryBalancesMsg(owner)

--- a/apps/extension/src/provider/InjectedAnoma.ts
+++ b/apps/extension/src/provider/InjectedAnoma.ts
@@ -38,10 +38,10 @@ export class InjectedAnoma implements IAnoma {
 
   public async balances(
     owner: string
-  ): Promise<{ token: string; amount: number }[]> {
+  ): Promise<{ token: string; amount: string }[]> {
     return await InjectedProxy.requestMethod<
       string,
-      { token: string; amount: number }[]
+      { token: string; amount: string }[]
     >("balances", owner);
   }
 

--- a/apps/extension/src/provider/messages.ts
+++ b/apps/extension/src/provider/messages.ts
@@ -156,7 +156,7 @@ export class QueryAccountsMsg extends Message<DerivedAccount[]> {
 export class QueryBalancesMsg extends Message<
   {
     token: string;
-    amount: number;
+    amount: string;
   }[]
 > {
   public static type(): MessageType {

--- a/apps/namada-interface/package.json
+++ b/apps/namada-interface/package.json
@@ -12,6 +12,7 @@
     "@anoma/integrations": "0.1.0",
     "@anoma/utils": "0.1.0",
     "@reduxjs/toolkit": "^1.8.0",
+    "bignumber.js": "^9.1.1",
     "buffer": "^6.0.3",
     "crypto-browserify": "^3.12.0",
     "dompurify": "^3.0.2",

--- a/apps/namada-interface/package.json
+++ b/apps/namada-interface/package.json
@@ -31,7 +31,7 @@
     "redux-thunk": "^2.4.1",
     "stream": "^0.0.2",
     "styled-components": "^5.3.3",
-    "typescript": "^4.5.5",
+    "typescript": "^5.1.3",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/apps/namada-interface/src/App/AccountOverview/AccountOverview.tsx
+++ b/apps/namada-interface/src/App/AccountOverview/AccountOverview.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import BigNumber from "bignumber.js";
 
 import { chains } from "@anoma/chains";
 import {
@@ -67,7 +68,7 @@ export const AccountOverview = (): JSX.Element => {
   const currentExtensionAttachStatus =
     extensionAttachStatus[chain.extension.id];
 
-  const [total, setTotal] = useState(0);
+  const [total, setTotal] = useState<BigNumber>(new BigNumber(0));
 
   const handleDownloadExtension = (url: string): void => {
     window.open(url, "_blank", "noopener,noreferrer");

--- a/apps/namada-interface/src/App/AccountOverview/AccountOverview.tsx
+++ b/apps/namada-interface/src/App/AccountOverview/AccountOverview.tsx
@@ -68,7 +68,7 @@ export const AccountOverview = (): JSX.Element => {
   const currentExtensionAttachStatus =
     extensionAttachStatus[chain.extension.id];
 
-  const [total, setTotal] = useState<BigNumber>(new BigNumber(0));
+  const [total, setTotal] = useState(new BigNumber(0));
 
   const handleDownloadExtension = (url: string): void => {
     window.open(url, "_blank", "noopener,noreferrer");

--- a/apps/namada-interface/src/App/AccountOverview/DerivedAccounts/DerivedAccounts.tsx
+++ b/apps/namada-interface/src/App/AccountOverview/DerivedAccounts/DerivedAccounts.tsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect, useState } from "react";
 import { ThemeContext } from "styled-components";
 import { useNavigate } from "react-router-dom";
+import BigNumber from "bignumber.js";
 
 import { chains } from "@anoma/chains";
 import { useAppDispatch, useAppSelector } from "store";
@@ -38,7 +39,7 @@ import { CoinsState, fetchConversionRates } from "slices/coins";
 import Config from "config";
 
 type Props = {
-  setTotal: (total: number) => void;
+  setTotal: (total: BigNumber) => void;
 };
 
 const assetIconByToken: Record<TokenType, { light: string; dark: string }> = {
@@ -86,21 +87,20 @@ const DerivedAccounts = ({ setTotal }: Props): JSX.Element => {
     setActiveAccountAddress(address === activeAccountAddress ? "" : address);
   };
 
-  const balanceToFiat = (balance: Balance): number => {
+  const balanceToFiat = (balance: Balance): BigNumber => {
     return Object.entries(balance).reduce((acc, [token, value]) => {
-      return (
-        acc +
+      return acc.plus(
         (rates[token] && rates[token][fiatCurrency]
-          ? value * rates[token][fiatCurrency].rate
+          ? value.multipliedBy(rates[token][fiatCurrency].rate)
           : value)
       );
-    }, 0);
+    }, new BigNumber(0));
   };
 
   useEffect(() => {
     const total = accounts.reduce((acc, { balance }) => {
-      return acc + balanceToFiat(balance);
-    }, 0);
+      return acc.plus(balanceToFiat(balance));
+    }, new BigNumber(0));
     setTotal(total);
     setActiveAccountAddress(accounts[0]?.details.address);
   }, [derived[chainId], chainId]);
@@ -174,7 +174,7 @@ const DerivedAccounts = ({ setTotal }: Props): JSX.Element => {
                                 );
                               }}
                             />
-                            {amount} {token}
+                            {amount.toString()} {token}
                           </TokenBalance>
                         );
                       })}

--- a/apps/namada-interface/src/App/Staking/NewBondingPosition/NewBondingPosition.tsx
+++ b/apps/namada-interface/src/App/Staking/NewBondingPosition/NewBondingPosition.tsx
@@ -1,4 +1,6 @@
 import { useState } from "react";
+import BigNumber from "bignumber.js";
+
 import {
   BondingPositionContainer,
   BondingAmountInputContainer,
@@ -66,8 +68,8 @@ export const NewBondingPosition = (props: Props): JSX.Element => {
   const currentBondingPosition = currentBondingPositions.find(
     (pos) => pos.owner === currentAccount?.details.address
   );
-  const stakedAmount = Number(currentBondingPosition?.stakedAmount || "0");
-  const currentNAMBalance = currentAccount.balance["NAM"] || 0;
+  const stakedAmount: BigNumber = new BigNumber(currentBondingPosition?.stakedAmount || "0");
+  const currentNAMBalance: BigNumber = currentAccount.balance["NAM"] || new BigNumber(0);
 
   const handleAddressChange = (
     e: React.ChangeEvent<HTMLSelectElement>
@@ -89,13 +91,13 @@ export const NewBondingPosition = (props: Props): JSX.Element => {
   // unbonding amount and displayed value with a very naive validation
   // TODO (https://github.com/anoma/namada-interface/issues/4#issuecomment-1260564499)
   // do proper validation as part of input
-  const amountToBondNumber = Number(amountToBond);
+  const amountToBondNumber: BigNumber = new BigNumber(amountToBond);
 
   // if this is the case, we display error message
   const isEntryIncorrect =
-    (amountToBond !== "" && amountToBondNumber <= 0) ||
-    amountToBondNumber > currentNAMBalance ||
-    Number.isNaN(amountToBondNumber);
+    (amountToBond !== "" && amountToBondNumber.isLessThanOrEqualTo(0)) ||
+    amountToBondNumber.isGreaterThan(currentNAMBalance) ||
+    amountToBondNumber.isNaN();
 
   // if incorrect or empty value we disable the button
   const isEntryIncorrectOrEmpty = isEntryIncorrect || amountToBond === "";
@@ -103,7 +105,7 @@ export const NewBondingPosition = (props: Props): JSX.Element => {
   // we convey this with an object that can be used
   const remainsBondedToDisplay = isEntryIncorrect
     ? `The bonding amount can be more than 0 and at most ${currentNAMBalance}`
-    : `${stakedAmount + amountToBondNumber}`;
+    : `${stakedAmount.plus(amountToBondNumber).toString()}`;
 
   // data for the table
   const bondingSummary = [

--- a/apps/namada-interface/src/App/Staking/NewBondingPosition/NewBondingPosition.tsx
+++ b/apps/namada-interface/src/App/Staking/NewBondingPosition/NewBondingPosition.tsx
@@ -91,7 +91,7 @@ export const NewBondingPosition = (props: Props): JSX.Element => {
   // unbonding amount and displayed value with a very naive validation
   // TODO (https://github.com/anoma/namada-interface/issues/4#issuecomment-1260564499)
   // do proper validation as part of input
-  const amountToBondNumber: BigNumber = new BigNumber(amountToBond);
+  const amountToBondNumber = new BigNumber(amountToBond);
 
   // if this is the case, we display error message
   const isEntryIncorrect =

--- a/apps/namada-interface/src/App/Staking/Staking.tsx
+++ b/apps/namada-interface/src/App/Staking/Staking.tsx
@@ -148,7 +148,7 @@ export const Staking = (props: Props): JSX.Element => {
       // triggers fetching of further details
       setBreadcrumb(newBreadcrumb);
     }
-  }, [location, JSON.stringify(breadcrumb)]);
+  }, [location.pathname, JSON.stringify(breadcrumb)]);
 
   const navigateToValidatorDetails = (validatorId: string): void => {
     navigate(

--- a/apps/namada-interface/src/App/Staking/StakingOverview/StakingOverview.tsx
+++ b/apps/namada-interface/src/App/Staking/StakingOverview/StakingOverview.tsx
@@ -1,3 +1,4 @@
+import BigNumber from "bignumber.js";
 import { Table, TableLink, TableConfigurations } from "@anoma/components";
 import { Account } from "slices/accounts";
 import { Validator, MyValidators } from "slices/StakingAndGovernance";
@@ -128,29 +129,29 @@ export const StakingOverview = (props: Props): JSX.Element => {
     navigateToValidatorDetails
   );
   const totalBonded = myValidators.reduce(
-    (acc, validator) => acc + Number(validator.stakedAmount),
-    0
+    (acc, validator) => acc.plus(validator.stakedAmount),
+    new BigNumber(0)
   );
   const totalBalance = accounts.reduce((acc, curr) => {
-    return acc + (curr.balance["NAM"] ?? 0);
-  }, 0);
+    return acc.plus(curr.balance["NAM"] ?? new BigNumber(0));
+  }, new BigNumber(0));
 
   return (
     <StakingOverviewContainer>
       {/* my balances */}
       <StakingBalances>
         <StakingBalancesLabel>Total Balance</StakingBalancesLabel>
-        <StakingBalancesValue>NAM {totalBalance}</StakingBalancesValue>
+        <StakingBalancesValue>NAM {totalBalance.toString()}</StakingBalancesValue>
 
         <StakingBalancesLabel>Total Bonded</StakingBalancesLabel>
-        <StakingBalancesValue>NAM {totalBonded}</StakingBalancesValue>
+        <StakingBalancesValue>NAM {totalBonded.toString()}</StakingBalancesValue>
 
         <StakingBalancesLabel>Pending Rewards</StakingBalancesLabel>
         <StakingBalancesValue>TBD</StakingBalancesValue>
 
         <StakingBalancesLabel>Available for bonding</StakingBalancesLabel>
         <StakingBalancesValue>
-          NAM {totalBalance - totalBonded}
+          NAM {totalBalance.minus(totalBonded).toString()}
         </StakingBalancesValue>
       </StakingBalances>
 

--- a/apps/namada-interface/src/App/Token/IBCTransfer/IBCTransfer.tsx
+++ b/apps/namada-interface/src/App/Token/IBCTransfer/IBCTransfer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import BigNumber from "bignumber.js";
 
 import { chains } from "@anoma/chains";
 import {
@@ -103,7 +104,7 @@ const IBCTransfer = (): JSX.Element => {
     label: channel,
   }));
 
-  const [amount, setAmount] = useState(0);
+  const [amount, setAmount] = useState<BigNumber>(new BigNumber(0));
   const [selectedChannelId, setSelectedChannelId] = useState("");
   const [showAddChannelForm, setShowAddChannelForm] = useState(false);
   const [channelId, setChannelId] = useState<string>();
@@ -386,13 +387,13 @@ const IBCTransfer = (): JSX.Element => {
             <Input
               variant={InputVariants.Number}
               label={"Amount"}
-              value={amount}
+              value={amount.toString()}
               onChangeCallback={(e) => {
                 const { value } = e.target;
-                setAmount(parseFloat(`${value}`));
+                setAmount(new BigNumber(`${value}`));
               }}
               onFocus={handleFocus}
-              error={amount <= currentBalance ? undefined : "Invalid amount!"}
+              error={amount.isLessThanOrEqualTo(currentBalance) ? undefined : "Invalid amount!"}
             />
           </InputContainer>
 
@@ -415,8 +416,8 @@ const IBCTransfer = (): JSX.Element => {
             <Button
               variant={ButtonVariant.Contained}
               disabled={
-                amount > currentBalance ||
-                amount === 0 ||
+                amount.isGreaterThan(currentBalance) ||
+                amount.isZero() ||
                 !recipient ||
                 isBridgeTransferSubmitting ||
                 !(destinationChain.bridgeType.indexOf(BridgeType.IBC) > -1

--- a/apps/namada-interface/src/schema/index.ts
+++ b/apps/namada-interface/src/schema/index.ts
@@ -3,7 +3,7 @@ import BN from "bn.js";
 export class TokenAmount {
   micro: BN;
   constructor(properties: { micro: BN }) {
-    this.micro = new BN(properties.micro, 64);
+    this.micro = new BN(properties.micro);
   }
 }
 

--- a/apps/namada-interface/src/slices/StakingAndGovernance/actions.ts
+++ b/apps/namada-interface/src/slices/StakingAndGovernance/actions.ts
@@ -1,4 +1,5 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
+import BigNumber from "bignumber.js";
 
 import { Query } from "@anoma/shared";
 import { amountToMicro } from "@anoma/utils";
@@ -28,7 +29,7 @@ const toValidator = ([address, votingPower]: [string, string]): Validator => ({
   name: address,
   // TODO: voting power is multiplied by votes_per_token value defined in genesis file
   // currently it is 10
-  votingPower: String(BigInt(votingPower) * BigInt(10)),
+  votingPower: (new BigNumber(votingPower)).multipliedBy(10).toString(),
   homepageUrl: "http://namada.net",
   commission: "TBD",
   description: "TBD",
@@ -48,15 +49,18 @@ const toMyValidators = (
           ...arr.slice(idx + 1),
         ];
 
+  const stakedAmount =
+    (new BigNumber(stake)).plus(new BigNumber(v?.stakedAmount || 0)).toString();
+
   return [
     ...sliceFn(acc, index),
     {
       uuid: validator,
       stakingStatus: "Bonded",
-      stakedAmount: String(Number(stake) + Number(v?.stakedAmount || 0)),
+      stakedAmount,
       validator: toValidator([
         validator,
-        String(Number(stake) + Number(v?.stakedAmount || 0)),
+        stakedAmount,
       ]),
     },
   ];
@@ -163,12 +167,12 @@ export const postNewBonding = createAsyncThunk<
   await signer.submitBond({
     source: change.owner,
     validator: change.validatorId,
-    amount: amountToMicro(Number(change.amount)),
+    amount: amountToMicro(new BigNumber(change.amount)),
     nativeToken: Tokens.NAM.address || "",
     tx: {
       token: Tokens.NAM.address || "",
-      feeAmount: 0,
-      gasLimit: 0,
+      feeAmount: new BigNumber(0),
+      gasLimit: new BigNumber(0),
       chainId,
     },
   });
@@ -190,11 +194,11 @@ export const postNewUnbonding = createAsyncThunk<
   await signer.submitUnbond({
     source: change.owner,
     validator: change.validatorId,
-    amount: amountToMicro(Number(change.amount)),
+    amount: amountToMicro(new BigNumber(change.amount)),
     tx: {
       token: Tokens.NAM.address || "",
-      feeAmount: 0,
-      gasLimit: 0,
+      feeAmount: new BigNumber(0),
+      gasLimit: new BigNumber(0),
       chainId,
     },
   });

--- a/apps/namada-interface/src/slices/accounts.ts
+++ b/apps/namada-interface/src/slices/accounts.ts
@@ -1,4 +1,5 @@
 import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
+import BigNumber from "bignumber.js";
 
 import { Account as AccountDetails, TokenType } from "@anoma/types";
 import { chains } from "@anoma/chains";
@@ -10,7 +11,7 @@ type ChainId = string;
 type Address = string;
 type Details = AccountDetails;
 
-export type Balance = Partial<Record<TokenType, number>>;
+export type Balance = Partial<Record<TokenType, BigNumber>>;
 export type Account = { details: Details; balance: Balance };
 
 export type AccountsState = {
@@ -56,7 +57,7 @@ export const fetchBalances = createAsyncThunk<
         const results = await integration.queryBalances(address);
 
         const balance = results.reduce(
-          (acc, curr) => ({ ...acc, [curr.token]: curr.amount }),
+          (acc, curr) => ({ ...acc, [curr.token]: new BigNumber(curr.amount) }),
           {} as Balance
         );
 
@@ -93,7 +94,7 @@ const accountsSlice = createSlice({
             isShielded,
           },
           balance: {
-            [currencySymbol]: 0,
+            [currencySymbol]: new BigNumber(0),
           },
         };
       });

--- a/apps/namada-interface/src/slices/transfers.ts
+++ b/apps/namada-interface/src/slices/transfers.ts
@@ -1,4 +1,5 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import BigNumber from "bignumber.js";
 
 import { Account, Tokens, TokenType, Signer } from "@anoma/types";
 import { amountToMicro } from "@anoma/utils";
@@ -115,10 +116,10 @@ type TxArgs = {
   account: Account;
   token: TokenType;
   target: string;
-  amount: number;
+  amount: BigNumber;
   memo?: string;
-  feeAmount?: number;
-  gasLimit?: number;
+  feeAmount?: BigNumber;
+  gasLimit?: BigNumber;
 };
 
 type TxTransferArgs = TxArgs & {
@@ -158,8 +159,8 @@ export const submitTransferTransaction = createAsyncThunk<
     await signer.submitTransfer({
       tx: {
         token: Tokens.NAM.address || "",
-        feeAmount: 0,
-        gasLimit: 0,
+        feeAmount: new BigNumber(0),
+        gasLimit: new BigNumber(0),
         chainId,
       },
       source: txTransferArgs.account.address,
@@ -191,8 +192,8 @@ export const submitIbcTransferTransaction = createAsyncThunk<
       ibcProps: {
         tx: {
           token: Tokens.NAM.address || "",
-          feeAmount: 0,
-          gasLimit: 0,
+          feeAmount: new BigNumber(0),
+          gasLimit: new BigNumber(0),
           chainId,
         },
         source: txIbcTransferArgs.account.address,
@@ -234,8 +235,8 @@ export const submitBridgeTransferTransaction = createAsyncThunk<
       bridgeProps: {
         tx: {
           token: Tokens.NAM.address || "",
-          feeAmount: 0,
-          gasLimit: 0,
+          feeAmount: new BigNumber(0),
+          gasLimit: new BigNumber(0),
           chainId,
         },
         source: txBridgeTransferArgs.account.address,

--- a/apps/namada-interface/src/store/mocks.ts
+++ b/apps/namada-interface/src/store/mocks.ts
@@ -1,3 +1,5 @@
+import BigNumber from "bignumber.js";
+
 import { RootState } from "./store";
 import { TransferType } from "slices/transfers";
 import { StakingOrUnstakingState } from "slices/StakingAndGovernance";
@@ -16,9 +18,9 @@ export const mockAppState: RootState = {
               isShielded: false,
             },
             balance: {
-              NAM: 1000,
-              ATOM: 1000,
-              ETH: 1000,
+              NAM: new BigNumber(1000),
+              ATOM: new BigNumber(1000),
+              ETH: new BigNumber(1000),
             },
           },
       },
@@ -32,9 +34,9 @@ export const mockAppState: RootState = {
             isShielded: false,
           },
           balance: {
-            NAM: 1000,
-            ATOM: 1000,
-            ETH: 1000,
+            NAM: new BigNumber(1000),
+            ATOM: new BigNumber(1000),
+            ETH: new BigNumber(1000),
           },
         },
       },
@@ -48,9 +50,9 @@ export const mockAppState: RootState = {
           },
 
           balance: {
-            NAM: 1000,
-            ATOM: 1000,
-            ETH: 1000,
+            NAM: new BigNumber(1000),
+            ATOM: new BigNumber(1000),
+            ETH: new BigNumber(1000),
           },
         },
       },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "borsh": "^0.7.0",
     "bs58": "^5.0.0",
     "buffer": "^6.0.3",
-    "typescript": "^4.5.5",
+    "typescript": "^5.1.3",
     "web-vitals": "^2.1.4"
   },
   "devDependencies": {

--- a/packages/chains/package.json
+++ b/packages/chains/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "typescript": "^4.9.3",
+    "typescript": "^5.1.3",
     "@anoma/types": "0.1.0"
   },
   "devDependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -16,7 +16,7 @@
     "@anoma/utils": "0.1.0",
     "react": "^17.0.2",
     "styled-components": "^5.3.5",
-    "typescript": "^4.8.3"
+    "typescript": "^5.1.3"
   },
   "devDependencies": {
     "@types/react": "^17.0.39",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -16,7 +16,7 @@
     "test-wasm:ci": "cd ./lib && cargo test"
   },
   "dependencies": {
-    "typescript": "^4.8.2"
+    "typescript": "^5.1.3"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.18.6",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -18,7 +18,7 @@
     "@anoma/types": "0.1.0",
     "@anoma/utils": "0.1.0",
     "react": "^17.0.2",
-    "typescript": "^4.8.3"
+    "typescript": "^5.1.3"
   },
   "devDependencies": {
     "@types/react": "^17.0.39",

--- a/packages/integrations/src/Anoma.ts
+++ b/packages/integrations/src/Anoma.ts
@@ -8,6 +8,7 @@ import {
   TokenBalance,
   WindowWithAnoma,
 } from "@anoma/types";
+import BigNumber from "bignumber.js";
 
 import { BridgeProps, Integration } from "./types/Integration";
 
@@ -57,8 +58,8 @@ export default class Anoma implements Integration<Account, Signer> {
         tx: {
           chainId: this.chain.chainId,
           token: Tokens.NAM.address || "",
-          feeAmount: 0,
-          gasLimit: 0,
+          feeAmount: new BigNumber(0),
+          gasLimit: new BigNumber(0),
         },
         source,
         receiver,
@@ -80,12 +81,15 @@ export default class Anoma implements Integration<Account, Signer> {
     const tokenBalances = Object.keys(Tokens).map((tokenType: string) => {
       const { address: tokenAddress = "" } = Tokens[tokenType as TokenType];
       const amount =
-        balance.find(({ token }) => token === tokenAddress)?.amount || 0;
+        balance.find(({ token }) => token === tokenAddress)?.amount || new BigNumber(0);
 
+      // TODO: Implement balance fetching via SDK
       return {
         token: tokenType as TokenType,
-        // TODO: Implement balance fetching via SDK
-        amount,
+        // BigNumber is converted to string because BigNumber methods are lost
+        // when a BigNumber is sent using postMessage.
+        // See https://github.com/MikeMcl/bignumber.js/issues/245.
+        amount: amount.toString(),
       };
     });
 

--- a/packages/integrations/src/Keplr.ts
+++ b/packages/integrations/src/Keplr.ts
@@ -152,7 +152,7 @@ class Keplr implements Integration<Account, OfflineSigner> {
       const response = await client.sendIbcTokens(
         source,
         receiver,
-        coin(amount, CosmosTokens[token]),
+        coin(amount.toString(), CosmosTokens[token]),
         portId,
         channelId,
         {
@@ -180,7 +180,7 @@ class Keplr implements Integration<Account, OfflineSigner> {
     // Query balance for ATOM:
     return ((await client.getAllBalances(owner)) || []).map((coin: Coin) => ({
       token: CosmosTokens[coin.denom] || "ATOM",
-      amount: parseInt(coin.amount),
+      amount: coin.amount,
     }));
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,7 +13,7 @@
     "test-wasm:ci": "cd ./lib && cargo test"
   },
   "dependencies": {
-    "typescript": "^4.8.2"
+    "typescript": "^5.1.3"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.18.6",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -13,7 +13,7 @@
     "lint:ci": "yarn lint --max-warnings 0"
   },
   "dependencies": {
-    "typescript": "^4.8.2"
+    "typescript": "^5.1.3"
   },
   "devDependencies": {
     "@types/firefox-webext-browser": "^94.0.1",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -16,7 +16,7 @@
     "bn.js": "^5.2.1",
     "borsh": "^0.7.0",
     "slip44": "^2.0.4",
-    "typescript": "^4.8.4"
+    "typescript": "^5.1.3"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.1",

--- a/packages/types/src/anoma.ts
+++ b/packages/types/src/anoma.ts
@@ -7,7 +7,7 @@ export interface Anoma {
   accounts(chainId: string): Promise<DerivedAccount[] | undefined>;
   balances(
     owner: string
-  ): Promise<{ token: string; amount: number }[] | undefined>;
+  ): Promise<{ token: string; amount: string }[] | undefined>;
   suggestChain(chainConfig: Chain): Promise<void>;
   chain: (chainId: string) => Promise<Chain | undefined>;
   chains: () => Promise<Chain[] | undefined>;

--- a/packages/types/src/tx/schema/account.ts
+++ b/packages/types/src/tx/schema/account.ts
@@ -1,19 +1,26 @@
+import { Schema } from "borsh";
+import { SchemaObject } from "@anoma/utils";
+
 import { InitAccountProps } from "../types";
 
 export class AccountMsgValue {
   vp_code: Uint8Array;
 
-  constructor(properties: InitAccountProps) {
-    this.vp_code = properties.vpCode;
+  constructor(properties: InitAccountProps | SchemaObject<typeof accountMsgSchemaEntry>) {
+    this.vp_code = 'vpCode' in properties ?
+      properties.vpCode :
+      properties.vp_code;
   }
 }
 
+const accountMsgSchemaEntry = [
+  AccountMsgValue,
+  {
+    kind: "struct",
+    fields: [["vp_code", ["u8"]]],
+  },
+] as const; // needed for SchemaObject to deduce types correctly
+
 export const AccountMsgSchema = new Map([
-  [
-    AccountMsgValue,
-    {
-      kind: "struct",
-      fields: [["vp_code", ["u8"]]],
-    },
-  ],
-]);
+  accountMsgSchemaEntry as [unknown, unknown]
+]) as Schema;

--- a/packages/types/src/tx/schema/bond.ts
+++ b/packages/types/src/tx/schema/bond.ts
@@ -13,7 +13,7 @@ export class SubmitBondMsgValue {
   constructor(properties: SubmitBondProps) {
     this.source = properties.source;
     this.validator = properties.validator;
-    this.amount = new BN(properties.amount.toString(), 64);
+    this.amount = new BN(properties.amount.toString());
     this.native_token = properties.nativeToken;
     this.tx = new TxMsgValue(properties.tx);
   }

--- a/packages/types/src/tx/schema/bond.ts
+++ b/packages/types/src/tx/schema/bond.ts
@@ -2,6 +2,7 @@ import BN from "bn.js";
 import { Schema } from "borsh";
 import { SubmitBondProps } from "../types";
 import { TxMsgSchema, TxMsgValue } from "./tx";
+import { SchemaObject } from "@anoma/utils";
 
 export class SubmitBondMsgValue {
   source: string;
@@ -10,16 +11,18 @@ export class SubmitBondMsgValue {
   native_token: string;
   tx: TxMsgValue;
 
-  constructor(properties: SubmitBondProps) {
+  constructor(properties: SubmitBondProps | SchemaObject<typeof BondMsgSchema>) {
     this.source = properties.source;
     this.validator = properties.validator;
     this.amount = new BN(properties.amount.toString());
-    this.native_token = properties.nativeToken;
+    this.native_token = "nativeToken" in properties ?
+      properties.nativeToken :
+      properties.native_token;
     this.tx = new TxMsgValue(properties.tx);
   }
 }
 
-export const BondMsgSchema: [unknown, unknown] = [
+export const BondMsgSchema = [
   SubmitBondMsgValue,
   {
     kind: "struct",
@@ -31,9 +34,9 @@ export const BondMsgSchema: [unknown, unknown] = [
       ["tx", TxMsgValue],
     ],
   },
-];
+] as const; // needed for SchemaObject to deduce types correctly
 
 export const SubmitBondMsgSchema = new Map([
-  TxMsgSchema,
-  BondMsgSchema,
+  TxMsgSchema as [unknown, unknown],
+  BondMsgSchema as [unknown, unknown],
 ]) as Schema;

--- a/packages/types/src/tx/schema/bond.ts
+++ b/packages/types/src/tx/schema/bond.ts
@@ -13,7 +13,7 @@ export class SubmitBondMsgValue {
   constructor(properties: SubmitBondProps) {
     this.source = properties.source;
     this.validator = properties.validator;
-    this.amount = new BN(properties.amount, 64);
+    this.amount = new BN(properties.amount.toString(), 64);
     this.native_token = properties.nativeToken;
     this.tx = new TxMsgValue(properties.tx);
   }

--- a/packages/types/src/tx/schema/ibcTransfer.ts
+++ b/packages/types/src/tx/schema/ibcTransfer.ts
@@ -17,10 +17,10 @@ export class IbcTransferMsgValue {
 
   constructor(properties: IbcTransferProps) {
     const timeoutHeight = properties.timeoutHeight
-      ? new BN(properties.timeoutHeight, 64)
+      ? new BN(properties.timeoutHeight)
       : undefined;
     const timeoutSecOffset = properties.timeoutSecOffset
-      ? new BN(properties.timeoutSecOffset, 64)
+      ? new BN(properties.timeoutSecOffset)
       : undefined;
 
     this.tx = new TxMsgValue(properties.tx);
@@ -28,7 +28,7 @@ export class IbcTransferMsgValue {
     this.receiver = properties.receiver;
     this.token = properties.token;
     this.sub_prefix = properties.subPrefix;
-    this.amount = new BN(properties.amount.toString(), 64);
+    this.amount = new BN(properties.amount.toString());
     this.port_id = properties.portId;
     this.channel_id = properties.channelId;
     this.timeout_height = timeoutHeight;

--- a/packages/types/src/tx/schema/ibcTransfer.ts
+++ b/packages/types/src/tx/schema/ibcTransfer.ts
@@ -2,6 +2,7 @@ import BN from "bn.js";
 import { Schema } from "borsh";
 import { IbcTransferProps } from "../types";
 import { TxMsgSchema, TxMsgValue } from "./tx";
+import { SchemaObject } from "@anoma/utils";
 
 export class IbcTransferMsgValue {
   tx: TxMsgValue;
@@ -15,28 +16,40 @@ export class IbcTransferMsgValue {
   timeout_height?: BN;
   timeout_sec_offset?: BN;
 
-  constructor(properties: IbcTransferProps) {
-    const timeoutHeight = properties.timeoutHeight
-      ? new BN(properties.timeoutHeight)
-      : undefined;
-    const timeoutSecOffset = properties.timeoutSecOffset
-      ? new BN(properties.timeoutSecOffset)
-      : undefined;
+  constructor(properties: IbcTransferProps | SchemaObject<typeof IbcTransferMsgSchema>) {
+    const timeoutHeight =
+      "timeoutHeight" in properties ? properties.timeoutHeight :
+        "timeout_height" in properties ? properties.timeout_height :
+          undefined;
+
+    const timeoutSecOffset =
+      "timeoutSecOffset" in properties ? properties.timeoutSecOffset :
+        "timeout_sec_offset" in properties ? properties.timeout_sec_offset :
+          undefined;
 
     this.tx = new TxMsgValue(properties.tx);
     this.source = properties.source;
     this.receiver = properties.receiver;
     this.token = properties.token;
-    this.sub_prefix = properties.subPrefix;
+    this.sub_prefix =
+      'subPrefix' in properties ? properties.subPrefix :
+        'sub_prefix' in properties ? properties.sub_prefix :
+          undefined;
     this.amount = new BN(properties.amount.toString());
-    this.port_id = properties.portId;
-    this.channel_id = properties.channelId;
-    this.timeout_height = timeoutHeight;
-    this.timeout_sec_offset = timeoutSecOffset;
+    this.port_id = 'portId' in properties ?
+      properties.portId :
+      properties.port_id;
+    this.channel_id = 'channelId' in properties ?
+      properties.channelId :
+      properties.channel_id;
+    this.timeout_height =
+      timeoutHeight !== undefined ? new BN(timeoutHeight) : undefined;
+    this.timeout_sec_offset =
+      timeoutSecOffset !== undefined ? new BN(timeoutSecOffset) : undefined;
   }
 }
 
-const IbcTransferMsgSchema: [unknown, unknown] = [
+const IbcTransferMsgSchema = [
   IbcTransferMsgValue,
   {
     kind: "struct",
@@ -53,9 +66,9 @@ const IbcTransferMsgSchema: [unknown, unknown] = [
       ["timeout_sec_offset", { kind: "option", type: "u64" }],
     ],
   },
-];
+] as const; // needed for SchemaObject to deduce types correctly
 
 export const SubmitIbcTransferMsgSchema = new Map([
   TxMsgSchema,
-  IbcTransferMsgSchema,
+  IbcTransferMsgSchema as [unknown, unknown],
 ]) as Schema;

--- a/packages/types/src/tx/schema/ibcTransfer.ts
+++ b/packages/types/src/tx/schema/ibcTransfer.ts
@@ -28,7 +28,7 @@ export class IbcTransferMsgValue {
     this.receiver = properties.receiver;
     this.token = properties.token;
     this.sub_prefix = properties.subPrefix;
-    this.amount = new BN(properties.amount, 64);
+    this.amount = new BN(properties.amount.toString(), 64);
     this.port_id = properties.portId;
     this.channel_id = properties.channelId;
     this.timeout_height = timeoutHeight;

--- a/packages/types/src/tx/schema/shielded.ts
+++ b/packages/types/src/tx/schema/shielded.ts
@@ -51,7 +51,7 @@ export class ShieldedDataMsgValue {
     this.vout = properties.vout;
     this.lock_time = new BN(properties.lockTime, 64);
     this.expiry_height = new BN(properties.expiryHeight, 64);
-    this.value_balance = new BN(properties.valueBalance, 64);
+    this.value_balance = new BN(properties.valueBalance.toString(), 64);
     this.shielded_spends = properties.shieldedSpends;
     this.shielded_converts = properties.shieldedConverts;
     this.shielded_outputs = properties.shieldedOutputs;

--- a/packages/types/src/tx/schema/shielded.ts
+++ b/packages/types/src/tx/schema/shielded.ts
@@ -49,9 +49,9 @@ export class ShieldedDataMsgValue {
     this.version_group_id = properties.versionGroupId;
     this.vin = properties.vin;
     this.vout = properties.vout;
-    this.lock_time = new BN(properties.lockTime, 64);
-    this.expiry_height = new BN(properties.expiryHeight, 64);
-    this.value_balance = new BN(properties.valueBalance.toString(), 64);
+    this.lock_time = new BN(properties.lockTime);
+    this.expiry_height = new BN(properties.expiryHeight);
+    this.value_balance = new BN(properties.valueBalance.toString());
     this.shielded_spends = properties.shieldedSpends;
     this.shielded_converts = properties.shieldedConverts;
     this.shielded_outputs = properties.shieldedOutputs;

--- a/packages/types/src/tx/schema/transfer.ts
+++ b/packages/types/src/tx/schema/transfer.ts
@@ -18,7 +18,7 @@ export class TransferMsgValue {
     this.target = properties.target;
     this.token = properties.token;
     this.sub_prefix = properties.subPrefix;
-    this.amount = new BN(properties.amount.toString(), 64);
+    this.amount = new BN(properties.amount.toString());
     this.native_token = properties.nativeToken;
   }
 }

--- a/packages/types/src/tx/schema/transfer.ts
+++ b/packages/types/src/tx/schema/transfer.ts
@@ -18,7 +18,7 @@ export class TransferMsgValue {
     this.target = properties.target;
     this.token = properties.token;
     this.sub_prefix = properties.subPrefix;
-    this.amount = new BN(properties.amount, 64);
+    this.amount = new BN(properties.amount.toString(), 64);
     this.native_token = properties.nativeToken;
   }
 }

--- a/packages/types/src/tx/schema/tx.ts
+++ b/packages/types/src/tx/schema/tx.ts
@@ -9,8 +9,8 @@ export class TxMsgValue {
 
   constructor(properties: TxProps) {
     this.token = properties.token;
-    this.fee_amount = new BN(properties.feeAmount, 64);
-    this.gas_limit = new BN(properties.gasLimit, 64);
+    this.fee_amount = new BN(properties.feeAmount.toString(), 64);
+    this.gas_limit = new BN(properties.gasLimit.toString(), 64);
     this.chain_id = properties.chainId;
   }
 }

--- a/packages/types/src/tx/schema/tx.ts
+++ b/packages/types/src/tx/schema/tx.ts
@@ -9,8 +9,8 @@ export class TxMsgValue {
 
   constructor(properties: TxProps) {
     this.token = properties.token;
-    this.fee_amount = new BN(properties.feeAmount.toString(), 64);
-    this.gas_limit = new BN(properties.gasLimit.toString(), 64);
+    this.fee_amount = new BN(properties.feeAmount.toString());
+    this.gas_limit = new BN(properties.gasLimit.toString());
     this.chain_id = properties.chainId;
   }
 }

--- a/packages/types/src/tx/schema/tx.ts
+++ b/packages/types/src/tx/schema/tx.ts
@@ -1,5 +1,6 @@
 import BN from "bn.js";
 import { TxProps } from "../types";
+import { SchemaObject } from "@anoma/utils";
 
 export class TxMsgValue {
   token: string;
@@ -7,15 +8,21 @@ export class TxMsgValue {
   gas_limit: BN;
   chain_id: string;
 
-  constructor(properties: TxProps) {
+  constructor(properties: TxProps | SchemaObject<typeof TxMsgSchema>) {
     this.token = properties.token;
-    this.fee_amount = new BN(properties.feeAmount.toString());
-    this.gas_limit = new BN(properties.gasLimit.toString());
-    this.chain_id = properties.chainId;
+    this.fee_amount = 'feeAmount' in properties ?
+      new BN(properties.feeAmount.toString()) :
+      properties.fee_amount;
+    this.gas_limit = 'gasLimit' in properties ?
+      new BN(properties.gasLimit.toString()) :
+      properties.gas_limit;
+    this.chain_id = 'chainId' in properties ?
+      properties.chainId :
+      properties.chain_id;
   }
 }
 
-export const TxMsgSchema: [unknown, unknown] = [
+export const TxMsgSchema = [
   TxMsgValue,
   {
     kind: "struct",
@@ -26,4 +33,4 @@ export const TxMsgSchema: [unknown, unknown] = [
       ["chain_id", "string"],
     ],
   },
-];
+] as const; // needed for SchemaObject to deduce types correctly

--- a/packages/types/src/tx/schema/unbond.ts
+++ b/packages/types/src/tx/schema/unbond.ts
@@ -12,7 +12,7 @@ export class SubmitUnbondMsgValue {
   constructor(properties: SubmitUnbondProps) {
     this.source = properties.source;
     this.validator = properties.validator;
-    this.amount = new BN(properties.amount, 64);
+    this.amount = new BN(properties.amount.toString(), 64);
     this.tx = new TxMsgValue(properties.tx);
   }
 }

--- a/packages/types/src/tx/schema/unbond.ts
+++ b/packages/types/src/tx/schema/unbond.ts
@@ -12,7 +12,7 @@ export class SubmitUnbondMsgValue {
   constructor(properties: SubmitUnbondProps) {
     this.source = properties.source;
     this.validator = properties.validator;
-    this.amount = new BN(properties.amount.toString(), 64);
+    this.amount = new BN(properties.amount.toString());
     this.tx = new TxMsgValue(properties.tx);
   }
 }

--- a/packages/types/src/tx/schema/unbond.ts
+++ b/packages/types/src/tx/schema/unbond.ts
@@ -2,6 +2,7 @@ import BN from "bn.js";
 import { Schema } from "borsh";
 import { SubmitUnbondProps } from "../types";
 import { TxMsgSchema, TxMsgValue } from "./tx";
+import { SchemaObject } from "@anoma/utils";
 
 export class SubmitUnbondMsgValue {
   source: string;
@@ -9,7 +10,7 @@ export class SubmitUnbondMsgValue {
   amount: BN;
   tx: TxMsgValue;
 
-  constructor(properties: SubmitUnbondProps) {
+  constructor(properties: SubmitUnbondProps | SchemaObject<typeof UnbondMsgSchema>) {
     this.source = properties.source;
     this.validator = properties.validator;
     this.amount = new BN(properties.amount.toString());
@@ -17,7 +18,7 @@ export class SubmitUnbondMsgValue {
   }
 }
 
-export const UnbondMsgSchema: [unknown, unknown] = [
+export const UnbondMsgSchema = [
   SubmitUnbondMsgValue,
   {
     kind: "struct",
@@ -28,9 +29,9 @@ export const UnbondMsgSchema: [unknown, unknown] = [
       ["tx", TxMsgValue],
     ],
   },
-];
+] as const; // needed for SchemaObject to deduce types correctly
 
 export const SubmitUnbondMsgSchema = new Map([
-  TxMsgSchema,
-  UnbondMsgSchema,
+  TxMsgSchema as [unknown, unknown],
+  UnbondMsgSchema as [unknown, unknown],
 ]) as Schema;

--- a/packages/types/src/tx/tokens/types/index.ts
+++ b/packages/types/src/tx/tokens/types/index.ts
@@ -53,4 +53,4 @@ Tokens["ETH"].address =
   "atest1v4ehgw36xqmr2d3nx3ryvd2xxgmrq33j8qcns33sxezrgv6zxdzrydjrxveygd2yxumrsdpsf9jc2p";
 Tokens["ETH"].coinGeckoId = "ethereum";
 
-export type TokenBalance = { token: TokenType; amount: number };
+export type TokenBalance = { token: TokenType; amount: string };

--- a/packages/types/src/tx/types.ts
+++ b/packages/types/src/tx/types.ts
@@ -1,6 +1,8 @@
+import BigNumber from "bignumber.js";
+
 export type SubmitBondProps = {
   validator: string;
-  amount: number;
+  amount: BigNumber;
   source: string;
   nativeToken: string;
   tx: TxProps;
@@ -8,15 +10,15 @@ export type SubmitBondProps = {
 
 export type SubmitUnbondProps = {
   validator: string;
-  amount: number;
+  amount: BigNumber;
   source: string;
   tx: TxProps;
 };
 
 export type TxProps = {
   token: string;
-  feeAmount: number;
-  gasLimit: number;
+  feeAmount: BigNumber;
+  gasLimit: BigNumber;
   chainId: string;
 };
 
@@ -26,7 +28,7 @@ export type TransferProps = {
   target: string;
   token: string;
   subPrefix?: string;
-  amount: number;
+  amount: BigNumber;
   nativeToken: string;
 };
 
@@ -36,7 +38,7 @@ export type IbcTransferProps = {
   receiver: string;
   token: string;
   subPrefix?: string;
-  amount: number;
+  amount: BigNumber;
   portId: string;
   channelId: string;
   timeoutHeight?: number;
@@ -49,7 +51,7 @@ export type BridgeTransferProps = {
   source: string;
   target: string;
   token: string;
-  amount: number;
+  amount: BigNumber;
 };
 
 export type InitAccountProps = {
@@ -64,7 +66,7 @@ export type ShieldedDataProps = {
   vout: Uint8Array;
   lockTime: number;
   expiryHeight: number;
-  valueBalance: number;
+  valueBalance: BigNumber;
   shieldedSpends: Uint8Array;
   shieldedConverts: Uint8Array;
   shieldedOutputs: Uint8Array;

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -33,6 +33,6 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-typescript": "^3.5.0",
     "eslint-plugin-import": "^2.26.0",
-    "typescript": "^4.7.4"
+    "typescript": "^5.1.3"
   }
 }

--- a/packages/utils/src/helpers/index.ts
+++ b/packages/utils/src/helpers/index.ts
@@ -2,6 +2,7 @@ import { JsonRpcRequest } from "@cosmjs/json-rpc";
 import { DateTime } from "luxon";
 import { JsonCompatibleArray, JsonCompatibleDictionary } from "@anoma/types";
 import BigNumber from "bignumber.js";
+import BN from "bn.js";
 
 const MICRO_FACTOR = 1000000; // 1,000,000
 
@@ -172,3 +173,70 @@ export const Result = {
     return { ok: false as const, error };
   },
 };
+
+
+// Translates Borsh type to JS type
+type FromBorsh<T> =
+  T extends "u8" | "u16" | "u32" ? number :
+  T extends "u64" | "u128" | "u256" | "u512" ? BN :
+  T extends "string" ? string :
+  T extends { kind: "option", type: infer S } ? FromBorsh<S> :
+  T extends new(...args: infer _) => infer Res ? Res :
+  T extends readonly unknown[] ? Uint8Array :
+  unknown;
+
+// Gets first element of a tuple pair
+type Key<T> =
+  T extends readonly [infer Key, unknown] ? Key : never;
+
+// Gets second element of a tuple pair
+type Value<T> =
+  T extends readonly [unknown, infer Value] ? Value : never;
+
+/**
+ * Turns a Borsh schema value into a type with fields translated from
+ * Borsh types to JS types.
+ *
+ * Useful when deserializing for making sure the object passed by
+ * Borsh to a constructor is properly typed. Without this, there is no
+ * guarantee that the object the constructor expects will match what
+ * Borsh passes to it as an argument.
+ *
+ * Usage:
+ *
+ *     class TxMsgValue {
+ *
+ *       constructor(args: SchemaObject<typeof TxMsgSchema>) {  // note use of typeof
+ *         args.token      // : string
+ *         args.fee_amount // : BN
+ *         ...
+ *       }
+ *     }
+ *
+ *     // schema value must match the following form:
+ *     const TxMsgSchema = [
+ *       TxMsgValue,
+ *       {
+ *         kind: "struct",
+ *         fields: [
+ *           ["token", "string"],
+ *           ["fee_amount", "u64"],
+ *           ["gas_limit", "u64"],
+ *           ["chain_id", "string"],
+ *         ],
+ *       },
+ *     ] as const; // as const needed for typeof to deduce types correctly
+ */
+export type SchemaObject<T> =
+  T extends readonly [unknown, { kind: "struct", fields: infer Fields }] ?
+    Fields extends readonly (infer FieldEntry extends (readonly [string, unknown]))[] ?
+      {
+        // optional types need special handling to add the '?' suffix to their keys
+        [KV in FieldEntry as Value<KV> extends { kind: "option" } ? Key<KV> : never]?:
+          Value<KV> extends { type: infer S } ? FromBorsh<S> : unknown;
+      } & {
+        [KV in FieldEntry as Value<KV> extends { kind: "option" } ? never : Key<KV>]:
+          FromBorsh<Value<KV>>;
+      } :
+      never :
+    never;

--- a/packages/utils/src/helpers/index.ts
+++ b/packages/utils/src/helpers/index.ts
@@ -1,21 +1,22 @@
 import { JsonRpcRequest } from "@cosmjs/json-rpc";
 import { DateTime } from "luxon";
 import { JsonCompatibleArray, JsonCompatibleDictionary } from "@anoma/types";
+import BigNumber from "bignumber.js";
 
 const MICRO_FACTOR = 1000000; // 1,000,000
 
 /**
  * Amount to Micro
  */
-export const amountToMicro = (amount: number): number => {
-  return amount * MICRO_FACTOR;
+export const amountToMicro = (amount: BigNumber): BigNumber => {
+  return amount.multipliedBy(MICRO_FACTOR);
 };
 
 /**
  * Amount from Micro
  */
-export const amountFromMicro = (micro: number): number => {
-  return micro / MICRO_FACTOR;
+export const amountFromMicro = (micro: BigNumber): BigNumber => {
+  return micro.dividedBy(MICRO_FACTOR);
 };
 
 /**
@@ -77,18 +78,29 @@ export const getParams = (
 };
 
 /**
- * Format by currency using the user's locale
+ * Format by currency using the user's locale.
+ * Returns null if the value cannot fit in a number primitive.
  * @param currency
  * @param value
  * @returns {string}
  */
-export const formatCurrency = (currency = "USD", value = 0): string => {
-  const formatter = Intl.NumberFormat(undefined, {
-    style: "currency",
-    currency,
-  });
+export const formatCurrency = (
+  currency = "USD",
+  value: BigNumber = new BigNumber(0)
+): string | null => {
+  // only allow -1 * Number.MAX_VALUE <= value <= Number.MAX_VALUE
+  if (value.absoluteValue().isGreaterThan(Number.MAX_VALUE)) {
+    return null;
+  } else {
+    const asNumber = value.toNumber();
 
-  return formatter.format(value);
+    const formatter = Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency,
+    });
+
+    return formatter.format(asNumber);
+  }
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -6702,6 +6702,11 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
+bignumber.js@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.1.tgz#c4df7dc496bd849d4c9464344c1aa74228b4dac6"
+  integrity sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==
+
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16774,35 +16774,10 @@ typescript-plugin-styled-components@^2.0.0:
   resolved "https://registry.yarnpkg.com/typescript-plugin-styled-components/-/typescript-plugin-styled-components-2.0.0.tgz#97e94187cca0f3058c6ad8fefffbca6766c56123"
   integrity sha512-Wu7F96dwuphgiACHfu63vTbRRg6tkPwLnpFJwdxM70Y0PLfeKLRnvs2Yo5MAySMwE120ODMKk9W4TtJgY1ZumA==
 
-typescript@^4.5.5:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
-  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
-
-typescript@^4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
-
-typescript@^4.8.2:
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
-  integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==
-
-typescript@^4.8.3:
-  version "4.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.3.tgz#d59344522c4bc464a65a730ac695007fdb66dd88"
-  integrity sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==
-
-typescript@^4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
-
-typescript@^4.9.3:
-  version "4.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
-  integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==
+typescript@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.3.tgz#8d84219244a6b40b6fb2b33cc1c062f715b9e826"
+  integrity sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==
 
 typeson-registry@^1.0.0-alpha.20:
   version "1.0.0-alpha.39"


### PR DESCRIPTION
- fix: use BigNumber for representing amounts
  
  - This is needed to avoid problems with base 2 floating point arithmetic (e.g. 0.1 + 0.2 = 0.30000000000000004) and to allow us to represent very big numbers without overflow.
  
- fix: use base 10 instead of base 64 for BNs
  
- chore: bump typescript to ^5.1.3
  
- fix: deserialize based on schema fields
  
  - This fixes a bug where calls to Borsh's deserialize function were silently failing to deserialize some fields. This is because the constructor functions passed to deserialize expected camelCase keys but the schemas are written with snake_case keys.
  
  - This fix generates the constructor parameter type from the associated schema value, so constructors should be well-typed for the objects passed in as arguments by Borsh.
