### PR TITLE
feat/366 - Redirect user to authorize if service worker goes inactive (Chrome)

### DIFF
--- a/apps/extension/src/App/Login/Login.tsx
+++ b/apps/extension/src/App/Login/Login.tsx
@@ -1,7 +1,12 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { Button, ButtonVariant, Input, InputVariants } from "@namada/components";
+import {
+  Button,
+  ButtonVariant,
+  Input,
+  InputVariants,
+} from "@namada/components";
 
 import { TopLevelRoute } from "App/types";
 import { ExtensionRequester } from "extension";

--- a/apps/extension/src/hooks/useAuth.tsx
+++ b/apps/extension/src/hooks/useAuth.tsx
@@ -1,26 +1,46 @@
-import { TopLevelRoute } from "App/types";
-import { ExtensionRequester } from "extension";
 import { useNavigate } from "react-router-dom";
-import { CheckIsLockedMsg } from "background/keyring";
 
+import { ExtensionRequester } from "extension";
 import { Ports } from "router";
+import { CheckIsLockedMsg } from "background/keyring";
+import { TopLevelRoute } from "App/types";
+import { paramsToUrl } from "@namada/utils";
+
+export const isKeyChainLocked = async (
+  requester: ExtensionRequester
+): Promise<boolean> => {
+  return await requester
+    .sendMessage(Ports.Background, new CheckIsLockedMsg())
+    .catch((e) => {
+      throw new Error(`Requester error: ${e}`);
+    });
+};
+
+export const redirectToLogin = (
+  navigate: ReturnType<typeof useNavigate>,
+  route: TopLevelRoute,
+  prompt: string
+): void => {
+  navigate(paramsToUrl(TopLevelRoute.Login, { redirect: route, prompt }));
+};
 
 const useAuth = (
   requester: ExtensionRequester
 ): ((
   route: TopLevelRoute,
   prompt: string,
-  callback: () => void
+  callback?: () => void
 ) => Promise<void>) => {
   const navigate = useNavigate();
-  return async (route: TopLevelRoute, prompt: string, callback: () => void) => {
-    const isKeyChainLocked = await requester.sendMessage(
-      Ports.Background,
-      new CheckIsLockedMsg()
-    );
-    if (isKeyChainLocked) {
-      navigate(`${TopLevelRoute.Login}?redirect=${route}&prompt=${prompt}`);
-    } else {
+  return async (
+    route: TopLevelRoute,
+    prompt: string,
+    callback?: () => void
+  ): Promise<void> => {
+    if (await isKeyChainLocked(requester)) {
+      return redirectToLogin(navigate, route, prompt);
+    }
+    if (callback) {
       callback();
     }
   };


### PR DESCRIPTION
Resolves #366 

When deriving an address (from a mnemonic account), if the service worker goes inactive while the user is entering data in the form, the flow would break, as the password goes out of scope, and an error would be thrown. In this case, we should redirect the user to authenticate, where they can try again to derive the address. This prevents us from needing to keep the password in application state, as we have done before, but also allows a user to continue if the password is removed due to a service worker restart.

- [x] Redirect to `Login` if service worker times out on `AddAccount`
- [x] Existing `AddAccount` functionality works as expected

### Testing

1. In Chrome, open the Extensions tab (so you can monitor Service Worker status)
2. Launch the extension (we'll assume that you've already set up a mnemonic account)
3. Click the `+` icon to add an account
4. Authenticate the extension, then enter an account `alias` (Do _not_ click `Add Account` yet!)
5. In the Manage Extensions tab, wait for the Service Worker to show `(Inactive)`, then click `Add Account`
  - You should see that you are redirected to authenticate. Once you authenticate, you should be able to add your account details and try again
  - Note that I considered posting the previously entered account details on successful login, which we may still implement in the future, so that upon re-authenticating, the details you already have entered will be submitted. Currently, in this PR, it requires you to re-enter them, though I don't think it will be a frequent use-case. Another option would be to pre-populate the form with the previously entered details. It would probably be cleanest if we simply submit _after_ the re-authentication is successful (using a callback). That is a little tricky with the current Login redirect. Yet another option would be to embed the Login component without any redirect, so a user can continue the flow and submit the previously entered details. This actually might be best, and we can address this along with other UX concerns, as it's relatively simple, but will likely be dependent on the UX product intends to present, so we should probably leave it as is until we have that direction.