### PR TITLE
Fix up staking

### DIFF
--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -646,6 +646,18 @@ export class KeyRing {
     }
   }
 
+  async submitWithdraw(txMsg: Uint8Array): Promise<void> {
+    if (!this._password) {
+      throw new Error("Not authenticated!");
+    }
+
+    try {
+      await this.sdk.submit_withdraw(txMsg, this._password);
+    } catch (e) {
+      throw new Error(`Could not submit withdraw tx: ${e}`);
+    }
+  }
+
   async submitTransfer(
     txMsg: Uint8Array,
     submit: (password: string, xsk?: string) => Promise<void>

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -207,6 +207,15 @@ export class KeyRingService {
     }
   }
 
+  async submitWithdraw(txMsg: string): Promise<void> {
+    try {
+      await this._keyRing.submitWithdraw(fromBase64(txMsg));
+    } catch (e) {
+      console.warn(e);
+      throw new Error(`Unable to submit withdraw tx! ${e}`);
+    }
+  }
+
   private async submitTransferChrome(
     txMsg: string,
     msgId: string,

--- a/apps/extension/src/provider/InjectedNamada.ts
+++ b/apps/extension/src/provider/InjectedNamada.ts
@@ -73,6 +73,13 @@ export class InjectedNamada implements INamada {
     );
   }
 
