### PR TITLE
feat/358 - Implement notifications for all tx types

### DIFF
--- a/apps/extension/src/Approvals/ApproveTx/ApproveTx.tsx
+++ b/apps/extension/src/Approvals/ApproveTx/ApproveTx.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect } from "react";
 
 import { Button, ButtonVariant } from "@namada/components";
 import { shortenAddress } from "@namada/utils";
-import { AccountType, Tokens } from "@namada/types";
+import { AccountType, Tokens, TxTypeLabel } from "@namada/types";
 import { TxType } from "@namada/shared";
 import { useSanitizedParams } from "@namada/hooks";
 
@@ -13,7 +13,7 @@ import {
   ApprovalContainer,
   ButtonContainer,
 } from "Approvals/Approvals.components";
-import { TopLevelRoute, TxTypeLabel } from "Approvals/types";
+import { TopLevelRoute } from "Approvals/types";
 import { Ports } from "router";
 import { RejectTxMsg } from "background/approvals";
 import { useRequester } from "hooks/useRequester";

--- a/apps/extension/src/Approvals/ApproveTx/ApproveTx.tsx
+++ b/apps/extension/src/Approvals/ApproveTx/ApproveTx.tsx
@@ -3,8 +3,8 @@ import { useCallback, useEffect } from "react";
 
 import { Button, ButtonVariant } from "@namada/components";
 import { shortenAddress } from "@namada/utils";
-import { AccountType, Tokens, TxTypeLabel } from "@namada/types";
-import { TxType } from "@namada/shared";
+import { AccountType, Tokens } from "@namada/types";
+import { TxType, TxTypeLabel } from "@namada/shared";
 import { useSanitizedParams } from "@namada/hooks";
 
 import { useQuery } from "hooks";

--- a/apps/extension/src/Approvals/ApproveTx/ConfirmLedgerTx.tsx
+++ b/apps/extension/src/Approvals/ApproveTx/ConfirmLedgerTx.tsx
@@ -5,14 +5,8 @@ import BigNumber from "bignumber.js";
 import { LedgerError } from "@namada/ledger-namada";
 import { Button, ButtonVariant } from "@namada/components";
 import { defaultChainId as chainId } from "@namada/chains";
