### PR TITLE
fix: use es2015 in interface

### DIFF
--- a/apps/namada-interface/tsconfig.json
+++ b/apps/namada-interface/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": "./src",
-    "target": "es5",
+    "target": "es2015",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
This fixes a bug introduced in #317 where `new Query` cannot be called because Query was transpiled to ES5 and relies on the class it extends to also be transpiled, but the parent class was generated from Rust and not transpiled.

PR #317 already fixed this for the extension; this commit just sets the target JS version for namada-interface too.