### PR TITLE
Improve extension errors

### DIFF
--- a/apps/extension/src/extension/ExtensionMessenger.ts
+++ b/apps/extension/src/extension/ExtensionMessenger.ts
@@ -12,7 +12,7 @@ export type Callback = (
 ) => Promise<RouterResult | void>;
 
 export type Result<M> = {
-  error?: string;
+  error?: { message: string, stack: string };
   return: Promise<M extends Message<infer R> ? R : never>;
 };
 

--- a/apps/extension/src/extension/ExtensionRequester.ts
+++ b/apps/extension/src/extension/ExtensionRequester.ts
@@ -33,7 +33,10 @@ export class ExtensionRequester {
     }
 
     if (result.error) {
-      throw new Error(result.error);
+      const { message, stack } = result.error;
+      const error = new Error(message);
+      error.stack = stack;
+      throw error;
     }
 
     return result.return;

--- a/apps/extension/src/extension/ExtensionRouter.ts
+++ b/apps/extension/src/extension/ExtensionRouter.ts
@@ -61,7 +61,14 @@ export class ExtensionRouter extends Router {
         return: result,
       };
     } catch (e) {
-      return Promise.resolve({ error: e });
+      if (!(e instanceof Error)) {
+        throw e;
+      }
+      // Error is not JSON-ifiable so we make a new object with the
+      // data needed to reconstruct the Error later.
+      // See https://github.com/anoma/namada-interface/issues/139
+      const { message, stack } = e;
+      return Promise.resolve({ error: { message, stack } });
     }
   }
 }

--- a/apps/extension/src/manifest/v2/_devOnly.json
+++ b/apps/extension/src/manifest/v2/_devOnly.json
@@ -1,0 +1,3 @@
+{
+  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self';"
+}

--- a/apps/extension/tsconfig.json
+++ b/apps/extension/tsconfig.json
@@ -16,6 +16,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
+    "sourceMap": true,
     "target": "es2015"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],

--- a/apps/extension/webpack.config.js
+++ b/apps/extension/webpack.config.js
@@ -15,6 +15,7 @@ const MANIFEST_VERSION = TARGET === "firefox" ? "v2" : "v3";
 const MANIFEST_BASE_PATH = `./src/manifest/_base.json`;
 const MANIFEST_BASE_VERSION_PATH = `./src/manifest/${MANIFEST_VERSION}/_base.json`;
 const MANIFEST_PATH = `./src/manifest/${MANIFEST_VERSION}/${TARGET}.json`;
+const MANIFEST_V2_DEV_ONLY_PATH = `./src/manifest/v2/_devOnly.json`;
 
 const copyPatterns = [
   {
@@ -41,7 +42,12 @@ const plugins = [
     patterns: copyPatterns,
   }),
   new MergeJsonWebpackPlugin({
-    files: [MANIFEST_BASE_PATH, MANIFEST_BASE_VERSION_PATH, MANIFEST_PATH],
+    files: [
+      MANIFEST_BASE_PATH,
+      MANIFEST_BASE_VERSION_PATH,
+      MANIFEST_PATH,
+      ...(NODE_ENV === "development" && TARGET === "firefox" ? [MANIFEST_V2_DEV_ONLY_PATH] : [])
+    ],
     output: {
       fileName: "./manifest.json",
     },
@@ -74,7 +80,7 @@ if (NODE_ENV === "development") {
 module.exports = {
   mode: NODE_ENV,
   target: "web",
-  devtool: false,
+  devtool: TARGET === "firefox" ? "eval-source-map" : false,
   entry: {
     content: "./src/content",
     background: "./src/background",


### PR DESCRIPTION
This PR fixes a bug where background errors were getting logged as `[Object, object]` in Chrome, and adds source maps for the extension on Firefox in development mode. These changes should make error reporting in the extension better.

I wanted to add source maps for Chrome, but the type of source map I chose uses `eval`, which is not supported in manifest v3. There are non-eval source maps, but these crashed webpack when I tried them.

---

### Changed

- Print background errors properly on Chrome (83792a18)

### Added

- Add extension source maps on Firefox (8890336d)