-import { TxType } from "@namada/shared";
-import {
-  Message,
-  Tokens,
-  TxProps,
-  TxMsgValue,
-  TxTypeLabel,
-} from "@namada/types";
+import { TxType, TxTypeLabel } from "@namada/shared";
+import { Message, Tokens, TxProps, TxMsgValue } from "@namada/types";
 
 import {
   GetRevealPKBytesMsg,

--- a/apps/extension/src/Approvals/ApproveTx/ConfirmLedgerTx.tsx
+++ b/apps/extension/src/Approvals/ApproveTx/ConfirmLedgerTx.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { toBase64 } from "@cosmjs/encoding";
 import BigNumber from "bignumber.js";
 
@@ -6,7 +6,13 @@ import { LedgerError } from "@namada/ledger-namada";
 import { Button, ButtonVariant } from "@namada/components";
 import { defaultChainId as chainId } from "@namada/chains";
 import { TxType } from "@namada/shared";
-import { Message, Tokens, TxProps, TxMsgValue } from "@namada/types";
+import {
+  Message,
+  Tokens,
+  TxProps,
+  TxMsgValue,
+  TxTypeLabel,
+} from "@namada/types";
 
 import {
   GetRevealPKBytesMsg,
@@ -29,7 +35,6 @@ import {
 import { InfoHeader, InfoLoader } from "Approvals/Approvals.components";
 
 import { QueryPublicKeyMsg } from "background/keyring";
-import { TxTypeLabel } from "Approvals/types";
 
 type Props = {
   details?: ApprovalDetails;
@@ -41,6 +46,12 @@ export const ConfirmLedgerTx: React.FC<Props> = ({ details }) => {
   const [status, setStatus] = useState<Status>();
   const [statusInfo, setStatusInfo] = useState("");
   const { source, msgId, publicKey, txType } = details || {};
+
+  useEffect(() => {
+    if (status === Status.Completed) {
+      closeCurrentTab();
+    }
+  }, [status]);
 
   const revealPk = async (ledger: Ledger, publicKey: string): Promise<void> => {
     setStatusInfo(
@@ -142,9 +153,7 @@ export const ConfirmLedgerTx: React.FC<Props> = ({ details }) => {
     }
 
     // Submit signatures for tx
-    setStatusInfo(`Submitting ${txLabel} transaction...`);
-
-    await requester
+    requester
       .sendMessage(
         Ports.Background,
         new SubmitSignedTxMsg(txType, msgId, toBase64(bytes), signatures)
@@ -152,6 +161,8 @@ export const ConfirmLedgerTx: React.FC<Props> = ({ details }) => {
       .catch((e) => {
         throw new Error(`Requester error: ${e}`);
       });
+
+    setStatus(Status.Completed);
   };
 
   const handleSubmitTx = useCallback(async (): Promise<void> => {
@@ -210,9 +221,7 @@ export const ConfirmLedgerTx: React.FC<Props> = ({ details }) => {
           }
         }
 
-        await submitTx(ledger);
-
-        return setStatus(Status.Completed);
+        submitTx(ledger);
       }
     } catch (e) {
       await ledger.closeTransport();
@@ -220,10 +229,6 @@ export const ConfirmLedgerTx: React.FC<Props> = ({ details }) => {
       setStatus(Status.Failed);
     }
   }, [source, publicKey]);
-
-  const handleCloseTab = useCallback(async (): Promise<void> => {
-    await closeCurrentTab();
-  }, []);
 
   return (
     <ApprovalContainer>
@@ -246,16 +251,6 @@ export const ConfirmLedgerTx: React.FC<Props> = ({ details }) => {
           <ButtonContainer>
             <Button variant={ButtonVariant.Contained} onClick={handleSubmitTx}>
               Submit
-            </Button>
-          </ButtonContainer>
-        </>
-      )}
-      {status === Status.Completed && (
-        <>
-          <p>Success! You may close this window.</p>
-          <ButtonContainer>
-            <Button variant={ButtonVariant.Contained} onClick={handleCloseTab}>
-              Close
             </Button>
           </ButtonContainer>
         </>

--- a/apps/extension/src/Approvals/ApproveTx/ConfirmLedgerTx.tsx
+++ b/apps/extension/src/Approvals/ApproveTx/ConfirmLedgerTx.tsx
@@ -81,7 +81,7 @@ export const ConfirmLedgerTx: React.FC<Props> = ({ details }) => {
     }
 
     // Submit signatures for tx
-    setStatusInfo("Submitting reveal pk tx...");
+    setStatusInfo("Revealing public key on chain...");
 
     await requester
       .sendMessage(
@@ -180,6 +180,7 @@ export const ConfirmLedgerTx: React.FC<Props> = ({ details }) => {
       return setStatus(Status.Failed);
     }
 
+    setStatusInfo("Preparing transaction...");
     setStatus(Status.Pending);
 
     try {

--- a/apps/extension/src/Approvals/ApproveTx/ConfirmTx.tsx
+++ b/apps/extension/src/Approvals/ApproveTx/ConfirmTx.tsx
@@ -9,6 +9,7 @@ import {
 } from "@namada/components";
 import { shortenAddress } from "@namada/utils";
 import { TxType } from "@namada/shared";
+import { TxTypeLabel } from "@namada/types";
 
 import { ApprovalDetails, Status } from "Approvals/Approvals";
 import {
@@ -22,7 +23,7 @@ import { useRequester } from "hooks/useRequester";
 import { Address } from "App/Accounts/AccountListing.components";
 import { closeCurrentTab } from "utils";
 import { FetchAndStoreMaspParamsMsg, HasMaspParamsMsg } from "provider";
-import { ApproveMsg, SupportedTx, TxTypeLabel, txMap } from "Approvals/types";
+import { ApproveMsg, SupportedTx, txMap } from "Approvals/types";
 
 type Props = {
   details?: ApprovalDetails;
@@ -70,7 +71,7 @@ export const ConfirmTx: React.FC<Props> = ({ details }) => {
         }
       }
 
-      await requester.sendMessage(Ports.Background, new Msg(msgId, password));
+      requester.sendMessage(Ports.Background, new Msg(msgId, password));
       setStatus(Status.Completed);
     } catch (e) {
       console.info(e);
@@ -80,11 +81,9 @@ export const ConfirmTx: React.FC<Props> = ({ details }) => {
   }, [password]);
 
   useEffect(() => {
-    (async () => {
-      if (status === Status.Completed) {
-        await closeCurrentTab();
-      }
-    })();
+    if (status === Status.Completed) {
+      closeCurrentTab();
+    }
   }, [status]);
 
   return (

--- a/apps/extension/src/Approvals/ApproveTx/ConfirmTx.tsx
+++ b/apps/extension/src/Approvals/ApproveTx/ConfirmTx.tsx
@@ -8,8 +8,7 @@ import {
   InputVariants,
 } from "@namada/components";
 import { shortenAddress } from "@namada/utils";
-import { TxType } from "@namada/shared";
-import { TxTypeLabel } from "@namada/types";
+import { TxType, TxTypeLabel } from "@namada/shared";
 
 import { ApprovalDetails, Status } from "Approvals/Approvals";
 import {

--- a/apps/extension/src/Approvals/types.ts
+++ b/apps/extension/src/Approvals/types.ts
@@ -19,14 +19,6 @@ export enum TopLevelRoute {
   ConfirmLedgerTx = "/confirm-ledger-tx",
 }
 
-export const TxTypeLabel: Record<TxType, string> = {
-  [TxType.Bond]: "bond",
-  [TxType.Unbond]: "unbond",
-  [TxType.Transfer]: "transfer",
-  [TxType.Withdraw]: "withdraw",
-  [TxType.RevealPK]: "reveal-pk",
-};
-
 export type SupportedTx = Extract<
   TxType,
   TxType.Bond | TxType.Unbond | TxType.Transfer | TxType.Withdraw

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -10,6 +10,7 @@ import { init as initShared } from "@namada/shared/src/init";
 import { Query, Sdk } from "@namada/shared";
 
 import {
+  ExtensionBroadcaster,
   ExtensionRouter,
   ExtensionGuards,
   ContentScriptEnv,
@@ -84,6 +85,11 @@ const init = new Promise<void>(async (resolve) => {
 
   const routerId = await getNamadaRouterId(extensionStore);
   const requester = new ExtensionRequester(messenger, routerId);
+  const broadcaster = new ExtensionBroadcaster(
+    connectedTabsStore,
+    defaultChainId,
+    requester
+  );
 
   const chainsService = new ChainsService(store, [chains[defaultChainId]]);
   const keyRingService = new KeyRingService(
@@ -96,7 +102,8 @@ const init = new Promise<void>(async (resolve) => {
     sdk,
     query,
     cryptoMemory,
-    requester
+    requester,
+    broadcaster
   );
   const ledgerService = new LedgerService(
     keyRingService,
@@ -107,7 +114,8 @@ const init = new Promise<void>(async (resolve) => {
     revealedPKStore,
     defaultChainId,
     sdk,
-    requester
+    requester,
+    broadcaster
   );
   const approvalsService = new ApprovalsService(
     txStore,

--- a/apps/extension/src/background/ledger/service.ts
+++ b/apps/extension/src/background/ledger/service.ts
@@ -115,6 +115,8 @@ export class LedgerService {
     const rawSig = encodeSignature(rawSignature);
     const wrapperSig = encodeSignature(wrapperSignature);
 
+    await this.keyringService.broadcastTxStarted(msgId, txType);
+
     try {
       await this.sdk.submit_signed_tx(
         encodedTx,
@@ -123,6 +125,7 @@ export class LedgerService {
         wrapperSig
       );
 
+      await this.keyringService.broadcastTxCompleted(msgId, txType, true);
       // Clear pending tx if successful
       await this.txStore.set(msgId, null);
 
@@ -134,6 +137,7 @@ export class LedgerService {
       }
     } catch (e) {
       console.warn(e);
+      await this.keyringService.broadcastTxCompleted(msgId, txType, false);
     }
   }
 

--- a/apps/extension/src/background/ledger/service.ts
+++ b/apps/extension/src/background/ledger/service.ts
@@ -138,7 +138,7 @@ export class LedgerService {
       }
     } catch (e) {
       console.warn(e);
-      this.broadcaster.completeTx(msgId, txType, false);
+      this.broadcaster.completeTx(msgId, txType, false, `${e}`);
     }
   }
 

--- a/apps/extension/src/background/ledger/service.ts
+++ b/apps/extension/src/background/ledger/service.ts
@@ -21,7 +21,7 @@ import {
   TabStore,
 } from "background/keyring";
 import { encodeSignature, generateId, getEncodedTxByType } from "utils";
-import { ExtensionRequester } from "extension";
+import { ExtensionBroadcaster, ExtensionRequester } from "extension";
 
 export const LEDGERSTORE_KEY = "ledger-store";
 const UUID_NAMESPACE = "be9fdaee-ffa2-11ed-8ef1-325096b39f47";
@@ -39,7 +39,8 @@ export class LedgerService {
     protected readonly revealedPKStore: KVStore<string[]>,
     protected readonly chainId: string,
     protected readonly sdk: Sdk,
-    protected readonly requester: ExtensionRequester
+    protected readonly requester: ExtensionRequester,
+    protected readonly broadcaster: ExtensionBroadcaster
   ) {
     this._ledgerStore = new Store(LEDGERSTORE_KEY, kvStore);
   }
@@ -115,7 +116,7 @@ export class LedgerService {
     const rawSig = encodeSignature(rawSignature);
     const wrapperSig = encodeSignature(wrapperSignature);
 
-    await this.keyringService.broadcastTxStarted(msgId, txType);
+    await this.broadcaster.startTx(msgId, txType);
 
     try {
       await this.sdk.submit_signed_tx(
@@ -125,19 +126,19 @@ export class LedgerService {
         wrapperSig
       );
 
-      await this.keyringService.broadcastTxCompleted(msgId, txType, true);
       // Clear pending tx if successful
       await this.txStore.set(msgId, null);
 
       // Broadcast update events
-      this.keyringService.broadcastUpdateBalance();
+      this.broadcaster.completeTx(msgId, txType, true);
+      this.broadcaster.updateBalance();
 
       if ([TxType.Bond, TxType.Unbond, TxType.Withdraw].includes(txType)) {
-        await this.keyringService.broadcastUpdateStaking();
+        this.broadcaster.updateStaking();
       }
     } catch (e) {
       console.warn(e);
-      await this.keyringService.broadcastTxCompleted(msgId, txType, false);
+      this.broadcaster.completeTx(msgId, txType, false);
     }
   }
 

--- a/apps/extension/src/content/events.ts
+++ b/apps/extension/src/content/events.ts
@@ -171,7 +171,9 @@ export class TxCompletedEvent extends Message<void> {
   constructor(
     public readonly chainId: string,
     public readonly msgId: string,
-    public readonly txType: TxType
+    public readonly txType: TxType,
+    public readonly success: boolean,
+    public readonly payload?: string
   ) {
     super();
   }
@@ -187,6 +189,10 @@ export class TxCompletedEvent extends Message<void> {
 
     if (!this.txType) {
       throw new Error("txType should not be empty");
+    }
+
+    if (!this.success) {
+      throw new Error("success should not be empty");
     }
   }
 

--- a/apps/extension/src/content/events.ts
+++ b/apps/extension/src/content/events.ts
@@ -1,6 +1,7 @@
 import { Events } from "@namada/types";
 
 import { Message, Router, Routes } from "../router";
+import { TxType } from "@namada/shared";
 
 export class AccountChangedEventMsg extends Message<void> {
   public static type(): Events {
@@ -126,10 +127,84 @@ export class UpdatedStakingEventMsg extends Message<void> {
   }
 }
 
+export class TxStartedEvent extends Message<void> {
+  public static type(): Events {
+    return Events.TxStarted;
+  }
+
+  constructor(
+    public readonly chainId: string,
+    public readonly msgId: string,
+    public readonly txType: TxType
+  ) {
+    super();
+  }
+
+  validate(): void {
+    if (!this.chainId) {
+      throw new Error("chainId must not be empty");
+    }
+
+    if (!this.msgId) {
+      throw new Error("msgId should not be empty");
+    }
+
+    if (!this.txType) {
+      throw new Error("txType should not be empty");
+    }
+  }
+
+  route(): string {
+    return Routes.InteractionForeground;
+  }
+
+  type(): string {
+    return TxStartedEvent.type();
+  }
+}
+
+export class TxCompletedEvent extends Message<void> {
+  public static type(): Events {
+    return Events.TxCompleted;
+  }
+
+  constructor(
+    public readonly chainId: string,
+    public readonly msgId: string,
+    public readonly txType: TxType
+  ) {
+    super();
+  }
+
+  validate(): void {
+    if (!this.chainId) {
+      throw new Error("chainId must not be empty");
+    }
+
+    if (!this.msgId) {
+      throw new Error("msgId should not be empty");
+    }
+
+    if (!this.txType) {
+      throw new Error("txType should not be empty");
+    }
+  }
+
+  route(): string {
+    return Routes.InteractionForeground;
+  }
+
+  type(): string {
+    return TxCompletedEvent.type();
+  }
+}
+
 export function initEvents(router: Router): void {
   router.registerMessage(AccountChangedEventMsg);
   router.registerMessage(TransferStartedEvent);
   router.registerMessage(TransferCompletedEvent);
+  router.registerMessage(TxStartedEvent);
+  router.registerMessage(TxCompletedEvent);
   router.registerMessage(UpdatedBalancesEventMsg);
   router.registerMessage(UpdatedStakingEventMsg);
 
@@ -155,6 +230,16 @@ export function initEvents(router: Router): void {
       case TransferCompletedEvent:
         window.dispatchEvent(
           new CustomEvent(Events.TransferCompleted, { detail: clonedMsg })
+        );
+        break;
+      case TxStartedEvent:
+        window.dispatchEvent(
+          new CustomEvent(Events.TxStarted, { detail: clonedMsg })
+        );
+        break;
+      case TxCompletedEvent:
+        window.dispatchEvent(
+          new CustomEvent(Events.TxCompleted, { detail: clonedMsg })
         );
         break;
       case UpdatedBalancesEventMsg:

--- a/apps/extension/src/extension/ExtensionBroadcaster.ts
+++ b/apps/extension/src/extension/ExtensionBroadcaster.ts
@@ -1,0 +1,78 @@
+import { TxType } from "@namada/shared";
+import { KVStore } from "@namada/storage";
+import { TabStore, syncTabs } from "background/keyring";
+import {
+  TxCompletedEvent,
+  TxStartedEvent,
+  UpdatedBalancesEventMsg,
+  UpdatedStakingEventMsg,
+} from "content/events";
+import { ExtensionRequester } from "extension";
+import { Message, Ports } from "router";
+
+export class ExtensionBroadcaster {
+  constructor(
+    protected readonly connectedTabsStore: KVStore<TabStore[]>,
+    protected readonly chainId: string,
+    protected readonly requester: ExtensionRequester
+  ) { }
+
+  async startTx(msgId: string, txType: TxType): Promise<void> {
+    try {
+      await this.sendMsgToTabs(new TxStartedEvent(this.chainId, msgId, txType));
+    } catch (e) {
+      console.warn(`${e}`);
+    }
+  }
+
+  async completeTx(
+    msgId: string,
+    txType: TxType,
+    success: boolean,
+    payload?: string
+  ): Promise<void> {
+    if (!success) {
+      //TODO: pass error message to the TxCompletedEvent and display it in the UI
+      console.error(payload);
+    }
+    try {
+      await this.sendMsgToTabs(
+        new TxCompletedEvent(this.chainId, msgId, txType)
+      );
+    } catch (e) {
+      console.warn(`${e}`);
+    }
+  }
+
+  async updateBalance(): Promise<void> {
+    try {
+      await this.sendMsgToTabs(new UpdatedBalancesEventMsg(this.chainId));
+    } catch (e) {
+      console.warn(e);
+    }
+  }
+
+  async updateStaking(): Promise<void> {
+    try {
+      await this.sendMsgToTabs(new UpdatedStakingEventMsg(this.chainId));
+    } catch (e) {
+      console.warn(e);
+    }
+  }
+
+  private async sendMsgToTabs(msg: Message<unknown>): Promise<void> {
+    const tabs = await syncTabs(
+      this.connectedTabsStore,
+      this.requester,
+      this.chainId
+    );
+
+    try {
+      tabs?.forEach(({ tabId }: TabStore) => {
+        this.requester.sendMessageToTab(tabId, Ports.WebBrowser, msg);
+      });
+    } catch (e) {
+      console.warn(e);
+    }
+  }
+}

--- a/apps/extension/src/extension/ExtensionBroadcaster.ts
+++ b/apps/extension/src/extension/ExtensionBroadcaster.ts
@@ -19,11 +19,7 @@ export class ExtensionBroadcaster {
   ) { }
 
   async startTx(msgId: string, txType: TxType): Promise<void> {
-    try {
-      await this.sendMsgToTabs(new TxStartedEvent(this.chainId, msgId, txType));
-    } catch (e) {
-      console.warn(`${e}`);
-    }
+    await this.sendMsgToTabs(new TxStartedEvent(this.chainId, msgId, txType));
   }
 
   async completeTx(
@@ -32,36 +28,27 @@ export class ExtensionBroadcaster {
     success: boolean,
     payload?: string
   ): Promise<void> {
-    if (!success) {
-      //TODO: pass error message to the TxCompletedEvent and display it in the UI
-      console.error(payload);
-    }
-    try {
-      await this.sendMsgToTabs(
-        new TxCompletedEvent(this.chainId, msgId, txType, success, payload)
-      );
-    } catch (e) {
-      console.warn(`${e}`);
-    }
+    await this.sendMsgToTabs(
+      new TxCompletedEvent(this.chainId, msgId, txType, success, payload)
+    );
   }
 
   async updateBalance(): Promise<void> {
-    try {
-      await this.sendMsgToTabs(new UpdatedBalancesEventMsg(this.chainId));
-    } catch (e) {
-      console.warn(e);
-    }
+    await this.sendMsgToTabs(new UpdatedBalancesEventMsg(this.chainId));
   }
 
   async updateStaking(): Promise<void> {
-    try {
-      await this.sendMsgToTabs(new UpdatedStakingEventMsg(this.chainId));
-    } catch (e) {
-      console.warn(e);
-    }
+    await this.sendMsgToTabs(new UpdatedStakingEventMsg(this.chainId));
   }
 
-  private async sendMsgToTabs(msg: Message<unknown>): Promise<void> {
+  async updateAccounts(): Promise<void> {
+    await this.sendMsgToTabs(new AccountChangedEventMsg(this.chainId));
+  }
+
+  /**
+   * Query all existing tabs, and send provided message to each
+   */
+  async sendMsgToTabs(msg: Message<unknown>): Promise<void> {
     const tabs = await syncTabs(
       this.connectedTabsStore,
       this.requester,
@@ -75,26 +62,5 @@ export class ExtensionBroadcaster {
     } catch (e) {
       console.warn(e);
     }
-  }
-
-  async updateAccounts(): Promise<void> {
-    const tabs = await syncTabs(
-      this.connectedTabsStore,
-      this.requester,
-      this.chainId
-    );
-    try {
-      tabs?.forEach(({ tabId }: TabStore) => {
-        this.requester.sendMessageToTab(
-          tabId,
-          Ports.WebBrowser,
-          new AccountChangedEventMsg(this.chainId)
-        );
-      });
-    } catch (e) {
-      console.warn(e);
-    }
-
-    return;
   }
 }

--- a/apps/extension/src/extension/index.ts
+++ b/apps/extension/src/extension/index.ts
@@ -1,3 +1,4 @@
+export * from "./ExtensionBroadcaster";
 export * from "./ExtensionRequester";
 export * from "./ExtensionMessenger";
 export * from "./ExtensionMessengerMock";

--- a/apps/extension/src/test/init.ts
+++ b/apps/extension/src/test/init.ts
@@ -4,6 +4,7 @@ import { KVStore } from "@namada/storage";
 import { Chain } from "@namada/types";
 
 import {
+  ExtensionBroadcaster,
   ExtensionRouter,
   ExtensionMessengerMock,
   ExtensionRequester,
@@ -36,7 +37,7 @@ const chainId = "namada-75a7e12.69483d59a9fb174";
 export class KVStoreMock<T> implements KVStore<T> {
   private storage: { [key: string]: T | null } = {};
 
-  constructor(readonly _prefix: string) {}
+  constructor(readonly _prefix: string) { }
 
   get<U extends T>(key: string): Promise<U | undefined> {
     return new Promise((resolve) => {
@@ -73,6 +74,11 @@ export const init = async (): Promise<{
   const namadaRouterId = await getNamadaRouterId(extStore);
   const requester = new ExtensionRequester(messenger, namadaRouterId);
   const txStore = new KVStoreMock<string>(KVPrefix.LocalStorage);
+  const broadcaster = new ExtensionBroadcaster(
+    connectedTabsStore,
+    chainId,
+    requester
+  );
 
   const router = new ExtensionRouter(
     () => ({
@@ -103,7 +109,8 @@ export const init = async (): Promise<{
     sdk,
     query,
     cryptoMemory,
-    requester
+    requester,
+    broadcaster
   );
 
   const ledgerService = new LedgerService(
@@ -115,7 +122,8 @@ export const init = async (): Promise<{
     revealedPKStore,
     chainId,
     sdk,
-    requester
+    requester,
+    broadcaster
   );
 
   const approvalsService = new ApprovalsService(

--- a/apps/namada-interface/src/services/extensionEvents/handlers/namada.ts
+++ b/apps/namada-interface/src/services/extensionEvents/handlers/namada.ts
@@ -2,12 +2,12 @@ import { Dispatch } from "react";
 
 import { chains } from "@namada/chains";
 import { Namada } from "@namada/integrations";
+import { TxType, TxTypeLabel } from "@namada/shared";
 
 import { addAccounts, fetchBalances } from "slices/accounts";
 import { actions as notificationsActions } from "slices/notifications";
 import { getToast, Toasts } from "slices/transfers";
 import { fetchValidators } from "slices/StakingAndGovernance/actions";
-import { TxType } from "@namada/shared";
 
 export const NamadaAccountChangedHandler =
   (dispatch: Dispatch<unknown>, integration: Namada) =>
@@ -36,14 +36,23 @@ export const NamadaUpdatedStakingHandler =
 export const NamadaTxStartedHandler =
   (dispatch: Dispatch<unknown>) => async (event: CustomEventInit) => {
     const { msgId, txType } = event.detail;
-    dispatch(notificationsActions.txStartedToast({ id: msgId, txType }));
+    dispatch(
+      notificationsActions.txStartedToast({
+        id: msgId,
+        txTypeLabel: TxTypeLabel[txType as TxType],
+      })
+    );
   };
 
 export const NamadaTxCompletedHandler =
   (dispatch: Dispatch<unknown>) => async (event: CustomEventInit) => {
     const { msgId, txType, success } = event.detail;
     dispatch(
-      notificationsActions.txCompletedToast({ id: msgId, txType, success })
+      notificationsActions.txCompletedToast({
+        id: msgId,
+        txTypeLabel: TxTypeLabel[txType as TxType],
+        success,
+      })
     );
   };
 

--- a/apps/namada-interface/src/services/extensionEvents/handlers/namada.ts
+++ b/apps/namada-interface/src/services/extensionEvents/handlers/namada.ts
@@ -7,6 +7,7 @@ import { addAccounts, fetchBalances } from "slices/accounts";
 import { actions as notificationsActions } from "slices/notifications";
 import { getToast, Toasts } from "slices/transfers";
 import { fetchValidators } from "slices/StakingAndGovernance/actions";
+import { TxType } from "@namada/shared";
 
 export const NamadaAccountChangedHandler =
   (dispatch: Dispatch<unknown>, integration: Namada) =>
@@ -32,6 +33,18 @@ export const NamadaUpdatedStakingHandler =
     dispatch(fetchValidators());
   };
 
+export const NamadaTxStartedHandler =
+  (dispatch: Dispatch<unknown>) => async (event: CustomEventInit) => {
+    const { msgId, txType } = event.detail;
+    dispatch(notificationsActions.txStartedToast({ id: msgId, txType }));
+  };
+
+export const NamadaTxCompletedHandler =
+  (dispatch: Dispatch<unknown>) => async (event: CustomEventInit) => {
+    const { msgId, txType } = event.detail;
+    dispatch(notificationsActions.txCompletedToast({ id: msgId, txType }));
+  };
+
 export const NamadaTransferStartedHandler =
   (dispatch: Dispatch<unknown>) => async (event: CustomEventInit) => {
     const { msgId } = event.detail;
@@ -40,7 +53,7 @@ export const NamadaTransferStartedHandler =
         getToast(
           `${event.detail.msgId}-transfer`,
           Toasts.TransferStarted
-        )({ msgId })
+        )({ msgId, txType: TxType.Transfer })
       )
     );
   };
@@ -53,7 +66,7 @@ export const NamadaTransferCompletedHandler =
         getToast(
           `${event.detail.msgId}-transfer`,
           Toasts.TransferCompleted
-        )({ msgId, success })
+        )({ msgId, success, txType: TxType.Transfer })
       )
     );
   };

--- a/apps/namada-interface/src/services/extensionEvents/handlers/namada.ts
+++ b/apps/namada-interface/src/services/extensionEvents/handlers/namada.ts
@@ -41,8 +41,10 @@ export const NamadaTxStartedHandler =
 
 export const NamadaTxCompletedHandler =
   (dispatch: Dispatch<unknown>) => async (event: CustomEventInit) => {
-    const { msgId, txType } = event.detail;
-    dispatch(notificationsActions.txCompletedToast({ id: msgId, txType }));
+    const { msgId, txType, success } = event.detail;
+    dispatch(
+      notificationsActions.txCompletedToast({ id: msgId, txType, success })
+    );
   };
 
 export const NamadaTransferStartedHandler =

--- a/apps/namada-interface/src/services/extensionEvents/handlers/namada.ts
+++ b/apps/namada-interface/src/services/extensionEvents/handlers/namada.ts
@@ -6,7 +6,6 @@ import { TxType, TxTypeLabel } from "@namada/shared";
 
 import { addAccounts, fetchBalances } from "slices/accounts";
 import { actions as notificationsActions } from "slices/notifications";
-import { getToast, Toasts } from "slices/transfers";
 import { fetchValidators } from "slices/StakingAndGovernance/actions";
 
 export const NamadaAccountChangedHandler =
@@ -46,38 +45,13 @@ export const NamadaTxStartedHandler =
 
 export const NamadaTxCompletedHandler =
   (dispatch: Dispatch<unknown>) => async (event: CustomEventInit) => {
-    const { msgId, txType, success } = event.detail;
+    const { msgId, txType, success, payload } = event.detail;
     dispatch(
       notificationsActions.txCompletedToast({
         id: msgId,
         txTypeLabel: TxTypeLabel[txType as TxType],
         success,
+        error: payload || "",
       })
-    );
-  };
-
-export const NamadaTransferStartedHandler =
-  (dispatch: Dispatch<unknown>) => async (event: CustomEventInit) => {
-    const { msgId } = event.detail;
-    dispatch(
-      notificationsActions.createToast(
-        getToast(
-          `${event.detail.msgId}-transfer`,
-          Toasts.TransferStarted
-        )({ msgId, txType: TxType.Transfer })
-      )
-    );
-  };
-
-export const NamadaTransferCompletedHandler =
-  (dispatch: Dispatch<unknown>) => async (event: CustomEventInit) => {
-    const { msgId, success } = event.detail;
-    dispatch(
-      notificationsActions.createToast(
-        getToast(
-          `${event.detail.msgId}-transfer`,
-          Toasts.TransferCompleted
-        )({ msgId, success, txType: TxType.Transfer })
-      )
     );
   };

--- a/apps/namada-interface/src/services/extensionEvents/provider.tsx
+++ b/apps/namada-interface/src/services/extensionEvents/provider.tsx
@@ -12,8 +12,6 @@ import { useEventListenerOnce, useIntegration } from "@namada/hooks";
 import { useAppDispatch } from "store";
 import {
   NamadaAccountChangedHandler,
-  NamadaTransferCompletedHandler,
-  NamadaTransferStartedHandler,
   NamadaTxStartedHandler,
   NamadaTxCompletedHandler,
   NamadaUpdatedBalancesHandler,
@@ -35,9 +33,6 @@ export const ExtensionEventsProvider: React.FC = (props): JSX.Element => {
     dispatch,
     namadaIntegration as Namada
   );
-  const namadaTransferStartedHandler = NamadaTransferStartedHandler(dispatch);
-  const namadaTransferCompletedHandler =
-    NamadaTransferCompletedHandler(dispatch);
   const namadaTxStartedHandler = NamadaTxStartedHandler(dispatch);
   const namadaTxCompletedHandler = NamadaTxCompletedHandler(dispatch);
   const namadaUpdatedBalancesHandler = NamadaUpdatedBalancesHandler(dispatch);
@@ -57,11 +52,6 @@ export const ExtensionEventsProvider: React.FC = (props): JSX.Element => {
 
   // Register handlers:
   useEventListenerOnce(Events.AccountChanged, namadaAccountChangedHandler);
-  useEventListenerOnce(Events.TransferStarted, namadaTransferStartedHandler);
-  useEventListenerOnce(
-    Events.TransferCompleted,
-    namadaTransferCompletedHandler
-  );
   useEventListenerOnce(Events.UpdatedBalances, namadaUpdatedBalancesHandler);
   useEventListenerOnce(Events.UpdatedStaking, namadaUpdatedStakingHandler);
   useEventListenerOnce(Events.TxStarted, namadaTxStartedHandler);

--- a/apps/namada-interface/src/services/extensionEvents/provider.tsx
+++ b/apps/namada-interface/src/services/extensionEvents/provider.tsx
@@ -14,6 +14,8 @@ import {
   NamadaAccountChangedHandler,
   NamadaTransferCompletedHandler,
   NamadaTransferStartedHandler,
+  NamadaTxStartedHandler,
+  NamadaTxCompletedHandler,
   NamadaUpdatedBalancesHandler,
   NamadaUpdatedStakingHandler,
   KeplrAccountChangedHandler,
@@ -36,6 +38,8 @@ export const ExtensionEventsProvider: React.FC = (props): JSX.Element => {
   const namadaTransferStartedHandler = NamadaTransferStartedHandler(dispatch);
   const namadaTransferCompletedHandler =
     NamadaTransferCompletedHandler(dispatch);
+  const namadaTxStartedHandler = NamadaTxStartedHandler(dispatch);
+  const namadaTxCompletedHandler = NamadaTxCompletedHandler(dispatch);
   const namadaUpdatedBalancesHandler = NamadaUpdatedBalancesHandler(dispatch);
   const namadaUpdatedStakingHandler = NamadaUpdatedStakingHandler(dispatch);
 
@@ -60,6 +64,8 @@ export const ExtensionEventsProvider: React.FC = (props): JSX.Element => {
   );
   useEventListenerOnce(Events.UpdatedBalances, namadaUpdatedBalancesHandler);
   useEventListenerOnce(Events.UpdatedStaking, namadaUpdatedStakingHandler);
+  useEventListenerOnce(Events.TxStarted, namadaTxStartedHandler);
+  useEventListenerOnce(Events.TxCompleted, namadaTxCompletedHandler);
   useEventListenerOnce(KeplrEvents.AccountChanged, keplrAccountChangedHandler);
   useEventListenerOnce(
     MetamaskEvents.AccountChanged,

--- a/apps/namada-interface/src/slices/notifications/reducers.ts
+++ b/apps/namada-interface/src/slices/notifications/reducers.ts
@@ -14,8 +14,6 @@ import {
   NotificationsState,
   ToastTimeout,
 } from "./types";
-import { TxType } from "@namada/shared";
-import { TxTypeLabel } from "@namada/types";
 
 export const DEFAULT_TIMEOUT = 2000;
 export const THUNK_MATCH_REGEXP = /^.*(?=\/(pending|fulfilled|rejected)$)/;
@@ -45,12 +43,13 @@ export const reducers = {
   },
   txStartedToast(
     state: NotificationsState,
-    action: PayloadAction<{ id: ToastId; txType: TxType }>
+    action: PayloadAction<{ id: ToastId; txTypeLabel: string }>
   ) {
+    const { id, txTypeLabel } = action.payload;
     state.toasts = {
       ...state.toasts,
-      [action.payload.id]: {
-        title: `${TxTypeLabel[action.payload.txType]} Tx started`,
+      [id]: {
+        title: `${txTypeLabel} started`,
         message: "Waiting for transaction confirmation",
         type: "info",
         timeout: ToastTimeout.None(),
@@ -59,13 +58,17 @@ export const reducers = {
   },
   txCompletedToast(
     state: NotificationsState,
-    action: PayloadAction<{ id: ToastId; txType: TxType; success: boolean }>
+    action: PayloadAction<{
+      id: ToastId;
+      txTypeLabel: string;
+      success: boolean;
+    }>
   ) {
-    const { id, txType, success } = action.payload;
+    const { id, txTypeLabel, success } = action.payload;
     state.toasts = {
       ...state.toasts,
       [id]: {
-        title: `${TxTypeLabel[txType]} Tx completed`,
+        title: `${txTypeLabel} completed`,
         message: `Transaction ${success ? "confirmed" : "rejected"}`,
         type: success ? "success" : "error",
         timeout: ToastTimeout.Default(),

--- a/apps/namada-interface/src/slices/notifications/reducers.ts
+++ b/apps/namada-interface/src/slices/notifications/reducers.ts
@@ -14,6 +14,7 @@ import {
   NotificationsState,
   ToastTimeout,
 } from "./types";
+import { TxLabel } from "@namada/shared";
 
 export const DEFAULT_TIMEOUT = 2000;
 export const THUNK_MATCH_REGEXP = /^.*(?=\/(pending|fulfilled|rejected)$)/;
@@ -43,14 +44,14 @@ export const reducers = {
   },
   txStartedToast(
     state: NotificationsState,
-    action: PayloadAction<{ id: ToastId; txTypeLabel: string }>
+    action: PayloadAction<{ id: ToastId; txTypeLabel: TxLabel }>
   ) {
     const { id, txTypeLabel } = action.payload;
     state.toasts = {
       ...state.toasts,
       [id]: {
         title: `${txTypeLabel} started`,
-        message: "Waiting for transaction confirmation",
+        message: "Waiting for confirmation",
         type: "info",
         timeout: ToastTimeout.None(),
       },
@@ -60,16 +61,17 @@ export const reducers = {
     state: NotificationsState,
     action: PayloadAction<{
       id: ToastId;
-      txTypeLabel: string;
+      txTypeLabel: TxLabel;
       success: boolean;
+      error: string;
     }>
   ) {
-    const { id, txTypeLabel, success } = action.payload;
+    const { error, id, success, txTypeLabel } = action.payload;
     state.toasts = {
       ...state.toasts,
       [id]: {
-        title: `${txTypeLabel} completed`,
-        message: `Transaction ${success ? "confirmed" : "rejected"}`,
+        title: `${txTypeLabel} ${success ? "confirmed" : "rejected"}`,
+        message: success ? "Transaction completed!" : error,
         type: success ? "success" : "error",
         timeout: ToastTimeout.Default(),
       },

--- a/apps/namada-interface/src/slices/notifications/reducers.ts
+++ b/apps/namada-interface/src/slices/notifications/reducers.ts
@@ -59,14 +59,15 @@ export const reducers = {
   },
   txCompletedToast(
     state: NotificationsState,
-    action: PayloadAction<{ id: ToastId; txType: TxType }>
+    action: PayloadAction<{ id: ToastId; txType: TxType; success: boolean }>
   ) {
+    const { id, txType, success } = action.payload;
     state.toasts = {
       ...state.toasts,
-      [action.payload.id]: {
-        title: `${TxTypeLabel[action.payload.txType]} Tx completed`,
-        message: "Transaction confirmed",
-        type: "success",
+      [id]: {
+        title: `${TxTypeLabel[txType]} Tx completed`,
+        message: `Transaction ${success ? "confirmed" : "rejected"}`,
+        type: success ? "success" : "error",
         timeout: ToastTimeout.Default(),
       },
     };

--- a/apps/namada-interface/src/slices/notifications/reducers.ts
+++ b/apps/namada-interface/src/slices/notifications/reducers.ts
@@ -14,6 +14,8 @@ import {
   NotificationsState,
   ToastTimeout,
 } from "./types";
+import { TxType } from "@namada/shared";
+import { TxTypeLabel } from "@namada/types";
 
 export const DEFAULT_TIMEOUT = 2000;
 export const THUNK_MATCH_REGEXP = /^.*(?=\/(pending|fulfilled|rejected)$)/;
@@ -40,6 +42,34 @@ export const reducers = {
   ) => {
     const { [action.payload.id]: _, ...newToasts } = state.toasts;
     state.toasts = newToasts;
+  },
+  txStartedToast(
+    state: NotificationsState,
+    action: PayloadAction<{ id: ToastId; txType: TxType }>
+  ) {
+    state.toasts = {
+      ...state.toasts,
+      [action.payload.id]: {
+        title: `${TxTypeLabel[action.payload.txType]} Tx started`,
+        message: "Waiting for transaction confirmation",
+        type: "info",
+        timeout: ToastTimeout.None(),
+      },
+    };
+  },
+  txCompletedToast(
+    state: NotificationsState,
+    action: PayloadAction<{ id: ToastId; txType: TxType }>
+  ) {
+    state.toasts = {
+      ...state.toasts,
+      [action.payload.id]: {
+        title: `${TxTypeLabel[action.payload.txType]} Tx completed`,
+        message: "Transaction confirmed",
+        type: "success",
+        timeout: ToastTimeout.Default(),
+      },
+    };
   },
 };
 

--- a/apps/namada-interface/src/slices/transfers.ts
+++ b/apps/namada-interface/src/slices/transfers.ts
@@ -2,66 +2,10 @@ import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import BigNumber from "bignumber.js";
 
 import { Account, Tokens, TokenType, Signer } from "@namada/types";
-import { assertNever } from "@namada/utils";
 import { getIntegration } from "@namada/hooks";
 
-import {
-  CreateToastPayload,
-  ToastId,
-  ToastTimeout,
-  ToastType,
-} from "slices/notifications";
 import { RootState } from "store";
-import { TxType } from "@namada/shared";
-
-export enum Toasts {
-  TransferStarted,
-  TransferCompleted,
-}
-
-type TransferCompletedToastProps = {
-  msgId: string;
-  txType: TxType;
-  success: boolean;
-};
-type TransferStartedToastProps = { msgId: string; txType: TxType };
-type GetToastProps<T extends Toasts> = T extends Toasts.TransferStarted
-  ? TransferStartedToastProps
-  : T extends Toasts.TransferCompleted
-  ? TransferCompletedToastProps
-  : never;
-
-export const getToast = <T extends Toasts>(
-  toastId: ToastId,
-  toast: T
-): ((props: GetToastProps<T>) => CreateToastPayload) => {
-  const toastFunction =
-    toast === Toasts.TransferStarted
-      ? (payload: TransferCompletedToastProps) => ({
-          id: toastId,
-          data: {
-            title: "Transfer in progress!",
-            message: payload.msgId,
-            type: "pending-info" as ToastType,
-            timeout: ToastTimeout.None(),
-          },
-        })
-      : toast === Toasts.TransferCompleted
-      ? ({ success, msgId }: TransferCompletedToastProps) => ({
-          id: toastId,
-          data: {
-            title: success ? "Transfer successful!" : "Transfer failed.",
-            message: msgId,
-            type: success ? "success" : "error",
-          },
-        })
-      : assertNever(toast);
-
-  return toastFunction as (props: GetToastProps<T>) => CreateToastPayload;
-};
-
 const TRANSFERS_ACTIONS_BASE = "transfers";
-/* const MASP_ADDRESS = TRANSFER_CONFIGURATION.maspAddress; */
 
 export type IBCTransferAttributes = {
   sourceChannel: string;
@@ -186,16 +130,9 @@ export const submitIbcTransferTransaction = createAsyncThunk<
   { state: RootState }
 >(
   `${TRANSFERS_ACTIONS_BASE}/${TransfersThunkActions.SubmitIbcTransferTransaction}`,
-  async (txIbcTransferArgs, { getState /* dispatch, requestId */ }) => {
+  async (txIbcTransferArgs, { getState }) => {
     const { chainId } = getState().settings;
     const integration = getIntegration(chainId);
-
-    // TODO: Add toast props
-    //dispatch(
-    //  notificationsActions.createToast(
-    //    getToast(`${requestId}-pending`, Toasts.TransferStarted)()
-    //  )
-    //);
 
     await integration.submitBridgeTransfer({
       ibcProps: {
@@ -213,13 +150,6 @@ export const submitIbcTransferTransaction = createAsyncThunk<
         channelId: txIbcTransferArgs.channelId,
       },
     });
-
-    // TODO: Add toast props
-    //dispatch(
-    //  notificationsActions.createToast(
-    //    getToast(`${requestId}-fullfilled`, Toasts.TransferCompleted)()
-    //  )
-    //);
   }
 );
 
@@ -229,16 +159,9 @@ export const submitBridgeTransferTransaction = createAsyncThunk<
   { state: RootState }
 >(
   `${TRANSFERS_ACTIONS_BASE}/${TransfersThunkActions.SubmitBridgeTransferTransaction}`,
-  async (txBridgeTransferArgs, { getState /* dispatch, requestId */ }) => {
+  async (txBridgeTransferArgs, { getState }) => {
     const { chainId } = getState().settings;
     const integration = getIntegration(chainId);
-
-    // TODO: Add toast props
-    //dispatch(
-    //  notificationsActions.createToast(
-    //    getToast(`${requestId}-pending`, Toasts.TransferStarted)()
-    //  )
-    //);
 
     await integration.submitBridgeTransfer({
       // TODO: tx (below) is *not* required for Keplr, but are required for this type.
@@ -256,13 +179,6 @@ export const submitBridgeTransferTransaction = createAsyncThunk<
         amount: txBridgeTransferArgs.amount,
       },
     });
-
-    // TODO: Add toast props
-    //dispatch(
-    //  notificationsActions.createToast(
-    //    getToast(`${requestId}-fullfilled`, Toasts.TransferCompleted)()
-    //  )
-    //);
   }
 );
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -49,3 +49,5 @@ export class Query extends RustQuery {
     super.query_my_validators.bind(this)
   );
 }
+
+export * from "./types";

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,6 +1,8 @@
 import { TxType } from "./shared/shared";
 
-export const TxTypeLabel: Record<TxType, string> = {
+export type TxLabel = "Bond" | "Unbond" | "Transfer" | "Withdraw" | "RevealPK";
+
+export const TxTypeLabel: Record<TxType, TxLabel> = {
   [TxType.Bond]: "Bond",
   [TxType.Unbond]: "Unbond",
   [TxType.Transfer]: "Transfer",

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,0 +1,9 @@
+import { TxType } from "./shared/shared";
+
+export const TxTypeLabel: Record<TxType, string> = {
+  [TxType.Bond]: "Bond",
+  [TxType.Unbond]: "Unbond",
+  [TxType.Transfer]: "Transfer",
+  [TxType.Withdraw]: "Withdraw",
+  [TxType.RevealPK]: "RevealPK",
+};

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -5,6 +5,8 @@ export enum Events {
   AccountChanged = "namada-account-changed",
   TransferStarted = "namada-transfer-started",
   TransferCompleted = "namada-transfer-completed",
+  TxStarted = "namada-tx-started",
+  TxCompleted = "namada-tx-completed",
   UpdatedBalances = "namada-updated-balances",
   UpdatedStaking = "namada-updated-staking",
 }

--- a/packages/types/src/tx/types.ts
+++ b/packages/types/src/tx/types.ts
@@ -1,5 +1,7 @@
 import BigNumber from "bignumber.js";
 
+import { TxType } from "@namada/shared";
+
 export type SubmitBondProps = {
   validator: string;
   amount: BigNumber;
@@ -73,4 +75,12 @@ export type SignatureProps = {
   indices: Uint8Array;
   pubkey: Uint8Array;
   signature: Uint8Array;
+};
+
+export const TxTypeLabel: Record<TxType, string> = {
+  [TxType.Bond]: "Bond",
+  [TxType.Unbond]: "Unbond",
+  [TxType.Transfer]: "Transfer",
+  [TxType.Withdraw]: "Withdraw",
+  [TxType.RevealPK]: "RevealPK",
 };

--- a/packages/types/src/tx/types.ts
+++ b/packages/types/src/tx/types.ts
@@ -1,7 +1,5 @@
 import BigNumber from "bignumber.js";
 
-import { TxType } from "@namada/shared";
-
 export type SubmitBondProps = {
   validator: string;
   amount: BigNumber;
@@ -75,12 +73,4 @@ export type SignatureProps = {
   indices: Uint8Array;
   pubkey: Uint8Array;
   signature: Uint8Array;
-};
-
-export const TxTypeLabel: Record<TxType, string> = {
-  [TxType.Bond]: "Bond",
-  [TxType.Unbond]: "Unbond",
-  [TxType.Transfer]: "Transfer",
-  [TxType.Withdraw]: "Withdraw",
-  [TxType.RevealPK]: "RevealPK",
 };


### PR DESCRIPTION
Resolves #358 

- [x] All transactions (aside from `RevealPK`) dispatch the appropriate notification to the interface
- [x] Approval window should close when the notification event is dispatched (does not apply to `RevealPK`) - behavior should be identical for all approved Tx
- [x] Toast indicates Tx type
- [x] Fix unit test failures

Optional may have implications and possibly should be skipped on this PR):
- [x] Reuse `TxStartedEvent` and `TxCompletedEvent` for transfers
  - [x] TODO - clean up unused event logic