### PR TITLE
feat: cleanup memory on rust panic

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -22,7 +22,8 @@
     "test": "./scripts/build-node.sh && yarn jest",
     "test:watch": "./scripts/build-node.sh && yarn jest --watchAll=true",
     "test:ci": "jest",
-    "wasm:build": "./scripts/build.sh"
+    "wasm:build": "./scripts/build.sh --release",
+    "wasm:build:dev": "./scripts/build.sh"
   },
   "dependencies": {
     "@anoma/chains": "0.1.0",

--- a/apps/extension/scripts/build.sh
+++ b/apps/extension/scripts/build.sh
@@ -3,5 +3,12 @@
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd -P)
 PACKAGES_PATH="../../../packages"
 
-cd "${SCRIPT_DIR}/${PACKAGES_PATH}/crypto" && yarn wasm:build
-cd "${SCRIPT_DIR}/${PACKAGES_PATH}/shared" && yarn wasm:build
+suffix=""
+
+if [ "$1" != "--release" ]
+then
+    suffix=":dev"
+fi
+
+cd "${SCRIPT_DIR}/${PACKAGES_PATH}/crypto" && yarn wasm:build$suffix
+cd "${SCRIPT_DIR}/${PACKAGES_PATH}/shared" && yarn wasm:build$suffix

--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -735,14 +735,19 @@ export class KeyRing {
       throw new Error(`Account not found.`);
     }
 