+  public async submitWithdraw(txMsg: string): Promise<void> {
+    return await InjectedProxy.requestMethod<string, void>(
+      "submitWithdraw",
+      txMsg
+    );
+  }
+
   public async submitTransfer(props: {
     txMsg: string;
     type: AccountType;

--- a/apps/extension/src/provider/Namada.ts
+++ b/apps/extension/src/provider/Namada.ts
@@ -10,6 +10,7 @@ import {
   ApproveTransferMsg,
   ApproveBondMsg,
   ApproveUnbondMsg,
+  ApproveWithdrawMsg,
   ConnectInterfaceMsg,
   GetChainMsg,
   GetChainsMsg,
@@ -104,6 +105,13 @@ export class Namada implements INamada {
     return await this.requester?.sendMessage(
       Ports.Background,
       new ApproveUnbondMsg(txMsg)
+    );
+  }
+
+  public async submitWithdraw(txMsg: string): Promise<void> {
+    return await this.requester?.sendMessage(
+      Ports.Background,
+      new ApproveWithdrawMsg(txMsg)
     );
   }
 

--- a/apps/extension/src/provider/Signer.ts
+++ b/apps/extension/src/provider/Signer.ts
@@ -14,6 +14,7 @@ import {
   SubmitBondProps,
   SubmitBondMsgValue,
   SubmitUnbondMsgValue,
+  SubmitWithdrawMsgValue,
 } from "@namada/types";
 
 export class Signer implements ISigner {
@@ -64,6 +65,18 @@ export class Signer implements ISigner {
     const encoded = msg.encode(msgValue);
 
     return await this._namada.submitUnbond(toBase64(encoded));
+  }
+
+  /**
+   * Submit withdraw transaction
+   */
+  public async submitWithdraw(args: SubmitBondProps): Promise<void> {
+    const msgValue = new SubmitWithdrawMsgValue(args);
+
+    const msg = new Message<SubmitWithdrawMsgValue>();
+    const encoded = msg.encode(msgValue);
+
+    return await this._namada.submitWithdraw(toBase64(encoded));
   }
 
   /**

--- a/apps/extension/src/provider/messages.ts
+++ b/apps/extension/src/provider/messages.ts
@@ -19,6 +19,7 @@ enum MessageType {
   ApproveTransfer = "approve-transfer",
   ApproveBond = "approve-bond",
   ApproveUnbond = "approve-unbond",
+  ApproveWithdraw = "approve-withdraw",
   QueryBalances = "query-balances",
   SubmitIbcTransfer = "submit-ibc-transfer",
   SubmitLedgerTransfer = "submit-ledger-transfer",
@@ -334,6 +335,31 @@ export class ApproveUnbondMsg extends Message<void> {
   validate(): void {
     if (!this.txMsg) {
       throw new Error("txMsg was not provided!");
+    }
+    return;
+  }
+
+  route(): string {
+    return Route.Approvals;
+  }
+
+  type(): string {
+    return ApproveUnbondMsg.type();
+  }
+}
+
+export class ApproveWithdrawMsg extends Message<void> {
+  public static type(): MessageType {
+    return MessageType.ApproveWithdraw;
+  }
+
+  constructor(public readonly txMsg: string) {
+    super();
+  }
+
+  validate(): void {
+    if (!this.txMsg) {
+      throw new Error("An encoded txMsg is required!");
     }
     return;
   }

--- a/apps/namada-interface/src/App/Staking/NewBondingPosition/NewBondingPosition.tsx
+++ b/apps/namada-interface/src/App/Staking/NewBondingPosition/NewBondingPosition.tsx
@@ -166,7 +166,7 @@ export const NewBondingPosition = (props: Props): JSX.Element => {
         variant={ButtonVariant.Contained}
         onClick={() => {
           const changeInStakingPosition: ChangeInStakingPosition = {
-            amount: amountToBond,
+            amount: amountToBondNumber,
             owner: currentAddress,
             validatorId: currentBondingPositions[0].validatorId,
           };

--- a/apps/namada-interface/src/App/Staking/Staking.tsx
+++ b/apps/namada-interface/src/App/Staking/Staking.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { Routes, Route, useNavigate } from "react-router-dom";
+import BigNumber from "bignumber.js";
 
 import { truncateInMiddle } from "@namada/utils";
 import { Modal } from "@namada/components";
@@ -11,7 +12,6 @@ import { ValidatorDetails } from "./ValidatorDetails";
 import { TopLevelRoute, StakingAndGovernanceSubRoute } from "App/types";
 import {
   Validator,
-  MyValidators,
   StakingPosition,
   ChangeInStakingPosition,
 } from "slices/StakingAndGovernance";
@@ -52,8 +52,8 @@ const validatorNameFromUrl = (path: string): string | undefined => {
 
 const emptyStakingPosition = (validatorId: string): StakingPosition => ({
   uuid: validatorId,
-  stakingStatus: "",
-  stakedAmount: "",
+  bonded: true,
+  stakedAmount: new BigNumber(0),
   owner: "",
   totalRewards: "",
   validatorId: validatorId,
@@ -62,7 +62,6 @@ const emptyStakingPosition = (validatorId: string): StakingPosition => ({
 type Props = {
   accounts: Account[];
   validators: Validator[];
-  myValidators: MyValidators[];
   myStakingPositions: StakingPosition[];
   selectedValidatorId: string | undefined;
   // will be called at first load, parent decides what happens
@@ -106,7 +105,6 @@ export const Staking = (props: Props): JSX.Element => {
     postNewBonding,
     postNewUnbonding,
     validators,
-    myValidators,
     myStakingPositions,
     selectedValidatorId,
   } = props;
@@ -228,9 +226,6 @@ export const Staking = (props: Props): JSX.Element => {
           element={
             <StakingOverview
               navigateToValidatorDetails={navigateToValidatorDetails}
-              myValidators={myValidators}
-              validators={validators}
-              accounts={accounts}
             />
           }
         />

--- a/apps/namada-interface/src/App/Staking/StakingOverview/AllValidatorsTable/AllValidatorsTable.components.ts
+++ b/apps/namada-interface/src/App/Staking/StakingOverview/AllValidatorsTable/AllValidatorsTable.components.ts
@@ -1,0 +1,5 @@
+import styled from "styled-components";
+
+export const AllValidatorsSearchBar = styled.div`
+  margin-bottom: 8px;
+`;

--- a/apps/namada-interface/src/App/Staking/StakingOverview/AllValidatorsTable/AllValidatorsTable.tsx
+++ b/apps/namada-interface/src/App/Staking/StakingOverview/AllValidatorsTable/AllValidatorsTable.tsx
@@ -1,0 +1,181 @@
+import { useState, useCallback } from "react";
+import { Table, TableLink, TableConfigurations } from "@namada/components";
+import { Validator } from "slices/StakingAndGovernance";
+import {
+  AllValidatorsSearchBar
+} from "./AllValidatorsTable.components";
+import { formatPercentage, assertNever } from "@namada/utils";
+import { useAppSelector, RootState } from "store";
+import { ValidatorsCallbacks } from "../StakingOverview";
+
+// AllValidators table row renderer and configuration
+// it contains callbacks defined in AllValidatorsCallbacks
+const AllValidatorsRowRenderer = (
+  validator: Validator,
+  callbacks?: ValidatorsCallbacks
+): JSX.Element => {
+  return (
+    <>
+      <td>
+        <TableLink
+          onClick={() => {
+            const formattedValidatorName = validator.name
+              .replace(" ", "-")
+              .toLowerCase();
+
+            callbacks && callbacks.onClickValidator(formattedValidatorName);
+          }}
+        >
+          {validator.name}
+        </TableLink>
+      </td>
+      <td>{validator.votingPower?.toString() ?? ""}</td>
+      <td>{formatPercentage(validator.commission)}</td>
+    </>
+  );
+};
+
+const getAllValidatorsConfiguration = (
+  navigateToValidatorDetails: (validatorId: string) => void,
+  onColumnClick: (column: AllValidatorsColumn) => void,
+  sort: Sort,
+): TableConfigurations<Validator, ValidatorsCallbacks> => {
+  const getLabelWithTriangle = (column: AllValidatorsColumn): string => {
+    let triangle = "";
+    if (sort.column === column) {
+      if (sort.ascending) {
+        triangle = " \u25b5"; // white up-pointing small triangle
+      } else {
+        triangle = " \u25bf"; // white down-pointing small triangle
+      }
+    }
+
+    return `${column}${triangle}`;
+  }
+
+  return {
+    rowRenderer: AllValidatorsRowRenderer,
+    callbacks: {
+      onClickValidator: navigateToValidatorDetails,
+    },
+    columns: [
+      {
+        uuid: "1",
+        columnLabel: getLabelWithTriangle(AllValidatorsColumn.Validator),
+        width: "45%",
+        onClick: () => onColumnClick(AllValidatorsColumn.Validator),
+      },
+      {
+        uuid: "2",
+        columnLabel: getLabelWithTriangle(AllValidatorsColumn.VotingPower),
+        width: "25%",
+        onClick: () => onColumnClick(AllValidatorsColumn.VotingPower),
+      },
+      {
+        uuid: "3",
+        columnLabel: getLabelWithTriangle(AllValidatorsColumn.Commission),
+        width: "30%",
+        onClick: () => onColumnClick(AllValidatorsColumn.Commission),
+      },
+    ],
+  };
+};
+
+const sortValidators = (sort: Sort, validators: Validator[]): Validator[] => {
+  const direction = sort.ascending ? 1 : -1;
+
+  const ascendingSortFn: (a: Validator, b: Validator) => number =
+    sort.column === AllValidatorsColumn.Validator ?
+      (a, b) => a.name.localeCompare(b.name) :
+    sort.column === AllValidatorsColumn.VotingPower ?
+      ((a, b) =>
+        !a.votingPower || !b.votingPower ? 0 :
+        a.votingPower.isLessThan(b.votingPower) ? -1 : 1) :
+    sort.column === AllValidatorsColumn.Commission ?
+      ((a, b) => a.commission.isLessThan(b.commission) ? -1 : 1) :
+    assertNever(sort.column);
+
+  const cloned = validators.slice();
+  cloned.sort((a, b) => direction * ascendingSortFn(a, b));
+
+  return cloned;
+}
+
+const filterValidators = (search: string, validators: Validator[]): Validator[] =>
+  validators.filter(v =>
+    search === ""
+      ? true
+      : v.name.toLowerCase().startsWith(search.toLowerCase())
+  );
+
+const selectSortedFilteredValidators = (sort: Sort, search: string) =>
+  (state: RootState): Validator[] => {
+    const validators = state.stakingAndGovernance.validators;
+
+    const sorted = sortValidators(sort, validators);
+    const sortedAndFiltered = filterValidators(search, sorted);
+
+    return sortedAndFiltered;
+  };
+
+enum AllValidatorsColumn {
+  Validator = "Validator",
+  VotingPower = "Voting power",
+  Commission = "Commission"
+};
+
+type Sort = {
+  column: AllValidatorsColumn;
+  ascending: boolean;
+};
+
+export const AllValidatorsTable: React.FC<{
+  navigateToValidatorDetails: (validatorId: string) => void;
+}> = ({
+  navigateToValidatorDetails,
+}) => {
+  const [search, setSearch] = useState("");
+
+  const [sort, setSort] = useState<Sort>({
+    column: AllValidatorsColumn.Validator,
+    ascending: true
+  });
+
+  const sortedFilteredValidators = useAppSelector(
+    selectSortedFilteredValidators(sort, search)
+  );
+
+  const handleColumnClick = useCallback(
+    (column: AllValidatorsColumn): void =>
+      setSort({
+        column,
+        ascending: sort.column === column ? !sort.ascending : true
+      }),
+    [sort]
+  );
+
+  const allValidatorsConfiguration = getAllValidatorsConfiguration(
+    navigateToValidatorDetails,
+    handleColumnClick,
+    sort
+  );
+
+  return (
+    <Table
+      title="All Validators"
+      subheadingSlot={
+        <AllValidatorsSearchBar>
+          <input
+            type="search"
+            placeholder="Validator"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+          >
+          </input>
+        </AllValidatorsSearchBar>
+      }
+      data={sortedFilteredValidators}
+      tableConfigurations={allValidatorsConfiguration}
+    />
+  );
+};

--- a/apps/namada-interface/src/App/Staking/StakingOverview/AllValidatorsTable/index.ts
+++ b/apps/namada-interface/src/App/Staking/StakingOverview/AllValidatorsTable/index.ts
@@ -1,0 +1,1 @@
+export { AllValidatorsTable } from "./AllValidatorsTable";

--- a/apps/namada-interface/src/App/Staking/StakingOverview/MyValidatorsTable/MyValidatorsTable.tsx
+++ b/apps/namada-interface/src/App/Staking/StakingOverview/MyValidatorsTable/MyValidatorsTable.tsx
@@ -1,0 +1,77 @@
+import { Table, TableLink, TableConfigurations } from "@namada/components";
+import { MyValidators, StakingAndGovernanceState } from "slices/StakingAndGovernance";
+import { showMaybeNam } from "@namada/utils";
+import { useAppSelector } from "store";
+import { ValidatorsCallbacks } from "../StakingOverview";
+
+const MyValidatorsRowRenderer = (
+  myValidatorRow: MyValidators,
+  callbacks?: ValidatorsCallbacks
+): JSX.Element => {
+  return (
+    <>
+      <td>
+        <TableLink
+          onClick={() => {
+            const formattedValidatorName = myValidatorRow.validator.name
+              .replace(" ", "-")
+              .toLowerCase();
+
+            // this function is defined at <Staking />
+            // there it triggers a navigation. It then calls a callback
+            // that was passed to it by its' parent <StakingAndGovernance />
+            // in that callback function that is defined in <StakingAndGovernance />
+            // an action is dispatched to fetch validator data and make in available
+            callbacks && callbacks.onClickValidator(formattedValidatorName);
+          }}
+        >
+          {myValidatorRow.validator.name}
+        </TableLink>
+      </td>
+      <td>{myValidatorRow.stakingStatus}</td>
+      <td>{showMaybeNam(myValidatorRow.stakedAmount)}</td>
+      <td>{showMaybeNam(myValidatorRow.unbondedAmount)}</td>
+      <td>{showMaybeNam(myValidatorRow.withdrawableAmount)}</td>
+    </>
+  );
+};
+
+const getMyValidatorsConfiguration = (
+  navigateToValidatorDetails: (validatorId: string) => void
+): TableConfigurations<MyValidators, ValidatorsCallbacks> => {
+  return {
+    rowRenderer: MyValidatorsRowRenderer,
+    columns: [
+      { uuid: "1", columnLabel: "Validator", width: "30%" },
+      { uuid: "2", columnLabel: "Status", width: "20%" },
+      { uuid: "3", columnLabel: "Staked Amount", width: "30%" },
+      { uuid: "4", columnLabel: "Unbonded Amount", width: "30%" },
+      { uuid: "5", columnLabel: "Withdrawable Amount", width: "30%" },
+    ],
+    callbacks: {
+      onClickValidator: navigateToValidatorDetails,
+    },
+  };
+};
+
+export const MyValidatorsTable: React.FC<{
+  navigateToValidatorDetails: (validatorId: string) => void;
+}> = ({
+  navigateToValidatorDetails,
+}) => {
+  const stakingAndGovernanceState = useAppSelector<StakingAndGovernanceState>(
+    state => state.stakingAndGovernance);
+  const myValidators = stakingAndGovernanceState.myValidators ?? [];
+
+  const myValidatorsConfiguration = getMyValidatorsConfiguration(
+    navigateToValidatorDetails
+  );
+
+  return (
+    <Table
+      title="My Validators"
+      data={myValidators}
+      tableConfigurations={myValidatorsConfiguration}
+    />
+  );
+};

--- a/apps/namada-interface/src/App/Staking/StakingOverview/MyValidatorsTable/index.ts
+++ b/apps/namada-interface/src/App/Staking/StakingOverview/MyValidatorsTable/index.ts
@@ -1,0 +1,1 @@
+export { MyValidatorsTable } from "./MyValidatorsTable";

--- a/apps/namada-interface/src/App/Staking/StakingOverview/StakingBalancesList/StakingBalancesList.components.ts
+++ b/apps/namada-interface/src/App/Staking/StakingOverview/StakingBalancesList/StakingBalancesList.components.ts
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+export const StakingBalances = styled.div`
+  width: 100%;
+  display: grid;
+  grid-template-columns: minmax(150px, 30%) 1fr;
+`;
+export const StakingBalancesLabel = styled.div``;
+
+export const StakingBalancesValue = styled.div``;

--- a/apps/namada-interface/src/App/Staking/StakingOverview/StakingBalancesList/StakingBalancesList.tsx
+++ b/apps/namada-interface/src/App/Staking/StakingOverview/StakingBalancesList/StakingBalancesList.tsx
@@ -1,0 +1,78 @@
+import BigNumber from "bignumber.js";
+import {
+  StakingBalances,
+  StakingBalancesLabel,
+  StakingBalancesValue,
+} from "./StakingBalancesList.components";
+import { showMaybeNam, mapUndefined } from "@namada/utils";
+import { useAppSelector, RootState } from "store";
+
+type Totals = {
+  totalBonded: BigNumber,
+  totalUnbonded: BigNumber,
+  totalWithdrawable: BigNumber,
+};
+
+const selectStakingTotals = (state: RootState): Totals | undefined => {
+  const { myValidators } = state.stakingAndGovernance;
+
+  if (myValidators === undefined) {
+    return undefined;
+  }
+
+  const totalBonded = myValidators.reduce(
+    (acc, validator) => acc.plus(validator.stakedAmount ?? 0),
+    new BigNumber(0)
+  );
+  const totalUnbonded = myValidators.reduce(
+    (acc, validator) => acc.plus(validator.unbondedAmount ?? 0),
+    new BigNumber(0)
+  );
+  const totalWithdrawable = myValidators.reduce(
+    (acc, validator) => acc.plus(validator.withdrawableAmount ?? 0),
+    new BigNumber(0)
+  );
+
+  return {
+    totalBonded,
+    totalUnbonded,
+    totalWithdrawable,
+  };
+};
+
+const selectTotalNamBalance = (state: RootState): BigNumber => {
+  const { chainId } = state.settings;
+  const { derived } = state.accounts;
+  const accounts = Object.values(derived[chainId]);
+
+  return accounts.reduce((acc, curr) => {
+    return acc.plus(curr.balance["NAM"] ?? new BigNumber(0));
+  }, new BigNumber(0));
+};
+
+const showTotalIfDefined = (totals: Totals | undefined, key: keyof Totals): string =>
+  showMaybeNam(mapUndefined(t => t[key], totals));
+
+export const StakingBalancesList: React.FC = () => {
+  const totals = useAppSelector(selectStakingTotals);
+  const availableForBonding = useAppSelector(selectTotalNamBalance);
+
+  return (
+    <StakingBalances>
+      <StakingBalancesLabel>Available for bonding</StakingBalancesLabel>
+      <StakingBalancesValue>NAM {availableForBonding.toString()}</StakingBalancesValue>
+
+      <StakingBalancesLabel>Total Bonded</StakingBalancesLabel>
+      <StakingBalancesValue>{showTotalIfDefined(totals, "totalBonded")}</StakingBalancesValue>
+
+      <StakingBalancesLabel>Total Unbonded</StakingBalancesLabel>
+      <StakingBalancesValue>{showTotalIfDefined(totals, "totalUnbonded")}</StakingBalancesValue>
+
+      <StakingBalancesLabel>Total Withdrawable</StakingBalancesLabel>
+      <StakingBalancesValue>{showTotalIfDefined(totals, "totalWithdrawable")}</StakingBalancesValue>
+
+      <StakingBalancesLabel>Pending Rewards</StakingBalancesLabel>
+      <StakingBalancesValue>TBD</StakingBalancesValue>
+    </StakingBalances>
+  );
+};

--- a/apps/namada-interface/src/App/Staking/StakingOverview/StakingBalancesList/index.ts
+++ b/apps/namada-interface/src/App/Staking/StakingOverview/StakingBalancesList/index.ts
@@ -1,0 +1,1 @@
+export { StakingBalancesList } from "./StakingBalancesList";

--- a/apps/namada-interface/src/App/Staking/StakingOverview/StakingOverview.components.ts
+++ b/apps/namada-interface/src/App/Staking/StakingOverview/StakingOverview.components.ts
@@ -11,12 +11,3 @@ export const StakingOverviewContainer = styled.div`
   color: ${(props) => props.theme.colors.utility2.main};
   background-color: ${(props) => props.theme.colors.utility1.main80};
 `;
-
-export const StakingBalances = styled.div`
-  width: 100%;
-  display: grid;
-  grid-template-columns: minmax(150px, 30%) 1fr;
-`;
-export const StakingBalancesLabel = styled.div``;
-
-export const StakingBalancesValue = styled.div``;

--- a/apps/namada-interface/src/App/Staking/StakingOverview/StakingOverview.tsx
+++ b/apps/namada-interface/src/App/Staking/StakingOverview/StakingOverview.tsx
@@ -1,114 +1,15 @@
-import BigNumber from "bignumber.js";
-import { Table, TableLink, TableConfigurations } from "@namada/components";
-import { Account } from "slices/accounts";
-import { Validator, MyValidators } from "slices/StakingAndGovernance";
-import {
-  StakingBalances,
-  StakingBalancesLabel,
-  StakingBalancesValue,
-  StakingOverviewContainer,
-} from "./StakingOverview.components";
-
-const MyValidatorsRowRenderer = (
-  myValidatorRow: MyValidators,
-  callbacks?: ValidatorsCallbacks
-): JSX.Element => {
-  return (
-    <>
-      <td>
-        <TableLink
-          onClick={() => {
-            const formattedValidatorName = myValidatorRow.validator.name
-              .replace(" ", "-")
-              .toLowerCase();
-
-            // this function is defined at <Staking />
-            // there it triggers a navigation. It then calls a callback
-            // that was passed to it by its' parent <StakingAndGovernance />
-            // in that callback function that is defined in <StakingAndGovernance />
-            // an action is dispatched to fetch validator data and make in available
-            callbacks && callbacks.onClickValidator(formattedValidatorName);
-          }}
-        >
-          {myValidatorRow.validator.name}
-        </TableLink>
-      </td>
-      <td>{myValidatorRow.stakingStatus}</td>
-      <td>NAM {myValidatorRow.stakedAmount}</td>
-    </>
-  );
-};
-
-const getMyValidatorsConfiguration = (
-  navigateToValidatorDetails: (validatorId: string) => void
-): TableConfigurations<MyValidators, ValidatorsCallbacks> => {
-  return {
-    rowRenderer: MyValidatorsRowRenderer,
-    columns: [
-      { uuid: "1", columnLabel: "Validator", width: "30%" },
-      { uuid: "2", columnLabel: "Status", width: "40%" },
-      { uuid: "3", columnLabel: "Staked Amount", width: "30%" },
-    ],
-    callbacks: {
-      onClickValidator: navigateToValidatorDetails,
-    },
-  };
-};
+import { StakingOverviewContainer } from "./StakingOverview.components";
+import { AllValidatorsTable } from "./AllValidatorsTable";
+import { MyValidatorsTable } from "./MyValidatorsTable";
+import { StakingBalancesList } from "./StakingBalancesList";
 
 // callbacks in this type are specific to a certain row type
-type ValidatorsCallbacks = {
+export type ValidatorsCallbacks = {
   onClickValidator: (validatorId: string) => void;
 };
 
-// AllValidators table row renderer and configuration
-// it contains callbacks defined in AllValidatorsCallbacks
-const AllValidatorsRowRenderer = (
-  validator: Validator,
-  callbacks?: ValidatorsCallbacks
-): JSX.Element => {
-  // this is now as a placeholder but in real case it will be in StakingOverview
-  return (
-    <>
-      <td>
-        <TableLink
-          onClick={() => {
-            const formattedValidatorName = validator.name
-              .replace(" ", "-")
-              .toLowerCase();
-
-            callbacks && callbacks.onClickValidator(formattedValidatorName);
-          }}
-        >
-          {validator.name}
-        </TableLink>
-      </td>
-      <td>{validator.votingPower}</td>
-      <td>{validator.commission}</td>
-    </>
-  );
-};
-
-const getAllValidatorsConfiguration = (
-  navigateToValidatorDetails: (validatorId: string) => void
-): TableConfigurations<Validator, ValidatorsCallbacks> => {
-  return {
-    rowRenderer: AllValidatorsRowRenderer,
-    callbacks: {
-      onClickValidator: navigateToValidatorDetails,
-    },
-    columns: [
-      { uuid: "1", columnLabel: "Validator", width: "45%" },
-      { uuid: "2", columnLabel: "Voting power", width: "25%" },
-      { uuid: "3", columnLabel: "Commission", width: "30%" },
-    ],
-  };
-};
-
 type Props = {
-  accounts: Account[];
   navigateToValidatorDetails: (validatorId: string) => void;
-  validators: Validator[];
-  myValidators: MyValidators[];
 };
 
 // This is the default view for the staking. it displays all the relevant
@@ -118,56 +19,18 @@ type Props = {
 //   view in the parent
 // * user can also navigate to sibling view for validator details
 export const StakingOverview = (props: Props): JSX.Element => {
-  const { navigateToValidatorDetails, validators, myValidators, accounts } =
-    props;
-
-  // we get the configurations for 2 tables that contain callbacks
-  const myValidatorsConfiguration = getMyValidatorsConfiguration(
-    navigateToValidatorDetails
-  );
-  const allValidatorsConfiguration = getAllValidatorsConfiguration(
-    navigateToValidatorDetails
-  );
-  const totalBonded = myValidators.reduce(
-    (acc, validator) => acc.plus(validator.stakedAmount),
-    new BigNumber(0)
-  );
-  const totalBalance = accounts.reduce((acc, curr) => {
-    return acc.plus(curr.balance["NAM"] ?? new BigNumber(0));
-  }, new BigNumber(0));
+  const { navigateToValidatorDetails } = props;
 
   return (
     <StakingOverviewContainer>
-      {/* my balances */}
-      <StakingBalances>
-        <StakingBalancesLabel>Total Balance</StakingBalancesLabel>
-        <StakingBalancesValue>NAM {totalBalance.toString()}</StakingBalancesValue>
+      <StakingBalancesList />
 
-        <StakingBalancesLabel>Total Bonded</StakingBalancesLabel>
-        <StakingBalancesValue>NAM {totalBonded.toString()}</StakingBalancesValue>
-
-        <StakingBalancesLabel>Pending Rewards</StakingBalancesLabel>
-        <StakingBalancesValue>TBD</StakingBalancesValue>
-
-        <StakingBalancesLabel>Available for bonding</StakingBalancesLabel>
-        <StakingBalancesValue>
-          NAM {totalBalance.minus(totalBonded).toString()}
-        </StakingBalancesValue>
-      </StakingBalances>
-
-      {/* my validators */}
-      <Table
-        title="My Validators"
-        // data={myValidatorData}
-        data={myValidators}
-        tableConfigurations={myValidatorsConfiguration}
+      <MyValidatorsTable
+        navigateToValidatorDetails={navigateToValidatorDetails}
       />
 
-      {/* all validators */}
-      <Table
-        title="All Validators"
-        data={validators}
-        tableConfigurations={allValidatorsConfiguration}
+      <AllValidatorsTable
+        navigateToValidatorDetails={navigateToValidatorDetails}
       />
     </StakingOverviewContainer>
   );

--- a/apps/namada-interface/src/App/Staking/UnbondPosition/UnbondPosition.tsx
+++ b/apps/namada-interface/src/App/Staking/UnbondPosition/UnbondPosition.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import BigNumber from "bignumber.js";
 
 import {
   Button,
@@ -74,7 +75,7 @@ export const UnbondPosition = (props: Props): JSX.Element => {
     (pos) => pos.owner === owner
   );
 
-  const stakedAmount = Number(currentBondingPosition?.stakedAmount || "0");
+  const stakedAmount = new BigNumber(currentBondingPosition?.stakedAmount || "0");
 
   // storing the bonding amount input value locally here as string
   // we threat them as strings except below in validation
@@ -95,14 +96,14 @@ export const UnbondPosition = (props: Props): JSX.Element => {
   // unbonding amount and displayed value with a very naive validation
   // TODO (https://github.com/anoma/namada-interface/issues/4#issuecomment-1260564499)
   // do proper validation as part of input
-  const amountToUnstakeAsNumber = Number(amountToBondOrUnbond);
-  const remainsBonded = stakedAmount - amountToUnstakeAsNumber;
+  const amountToUnstakeAsNumber = new BigNumber(amountToBondOrUnbond);
+  const remainsBonded = stakedAmount.minus(amountToUnstakeAsNumber);
 
   // if the input value is incorrect we display an error
   const isEntryIncorrect =
-    (amountToBondOrUnbond !== "" && amountToUnstakeAsNumber <= 0) ||
-    remainsBonded < 0 ||
-    Number.isNaN(amountToUnstakeAsNumber);
+    (amountToBondOrUnbond !== "" && amountToUnstakeAsNumber.isLessThanOrEqualTo(0)) ||
+    remainsBonded.isLessThan(0) ||
+    amountToUnstakeAsNumber.isNaN();
 
   // if the input value is incorrect or empty we disable the confirm button
   const isEntryIncorrectOrEmpty =
@@ -112,10 +113,6 @@ export const UnbondPosition = (props: Props): JSX.Element => {
   const remainsBondedToDisplay = isEntryIncorrect
     ? `The unbonding amount can be more than 0 and at most ${stakedAmount}`
     : `${remainsBonded}`;
-
-  // This is the value that we pass to be dispatch to the action
-  const delta = amountToUnstakeAsNumber * -1;
-  const deltaAsString = `${delta}`;
 
   // data for the summary table
   const unbondingSummary = [
@@ -151,7 +148,7 @@ export const UnbondPosition = (props: Props): JSX.Element => {
         variant={ButtonVariant.Contained}
         onClick={() => {
           const changeInStakingPosition: ChangeInStakingPosition = {
-            amount: deltaAsString,
+            amount: amountToUnstakeAsNumber,
             owner: owner as string,
             validatorId: currentBondingPositions[0].validatorId,
           };

--- a/apps/namada-interface/src/App/StakingAndGovernance/StakingAndGovernance.tsx
+++ b/apps/namada-interface/src/App/StakingAndGovernance/StakingAndGovernance.tsx
@@ -45,7 +45,7 @@ export const StakingAndGovernance = (): JSX.Element => {
   const [_integration, _status, withConnection] =
     useIntegrationConnection(chainId);
 
-  const { validators, myValidators, selectedValidatorId, myStakingPositions } =
+  const { validators, selectedValidatorId, myStakingPositions } =
     stakingAndGovernance;
 
   // we need one of the sub routes, staking alone has nothing
@@ -97,7 +97,6 @@ export const StakingAndGovernance = (): JSX.Element => {
             <Staking
               accounts={accounts}
               validators={validators}
-              myValidators={myValidators}
               myStakingPositions={myStakingPositions}
               selectedValidatorId={selectedValidatorId}
               onInitCallback={onStakingComponentInitCallback}

--- a/apps/namada-interface/src/slices/StakingAndGovernance/fakeData.ts
+++ b/apps/namada-interface/src/slices/StakingAndGovernance/fakeData.ts
@@ -1,3 +1,5 @@
+import BigNumber from "bignumber.js";
+
 import { Validator, StakingPosition, MyBalanceEntry } from "./types";
 export const myBalancesData: MyBalanceEntry[] = [
   {
@@ -29,24 +31,24 @@ export const myBalancesData: MyBalanceEntry[] = [
 export const myStakingData: StakingPosition[] = [
   {
     uuid: "1",
-    stakingStatus: "Bonded",
-    stakedAmount: "10.00",
+    bonded: true,
+    stakedAmount: new BigNumber(10_000_000),
     owner: "some-owner",
     totalRewards: "0.55",
     validatorId: "polychain-capital",
   },
   {
     uuid: "2",
-    stakingStatus: "Bonded Pending",
-    stakedAmount: "3.00",
+    bonded: true,
+    stakedAmount: new BigNumber(3_000_000),
     owner: "some-owner",
     totalRewards: "0.15",
     validatorId: "coinbase-custody",
   },
   {
     uuid: "3",
-    stakingStatus: "Unboding (22 days left)",
-    stakedAmount: "20.00",
+    bonded: true,
+    stakedAmount: new BigNumber(20_000_000),
     owner: "some-owner",
     totalRewards: "1.05",
     validatorId: "kraken",
@@ -58,8 +60,8 @@ export const allValidatorsData: Validator[] = [
     uuid: "polychain-capital",
     name: "Polychain capital",
     homepageUrl: "https://polychain.capital",
-    votingPower: "NAM 100 000",
-    commission: "22%",
+    votingPower: new BigNumber(100_000),
+    commission: new BigNumber(0.22),
     description:
       "Polychain is an investment firm committed to exceptional returns for investors through actively managed portfolios of blockchain assets.",
   },
@@ -67,8 +69,8 @@ export const allValidatorsData: Validator[] = [
     uuid: "figment",
     name: "Figment",
     homepageUrl: "https://figment.io",
-    votingPower: "NAM 100 000",
-    commission: "20%",
+    votingPower: new BigNumber(100_000),
+    commission: new BigNumber(0.20),
     description:
       "Makers of Hubble and Canada’s largest Cosmos validator, Figment is the easiest and most secure way to stake your Atoms.",
   },
@@ -76,8 +78,8 @@ export const allValidatorsData: Validator[] = [
     uuid: "p2p",
     name: "P2P",
     homepageUrl: "https://p2p.org",
-    votingPower: "NAM 100 000",
-    commission: "20%",
+    votingPower: new BigNumber(100_000),
+    commission: new BigNumber(0.20),
     description:
       "One of the winners of Cosmos Game of Stakes. We provide a simple, secure and intelligent staking service to help you generate rewards on your blockchain assets across 9+ networks within a single interface. Let’s stake together - p2p.org.",
   },
@@ -85,16 +87,16 @@ export const allValidatorsData: Validator[] = [
     uuid: "coinbase-custody",
     name: "Coinbase Custody",
     homepageUrl: "https://custody.coinbase.com",
-    votingPower: "NAM 100 000",
-    commission: "20%",
+    votingPower: new BigNumber(100_000),
+    commission: new BigNumber(0.20),
     description: "Coinbase Custody Cosmos Validator",
   },
   {
     uuid: "chorus-one",
     name: "Chorus One",
     homepageUrl: "https://chorus.one",
-    votingPower: "NAM 100 000",
-    commission: "20%",
+    votingPower: new BigNumber(100_000),
+    commission: new BigNumber(0.20),
     description:
       "Secure Cosmos and shape its future by delegating to Chorus One, a highly secure and stable validator. By delegating, you agree to the terms of service at: https://chorus.one/cosmos/tos",
   },
@@ -102,16 +104,16 @@ export const allValidatorsData: Validator[] = [
     uuid: "binance-staking",
     name: "Binance Staking",
     homepageUrl: "https://binance.com",
-    votingPower: "NAM 100 000",
-    commission: "20%",
+    votingPower: new BigNumber(100_000),
+    commission: new BigNumber(0.20),
     description: "Exchange the world",
   },
   {
     uuid: "dokiacapital",
     name: "DokiaCapital",
     homepageUrl: "https://staking.dokia.cloud",
-    votingPower: "NAM 100 000",
-    commission: "20%",
+    votingPower: new BigNumber(100_000),
+    commission: new BigNumber(0.20),
     description:
       "Downtime is not an option for Dokia Capital. We operate an enterprise-grade infrastructure that is robust and secure.",
   },
@@ -119,16 +121,16 @@ export const allValidatorsData: Validator[] = [
     uuid: "kraken",
     name: "Kraken",
     homepageUrl: "https://kraken.com",
-    votingPower: "NAM 100 000",
-    commission: "20%",
+    votingPower: new BigNumber(100_000),
+    commission: new BigNumber(0.20),
     description: "Kraken Exchange validator",
   },
   {
     uuid: "zero-knowledge-validator-(ZKV)",
     name: "Zero Knowledge Validator (ZKV)",
     homepageUrl: "https://zkvalidator.com",
-    votingPower: "NAM 100 000",
-    commission: "20%",
+    votingPower: new BigNumber(100_000),
+    commission: new BigNumber(0.20),
     description:
       "Zero Knowledge Validator: Stake & Support ZKP Research & Privacy Tech",
   },
@@ -136,8 +138,8 @@ export const allValidatorsData: Validator[] = [
     uuid: "paradigm",
     name: "Paradigm",
     homepageUrl: "https://www.paradigm.xyz",
-    votingPower: "NAM 100 000",
-    commission: "20%",
+    votingPower: new BigNumber(100_000),
+    commission: new BigNumber(0.20),
     description: "",
   },
 ];

--- a/apps/namada-interface/src/slices/StakingAndGovernance/index.ts
+++ b/apps/namada-interface/src/slices/StakingAndGovernance/index.ts
@@ -4,6 +4,7 @@ export {
   fetchValidatorDetails,
   postNewBonding,
   postNewUnbonding,
+  postNewWithdraw,
 } from "./actions";
 export { reducer as stakingAndGovernanceReducers } from "./reducers";
 export type {

--- a/apps/namada-interface/src/slices/StakingAndGovernance/reducers.ts
+++ b/apps/namada-interface/src/slices/StakingAndGovernance/reducers.ts
@@ -4,6 +4,7 @@ import {
   fetchValidators,
   fetchMyValidators,
   fetchMyStakingPositions,
+  fetchEpoch,
   postNewBonding,
   postNewUnbonding,
 } from "./actions";
@@ -15,9 +16,10 @@ import {
 
 const initialState: StakingAndGovernanceState = {
   validators: [],
-  myValidators: [],
+  myValidators: undefined,
   myStakingPositions: [],
   stakingOrUnstakingState: StakingOrUnstakingState.Idle,
+  epoch: undefined,
 };
 
 export const stakingAndGovernanceSlice = createSlice({
@@ -37,7 +39,6 @@ export const stakingAndGovernanceSlice = createSlice({
       .addCase(fetchMyValidators.fulfilled, (state, action) => {
         // stop the loader
         state.myValidators = action.payload.myValidators;
-        state.myStakingPositions = action.payload.myStakingPositions;
       })
       .addCase(fetchMyValidators.rejected, (state, _action) => {
         // stop the loader
@@ -54,6 +55,9 @@ export const stakingAndGovernanceSlice = createSlice({
       .addCase(fetchMyStakingPositions.fulfilled, (state, action) => {
         // stop the loader
         state.myStakingPositions = action.payload?.myStakingPositions;
+      })
+      .addCase(fetchEpoch.fulfilled, (state, action) => {
+        state.epoch = action.payload.epoch;
       })
       .addCase(postNewBonding.pending, (state, _action) => {
         // stop the loader

--- a/apps/namada-interface/src/slices/StakingAndGovernance/types.ts
+++ b/apps/namada-interface/src/slices/StakingAndGovernance/types.ts
@@ -1,7 +1,10 @@
+import BigNumber from "bignumber.js";
+
 export const STAKING_AND_GOVERNANCE = "stakingAndGovernance";
 export const FETCH_VALIDATORS = `${STAKING_AND_GOVERNANCE}/FETCH_VALIDATORS`;
 export const FETCH_MY_VALIDATORS = `${STAKING_AND_GOVERNANCE}/FETCH_MY_VALIDATORS`;
 export const FETCH_MY_STAKING_POSITIONS = `${STAKING_AND_GOVERNANCE}/FETCH_MY_STAKING_POSITIONS`;
+export const FETCH_EPOCH = `${STAKING_AND_GOVERNANCE}/FETCH_EPOCH`;
 export const FETCH_VALIDATOR_DETAILS = `${STAKING_AND_GOVERNANCE}/FETCH_VALIDATOR_DETAILS`;
 export const POST_NEW_STAKING = `${STAKING_AND_GOVERNANCE}/POST_NEW_STAKING`;
 export const POST_UNSTAKING = `${STAKING_AND_GOVERNANCE}/POST_UNSTAKING`;
@@ -21,16 +24,17 @@ type Unique = {
 // represents the details of a validator
 export type Validator = Unique & {
   name: string;
-  votingPower: string;
+  votingPower?: BigNumber;
   homepageUrl: string;
-  commission: string;
+  commission: BigNumber;
   description: string;
 };
 
 // represents users staking position
 export type StakingPosition = Unique & {
-  stakingStatus: string;
-  stakedAmount: string;
+  bonded: boolean;
+  withdrawableEpoch?: BigNumber;
+  stakedAmount: BigNumber;
   owner: string;
   totalRewards: string;
   validatorId: ValidatorId;
@@ -39,7 +43,9 @@ export type StakingPosition = Unique & {
 // represents users staking position combined with the validator
 export type MyValidators = Unique & {
   stakingStatus: string;
-  stakedAmount: string;
+  stakedAmount?: BigNumber;
+  unbondedAmount?: BigNumber;
+  withdrawableAmount?: BigNumber;
   validator: Validator;
 };
 
@@ -63,18 +69,17 @@ export enum StakingOrUnstakingState {
 }
 
 // this represents a change in staking position
-// if positive, we are posting new bonding
-// negative, we are decreasing it
 export type ChangeInStakingPosition = {
   validatorId: ValidatorId;
   owner: string;
-  amount: string;
+  amount: BigNumber;
 };
 
 export type StakingAndGovernanceState = {
   validators: Validator[];
-  myValidators: MyValidators[];
+  myValidators?: MyValidators[];
   myStakingPositions: StakingPosition[];
   selectedValidatorId?: ValidatorId;
   stakingOrUnstakingState: StakingOrUnstakingState;
+  epoch?: BigNumber;
 };

--- a/packages/components/src/Modal/Modal.components.ts
+++ b/packages/components/src/Modal/Modal.components.ts
@@ -5,11 +5,13 @@ export const ModalContainer = styled.div`
   flex-direction: column;
   align-items: center;
   width: 100%;
+  background-color: ${(props) => props.theme.colors.utility1.main80};
 `;
 export const ModalHeader = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  color: ${(props) => props.theme.colors.utility1.main20};
 `;
 
 export const ModalContent = styled.div`

--- a/packages/components/src/Modal/Modal.tsx
+++ b/packages/components/src/Modal/Modal.tsx
@@ -1,4 +1,6 @@
 import { default as ReactModal } from "react-modal";
+import { ThemeProvider } from "styled-components";
+import { loadColorMode, getTheme } from "@namada/utils";
 import {
   ModalContainer,
   ModalContent,
@@ -14,6 +16,9 @@ type Props = {
 
 export const Modal = (props: Props): JSX.Element => {
   const { children, isOpen, title, onBackdropClick } = props;
+
+  const theme = getTheme(loadColorMode());
+
   return (
     <ReactModal
       shouldCloseOnOverlayClick={onBackdropClick !== undefined}
@@ -39,17 +44,20 @@ export const Modal = (props: Props): JSX.Element => {
           width: "80%",
           maxWidth: "640px",
           height: "80%",
+          padding: 0,
         },
       }}
       isOpen={isOpen}
       ariaHideApp={false}
     >
-      <ModalContainer>
-        <ModalHeader>
-          <ModalTitle>{title}</ModalTitle>
-        </ModalHeader>
-        <ModalContent>{children}</ModalContent>
-      </ModalContainer>
+      <ThemeProvider theme={theme}>
+        <ModalContainer>
+          <ModalHeader>
+            <ModalTitle>{title}</ModalTitle>
+          </ModalHeader>
+          <ModalContent>{children}</ModalContent>
+        </ModalContainer>
+      </ThemeProvider>
     </ReactModal>
   );
 };

--- a/packages/components/src/Table/Table.tsx
+++ b/packages/components/src/Table/Table.tsx
@@ -6,6 +6,7 @@ export type Props<RowType extends RowBase, Callbacks> = {
   data: RowType[];
   tableConfigurations: TableConfigurations<RowType, Callbacks>;
   className?: string;
+  subheadingSlot?: JSX.Element;
 };
 
 const getRenderedHeaderRow = (
@@ -22,6 +23,7 @@ const getRenderedHeaderRow = (
       <th
         key={`header_${columnDefinition.uuid}`}
         style={{ textAlign: "left", width: `${columnDefinition.width}` }}
+        onClick={columnDefinition.onClick}
       >
         {columnDefinition.columnLabel}
       </th>
@@ -54,7 +56,7 @@ const getRenderedDataRows = <RowType extends RowBase, Callbacks>(
 export const Table = <RowType extends RowBase, Callbacks>(
   props: Props<RowType, Callbacks>
 ): JSX.Element => {
-  const { data, tableConfigurations, title, className } = props;
+  const { data, tableConfigurations, title, className, subheadingSlot } = props;
   const { columns, rowRenderer, callbacks } =
     tableConfigurations && tableConfigurations;
 
@@ -69,6 +71,7 @@ export const Table = <RowType extends RowBase, Callbacks>(
   return (
     <TableContainer className={className}>
       <h3>{title}</h3>
+      {subheadingSlot}
       <TableElement style={{ borderCollapse: "collapse" }}>
         <tbody>{renderedRows}</tbody>
       </TableElement>

--- a/packages/components/src/Table/types.ts
+++ b/packages/components/src/Table/types.ts
@@ -2,6 +2,7 @@ export type ColumnDefinition = {
   uuid: string;
   columnLabel: string;
   width: string;
+  onClick?: () => void;
 };
 
 export type TableConfigurations<RowType, Callbacks> = {

--- a/packages/shared/lib/src/sdk/mod.rs
+++ b/packages/shared/lib/src/sdk/mod.rs
@@ -397,6 +397,23 @@ impl Sdk {
 
         Ok(())
     }
+
+    pub async fn submit_withdraw(
+        &mut self,
+        tx_msg: &[u8],
+        password: Option<String>,
+    ) -> Result<(), JsError> {
+        let args = tx::withdraw_tx_args(tx_msg, password)?;
+
+        let (tx, _, pk) =
+            namada::ledger::tx::build_withdraw(&mut self.client, &mut self.wallet, args.clone())
+                .await
+                .map_err(JsError::from)?;
+
+        self.sign_and_process_tx(args.tx, tx, pk).await?;
+
+        Ok(())
+    }
 }
 
 #[wasm_bindgen(module = "/src/sdk/mod.js")]

--- a/packages/types/src/namada.ts
+++ b/packages/types/src/namada.ts
@@ -17,6 +17,7 @@ export interface Namada {
     publicKey?: string;
   }) => Promise<void>;
   submitUnbond: (txMsg: string) => Promise<void>;
+  submitWithdraw: (txMsg: string) => Promise<void>;
   submitTransfer: (props: {
     txMsg: string;
     type: AccountType;

--- a/packages/types/src/signer.ts
+++ b/packages/types/src/signer.ts
@@ -4,6 +4,7 @@ import {
   InitAccountProps,
   SubmitBondProps,
   SubmitUnbondProps,
+  SubmitWithdrawProps,
   TransferProps,
 } from "./tx";
 
@@ -15,6 +16,7 @@ export interface Signer {
     publicKey?: string
   ): Promise<void>;
   submitUnbond(args: SubmitUnbondProps): Promise<void>;
+  submitWithdraw(args: SubmitWithdrawProps): Promise<void>;
   submitTransfer(args: TransferProps, type: AccountType): Promise<void>;
   submitIbcTransfer(args: IbcTransferProps): Promise<void>;
   encodeInitAccount(

--- a/packages/types/src/tx/schema/index.ts
+++ b/packages/types/src/tx/schema/index.ts
@@ -5,12 +5,14 @@ export * from "./bond";
 export * from "./signature";
 export * from "./revealPK";
 export * from "./unbond";
+export * from "./withdraw";
 
 import { AccountMsgValue } from "./account";
 import { IbcTransferMsgValue } from "./ibcTransfer";
 import { TransferMsgValue } from "./transfer";
 import { SubmitBondMsgValue } from "./bond";
 import { SubmitUnbondMsgValue } from "./unbond";
+import { SubmitWithdrawMsgValue } from "./withdraw";
 import { SubmitRevealPKMsgValue } from "./revealPK";
 import { SignatureMsgValue } from "./signature";
 
@@ -20,5 +22,6 @@ export type Schema =
   | TransferMsgValue
   | SubmitBondMsgValue
   | SubmitUnbondMsgValue
+  | SubmitWithdrawMsgValue
   | SubmitRevealPKMsgValue
   | SignatureMsgValue;

--- a/packages/types/src/tx/schema/withdraw.ts
+++ b/packages/types/src/tx/schema/withdraw.ts
@@ -1,0 +1,20 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { field } from "@dao-xyz/borsh";
+import { TxMsgValue } from "./tx";
+import { SubmitWithdrawProps } from "../types";
+
+export class SubmitWithdrawMsgValue {
+  @field({ type: "string" })
+  source!: string;
+
+  @field({ type: "string" })
+  validator!: string;
+
+  @field({ type: TxMsgValue })
+  tx!: TxMsgValue;
+
+  constructor(data: SubmitWithdrawProps) {
+    Object.assign(this, data);
+    this.tx = new TxMsgValue({ ...data.tx, publicKey: data.tx.publicKey });
+  }
+}

--- a/packages/types/src/tx/types.ts
+++ b/packages/types/src/tx/types.ts
@@ -15,6 +15,12 @@ export type SubmitUnbondProps = {
   tx: TxProps;
 };
 
+export type SubmitWithdrawProps = {
+  validator: string;
+  source: string;
+  tx: TxProps;
+};
+
 export type TxProps = {
   token: string;
   feeAmount: BigNumber;

--- a/packages/utils/src/helpers/index.ts
+++ b/packages/utils/src/helpers/index.ts
@@ -221,3 +221,17 @@ export function paramsToUrl(
   }
   return url;
 }
+
+export const formatPercentage = (bigNumber: BigNumber): string =>
+  bigNumber.multipliedBy(100).toString() + "%";
+
+/**
+ * Applies a function to a value that is possibly undefined.
+ */
+export const mapUndefined = <A, B>(f: (a: A) => B, a: A | undefined): B | undefined =>
+  a === undefined
+    ? undefined
+    : f(a);
+
+export const showMaybeNam = (maybeNam: BigNumber | undefined): string =>
+  mapUndefined(nam => `NAM ${nam.toString()}`, maybeNam) ?? "-";


### PR DESCRIPTION
- refactor(StakingOverview): Split into separate components

- fix: Display some unfetched amounts as "-" instead of "NAM 0"

- fix: Use more redux selectors instead of passing props

- feat(StakingBalancesList): Display total unbonded and withdrawable amounts

- feat(MyValidatorsTable): Display unbonded and withdrawable amounts

- feat(AllValidatorsTable): Add filtering by search and sorting by column

- feat(ValidatorDetails): Add UI to withdraw unbonded tokens

- feat(ValidatorDetails): Display each bond and unbond individually

- fix(ValidatorDetails): Display http URLs as links

- fix(UnbondPosition): Make stakedAmount BigNumber instead of number

- fix(StakingAndGovernance/types): Make ChangeInStakingPosition amount always positive (negative does not represent unbond)

- fix(StakingAndGovernance/types): Make more types optional; for when data is unfetched

- fix(StakingAndGovernance/types): Make some amounts BigNumbers; for use in calculations

- fix(StakingAndGovernance/actions): Make voting power 1:1 with staked amount in namnam

- fix(Modal): Apply app theme to modals

- feat(Table): Add subheading slot; for elements between table and heading

- feat(Table): Add onClick prop; called when a column heading is clicked

- fix(shared): Send bond amount in NAM