### PR TITLE
refactor: use wasm-pack for builds

### DIFF
--- a/packages/crypto/lib/Cargo.toml
+++ b/packages/crypto/lib/Cargo.toml
@@ -34,15 +34,25 @@ zeroize = "1.6.0"
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"
 
-[package.metadata.wasm-pack.profile.release]
-wasm-opt = true
-
-[package.metadata.wasm-pack.profile.dev]
-wasm-opt = false
-
+# https://doc.rust-lang.org/cargo/reference/profiles.html
 [profile.release]
 lto = true
 opt-level = "s"
 
 [profile.dev]
-opt-level = "s"
+# We do not wan't to make any optimizations for dev
+opt-level = 0
+
+# wasm-pack sepcific configuration
+[package.metadata.wasm-pack.profile.release]
+# https://docs.rs/wasm-opt/latest/wasm_opt/
+wasm-opt = ['-O4']
+
+[package.metadata.wasm-pack.profile.dev]
+wasm-opt = false
+
+[package.metadata.wasm-pack.profile.dev.wasm-bindgen]
+omit-default-module-path = true
+
+[package.metadata.wasm-pack.profile.release.wasm-bindgen]
+omit-default-module-path = true

--- a/packages/crypto/scripts/build-test.sh
+++ b/packages/crypto/scripts/build-test.sh
@@ -2,4 +2,4 @@
 
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd -P)
 
-wasm-pack build $SCRIPT_DIR/../lib --target nodejs --out-dir $SCRIPT_DIR/../src/crypto
+wasm-pack build $SCRIPT_DIR/../lib --dev --target nodejs --out-dir $SCRIPT_DIR/../src/crypto

--- a/packages/crypto/scripts/build.sh
+++ b/packages/crypto/scripts/build.sh
@@ -3,19 +3,21 @@
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd -P)
 
 path=""
+profile=""
 
 if [ "$1" = "" ]
 then
     echo "Building \"crypto\" in dev mode."
+    profile="--dev"
     path="debug"
 elif [ "$1" = "--release" ]
 then
     echo "Building \"crypto\" in release mode."
+    profile="--release"
     path="release"
 else
     echo "Unsupported build mode \"$1\""
     exit 1
 fi
 
-cd $SCRIPT_DIR/../lib; cargo build --target wasm32-unknown-unknown ${1} $features
-wasm-bindgen --out-dir=$SCRIPT_DIR/../src/crypto --target=web --omit-default-module-path target/wasm32-unknown-unknown/$path/crypto.wasm
+wasm-pack build $SCRIPT_DIR/../lib $profile --target web --out-dir $SCRIPT_DIR/../src/crypto

--- a/packages/shared/lib/Cargo.toml
+++ b/packages/shared/lib/Cargo.toml
@@ -56,16 +56,25 @@ borsh-derive = {git = "https://github.com/heliaxdev/borsh-rs.git", rev = "cd5223
 borsh-derive-internal = {git = "https://github.com/heliaxdev/borsh-rs.git", rev = "cd5223e5103c4f139e0c54cf8259b7ec5ec4073a"}
 borsh-schema-derive-internal = {git = "https://github.com/heliaxdev/borsh-rs.git", rev = "cd5223e5103c4f139e0c54cf8259b7ec5ec4073a"}
 
-[package.metadata.wasm-pack.profile.release]
-wasm-opt = true
-
-[package.metadata.wasm-pack.profile.dev]
-wasm-opt = false
-
+# https://doc.rust-lang.org/cargo/reference/profiles.html
 [profile.release]
 lto = true
 opt-level = "s"
 
 [profile.dev]
-# TODO: we can experiment with optimization levels
-opt-level = "s"
+# We do not wan't to make any optimizations for dev
+opt-level = 0
+
+# wasm-pack sepcific configuration
+[package.metadata.wasm-pack.profile.release]
+# https://docs.rs/wasm-opt/latest/wasm_opt/
+wasm-opt = ['-O4']
+
+[package.metadata.wasm-pack.profile.dev]
+wasm-opt = false
+
+[package.metadata.wasm-pack.profile.dev.wasm-bindgen]
+omit-default-module-path = true
+
+[package.metadata.wasm-pack.profile.release.wasm-bindgen]
+omit-default-module-path = true

--- a/packages/shared/scripts/build-test.sh
+++ b/packages/shared/scripts/build-test.sh
@@ -2,4 +2,4 @@
 
 SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd -P)
 
-wasm-pack build $SCRIPT_DIR/../lib --target nodejs --out-dir $SCRIPT_DIR/../src/shared
+wasm-pack build $SCRIPT_DIR/../lib --dev --target nodejs --out-dir $SCRIPT_DIR/../src/shared

--- a/packages/shared/scripts/build.sh
+++ b/packages/shared/scripts/build.sh
@@ -4,20 +4,22 @@ SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd -P)
 
 features=""
 path=""
+profile=""
 
 if [ "$1" = "" ]
 then
     echo "Building \"shared\" in dev mode."
+    profile="--dev"
     features="--features dev"
     path="debug"
 elif [ "$1" = "--release" ]
 then
     echo "Building \"shared\" in release mode."
+    profile="--release"
     path="release"
 else
     echo "Unsupported build mode \"$1\""
     exit 1
 fi
 
-cd $SCRIPT_DIR/../lib; cargo build --target wasm32-unknown-unknown ${1} $features
-wasm-bindgen --out-dir=$SCRIPT_DIR/../src/shared --target=web --omit-default-module-path target/wasm32-unknown-unknown/$path/shared.wasm
+wasm-pack build $SCRIPT_DIR/../lib $profile --target web --out-dir $SCRIPT_DIR/../src/shared -- $features


### PR DESCRIPTION
`wasm-pack` has built in support for `wasm-opt`, so it makes sense to use it for builds
I've also changed:
- opt levels a bit, not sure if it helps with anything though :D 
- test build profile to `dev` as it does skip optimizations