-    return (await this.query.query_balance(account.owner)).map(
-      ([token, amount]: [string, string]) => {
-        return {
-          token,
-          amount,
-        };
-      }
-    );
+    try {
+      return (await this.query.query_balance(account.owner)).map(
+        ([token, amount]: [string, string]) => {
+          return {
+            token,
+            amount,
+          };
+        }
+      );
+    } catch (e) {
+      console.error(e);
+      return [];
+    }
   }
 
   private async addSecretKey(

--- a/apps/extension/src/provider/Anoma.test.ts
+++ b/apps/extension/src/provider/Anoma.test.ts
@@ -1,6 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { deepMock } from "mockzilla";
-import type { Browser } from "webextension-polyfill";
 import { toBase64 } from "@cosmjs/encoding";
 import BigNumber from "bignumber.js";
 
@@ -33,8 +31,7 @@ import { Sdk } from "@anoma/shared";
 import * as utils from "extension/utils";
 
 // Needed for now as utils import webextension-polyfill directly
-const [browser] = deepMock<Browser>("browser", false);
-jest.mock("webextension-polyfill", () => browser);
+jest.mock("webextension-polyfill", () => ({}));
 
 describe("Anoma", () => {
   let anoma: Anoma;

--- a/apps/extension/tsconfig.json
+++ b/apps/extension/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": "./src",
-    "target": "es5",
+    "target": "es2015",
     "lib": ["dom", "dom.iterable", "esnext", "webworker"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/apps/namada-interface/package.json
+++ b/apps/namada-interface/package.json
@@ -42,15 +42,16 @@
     "lint": "npx eslint src --ext .ts,.tsx",
     "lint:fix": "yarn lint -- --fix",
     "lint:ci": "yarn lint --max-warnings 0",
-    "test": "yarn wasm:build-node && yarn jest",
-    "test:watch": "yarn wasm:build-node && yarn jest --watchAll=true",
-    "test:coverage": "yarn wasm:build-node && yarn test --coverage",
+    "test": "yarn wasm:build:node && yarn jest",
+    "test:watch": "yarn wasm:build:node && yarn jest --watchAll=true",
+    "test:coverage": "yarn wasm:build:node && yarn test --coverage",
     "test:ci": "jest",
     "e2e-test": "PLAYWRIGHT_BASE_URL=http://localhost:3000 yarn playwright test",
     "e2e-test:headed": "PLAYWRIGHT_BASE_URL=http://localhost:3000 yarn playwright test --project=chromium --headed",
     "eject": "npx react-scripts eject",
-    "wasm:build": "./scripts/build.sh",
-    "wasm:build-node": "./scripts/build-node.sh"
+    "wasm:build": "./scripts/build.sh --release",
+    "wasm:build:dev": "./scripts/build.sh",
+    "wasm:build:node": "./scripts/build-node.sh"
   },
   "browserslist": {
     "production": [

--- a/packages/crypto/lib/Cargo.toml
+++ b/packages/crypto/lib/Cargo.toml
@@ -37,6 +37,12 @@ wasm-bindgen-test = "0.3.13"
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = true
 
+[package.metadata.wasm-pack.profile.dev]
+wasm-opt = false
+
 [profile.release]
-opt-level = "s"
 lto = true
+opt-level = "s"
+
+[profile.dev]
+opt-level = "s"

--- a/packages/crypto/lib/src/utils.rs
+++ b/packages/crypto/lib/src/utils.rs
@@ -6,4 +6,3 @@ pub fn encryption_key(salt: &kdf::Salt, password: String) -> kdf::SecretKey {
         .and_then(|password| kdf::derive_key(&password, salt, 3, 1 << 16, 32))
         .expect("Generation of encryption secret key shouldn't fail")
 }
-

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "private": false,
   "scripts": {
-    "wasm:build": "./scripts/build.sh",
+    "wasm:build": "./scripts/build.sh --release",
+    "wasm:build:dev": "./scripts/build.sh",
     "wasm:build:node": "./scripts/build-test.sh",
     "test": "yarn wasm:build:node && yarn jest",
     "test:watch": "yarn wasm:build:node && yarn test --watch",

--- a/packages/crypto/scripts/build.sh
+++ b/packages/crypto/scripts/build.sh
@@ -2,5 +2,20 @@
 
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd -P)
 
-cd $SCRIPT_DIR/../lib; cargo build --target wasm32-unknown-unknown --release
-wasm-bindgen --out-dir=$SCRIPT_DIR/../src/crypto --target=web --omit-default-module-path target/wasm32-unknown-unknown/release/crypto.wasm
+path=""
+
+if [ "$1" = "" ]
+then
+    echo "Building \"crypto\" in dev mode."
+    path="debug"
+elif [ "$1" = "--release" ]
+then
+    echo "Building \"crypto\" in release mode."
+    path="release"
+else
+    echo "Unsupported build mode \"$1\""
+    exit 1
+fi
+
+cd $SCRIPT_DIR/../lib; cargo build --target wasm32-unknown-unknown ${1} $features
+wasm-bindgen --out-dir=$SCRIPT_DIR/../src/crypto --target=web --omit-default-module-path target/wasm32-unknown-unknown/$path/crypto.wasm

--- a/packages/crypto/tsconfig.json
+++ b/packages/crypto/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": "./src",
-    "target": "es5",
+    "target": "es2015",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/packages/shared/lib/Cargo.toml
+++ b/packages/shared/lib/Cargo.toml
@@ -10,6 +10,9 @@ license = "MIT"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+dev = []
+
 [dependencies]
 async-trait = {version = "0.1.51"}
 tiny-bip39 = "0.8.2"
@@ -65,8 +68,15 @@ borsh-schema-derive-internal = {git = "https://github.com/heliaxdev/borsh-rs.git
 bumpalo = {git = "https://github.com/fitzgen/bumpalo", version = "3.8.0"}
 
 [package.metadata.wasm-pack.profile.release]
+wasm-opt = true
+
+[package.metadata.wasm-pack.profile.dev]
 wasm-opt = false
 
 [profile.release]
-debug = true
+lto = true
+opt-level = "s"
+
+[profile.dev]
+# TODO: we can experiment with optimization levels
 opt-level = "s"

--- a/packages/shared/lib/src/query.rs
+++ b/packages/shared/lib/src/query.rs
@@ -11,7 +11,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::rpc_client::HttpClient;
 use crate::sdk::masp;
-use crate::utils::to_js_result;
+use crate::utils::{set_panic_hook, to_js_result};
 
 #[wasm_bindgen]
 /// Represents an API for querying the ledger
@@ -23,7 +23,7 @@ pub struct Query {
 impl Query {
     #[wasm_bindgen(constructor)]
     pub fn new(url: String) -> Query {
-        console_error_panic_hook::set_once();
+        set_panic_hook();
         let client = HttpClient::new(url);
         Query { client }
     }

--- a/packages/shared/lib/src/sdk/mod.rs
+++ b/packages/shared/lib/src/sdk/mod.rs
@@ -4,7 +4,11 @@ use namada::ledger::{
 };
 use wasm_bindgen::{prelude::wasm_bindgen, JsError, JsValue};
 
-use crate::{rpc_client::HttpClient, sdk::masp::WebShieldedUtils, utils::to_bytes};
+use crate::{
+    rpc_client::HttpClient,
+    sdk::masp::WebShieldedUtils,
+    utils::{set_panic_hook, to_bytes},
+};
 
 pub mod masp;
 mod tx;
@@ -24,7 +28,7 @@ pub struct Sdk {
 impl Sdk {
     #[wasm_bindgen(constructor)]
     pub fn new(url: String) -> Self {
-        console_error_panic_hook::set_once();
+        set_panic_hook();
         Sdk {
             client: HttpClient::new(url),
             wallet: Wallet::new(wallet::STORAGE_PATH.to_owned(), Store::default()),

--- a/packages/shared/lib/src/utils.rs
+++ b/packages/shared/lib/src/utils.rs
@@ -45,3 +45,14 @@ where
         Err(e) => Err(JsError::new(&e.to_string())),
     }
 }
+
+#[cfg(feature = "dev")]
+pub fn set_panic_hook() {
+    web_sys::console::log_1(&"Set panic hook".into());
+    console_error_panic_hook::set_once();
+}
+
+#[cfg(not(feature = "dev"))]
+pub fn set_panic_hook() {
+    web_sys::console::log_1(&"Do not set panic hook".into());
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "private": false,
   "scripts": {
-    "wasm:build": "./scripts/build.sh",
+    "wasm:build": "./scripts/build.sh --release",
+    "wasm:build:dev": "./scripts/build.sh",
     "wasm:build:node": "./scripts/build-test.sh",
     "test-wasm:ci": "cd ./lib && cargo test"
   },

--- a/packages/shared/scripts/build.sh
+++ b/packages/shared/scripts/build.sh
@@ -2,5 +2,22 @@
 
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd -P)
 
-cd $SCRIPT_DIR/../lib; cargo build --target wasm32-unknown-unknown --release
-wasm-bindgen --out-dir=$SCRIPT_DIR/../src/shared --target=web --omit-default-module-path target/wasm32-unknown-unknown/release/shared.wasm
+features=""
+path=""
+
+if [ "$1" = "" ]
+then
+    echo "Building \"shared\" in dev mode."
+    features="--features dev"
+    path="debug"
+elif [ "$1" = "--release" ]
+then
+    echo "Building \"shared\" in release mode."
+    path="release"
+else
+    echo "Unsupported build mode \"$1\""
+    exit 1
+fi
+
+cd $SCRIPT_DIR/../lib; cargo build --target wasm32-unknown-unknown ${1} $features
+wasm-bindgen --out-dir=$SCRIPT_DIR/../src/shared --target=web --omit-default-module-path target/wasm32-unknown-unknown/$path/shared.wasm

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,1 +1,26 @@
+import { Query as RustQuery } from "./shared/shared";
 export * from "./shared/shared";
+
+/**
+ *  CallWithTimeout - calls a function with specified timeout
+ */
+const cwt =
+  <U extends unknown[], T>(fn: (...args: U) => Promise<T>, timeout = 5) =>
+  (...args: U): Promise<T> => {
+    return new Promise(async (resolve, reject) => {
+      const t = setTimeout(() => {
+        reject(`Balance query timed out after ${timeout}s.`);
+      }, timeout * 1000);
+
+      const res = await fn(...args);
+      clearTimeout(t);
+      resolve(res);
+    });
+  };
+
+export class Query extends RustQuery {
+  query_balance = cwt(super.query_balance.bind(this), 10);
+  query_epoch = cwt(super.query_epoch.bind(this));
+  query_all_validators = cwt(super.query_all_validators.bind(this));
+  query_my_validators = cwt(super.query_my_validators.bind(this));
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": "./src",
-    "target": "es5",
+    "target": "es2015",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/scripts/build-test.sh
+++ b/scripts/build-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd -P)
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd -P)
-
-cd $SCRIPT_DIR/../packages/crypto && yarn wasm:build
-cd $SCRIPT_DIR/../packages/shared && yarn wasm:build


### PR DESCRIPTION
Context:

> So I found a pretty shitty workaround. So it seems like the only way to gc the memory is to free all the references to the WebAssembly instance exports/properties. We can't do it manually by accessing memory or sth.
> The problem tho is that because rust panics the js stops executing(just hangs there). Because of that extension service worker(which we use to run rust sdk code) can't get inactive(and drop the references to WebAssembly exports) :confused:
> So the shitty fix is to timeout calls to rust sdk, after certain amount of time. This way we can catch reject on timeout and handle it as a normal error. So we still have garbage in memory, but it will be freed after service worker goes inactive which is 30 seconds of no received messages. Unfortunately we can't stop the service worker manually, we can only deregister it, but then we can't register it again as this happens automatically on first extension load :neutral_face:

What've changed:
- query functions are wrapped in timeout
- added wasm build script for dev: `wasm:build:dev`
- with `wasm:build:dev` we define panic_hook - added `dev` feature
- changed build targets to `es2015` to be able to extend generated Query class

We can do something similar for the Sdk class, it might be a bit tricky though as for example submit shielded transfer can take a while