### PR TITLE
feat/354 - Ledger tx updated balances & staking

### DIFF
--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -179,7 +179,6 @@ export class ApprovalsService {
 
     if (tx) {
       await this.keyRingService.submitBond(tx, msgId);
-      await this.ledgerService.broadcastUpdateStaking();
 
       return await this._clearPendingTx(msgId);
     }

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -26,6 +26,7 @@ import {
   TransferCompletedEvent,
   TransferStartedEvent,
   UpdatedBalancesEventMsg,
+  UpdatedStakingEventMsg,
 } from "content/events";
 import {
   createOffscreenWithTxWorker,
@@ -191,6 +192,8 @@ export class KeyRingService {
     console.log(`TODO: Broadcast notification for ${msgId}`);
     try {
       await this._keyRing.submitBond(fromBase64(txMsg));
+      this.broadcastUpdateStaking();
+      this.broadcastUpdateBalance();
     } catch (e) {
       console.warn(e);
       throw new Error(`Unable to submit bond tx! ${e}`);
@@ -201,6 +204,8 @@ export class KeyRingService {
     console.log(`TODO: Broadcast notification for ${msgId}`);
     try {
       await this._keyRing.submitUnbond(fromBase64(txMsg));
+      this.broadcastUpdateStaking();
+      this.broadcastUpdateBalance();
     } catch (e) {
       console.warn(e);
       throw new Error(`Unable to submit unbond tx! ${e}`);
@@ -211,6 +216,8 @@ export class KeyRingService {
     console.log(`TODO: Broadcast notification for ${msgId}`);
     try {
       await this._keyRing.submitWithdraw(fromBase64(txMsg));
+      this.broadcastUpdateStaking();
+      this.broadcastUpdateBalance();
     } catch (e) {
       console.warn(e);
       throw new Error(`Unable to submit withdraw tx! ${e}`);
@@ -432,6 +439,27 @@ export class KeyRingService {
           tabId,
           Ports.WebBrowser,
           new UpdatedBalancesEventMsg(this.chainId)
+        );
+      });
+    } catch (e) {
+      console.warn(e);
+    }
+
+    return;
+  }
+
+  async broadcastUpdateStaking(): Promise<void> {
+    const tabs = await syncTabs(
+      this.connectedTabsStore,
+      this.requester,
+      this.chainId
+    );
+    try {
+      tabs?.forEach(({ tabId }: TabStore) => {
+        this.requester.sendMessageToTab(
+          tabId,
+          Ports.WebBrowser,
+          new UpdatedStakingEventMsg(this.chainId)
         );
       });
     } catch (e) {

--- a/apps/extension/src/content/events.ts
+++ b/apps/extension/src/content/events.ts
@@ -122,7 +122,7 @@ export class UpdatedStakingEventMsg extends Message<void> {
   }
 
   type(): string {
-    return UpdatedBalancesEventMsg.type();
+    return UpdatedStakingEventMsg.type();
   }
 }
 


### PR DESCRIPTION
Resolves #354 

For all Ledger Tx, the interface should update balances and staking positions after each successful transaction.

- [x] Submitting an approved Ledger transaction updates token balances in interface
- [x] Submitting an approved staking-related Ledger transaction (`bond`, `unbond`, `withdraw`) updates staking positions in interface
- [x] Submitting staking (`bond`, `unbond`, `withdraw`) transactions from private key accounts updates both token balance & staking amounts