### PR TITLE
feat/264 - Handle third-party extension events

### DIFF
--- a/apps/namada-interface/src/services/extensionEvents/handlers/keplr.ts
+++ b/apps/namada-interface/src/services/extensionEvents/handlers/keplr.ts
@@ -1,22 +1,16 @@
 import { Dispatch } from "react";
 
-import { chains } from "@anoma/chains";
 import { Keplr } from "@anoma/integrations";
 
 import { addAccounts, fetchBalances } from "slices/accounts";
 
 export const KeplrAccountChangedHandler =
-  (dispatch: Dispatch<unknown>, integration: Keplr) =>
-  async (event: CustomEventInit) => {
-    const chainId = event.detail?.chainId;
-    const chain = chains[chainId];
+  (dispatch: Dispatch<unknown>, integration: Keplr) => async () => {
+    const accounts = await integration.accounts();
+    console.log("KEPLR accounts", { accounts });
 
-    if (chain.extension.id === "keplr") {
-      const accounts = await integration.accounts();
-
-      if (accounts) {
-        dispatch(addAccounts(accounts));
-        dispatch(fetchBalances());
-      }
+    if (accounts) {
+      dispatch(addAccounts(accounts));
+      dispatch(fetchBalances());
     }
   };

--- a/apps/namada-interface/src/services/extensionEvents/handlers/keplr.ts
+++ b/apps/namada-interface/src/services/extensionEvents/handlers/keplr.ts
@@ -7,7 +7,6 @@ import { addAccounts, fetchBalances } from "slices/accounts";
 export const KeplrAccountChangedHandler =
   (dispatch: Dispatch<unknown>, integration: Keplr) => async () => {
     const accounts = await integration.accounts();
-    console.log("KEPLR accounts", { accounts });
 
     if (accounts) {
       dispatch(addAccounts(accounts));

--- a/apps/namada-interface/src/services/extensionEvents/handlers/metamask.ts
+++ b/apps/namada-interface/src/services/extensionEvents/handlers/metamask.ts
@@ -1,22 +1,13 @@
 import { Dispatch } from "react";
-
-import { chains } from "@anoma/chains";
 import { Metamask } from "@anoma/integrations";
-
 import { addAccounts, fetchBalances } from "slices/accounts";
 
 export const MetamaskAccountChangedHandler =
-  (dispatch: Dispatch<unknown>, integration: Metamask) =>
-  async (event: CustomEventInit) => {
-    const chainId = event.detail?.chainId;
-    const chain = chains[chainId];
+  (dispatch: Dispatch<unknown>, integration: Metamask) => async () => {
+    const accounts = await integration.accounts();
 
-    if (chain.extension.id === "metamask") {
-      const accounts = await integration.accounts();
-
-      if (accounts) {
-        dispatch(addAccounts(accounts));
-        dispatch(fetchBalances());
-      }
+    if (accounts) {
+      dispatch(addAccounts(accounts));
+      dispatch(fetchBalances());
     }
   };

--- a/apps/namada-interface/src/services/extensionEvents/provider.tsx
+++ b/apps/namada-interface/src/services/extensionEvents/provider.tsx
@@ -54,10 +54,11 @@ export const ExtensionEventsProvider: React.FC = (props): JSX.Element => {
   useEventListenerOnce(Events.TransferCompleted, anomaTransferCompletedHandler);
   useEventListenerOnce(Events.UpdatedBalances, anomaUpdatedBalancesHandler);
   useEventListenerOnce(KeplrEvents.AccountChanged, keplrAccountChangedHandler);
-  // TODO: This should be bound to window.ethereum:
   useEventListenerOnce(
     MetamaskEvents.AccountChanged,
-    metamaskAccountChangedHandler
+    metamaskAccountChangedHandler,
+    false,
+    true
   );
 
   return (

--- a/apps/namada-interface/src/services/extensionEvents/provider.tsx
+++ b/apps/namada-interface/src/services/extensionEvents/provider.tsx
@@ -58,7 +58,12 @@ export const ExtensionEventsProvider: React.FC = (props): JSX.Element => {
     MetamaskEvents.AccountChanged,
     metamaskAccountChangedHandler,
     false,
-    true
+    (event, handler) => {
+      window.ethereum.on(event, handler);
+    },
+    (event, handler) => {
+      window.ethereum.removeListener(event, handler);
+    }
   );
 
   return (

--- a/apps/namada-interface/src/services/extensionEvents/provider.tsx
+++ b/apps/namada-interface/src/services/extensionEvents/provider.tsx
@@ -1,8 +1,8 @@
 import { createContext } from "react";
 
 import { Events } from "@anoma/types";
-import { defaultChainId } from "@anoma/chains";
-import { Anoma } from "@anoma/integrations";
+import { chains, defaultChainId } from "@anoma/chains";
+import { Anoma, Keplr } from "@anoma/integrations";
 import { useEventListenerOnce, useIntegration } from "@anoma/hooks";
 
 import { useAppDispatch } from "store";
@@ -12,12 +12,15 @@ import {
   AnomaTransferStartedHandler,
   AnomaUpdatedBalancesHandler,
 } from "./handlers/anoma";
+import { KeplrAccountChangedHandler } from "./handlers";
 
 export const ExtensionEventsContext = createContext({});
 
 export const ExtensionEventsProvider: React.FC = (props): JSX.Element => {
   const dispatch = useAppDispatch();
   const anomaIntegration = useIntegration(defaultChainId);
+  // TODO: Don't hardcode chain id here!
+  const keplrIntegration = useIntegration("cosmoshub-4");
 
   // Instantiate handlers:
   const anomaAccountChangedHandler = AnomaAccountChangedHandler(
@@ -26,14 +29,20 @@ export const ExtensionEventsProvider: React.FC = (props): JSX.Element => {
   );
   const anomaTransferStartedHandler = AnomaTransferStartedHandler(dispatch);
   const anomaTransferCompletedHandler = AnomaTransferCompletedHandler(dispatch);
-
   const anomaUpdatedBalancesHandler = AnomaUpdatedBalancesHandler(dispatch);
+
+  // Keplr handlers
+  const keplrAccountChangedHandler = KeplrAccountChangedHandler(
+    dispatch,
+    keplrIntegration as Keplr
+  );
 
   // Register handlers:
   useEventListenerOnce(Events.AccountChanged, anomaAccountChangedHandler);
   useEventListenerOnce(Events.TransferStarted, anomaTransferStartedHandler);
   useEventListenerOnce(Events.TransferCompleted, anomaTransferCompletedHandler);
   useEventListenerOnce(Events.UpdatedBalances, anomaUpdatedBalancesHandler);
+  useEventListenerOnce("keplr_keystorechange", keplrAccountChangedHandler);
 
   return (
     <ExtensionEventsContext.Provider value={{}}>

--- a/packages/chains/src/index.ts
+++ b/packages/chains/src/index.ts
@@ -3,6 +3,8 @@ import namada from "./chains/namada";
 import ethereum from "./chains/ethereum";
 
 export const defaultChainId = namada.chainId;
+export const defaultCosmosChainId = cosmos.chainId;
+export const defaultEthereumChainId = ethereum.chainId;
 
 export const chains = {
   [cosmos.chainId]: cosmos,

--- a/packages/hooks/src/useEvent.ts
+++ b/packages/hooks/src/useEvent.ts
@@ -4,12 +4,18 @@ export const useEventListener = (
   event: string,
   handler: (e: CustomEventInit) => void,
   deps?: React.DependencyList,
-  useCapture = false
+  useCapture = false,
+  isEthereumEvent = false
 ): void => {
   useEffect(() => {
-    window.addEventListener(event, handler, useCapture);
+    isEthereumEvent
+      ? window.ethereum.on(event, handler)
+      : window.addEventListener(event, handler, useCapture);
 
     return () => {
+      if (isEthereumEvent) {
+        return window.ethereum.removeListener(event, handler);
+      }
       window.removeEventListener(event, handler);
     };
   }, deps);
@@ -18,7 +24,8 @@ export const useEventListener = (
 export const useEventListenerOnce = (
   event: string,
   handler: (e: CustomEventInit) => void,
-  useCapture = false
+  useCapture = false,
+  isEthereumEvent = false
 ): void => {
-  useEventListener(event, handler, [], useCapture);
+  useEventListener(event, handler, [], useCapture, isEthereumEvent);
 };

--- a/packages/hooks/src/useEvent.ts
+++ b/packages/hooks/src/useEvent.ts
@@ -1,20 +1,24 @@
 import { useEffect } from "react";
 
+type EventHandler = (e: CustomEventInit) => void;
+type EventCallback = (event: string, handler: EventHandler) => void;
+
 export const useEventListener = (
   event: string,
-  handler: (e: CustomEventInit) => void,
+  handler: EventHandler,
   deps?: React.DependencyList,
   useCapture = false,
-  isEthereumEvent = false
+  registerCallback?: EventCallback,
+  removeCallback?: EventCallback
 ): void => {
   useEffect(() => {
-    isEthereumEvent
-      ? window.ethereum.on(event, handler)
+    registerCallback
+      ? registerCallback(event, handler)
       : window.addEventListener(event, handler, useCapture);
 
     return () => {
-      if (isEthereumEvent) {
-        return window.ethereum.removeListener(event, handler);
+      if (removeCallback) {
+        return removeCallback(event, handler);
       }
       window.removeEventListener(event, handler);
     };
@@ -23,9 +27,17 @@ export const useEventListener = (
 
 export const useEventListenerOnce = (
   event: string,
-  handler: (e: CustomEventInit) => void,
+  handler: EventHandler,
   useCapture = false,
-  isEthereumEvent = false
+  registerCallback?: EventCallback,
+  removeCallback?: EventCallback
 ): void => {
-  useEventListener(event, handler, [], useCapture, isEthereumEvent);
+  useEventListener(
+    event,
+    handler,
+    [],
+    useCapture,
+    registerCallback,
+    removeCallback
+  );
 };

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -16,5 +16,4 @@ export enum KeplrEvents {
 // Metamask extension window.ethereum events
 export enum MetamaskEvents {
   AccountChanged = "accountsChanged",
-  NetworkChanged = "networkChanged",
 }

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -1,8 +1,20 @@
 // Constants defining events which may be subscribed to
 
+// Anoma extension events
 export enum Events {
   AccountChanged = "anoma-account-changed",
   TransferStarted = "anoma-transfer-started",
   TransferCompleted = "anoma-transfer-completed",
   UpdatedBalances = "anoma-updated-balances",
+}
+
+// Keplr extension events
+export enum KeplrEvents {
+  AccountChanged = "keplr_keystorechange",
+}
+
+// Metamask extension window.ethereum events
+export enum MetamaskEvents {
+  AccountChanged = "accountsChanged",
+  NetworkChanged = "networkChanged",
 }


### PR DESCRIPTION
Resolves #264 

- [x] Interface responds to Keplr account changes
- [x] Interface responds to Metamask account changes

## Testing

### Keplr

- Add a second (or more) account(s) in Keplr
- In Namada interface, select "Cosmos Hub", and make sure extension is connected
- In Keplr, select a different account, and the interface should reflect this

### Metamask

- Make sure you have more than one account in Metamask
- In Namada Interface, select "Goerli Testnet"
- In Metamask, in the "accounts" menu (icon at top-right) select a different account (_NOTE_ If this is a _new_ account, you will need to first click "connect" on the account name) and the interface should update the address

## TODO

- There is a display bug that has been introduced somewhere in the interface, where the listing of the Ethereum asset is broken (only the address displays) - This will be updated in a separate PR if I don't figure it out quickly