### PR TITLE
bug - Fix for crash on event registration

### DIFF
--- a/apps/namada-interface/src/services/extensionEvents/provider.tsx
+++ b/apps/namada-interface/src/services/extensionEvents/provider.tsx
@@ -59,10 +59,14 @@ export const ExtensionEventsProvider: React.FC = (props): JSX.Element => {
     metamaskAccountChangedHandler,
     false,
     (event, handler) => {
-      window.ethereum.on(event, handler);
+      if (window.ethereum) {
+        window.ethereum.on(event, handler);
+      }
     },
     (event, handler) => {
-      window.ethereum.removeListener(event, handler);
+      if (window.ethereum) {
+        window.ethereum.removeListener(event, handler);
+      }
     }
   );
 


### PR DESCRIPTION
Resolves #328 

This is a simple fix that resolves an issue where Event registration crashes the interface if the Metamask extension is not installed. This checks that `window.ehtereum` is present before attaching handlers.