### PR TITLE
fix: show web worker errors in extension console

### DIFF
--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -230,12 +230,18 @@ export class KeyRingService {
       await createOffscreenWithTxWorker(offscreenDocumentPath);
     }
 
-    await chrome.runtime.sendMessage({
+    const result = await chrome.runtime.sendMessage({
       type: SUBMIT_TRANSFER_MSG_TYPE,
       target: OFFSCREEN_TARGET,
       routerId,
       data: { txMsg, msgId, password, xsk },
     });
+
+    if (result?.error) {
+      const error = new Error(result.error?.message || "Error in web worker");
+      error.stack = result.error.stack;
+      throw error;
+    };
   }
 
   private async submitTransferFirefox(

--- a/apps/extension/src/background/web-workers/index.ts
+++ b/apps/extension/src/background/web-workers/index.ts
@@ -4,6 +4,7 @@ import {
   SubmitTransferMessageData,
   TRANSFER_FAILED_MSG,
   TRANSFER_SUCCESSFUL_MSG,
+  WEB_WORKER_ERROR_MSG,
 } from "./types";
 
 export const init = (
@@ -12,7 +13,8 @@ export const init = (
     msgId: string,
     success: boolean,
     payload?: string
-  ) => Promise<void>
+  ) => Promise<void>,
+  sendResponse?: (response?: unknown) => void
 ): void => {
   const w = new Worker("submit-transfer-web-worker.namada.js");
 
@@ -28,8 +30,10 @@ export const init = (
       transferCompletedHandler(data.msgId, false, payload).then(() =>
         w.terminate()
       );
+    } else if (msgName === WEB_WORKER_ERROR_MSG) {
+      sendResponse?.({ error: payload });
     } else {
-      console.warn("Not supporeted msg type.");
+      console.warn("Not supported msg type.");
     }
   };
 };

--- a/apps/extension/src/background/web-workers/submit-transfer-web-worker.ts
+++ b/apps/extension/src/background/web-workers/submit-transfer-web-worker.ts
@@ -9,6 +9,7 @@ import {
   SubmitTransferMessageData,
   TRANSFER_FAILED_MSG,
   TRANSFER_SUCCESSFUL_MSG,
+  WEB_WORKER_ERROR_MSG,
 } from "./types";
 import { ActiveAccountStore } from "background/keyring";
 
@@ -49,4 +50,10 @@ import { ActiveAccountStore } from "background/keyring";
   );
 
   postMessage({ msgName: INIT_MSG });
-})();
+})().catch(error => {
+  const { message, stack } = error;
+  postMessage({
+    msgName: WEB_WORKER_ERROR_MSG,
+    payload: { message, stack }
+  });
+});

--- a/apps/extension/src/background/web-workers/types.ts
+++ b/apps/extension/src/background/web-workers/types.ts
@@ -15,9 +15,11 @@ export type SubmitTransferMessageData = {
 export const INIT_MSG = "init";
 export const TRANSFER_SUCCESSFUL_MSG = "transfer-successful";
 export const TRANSFER_FAILED_MSG = "transfer-failed";
+export const WEB_WORKER_ERROR_MSG = "web-worker-error";
 export type MsgName =
   | typeof INIT_MSG
   | typeof TRANSFER_FAILED_MSG
-  | typeof TRANSFER_SUCCESSFUL_MSG;
+  | typeof TRANSFER_SUCCESSFUL_MSG
+  | typeof WEB_WORKER_ERROR_MSG;
 
 export type Msg = { msgName: MsgName; payload?: string };


### PR DESCRIPTION
This PR make sure errors thrown in web workers running the submit-transfer-web-worker.js script are logged properly in the extension console. The errors are passed from the web worker to the offscreen document and then to the background script where they are logged to the console. This fix should only affect Chrome.