### PR TITLE
bug/353 - Ledger error-handling improvments

### DIFF
--- a/apps/extension/src/Approvals/Approvals.components.tsx
+++ b/apps/extension/src/Approvals/Approvals.components.tsx
@@ -135,3 +135,10 @@ export const InfoLoader = styled.div`
     ${Spinner}
   }
 `;
+
+export const ErrorMessage = styled.div`
+  font-family: "Space Grotesk", sans-serif;
+  color: ${(props) => props.theme.colors.utility3.highAttention};
+  font-size: 12px;
+  padding: 0 0 8px;
+`;

--- a/apps/extension/src/Setup/Ledger/Ledger.components.ts
+++ b/apps/extension/src/Setup/Ledger/Ledger.components.ts
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-export const LedgerError = styled.div`
+export const LedgerErrorMessage = styled.div`
   color: ${(props) => props.theme.colors.utility3.highAttention};
   padding: 8px 0;
 `;

--- a/apps/extension/src/Setup/Ledger/LedgerConfirmation.tsx
+++ b/apps/extension/src/Setup/Ledger/LedgerConfirmation.tsx
@@ -13,7 +13,7 @@ import { shortenAddress } from "@namada/utils";
 import { useSanitizedParams } from "@namada/hooks";
 
 import { useRequester } from "hooks/useRequester";
-import { LedgerError } from "./Ledger.components";
+import { LedgerErrorMessage } from "./Ledger.components";
 import {
   TopSection,
   TopSectionHeaderContainer,
@@ -25,8 +25,8 @@ import {
   BodyText,
 } from "Setup/Setup.components";
 import { Ports } from "router";
-import { AddLedgerParentAccountMsg } from "background/ledger";
 import { closeCurrentTab } from "utils";
+import { AddLedgerParentAccountMsg } from "background/ledger";
 
 const LedgerConfirmation: React.FC = () => {
   const navigate = useNavigate();
@@ -71,7 +71,7 @@ const LedgerConfirmation: React.FC = () => {
         <Header1>Confirm Ledger Connection</Header1>
       </UpperContentContainer>
 
-      {error && <LedgerError>{error}</LedgerError>}
+      {error && <LedgerErrorMessage>{error}</LedgerErrorMessage>}
       <BodyText>
         Connection successful for <b>&quot;{alias}&quot;</b>!
       </BodyText>

--- a/apps/extension/src/background/ledger/ledger.ts
+++ b/apps/extension/src/background/ledger/ledger.ts
@@ -30,7 +30,7 @@ export const DEFAULT_LEDGER_BIP44_PATH = makeBip44Path(coinType, {
 });
 
 export class Ledger {
-  constructor(public readonly namadaApp: NamadaApp | undefined = undefined) { }
+  constructor(public readonly namadaApp: NamadaApp | undefined = undefined) {}
 
   /**
    * Returns an initialized Ledger class instance with initialized Transport
@@ -38,10 +38,13 @@ export class Ledger {
   static async init(transport?: Transport): Promise<Ledger> {
     const initializedTransport = transport ?? (await initLedgerUSBTransport());
 
-    const namadaApp = new NamadaApp(initializedTransport);
-    const ledger = new Ledger(namadaApp);
-
-    return ledger;
+    try {
+      const namadaApp = new NamadaApp(initializedTransport);
+      const ledger = new Ledger(namadaApp);
+      return ledger;
+    } catch (e) {
+      throw new Error(`${e}`);
+    }
   }
 
   /**

--- a/packages/shared/lib/src/sdk/mod.rs
+++ b/packages/shared/lib/src/sdk/mod.rs
@@ -293,11 +293,6 @@ impl Sdk {
     ) -> Result<(), JsError> {
         let transfer_tx = self.sign_tx(tx_bytes, raw_sig_bytes, wrapper_sig_bytes)?;
         let args = tx::tx_args_from_slice(tx_msg)?;
-        let verification_key = args.verification_key.clone();
-        let pk = validate_pk(verification_key)?;
-
-        self.submit_reveal_pk(&args, transfer_tx.clone(), &pk)
-            .await?;
 
         namada::ledger::tx::process_tx(&self.client, &mut self.wallet, &args, transfer_tx)
             .await


### PR DESCRIPTION
Resolves #353 

Any time an error is encountered with the Ledger device, the extensions should always allow the user to correct the issue and proceed. A locked device or unloaded app should not force the user to refresh! Also, the appropriate error should be reported to user in each case!

- Connect Ledger
  - [x] Recovers from device locked
  - [x] Recovers from app not loaded
  - [x] Recovers from device not plugged in, or device not initially unlocked (same error: "Access Denied")
- Add Account
  - [x] Recovers from device locked
  - [x] Recovers from app not loaded
  - [x] Recovers from device not plugged in, or device not initially unlocked (same error: "Access Denied")
- Reveal PK
  - [x] Does not proceed to next transaction if any errors are encountered (including tx rejection)
- Submit Tx (Reveal PK, Bond, Unbond, Withdraw, Transfer)
  - [x] Recovers from device locked
  - [x] Recovers from app not loaded
  - [x] Recovers from transaction rejected
  - [x] Recovers from device not plugged in, or device not initially unlocked (same error: "Access Denied")