### PR TITLE
fix: calculate toast props from toast type

### DIFF
--- a/apps/namada-interface/src/slices/transfers.ts
+++ b/apps/namada-interface/src/slices/transfers.ts
@@ -2,10 +2,10 @@ import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import BigNumber from "bignumber.js";
 
 import { Account, Tokens, TokenType, Signer } from "@namada/types";
+import { assertNever } from "@namada/utils";
 import { getIntegration } from "@namada/hooks";
 
 import {
-  actions as notificationsActions,
   CreateToastPayload,
   ToastId,
   ToastTimeout,
@@ -20,39 +20,43 @@ export enum Toasts {
 
 type TransferCompletedToastProps = { msgId: string; success: boolean };
 type TransferStartedToastProps = { msgId: string };
-type GetToastProps =
-  | TransferCompletedToastProps
-  | TransferStartedToastProps
-  | void;
+type GetToastProps<T extends Toasts> =
+  T extends Toasts.TransferStarted ? TransferStartedToastProps :
+  T extends Toasts.TransferCompleted ? TransferCompletedToastProps :
+  never;
 
-export const getToast = (
+export const getToast = <T extends Toasts>(
   toastId: ToastId,
-  toast: Toasts
-): ((props: GetToastProps) => CreateToastPayload) => {
-  const toasts = {
-    [Toasts.TransferStarted]: (payload: TransferCompletedToastProps) => ({
-      id: toastId,
-      data: {
-        title: "Transfer in progress!",
-        message: payload.msgId,
-        type: "pending-info" as ToastType,
-        timeout: ToastTimeout.None(),
-      },
-    }),
-    [Toasts.TransferCompleted]: ({
-      success,
-      msgId,
-    }: TransferCompletedToastProps) => ({
-      id: toastId,
-      data: {
-        title: success ? "Transfer successful!" : "Transfer failed.",
-        message: msgId,
-        type: success ? "success" : "error",
-      },
-    }),
-  };
+  toast: T
+): ((props: GetToastProps<T>) => CreateToastPayload) => {
+  const toastFunction =
+    toast === Toasts.TransferStarted ?
+      (payload: TransferCompletedToastProps) => ({
+        id: toastId,
+        data: {
+          title: "Transfer in progress!",
+          message: payload.msgId,
+          type: "pending-info" as ToastType,
+          timeout: ToastTimeout.None(),
+        },
+      }) :
 
-  return toasts[toast] as (props: GetToastProps) => CreateToastPayload;
+    toast === Toasts.TransferCompleted ?
+      ({
+        success,
+        msgId,
+      }: TransferCompletedToastProps) => ({
+        id: toastId,
+        data: {
+          title: success ? "Transfer successful!" : "Transfer failed.",
+          message: msgId,
+          type: success ? "success" : "error",
+        },
+      }) :
+
+    assertNever(toast);
+
+  return toastFunction as (props: GetToastProps<T>) => CreateToastPayload;
 };
 
 const TRANSFERS_ACTIONS_BASE = "transfers";
@@ -181,15 +185,16 @@ export const submitIbcTransferTransaction = createAsyncThunk<
   { state: RootState }
 >(
   `${TRANSFERS_ACTIONS_BASE}/${TransfersThunkActions.SubmitIbcTransferTransaction}`,
-  async (txIbcTransferArgs, { getState, dispatch, requestId }) => {
+  async (txIbcTransferArgs, { getState, /* dispatch, requestId */ }) => {
     const { chainId } = getState().settings;
     const integration = getIntegration(chainId);
 
-    dispatch(
-      notificationsActions.createToast(
-        getToast(`${requestId}-pending`, Toasts.TransferStarted)()
-      )
-    );
+    // TODO: Add toast props
+    //dispatch(
+    //  notificationsActions.createToast(
+    //    getToast(`${requestId}-pending`, Toasts.TransferStarted)()
+    //  )
+    //);
 
     await integration.submitBridgeTransfer({
       ibcProps: {
@@ -208,11 +213,12 @@ export const submitIbcTransferTransaction = createAsyncThunk<
       },
     });
 
-    dispatch(
-      notificationsActions.createToast(
-        getToast(`${requestId}-fullfilled`, Toasts.TransferCompleted)()
-      )
-    );
+    // TODO: Add toast props
+    //dispatch(
+    //  notificationsActions.createToast(
+    //    getToast(`${requestId}-fullfilled`, Toasts.TransferCompleted)()
+    //  )
+    //);
   }
 );
 
@@ -222,15 +228,16 @@ export const submitBridgeTransferTransaction = createAsyncThunk<
   { state: RootState }
 >(
   `${TRANSFERS_ACTIONS_BASE}/${TransfersThunkActions.SubmitBridgeTransferTransaction}`,
-  async (txBridgeTransferArgs, { getState, dispatch, requestId }) => {
+  async (txBridgeTransferArgs, { getState, /* dispatch, requestId */ }) => {
     const { chainId } = getState().settings;
     const integration = getIntegration(chainId);
 
-    dispatch(
-      notificationsActions.createToast(
-        getToast(`${requestId}-pending`, Toasts.TransferStarted)()
-      )
-    );
+    // TODO: Add toast props
+    //dispatch(
+    //  notificationsActions.createToast(
+    //    getToast(`${requestId}-pending`, Toasts.TransferStarted)()
+    //  )
+    //);
 
     await integration.submitBridgeTransfer({
       // TODO: tx (below) is *not* required for Keplr, but are required for this type.
@@ -249,11 +256,12 @@ export const submitBridgeTransferTransaction = createAsyncThunk<
       },
     });
 
-    dispatch(
-      notificationsActions.createToast(
-        getToast(`${requestId}-fullfilled`, Toasts.TransferCompleted)()
-      )
-    );
+    // TODO: Add toast props
+    //dispatch(
+    //  notificationsActions.createToast(
+    //    getToast(`${requestId}-fullfilled`, Toasts.TransferCompleted)()
+    //  )
+    //);
   }
 );
 


### PR DESCRIPTION
This fixes a problem where TypeScript was not throwing an error when getToast was called with the wrong arguments. The code calling getToast has been commented out for now.

~This PR is based on #325 since they both touch the same file, so this should be rebased to main after #325 is merged.~ Done.