### PR TITLE
feat/364 - Track revealed Ledger PKs

### DIFF
--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -43,7 +43,10 @@ const connectedTabsStore = new ExtensionKVStore(KVPrefix.LocalStorage, {
   get: browser.storage.local.get,
   set: browser.storage.local.set,
 });
-
+const revealedPKStore = new ExtensionKVStore(KVPrefix.RevealedPK, {
+  get: browser.storage.local.get,
+  set: browser.storage.local.set,
+});
 const txStore = new MemoryKVStore(KVPrefix.Memory);
 
 const DEFAULT_URL =
@@ -101,6 +104,7 @@ const init = new Promise<void>(async (resolve) => {
     sdkStore,
     connectedTabsStore,
     txStore,
+    revealedPKStore,
     defaultChainId,
     sdk,
     requester

--- a/apps/extension/src/background/keyring/types.ts
+++ b/apps/extension/src/background/keyring/types.ts
@@ -17,12 +17,6 @@ export type Argon2Params = KdfParams & {
   salt: string;
 };
 
-export type ScryptParams = KdfParams & {
-  log_n: number;
-  r: number;
-  p: number;
-};
-
 export type CryptoRecord<T = Argon2Params> = {
   cipher: {
     type: "aes-256-gcm";

--- a/apps/extension/src/background/keyring/types.ts
+++ b/apps/extension/src/background/keyring/types.ts
@@ -48,9 +48,6 @@ export interface AccountStore extends StoredRecord {
 
 export interface KeyStore<T = Argon2Params> extends AccountStore {
   crypto: CryptoRecord<T>;
-  meta?: {
-    [key: string]: string;
-  };
 }
 
 export type AccountState = DerivedAccount & {
@@ -84,6 +81,8 @@ export type ActiveAccountStore = {
 };
 
 export type UtilityStore = ActiveAccountStore | { [id: string]: CryptoRecord };
+
+export type RevealedPKStore = { [id: string]: string };
 
 export enum DeleteAccountError {
   BadPassword,

--- a/apps/extension/src/background/ledger/handler.ts
+++ b/apps/extension/src/background/ledger/handler.ts
@@ -8,6 +8,8 @@ import {
   SubmitSignedTxMsg,
   AddLedgerParentAccountMsg,
   DeleteLedgerAccountMsg,
+  QueryStoredPK,
+  StoreRevealedPK,
 } from "./messages";
 
 export const getHandler: (service: LedgerService) => Handler = (service) => {
@@ -40,6 +42,11 @@ export const getHandler: (service: LedgerService) => Handler = (service) => {
         );
       case SubmitSignedTxMsg:
         return handleSubmitSignedTxMsg(service)(env, msg as SubmitSignedTxMsg);
+      case QueryStoredPK:
+        return handleQueryStoredPKMsg(service)(env, msg as QueryStoredPK);
+
+      case StoreRevealedPK:
+        return handleStoreRevealedPK(service)(env, msg as StoreRevealedPK);
       default:
         throw new Error("Unknown msg type");
     }
@@ -112,5 +119,23 @@ const handleSubmitSignedTxMsg: (
   return async (_, msg) => {
     const { txType, bytes, msgId, signatures } = msg;
     return await service.submitTx(txType, msgId, bytes, signatures);
+  };
+};
+
+const handleQueryStoredPKMsg: (
+  service: LedgerService
+) => InternalHandler<QueryStoredPK> = (service) => {
+  return async (_, msg) => {
+    const { publicKey } = msg;
+    return await service.queryStoredRevealedPK(publicKey);
+  };
+};
+
+const handleStoreRevealedPK: (
+  service: LedgerService
+) => InternalHandler<StoreRevealedPK> = (service) => {
+  return async (_, msg) => {
+    const { publicKey } = msg;
+    return await service.storeRevealedPK(publicKey);
   };
 };

--- a/apps/extension/src/background/ledger/init.ts
+++ b/apps/extension/src/background/ledger/init.ts
@@ -8,6 +8,8 @@ import {
   SubmitSignedRevealPKMsg,
   AddLedgerParentAccountMsg,
   DeleteLedgerAccountMsg,
+  QueryStoredPK,
+  StoreRevealedPK,
 } from "./messages";
 import { getHandler } from "./handler";
 import { LedgerService } from "./service";
@@ -20,6 +22,8 @@ export function init(router: Router, service: LedgerService): void {
   router.registerMessage(GetRevealPKBytesMsg);
   router.registerMessage(SubmitSignedTxMsg);
   router.registerMessage(SubmitSignedRevealPKMsg);
+  router.registerMessage(QueryStoredPK);
+  router.registerMessage(StoreRevealedPK);
 
   router.addHandler(ROUTE, getHandler(service));
 }

--- a/apps/extension/src/background/ledger/messages.ts
+++ b/apps/extension/src/background/ledger/messages.ts
@@ -15,7 +15,10 @@ enum MessageType {
   GetRevealPKBytes = "get-reveal-pk-bytes",
   SubmitSignedTx = "submit-signed-tx",
   SubmitSignedRevealPK = "submit-signed-reveal-pk",
+  QueryStoredPK = "query-stored-pk",
+  StoreRevealedPK = "store-revealed-pk",
 }
+
 export class AddLedgerParentAccountMsg extends Message<DerivedAccount> {
   public static type(): MessageType {
     return MessageType.AddLedgerParentAccount;
@@ -267,5 +270,53 @@ export class DeleteLedgerAccountMsg extends Message<
 
   type(): string {
     return DeleteLedgerAccountMsg.type();
+  }
+}
+
+export class QueryStoredPK extends Message<boolean> {
+  public static type(): MessageType {
+    return MessageType.QueryStoredPK;
+  }
+
+  constructor(public publicKey: string) {
+    super();
+  }
+
+  validate(): void {
+    if (!this.publicKey) {
+      throw new Error("publicKey not provided!");
+    }
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return QueryStoredPK.type();
+  }
+}
+
+export class StoreRevealedPK extends Message<void> {
+  public static type(): MessageType {
+    return MessageType.StoreRevealedPK;
+  }
+
+  constructor(public publicKey: string) {
+    super();
+  }
+
+  validate(): void {
+    if (!this.publicKey) {
+      throw new Error("publicKey not provided!");
+    }
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return StoreRevealedPK.type();
   }
 }

--- a/apps/extension/src/background/ledger/service.ts
+++ b/apps/extension/src/background/ledger/service.ts
@@ -28,6 +28,7 @@ import { UpdatedStakingEventMsg } from "content/events";
 
 export const LEDGERSTORE_KEY = "ledger-store";
 const UUID_NAMESPACE = "be9fdaee-ffa2-11ed-8ef1-325096b39f47";
+const REVEALED_PK_STORE = "revealed-pk-store";
 
 export class LedgerService {
   private _ledgerStore: IStore<AccountStore>;
@@ -38,6 +39,7 @@ export class LedgerService {
     protected readonly sdkStore: KVStore<Record<string, string>>,
     protected readonly connectedTabsStore: KVStore<TabStore[]>,
     protected readonly txStore: KVStore<string>,
+    protected readonly revealedPKStore: KVStore<string[]>,
     protected readonly chainId: string,
     protected readonly sdk: Sdk,
     protected readonly requester: ExtensionRequester
@@ -249,5 +251,18 @@ export class LedgerService {
     }
 
     return;
+  }
+
+  async queryStoredRevealedPK(publicKey: string): Promise<boolean> {
+    const pks = await this.revealedPKStore.get(REVEALED_PK_STORE);
+    return pks?.includes(publicKey) || false;
+  }
+
+  async storeRevealedPK(publicKey: string): Promise<void> {
+    const pks = (await this.revealedPKStore.get(REVEALED_PK_STORE)) || [];
+    if (!pks.includes(publicKey)) {
+      pks.push(publicKey);
+    }
+    await this.revealedPKStore.set(REVEALED_PK_STORE, pks);
   }
 }

--- a/apps/extension/src/router/types/enums.ts
+++ b/apps/extension/src/router/types/enums.ts
@@ -20,6 +20,7 @@ export enum KVPrefix {
   SDK = "Namada::SDK",
   Utility = "Namada::Utility",
   ConnectedTabs = "Namada::ConnectedTabs",
+  RevealedPK = "Namada::RevealedPK",
 }
 
 export enum KVKeys {

--- a/apps/extension/src/test/init.ts
+++ b/apps/extension/src/test/init.ts
@@ -69,6 +69,7 @@ export const init = async (): Promise<{
   const connectedTabsStore = new KVStoreMock<TabStore[]>(
     KVPrefix.ConnectedTabs
   );
+  const revealedPKStore = new KVStoreMock<string[]>(KVPrefix.RevealedPK);
   const namadaRouterId = await getNamadaRouterId(extStore);
   const requester = new ExtensionRequester(messenger, namadaRouterId);
   const txStore = new KVStoreMock<string>(KVPrefix.LocalStorage);
@@ -111,6 +112,7 @@ export const init = async (): Promise<{
     sdkStore,
     connectedTabsStore,
     txStore,
+    revealedPKStore,
     chainId,
     sdk,
     requester

--- a/apps/namada-interface/src/App/AccountOverview/AccountOverview.components.ts
+++ b/apps/namada-interface/src/App/AccountOverview/AccountOverview.components.ts
@@ -32,6 +32,7 @@ export const AccountOverviewContainer = styled.div`
   align-items: center;
   width: 100%;
   height: 100%;
+  padding: 24px 0 0 0;
   h1 {
     margin: 0;
   }
@@ -56,40 +57,6 @@ export const AccountOverviewContent = styled.div`
   box-sizing: border-box;
   background-color: ${(props) =>
     getColor(ComponentColor.BackgroundActive, props.theme)};
-`;
-
-export const AccountTabsContainer = styled.div`
-  width: 100%;
-  height: 60px;
-  display: flex;
-  flex-direction: row;
-  padding: 0;
-  margin: 0;
-`;
-
-export const AccountTab = styled.div`
-  flex: 1;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 52px;
-  color: ${(props) => props.theme.colors.utility2.main80};
-  background-color: ${(props) => props.theme.colors.utility1.main60};
-  font-size: 14px;
-  font-weight: bold;
-  cursor: pointer;
-
-  &.active {
-    cursor: default;
-    color: ${(props) => getColor(ComponentColor.TabLabelActive, props.theme)};
-    background-color: ${(props) =>
-      getColor(ComponentColor.BackgroundActive, props.theme)};
-  }
-
-  &.disabled {
-    pointer-events: auto !important;
-    cursor: not-allowed !important;
-  }
 `;
 
 export const InputContainer = styled.div`

--- a/apps/namada-interface/src/App/AccountOverview/AccountOverview.tsx
+++ b/apps/namada-interface/src/App/AccountOverview/AccountOverview.tsx
@@ -9,6 +9,12 @@ import {
 } from "@namada/hooks";
 import { Account, ExtensionKey, Extensions } from "@namada/types";
 import { formatCurrency } from "@namada/utils";
+import {
+  Button,
+  ButtonVariant,
+  Heading,
+  HeadingLevel,
+} from "@namada/components";
 
 import { useAppSelector, useAppDispatch } from "store";
 import { AccountsState, addAccounts, fetchBalances } from "slices/accounts";
@@ -16,16 +22,8 @@ import { setIsConnected, SettingsState } from "slices/settings";
 import { TopLevelRoute } from "App/types";
 import { DerivedAccounts } from "./DerivedAccounts";
 import {
-  Button,
-  ButtonVariant,
-  Heading,
-  HeadingLevel,
-} from "@namada/components";
-import {
   AccountOverviewContainer,
   AccountOverviewContent,
-  AccountTab,
-  AccountTabsContainer,
   ButtonsContainer,
   ButtonsWrapper,
   HeadingContainer,
@@ -100,10 +98,6 @@ export const AccountOverview = (): JSX.Element => {
 
   return (
     <AccountOverviewContainer>
-      <AccountTabsContainer>
-        <AccountTab className={"active"}>Fungible</AccountTab>
-        <AccountTab className={"disabled"}>Non-Fungible</AccountTab>
-      </AccountTabsContainer>
       <AccountOverviewContent>
         <HeadingContainer>
           <div>
@@ -165,7 +159,7 @@ export const AccountOverview = (): JSX.Element => {
                 }
               >
                 {currentExtensionAttachStatus === "attached" ||
-                currentExtensionAttachStatus === "pending"
+                  currentExtensionAttachStatus === "pending"
                   ? `Connect to ${extensionAlias} Extension`
                   : "Click to download the extension"}
               </Button>


### PR DESCRIPTION
resolves #364 

- [x] Includes logic to track whether a Ledger public key has successfully been revealed, to bypass the public key query before Ledger tx
- [x] Should issue a query if any public key is not in storage and update storage if the key has already been revealed, i.e., in the case of restoring a wallet with keys that have already been revealed, it should only add it to storage without submitting RevealPK
- [x] Remove Account Overview tabs per previous discussion (unrelated, but throwing in as this is a small & simple PR)