### PR TITLE
Speed up CI

### DIFF
--- a/.github/workflows/deploy-wallet-at-pr.yml
+++ b/.github/workflows/deploy-wallet-at-pr.yml
@@ -74,6 +74,16 @@ jobs:
             ./packages/utils/node_modules
           key: ${{ runner.os }}-yarn-cache-${{ hashFiles('**/yarn.lock') }}
 
+      - name: Restore Rust unit-tests-js cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./packages/shared/lib/target
+            ./packages/crypto/lib/target
+          key: ${{ runner.os }}-rust-cache-unit-tests-js-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler
 
@@ -132,6 +142,16 @@ jobs:
             ./packages/utils/node_modules
           key: ${{ runner.os }}-yarn-cache-${{ hashFiles('**/yarn.lock') }}
 
+      - name: Restore Rust unit-tests-wasm cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./packages/shared/lib/target
+            ./packages/crypto/lib/target
+          key: ${{ runner.os }}-rust-cache-unit-tests-wasm-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler
 
@@ -186,6 +206,16 @@ jobs:
             ./packages/types/node_modules
             ./packages/utils/node_modules
           key: ${{ runner.os }}-yarn-cache-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Restore Rust build cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./packages/shared/lib/target
+            ./packages/crypto/lib/target
+          key: ${{ runner.os }}-rust-cache-build-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler

--- a/.github/workflows/deploy-wallet-at-pr.yml
+++ b/.github/workflows/deploy-wallet-at-pr.yml
@@ -29,7 +29,6 @@ jobs:
         run: yarn lint:ci
 
   unit-tests-js:
-    needs: lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -68,7 +67,6 @@ jobs:
           ${{ secrets.SLACK_WEBHOOK_WALLET_PR }}
 
   unit-tests-wasm:
-    needs: lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy-wallet-at-pr.yml
+++ b/.github/workflows/deploy-wallet-at-pr.yml
@@ -124,9 +124,6 @@ jobs:
       - name: Rustup add target
         run: rustup target add wasm32-unknown-unknown
 
-      - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli@0.2.87
-
       - name: build the site
         working-directory: ./apps/namada-interface
         run: yarn build

--- a/.github/workflows/deploy-wallet-at-pr.yml
+++ b/.github/workflows/deploy-wallet-at-pr.yml
@@ -22,6 +22,26 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Restore yarn cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ./node_modules
+            ./apps/namada-interface/node_modules
+            ./apps/extension/node_modules
+            ./packages/chains/node_modules
+            ./packages/components/node_modules
+            ./packages/crypto/node_modules
+            ./packages/hooks/node_modules
+            ./packages/integrations/node_modules
+            ./packages/ledger-namada/node_modules
+            ./packages/rpc/node_modules
+            ./packages/shared/node_modules
+            ./packages/storage/node_modules
+            ./packages/types/node_modules
+            ./packages/utils/node_modules
+          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('**/yarn.lock') }}
+
       - name: Install dependencies
         run: yarn
 
@@ -33,6 +53,26 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Restore yarn cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ./node_modules
+            ./apps/namada-interface/node_modules
+            ./apps/extension/node_modules
+            ./packages/chains/node_modules
+            ./packages/components/node_modules
+            ./packages/crypto/node_modules
+            ./packages/hooks/node_modules
+            ./packages/integrations/node_modules
+            ./packages/ledger-namada/node_modules
+            ./packages/rpc/node_modules
+            ./packages/shared/node_modules
+            ./packages/storage/node_modules
+            ./packages/types/node_modules
+            ./packages/utils/node_modules
+          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler
@@ -72,6 +112,26 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Restore yarn cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ./node_modules
+            ./apps/namada-interface/node_modules
+            ./apps/extension/node_modules
+            ./packages/chains/node_modules
+            ./packages/components/node_modules
+            ./packages/crypto/node_modules
+            ./packages/hooks/node_modules
+            ./packages/integrations/node_modules
+            ./packages/ledger-namada/node_modules
+            ./packages/rpc/node_modules
+            ./packages/shared/node_modules
+            ./packages/storage/node_modules
+            ./packages/types/node_modules
+            ./packages/utils/node_modules
+          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('**/yarn.lock') }}
+
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler
 
@@ -106,6 +166,26 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+
+      - name: Restore yarn cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ./node_modules
+            ./apps/namada-interface/node_modules
+            ./apps/extension/node_modules
+            ./packages/chains/node_modules
+            ./packages/components/node_modules
+            ./packages/crypto/node_modules
+            ./packages/hooks/node_modules
+            ./packages/integrations/node_modules
+            ./packages/ledger-namada/node_modules
+            ./packages/rpc/node_modules
+            ./packages/shared/node_modules
+            ./packages/storage/node_modules
+            ./packages/types/node_modules
+            ./packages/utils/node_modules
+          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install protoc
         run: sudo apt-get install -y protobuf-compiler
@@ -158,9 +238,31 @@ jobs:
         working-directory: ./apps/namada-interface
     steps:
       - uses: actions/checkout@v2
+
+      - name: Restore yarn cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ./node_modules
+            ./apps/namada-interface/node_modules
+            ./apps/extension/node_modules
+            ./packages/chains/node_modules
+            ./packages/components/node_modules
+            ./packages/crypto/node_modules
+            ./packages/hooks/node_modules
+            ./packages/integrations/node_modules
+            ./packages/ledger-namada/node_modules
+            ./packages/rpc/node_modules
+            ./packages/shared/node_modules
+            ./packages/storage/node_modules
+            ./packages/types/node_modules
+            ./packages/utils/node_modules
+          key: ${{ runner.os }}-yarn-cache-${{ hashFiles('**/yarn.lock') }}
+
       - uses: actions/setup-node@v2
         with:
           node-version: "18.x"
+
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.3.0
         with:

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "test": "wsrun --serial --exclude-missing -c test",
     "test:ci": "wsrun --serial --exclude-missing -c test:ci",
     "test-wasm:ci": "wsrun --serial --exclude-missing -c test-wasm:ci",
-    "lint": "wsrun --serial --exclude-missing -c lint",
-    "lint:fix": "wsrun --serial --exclude-missing -c lint:fix",
-    "lint:ci": "wsrun --serial --exclude-missing -c lint:ci"
+    "lint": "wsrun -l --exclude-missing -c lint",
+    "lint:fix": "wsrun -l --exclude-missing -c lint:fix",
+    "lint:ci": "wsrun -l --exclude-missing -c lint:ci"
   },
   "dependencies": {
     "@cosmjs/encoding": "^0.27.1",


### PR DESCRIPTION
This PR adds some things to speed up the CI, most importantly caching of Rust and yarn dependencies.

---

### Changed

- Run more CI jobs in parallel (1d3ea4a8)
- Run linting script in parallel (d70a1c31)

### Added

- Add yarn cache to CI (bb2b5f87)
- Add Rust caches to CI (44e1294f)

### Removed

- Don't install wasm-bindgen-cli in CI (ceb79e76)