### PR TITLE
feat/342 - Ledger - support for additional addresses

### DIFF
--- a/apps/extension/src/App/Accounts/AccountListing.tsx
+++ b/apps/extension/src/App/Accounts/AccountListing.tsx
@@ -62,6 +62,7 @@ const AccountListing = ({ account, parentAlias }: Props): JSX.Element => {
   const { address, alias, path, type } = account;
   const navigate = useNavigate();
   const isChildAccount = isChild(type, path);
+  const isLedgerParent = type === AccountType.Ledger && !isChildAccount;
 
   return (
     <AccountListingContainer>
@@ -76,7 +77,7 @@ const AccountListing = ({ account, parentAlias }: Props): JSX.Element => {
         <Address>{shortenAddress(address)}</Address>
       </Details>
       <Buttons>
-        {type === AccountType.Mnemonic && (
+        {(type === AccountType.Mnemonic || isLedgerParent) && (
           <Button
             onClick={() => {
               navigate(TopLevelRoute.AddAccount);

--- a/apps/extension/src/App/Settings/ExtraSettings/ExtraSettings.tsx
+++ b/apps/extension/src/App/Settings/ExtraSettings/ExtraSettings.tsx
@@ -1,6 +1,6 @@
 import { assertNever } from "@namada/utils";
-import { ExtensionRequester } from "extension";
 
+import { ExtensionRequester } from "extension";
 import { Mode, ExtraSetting } from "./types";
 import { ResetPassword } from "./ResetPassword";
 import { DeleteAccount } from "./DeleteAccount";
@@ -29,6 +29,7 @@ const ExtraSettings: React.FC<{
       ) : extraSetting.mode === Mode.DeleteAccount ? (
         <DeleteAccount
           accountId={extraSetting.accountId}
+          accountType={extraSetting.accountType}
           requester={requester}
           onDeleteAccount={onDeleteAccount}
         />

--- a/apps/extension/src/App/Settings/ExtraSettings/types.ts
+++ b/apps/extension/src/App/Settings/ExtraSettings/types.ts
@@ -1,3 +1,5 @@
+import { ParentAccount } from "background/keyring";
+
 // Extra settings modes
 export enum Mode {
   ResetPassword = "Reset password",
@@ -7,4 +9,5 @@ export enum Mode {
 export type ExtraSetting = {
   mode: Mode;
   accountId: string;
+  accountType: ParentAccount;
 };

--- a/apps/extension/src/App/Settings/Settings.tsx
+++ b/apps/extension/src/App/Settings/Settings.tsx
@@ -2,9 +2,8 @@ import React, { useEffect, useState, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import browser from "webextension-polyfill";
 
-import { DerivedAccount } from "@namada/types";
+import { AccountType, DerivedAccount } from "@namada/types";
 import { Button, ButtonVariant } from "@namada/components";
-import { assertNever } from "@namada/utils";
 
 import { ExtensionRequester } from "extension";
 import { Ports } from "router";
@@ -90,9 +89,7 @@ const Settings: React.FC<{
     }
   };
 
-  const handleDeleteAccount = async (
-    deletedAccountId: string
-  ): Promise<void> => {
+  const onDeleteAccount = async (): Promise<void> => {
     await fetchParentAccounts();
   };
 
@@ -135,6 +132,7 @@ const Settings: React.FC<{
                   setExtraSetting({
                     mode,
                     accountId: account.id,
+                    accountType: account.type as ParentAccount,
                   })
                 }
               />
@@ -164,7 +162,7 @@ const Settings: React.FC<{
             extraSetting={extraSetting}
             requester={requester}
             onClose={() => setExtraSetting(null)}
-            onDeleteAccount={handleDeleteAccount}
+            onDeleteAccount={onDeleteAccount}
           />
         </ThemedScrollbarContainer>
       </AccountsContainer>
@@ -196,6 +194,7 @@ const AccountListItem: React.FC<{
 
       {expanded && (
         <ModeSelect
+          type={account.type}
           onSelectMode={(mode) => {
             setExpanded(false);
             onSelectMode(mode);
@@ -211,8 +210,13 @@ const AccountListItem: React.FC<{
  */
 const ModeSelect: React.FC<{
   onSelectMode: (mode: Mode) => void;
-}> = ({ onSelectMode }) => {
-  const modes = [Mode.ResetPassword, Mode.DeleteAccount];
+  type: AccountType;
+}> = ({ onSelectMode, type }) => {
+  const modes = [Mode.DeleteAccount];
+
+  if (type !== AccountType.Ledger) {
+    modes.unshift(Mode.ResetPassword);
+  }
 
   return (
     <ModeSelectContainer>

--- a/apps/extension/src/Approvals/ApproveTx/ApproveTx.tsx
+++ b/apps/extension/src/Approvals/ApproveTx/ApproveTx.tsx
@@ -5,6 +5,7 @@ import { Button, ButtonVariant } from "@namada/components";
 import { shortenAddress } from "@namada/utils";
 import { AccountType, Tokens } from "@namada/types";
 import { TxType } from "@namada/shared";
+import { useSanitizedParams } from "@namada/hooks";
 
 import { useQuery } from "hooks";
 import { Address } from "App/Accounts/AccountListing.components";
@@ -17,7 +18,6 @@ import { Ports } from "router";
 import { RejectTxMsg } from "background/approvals";
 import { useRequester } from "hooks/useRequester";
 import { closeCurrentTab } from "utils";
-import { useSanitizedParams } from "@namada/hooks";
 import { ApprovalDetails } from "Approvals/Approvals";
 
 type Props = {

--- a/apps/extension/src/Approvals/ApproveTx/ConfirmLedgerTx.tsx
+++ b/apps/extension/src/Approvals/ApproveTx/ConfirmLedgerTx.tsx
@@ -8,13 +8,13 @@ import { defaultChainId as chainId } from "@namada/chains";
 import { TxType } from "@namada/shared";
 import { Message, Tokens, TxProps, TxMsgValue } from "@namada/types";
 
-import { Ledger } from "background/ledger";
 import {
   GetRevealPKBytesMsg,
   GetTxBytesMsg,
+  Ledger,
   SubmitSignedRevealPKMsg,
   SubmitSignedTxMsg,
-} from "background/ledger/messages";
+} from "background/ledger";
 import { Ports } from "router";
 import { closeCurrentTab } from "utils";
 import { useRequester } from "hooks/useRequester";

--- a/apps/extension/src/Setup/Ledger/LedgerConfirmation.tsx
+++ b/apps/extension/src/Setup/Ledger/LedgerConfirmation.tsx
@@ -25,7 +25,7 @@ import {
   BodyText,
 } from "Setup/Setup.components";
 import { Ports } from "router";
-import { AddLedgerAccountMsg } from "background/ledger/messages";
+import { AddLedgerParentAccountMsg } from "background/ledger";
 import { closeCurrentTab } from "utils";
 
 const LedgerConfirmation: React.FC = () => {
@@ -39,7 +39,7 @@ const LedgerConfirmation: React.FC = () => {
     try {
       await requester.sendMessage(
         Ports.Background,
-        new AddLedgerAccountMsg(alias, address, publicKey, {
+        new AddLedgerParentAccountMsg(alias, address, publicKey, {
           account: 0,
           change: 0,
           index: 0,

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -99,6 +99,7 @@ const { REACT_APP_NAMADA_URL = DEFAULT_URL } = process.env;
   const ledgerService = new LedgerService(
     keyRingService,
     store,
+    sdkStore,
     connectedTabsStore,
     txStore,
     defaultChainId,

--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -335,7 +335,7 @@ export class KeyRing {
     parentId: string
   ): DerivedAccountInfo {
     const { index = 0 } = path;
-    const id = generateId("shielded-account", parentId, index);
+    const id = generateId(UUID_NAMESPACE, "shielded-account", parentId, index);
     const zip32 = new ShieldedHDWallet(seed);
     const account = zip32.derive_to_serialized_keys(index);
 

--- a/apps/extension/src/background/ledger/handler.ts
+++ b/apps/extension/src/background/ledger/handler.ts
@@ -6,15 +6,27 @@ import {
   SubmitSignedRevealPKMsg,
   GetRevealPKBytesMsg,
   SubmitSignedTxMsg,
+  AddLedgerParentAccountMsg,
+  DeleteLedgerAccountMsg,
 } from "./messages";
 
 export const getHandler: (service: LedgerService) => Handler = (service) => {
   return (env: Env, msg: Message<unknown>) => {
     switch (msg.constructor) {
+      case AddLedgerParentAccountMsg:
+        return handleAddLedgerParentAccountMsg(service)(
+          env,
+          msg as AddLedgerParentAccountMsg
+        );
       case AddLedgerAccountMsg:
         return handleAddLedgerAccountMsg(service)(
           env,
           msg as AddLedgerAccountMsg
+        );
+      case DeleteLedgerAccountMsg:
+        return handleDeleteLedgerAccountMsg(service)(
+          env,
+          msg as DeleteLedgerAccountMsg
         );
       case GetTxBytesMsg:
         return handleGetTxBytesMsg(service)(env, msg as GetTxBytesMsg);
@@ -34,12 +46,36 @@ export const getHandler: (service: LedgerService) => Handler = (service) => {
   };
 };
 
+const handleAddLedgerParentAccountMsg: (
+  service: LedgerService
+) => InternalHandler<AddLedgerParentAccountMsg> = (service) => {
+  return async (_, msg) => {
+    const { alias, address, publicKey, bip44Path } = msg;
+    return await service.addAccount(alias, address, publicKey, bip44Path);
+  };
+};
+
 const handleAddLedgerAccountMsg: (
   service: LedgerService
 ) => InternalHandler<AddLedgerAccountMsg> = (service) => {
   return async (_, msg) => {
-    const { alias, address, publicKey, bip44Path } = msg;
-    return await service.addAccount(alias, address, publicKey, bip44Path);
+    const { alias, address, parentId, publicKey, bip44Path } = msg;
+    return await service.addAccount(
+      alias,
+      address,
+      publicKey,
+      bip44Path,
+      parentId
+    );
+  };
+};
+
+const handleDeleteLedgerAccountMsg: (
+  service: LedgerService
+) => InternalHandler<DeleteLedgerAccountMsg> = (service) => {
+  return async (_, msg) => {
+    const { accountId } = msg;
+    return await service.deleteAccount(accountId);
   };
 };
 

--- a/apps/extension/src/background/ledger/index.ts
+++ b/apps/extension/src/background/ledger/index.ts
@@ -2,3 +2,4 @@ export * from "./constants";
 export * from "./init";
 export * from "./ledger";
 export * from "./service";
+export * from "./messages";

--- a/apps/extension/src/background/ledger/init.ts
+++ b/apps/extension/src/background/ledger/init.ts
@@ -6,12 +6,16 @@ import {
   GetRevealPKBytesMsg,
   SubmitSignedTxMsg,
   SubmitSignedRevealPKMsg,
+  AddLedgerParentAccountMsg,
+  DeleteLedgerAccountMsg,
 } from "./messages";
 import { getHandler } from "./handler";
 import { LedgerService } from "./service";
 
 export function init(router: Router, service: LedgerService): void {
+  router.registerMessage(AddLedgerParentAccountMsg);
   router.registerMessage(AddLedgerAccountMsg);
+  router.registerMessage(DeleteLedgerAccountMsg);
   router.registerMessage(GetTxBytesMsg);
   router.registerMessage(GetRevealPKBytesMsg);
   router.registerMessage(SubmitSignedTxMsg);

--- a/apps/extension/src/background/ledger/messages.ts
+++ b/apps/extension/src/background/ledger/messages.ts
@@ -1,21 +1,24 @@
 import { ResponseSign } from "@namada/ledger-namada";
-import { Bip44Path } from "@namada/types";
+import { Bip44Path, DerivedAccount } from "@namada/types";
 
 import { Message } from "router";
 import { ROUTE } from "./constants";
 import { TxType } from "@namada/shared";
+import { Result } from "@namada/utils";
+import { DeleteAccountError } from "background/keyring";
 
 enum MessageType {
+  AddLedgerParentAccount = "add-ledger-parent-account",
   AddLedgerAccount = "add-ledger-account",
+  DeleteLedgerAccount = "delete-ledger-account",
   GetTxBytes = "get-tx-bytes",
   GetRevealPKBytes = "get-reveal-pk-bytes",
   SubmitSignedTx = "submit-signed-tx",
   SubmitSignedRevealPK = "submit-signed-reveal-pk",
 }
-
-export class AddLedgerAccountMsg extends Message<void> {
+export class AddLedgerParentAccountMsg extends Message<DerivedAccount> {
   public static type(): MessageType {
-    return MessageType.AddLedgerAccount;
+    return MessageType.AddLedgerParentAccount;
   }
 
   constructor(
@@ -34,6 +37,52 @@ export class AddLedgerAccountMsg extends Message<void> {
 
     if (!this.address) {
       throw new Error("Address was not provided!");
+    }
+
+    if (!this.publicKey) {
+      throw new Error("Public key was not provided!");
+    }
+
+    if (!this.bip44Path) {
+      throw new Error("BIP44 Path was not provided!");
+    }
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return AddLedgerParentAccountMsg.type();
+  }
+}
+
+export class AddLedgerAccountMsg extends Message<DerivedAccount> {
+  public static type(): MessageType {
+    return MessageType.AddLedgerAccount;
+  }
+
+  constructor(
+    public readonly alias: string,
+    public readonly address: string,
+    public readonly parentId: string,
+    public readonly publicKey: string,
+    public readonly bip44Path: Bip44Path
+  ) {
+    super();
+  }
+
+  validate(): void {
+    if (!this.alias) {
+      throw new Error("Alias must not be empty!");
+    }
+
+    if (!this.address) {
+      throw new Error("Address was not provided!");
+    }
+
+    if (!this.parentId) {
+      throw new Error("Parent ID was not provided!");
     }
 
     if (!this.publicKey) {
@@ -192,5 +241,31 @@ export class SubmitSignedTxMsg extends Message<void> {
 
   type(): string {
     return SubmitSignedTxMsg.type();
+  }
+}
+
+export class DeleteLedgerAccountMsg extends Message<
+  Result<null, DeleteAccountError>
+> {
+  public static type(): MessageType {
+    return MessageType.DeleteLedgerAccount;
+  }
+
+  constructor(public accountId: string) {
+    super();
+  }
+
+  validate(): void {
+    if (!this.accountId) {
+      throw new Error("accountId not provided!");
+    }
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return DeleteLedgerAccountMsg.type();
   }
 }

--- a/apps/extension/src/test/init.ts
+++ b/apps/extension/src/test/init.ts
@@ -36,7 +36,7 @@ const chainId = "namada-75a7e12.69483d59a9fb174";
 export class KVStoreMock<T> implements KVStore<T> {
   private storage: { [key: string]: T | null } = {};
 
-  constructor(readonly _prefix: string) { }
+  constructor(readonly _prefix: string) {}
 
   get<U extends T>(key: string): Promise<U | undefined> {
     return new Promise((resolve) => {
@@ -108,6 +108,7 @@ export const init = async (): Promise<{
   const ledgerService = new LedgerService(
     keyRingService,
     iDBStore as KVStore<AccountStore[]>,
+    sdkStore,
     connectedTabsStore,
     txStore,
     chainId,

--- a/packages/shared/lib/Cargo.lock
+++ b/packages/shared/lib/Cargo.lock
@@ -2916,8 +2916,8 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "namada"
-version = "0.20.0"
-source = "git+https://github.com/anoma/namada#b6714b5eca577c520b2b42b5f7f8048d46bb9d8b"
+version = "0.20.1"
+source = "git+https://github.com/anoma/namada#7fdf079540201546aaf436bf6cc7526acc6a13f8"
 dependencies = [
  "async-trait",
  "bimap",
@@ -2965,8 +2965,8 @@ dependencies = [
 
 [[package]]
 name = "namada_core"
-version = "0.20.0"
-source = "git+https://github.com/anoma/namada#b6714b5eca577c520b2b42b5f7f8048d46bb9d8b"
+version = "0.20.1"
+source = "git+https://github.com/anoma/namada#7fdf079540201546aaf436bf6cc7526acc6a13f8"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -3016,8 +3016,8 @@ dependencies = [
 
 [[package]]
 name = "namada_ethereum_bridge"
-version = "0.20.0"
-source = "git+https://github.com/anoma/namada#b6714b5eca577c520b2b42b5f7f8048d46bb9d8b"
+version = "0.20.1"
+source = "git+https://github.com/anoma/namada#7fdf079540201546aaf436bf6cc7526acc6a13f8"
 dependencies = [
  "borsh",
  "ethers",
@@ -3037,8 +3037,8 @@ dependencies = [
 
 [[package]]
 name = "namada_macros"
-version = "0.20.0"
-source = "git+https://github.com/anoma/namada#b6714b5eca577c520b2b42b5f7f8048d46bb9d8b"
+version = "0.20.1"
+source = "git+https://github.com/anoma/namada#7fdf079540201546aaf436bf6cc7526acc6a13f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3047,8 +3047,8 @@ dependencies = [
 
 [[package]]
 name = "namada_proof_of_stake"
-version = "0.20.0"
-source = "git+https://github.com/anoma/namada#b6714b5eca577c520b2b42b5f7f8048d46bb9d8b"
+version = "0.20.1"
+source = "git+https://github.com/anoma/namada#7fdf079540201546aaf436bf6cc7526acc6a13f8"
 dependencies = [
  "borsh",
  "data-encoding",

--- a/packages/shared/lib/Cargo.toml
+++ b/packages/shared/lib/Cargo.toml
@@ -23,7 +23,7 @@ gloo-utils = { version = "0.1.5", features = ["serde"] }
 js-sys = "0.3.60"
 masp_primitives = { git = "https://github.com/anoma/masp", rev = "252a6059565b125c1444e9e7d0b7c8da0fba8f8f" }
 masp_proofs = { git = "https://github.com/anoma/masp", rev = "252a6059565b125c1444e9e7d0b7c8da0fba8f8f", default-features = false, features = ["local-prover"] }
-namada = { git = "https://github.com/anoma/namada", version = "0.20.0", default-features = false, features = ["abciplus", "namada-sdk"] }
+namada = { git = "https://github.com/anoma/namada", version = "0.20.1", default-features = false, features = ["abciplus", "namada-sdk"] }
 prost = "0.9.0"
 prost-types = "0.9.0"
 rand = "0.8.5"


### PR DESCRIPTION
Resolves #342 

This PR enables address derivation from a user's Ledger hardware wallet. The initial account when connecting a Ledger uses path `/0'/0/0`, so the address form should start the user at `/0'/0/1`, otherwise behavior is the same as deriving from a mnemonic account. _Note_ that paths such as `m/44'/877'/0'/0` are not supported on Ledger, i.e., the path should always contain the `index` of the path as well.

- [x] User can derive and track additional aliases/addresses/public keys from Ledger wallet
- [x] User can successfully sign any supported Tx with these new accounts
- [x] User can remove Ledger connection from wallet
- [x] Disable "Reset password" for Ledger accounts (not needed)
- [x] Update to `v0.20.1`
- [x] Handle Ledger error states (e.g., Locked device, etc.) - these should be presented to user