### PR TITLE
feat: add ability to approve and revoke connections

### DIFF
--- a/apps/extension/src/App/Settings/ExtraSettings/ConnectedSites/ConnectedSites.components.ts
+++ b/apps/extension/src/App/Settings/ExtraSettings/ConnectedSites/ConnectedSites.components.ts
@@ -1,0 +1,57 @@
+import styled from "styled-components";
+
+export const ConnectedSitesList = styled.ul`
+  list-style-type: none;
+  padding: 0;
+  margin: 0 0 8px;
+  width: 100%;
+`;
+
+export const ConnectedSiteListItemContainer = styled.li`
+  padding: 0;
+  margin: 4px 0;
+  display: flex;
+  flex-direction: row;
+`;
+
+export const ConnectedSiteDetails = styled.div`
+  display: flex;
+  flex-direction: row;
+  width: 90%;
+  font-family: "Space Grotesk", sans-serif;
+  background-color: ${(props) => props.theme.colors.utility1.main};
+  font-size: 11px;
+  color: ${(props) => props.theme.colors.utility1.main40};
+  box-sizing: border-box;
+  border: 1px solid ${(props) => props.theme.colors.utility1.main};
+  border-radius: 8px;
+  box-sizing: border-box;
+  padding: 8px 8px;
+`;
+
+export const ConnectedSiteSideButton = styled.div`
+  display: flex;
+  flex-direction: row;
+  width: 10%;
+  font-family: "Space Grotesk", sans-serif;
+  background-color: ${(props) => props.theme.colors.utility1.main};
+  font-size: 11px;
+  color: ${(props) => props.theme.colors.utility1.main40};
+  box-sizing: border-box;
+  border: 1px solid ${(props) => props.theme.colors.utility1.main};
+  border-radius: 8px;
+  box-sizing: border-box;
+  padding: 8px 8px;
+  cursor: pointer;
+  text-align: center;
+
+  &::before {
+    content: "x";
+    transform: translate(50%);
+  }
+
+  &:hover {
+    color: ${(props) => props.theme.colors.utility1.main};
+    background-color: ${(props) => props.theme.colors.utility2.main};
+  }
+`;

--- a/apps/extension/src/App/Settings/ExtraSettings/ConnectedSites/ConnectedSites.tsx
+++ b/apps/extension/src/App/Settings/ExtraSettings/ConnectedSites/ConnectedSites.tsx
@@ -1,0 +1,64 @@
+import browser from "webextension-polyfill";
+import { useState, useEffect, useCallback } from "react";
+import { ExtensionKVStore } from "@namada/storage";
+
+import {
+  ConnectedSitesList,
+  ConnectedSiteListItemContainer,
+  ConnectedSiteDetails,
+  ConnectedSiteSideButton,
+} from "./ConnectedSites.components";
+import { Ports, KVPrefix } from "router";
+import {
+  ApprovedOriginsStore,
+  APPROVED_ORIGINS_KEY,
+  RevokeConnectionMsg
+} from "background/approvals";
+import { useRequester } from "hooks/useRequester";
+
+const approvedOriginsStore = new ExtensionKVStore<ApprovedOriginsStore>(
+  KVPrefix.LocalStorage,
+  {
+    get: browser.storage.local.get,
+    set: browser.storage.local.set,
+  }
+);
+
+const ConnectedSites: React.FC = ({
+}) => {
+  const [connectedSites, setConnectedSites] = useState<ApprovedOriginsStore>([]);
+  const requester = useRequester();
+
+  const fetchConnectedSites = useCallback(() => {
+    approvedOriginsStore.get(APPROVED_ORIGINS_KEY).then(origins =>
+      setConnectedSites(origins as ApprovedOriginsStore || [])
+    );
+  }, [setConnectedSites]);
+
+  useEffect(fetchConnectedSites);
+
+  const handleRevokeConnection = async (site: string): Promise<void> => {
+    await requester.sendMessage(
+      Ports.Background,
+      new RevokeConnectionMsg(site)
+    );
+    fetchConnectedSites();
+  };
+
+  return (
+    <ConnectedSitesList>
+      {connectedSites.map((site, i) => (
+        <ConnectedSiteListItemContainer key={i}>
+          <ConnectedSiteDetails>
+            {site}
+          </ConnectedSiteDetails>
+          <ConnectedSiteSideButton
+            onClick={() => handleRevokeConnection(site)}
+          />
+        </ConnectedSiteListItemContainer>
+      ))}
+    </ConnectedSitesList>
+  );
+};
+
+export default ConnectedSites;

--- a/apps/extension/src/App/Settings/ExtraSettings/ConnectedSites/index.ts
+++ b/apps/extension/src/App/Settings/ExtraSettings/ConnectedSites/index.ts
@@ -1,0 +1,1 @@
+export { default as ConnectedSites } from "./ConnectedSites";

--- a/apps/extension/src/App/Settings/ExtraSettings/ExtraSettings.tsx
+++ b/apps/extension/src/App/Settings/ExtraSettings/ExtraSettings.tsx
@@ -4,6 +4,7 @@ import { ExtensionRequester } from "extension";
 import { Mode, ExtraSetting } from "./types";
 import { ResetPassword } from "./ResetPassword";
 import { DeleteAccount } from "./DeleteAccount";
+import { ConnectedSites } from "./ConnectedSites";
 import { ExtraSettingsContainer, CloseLink } from "./ExtraSettings.components";
 
 /**
@@ -33,8 +34,10 @@ const ExtraSettings: React.FC<{
           requester={requester}
           onDeleteAccount={onDeleteAccount}
         />
+      ) : extraSetting.mode === Mode.ConnectedSites ? (
+        <ConnectedSites />
       ) : (
-        assertNever(extraSetting.mode)
+        assertNever(extraSetting)
       )}
     </ExtraSettingsContainer>
   );

--- a/apps/extension/src/App/Settings/ExtraSettings/types.ts
+++ b/apps/extension/src/App/Settings/ExtraSettings/types.ts
@@ -4,10 +4,11 @@ import { ParentAccount } from "background/keyring";
 export enum Mode {
   ResetPassword = "Reset password",
   DeleteAccount = "Delete account",
+  ConnectedSites = "Connected sites",
 }
 
-export type ExtraSetting = {
-  mode: Mode;
-  accountId: string;
-  accountType: ParentAccount;
-};
+
+export type ExtraSetting =
+  | { mode: Mode.ResetPassword, accountId: string }
+  | { mode: Mode.DeleteAccount, accountId: string, accountType: ParentAccount }
+  | { mode: Mode.ConnectedSites };

--- a/apps/extension/src/App/Settings/Settings.tsx
+++ b/apps/extension/src/App/Settings/Settings.tsx
@@ -158,6 +158,14 @@ const Settings: React.FC<{
             </Button>
           </ButtonsContainer>
 
+          <ModeSelectContainer>
+            <ModeSelectLink
+              onClick={() => setExtraSetting({ mode: Mode.ConnectedSites })}
+            >
+              {Mode.ConnectedSites}
+            </ModeSelectLink>
+          </ModeSelectContainer>
+
           <ExtraSettings
             extraSetting={extraSetting}
             requester={requester}
@@ -177,7 +185,7 @@ const AccountListItem: React.FC<{
   account: DerivedAccount;
   activeAccountId: string;
   onSelectAccount: () => void;
-  onSelectMode: (mode: Mode) => void;
+  onSelectMode: (mode: Mode.ResetPassword | Mode.DeleteAccount) => void;
 }> = ({ account, activeAccountId, onSelectAccount, onSelectMode }) => {
   const [expanded, setExpanded] = useState<boolean>(false);
 
@@ -209,14 +217,12 @@ const AccountListItem: React.FC<{
  * Contains a list of possible settings to open for a given account.
  */
 const ModeSelect: React.FC<{
-  onSelectMode: (mode: Mode) => void;
+  onSelectMode: (mode: Mode.ResetPassword | Mode.DeleteAccount) => void;
   type: AccountType;
 }> = ({ onSelectMode, type }) => {
-  const modes = [Mode.DeleteAccount];
-
-  if (type !== AccountType.Ledger) {
-    modes.unshift(Mode.ResetPassword);
-  }
+  const modes = type === AccountType.Ledger
+    ? [Mode.DeleteAccount] as const
+    : [Mode.ResetPassword, Mode.DeleteAccount] as const;
 
   return (
     <ModeSelectContainer>

--- a/apps/extension/src/Approvals/ApproveConnection/ApproveConnection.tsx
+++ b/apps/extension/src/Approvals/ApproveConnection/ApproveConnection.tsx
@@ -1,5 +1,9 @@
 import { Button, ButtonVariant } from "@namada/components";
 import { useQuery } from "hooks";
+import { Ports } from "router";
+import { closeCurrentTab } from "utils";
+import { useRequester } from "hooks/useRequester";
+import { ConnectInterfaceResponseMsg } from "background/approvals";
 
 import {
   ApprovalContainer,
@@ -7,17 +11,41 @@ import {
 } from "Approvals/Approvals.components";
 
 export const ApproveConnection: React.FC = () => {
+  const requester = useRequester();
   const params = useQuery();
+  const interfaceOrigin = params.get("interfaceOrigin");
   const chainId = params.get("chainId");
+  const interfaceTabId = params.get("interfaceTabId");
+
+  const handleResponse = (allowConnection: boolean): void => {
+    if (interfaceTabId && chainId && interfaceOrigin) {
+      requester.sendMessage(
+        Ports.Background,
+        new ConnectInterfaceResponseMsg(
+          parseInt(interfaceTabId),
+          chainId,
+          interfaceOrigin,
+          allowConnection
+        )
+      );
+      closeCurrentTab();
+    }
+  };
 
   return (
     <ApprovalContainer>
       <p>
-        Approve connection for chain <strong>{chainId}</strong>?
+        Approve connection for <strong>{interfaceOrigin}</strong>?
       </p>
       <ButtonContainer>
-        <Button variant={ButtonVariant.Contained}>Approve</Button>
-        <Button variant={ButtonVariant.Contained}>Reject</Button>
+        <Button
+          variant={ButtonVariant.Contained}
+          onClick={() => handleResponse(true)}
+        >Approve</Button>
+        <Button
+          variant={ButtonVariant.Contained}
+          onClick={() => handleResponse(false)}
+        >Reject</Button>
       </ButtonContainer>
     </ApprovalContainer>
   );

--- a/apps/extension/src/background/approvals/handler.ts
+++ b/apps/extension/src/background/approvals/handler.ts
@@ -7,6 +7,7 @@ import {
   ApproveIbcTransferMsg,
   ApproveWithdrawMsg,
   ApproveEthBridgeTransferMsg,
+  ApproveConnectInterfaceMsg,
 } from "provider";
 import {
   RejectTxMsg,
@@ -16,6 +17,8 @@ import {
   SubmitApprovedBondMsg,
   SubmitApprovedUnbondMsg,
   SubmitApprovedWithdrawMsg,
+  ConnectInterfaceResponseMsg,
+  RevokeConnectionMsg,
 } from "./messages";
 
 export const getHandler: (service: ApprovalsService) => Handler = (service) => {
@@ -77,6 +80,21 @@ export const getHandler: (service: ApprovalsService) => Handler = (service) => {
         return handleSubmitApprovedWithdrawMsg(service)(
           env,
           msg as SubmitApprovedUnbondMsg
+        );
+      case ApproveConnectInterfaceMsg:
+        return handleApproveConnectInterfaceMsg(service)(
+          env,
+          msg as ApproveConnectInterfaceMsg
+        );
+      case ConnectInterfaceResponseMsg:
+        return handleConnectInterfaceResponseMsg(service)(
+          env,
+          msg as ConnectInterfaceResponseMsg
+        );
+      case RevokeConnectionMsg:
+        return handleRevokeConnectionMsg(service)(
+          env,
+          msg as RevokeConnectionMsg
         );
       default:
         throw new Error("Unknown msg type");
@@ -185,5 +203,31 @@ const handleSubmitApprovedWithdrawMsg: (
 ) => InternalHandler<SubmitApprovedWithdrawMsg> = (service) => {
   return async (_, { msgId, password }) => {
     return await service.submitWithdraw(msgId, password);
+  };
+};
+
+const handleApproveConnectInterfaceMsg: (
+  service: ApprovalsService
+) => InternalHandler<ApproveConnectInterfaceMsg> = (service) => {
+  return async ({ senderTabId: interfaceTabId }, { chainId, origin }) => {
+    return await service.approveConnection(interfaceTabId, chainId, origin);
+  };
+};
+
+const handleConnectInterfaceResponseMsg: (
+  service: ApprovalsService
+) => InternalHandler<ConnectInterfaceResponseMsg> = (service) => {
+  return async ({ senderTabId: popupTabId }, { interfaceTabId, chainId, interfaceOrigin, allowConnection }) => {
+    return await service.approveConnectionResponse(
+      interfaceTabId, chainId, interfaceOrigin, allowConnection, popupTabId
+    );
+  };
+};
+
+const handleRevokeConnectionMsg: (
+  service: ApprovalsService
+) => InternalHandler<RevokeConnectionMsg> = (service) => {
+  return async (_, { originToRevoke }) => {
+    return await service.revokeConnection(originToRevoke);
   };
 };

--- a/apps/extension/src/background/approvals/index.ts
+++ b/apps/extension/src/background/approvals/index.ts
@@ -2,3 +2,5 @@ export * from "./constants";
 export * from "./init";
 export * from "./messages";
 export * from "./service";
+export * from "./utils";
+export * from "./types";

--- a/apps/extension/src/background/approvals/init.ts
+++ b/apps/extension/src/background/approvals/init.ts
@@ -6,6 +6,7 @@ import {
   ApproveEthBridgeTransferMsg,
   ApproveUnbondMsg,
   ApproveWithdrawMsg,
+  ApproveConnectInterfaceMsg,
 } from "provider";
 import {
   RejectTxMsg,
@@ -15,6 +16,8 @@ import {
   SubmitApprovedIbcTransferMsg,
   SubmitApprovedEthBridgeTransferMsg,
   SubmitApprovedWithdrawMsg,
+  ConnectInterfaceResponseMsg,
+  RevokeConnectionMsg,
 } from "./messages";
 
 import { ROUTE } from "./constants";
@@ -35,6 +38,9 @@ export function init(router: Router, service: ApprovalsService): void {
   router.registerMessage(SubmitApprovedIbcTransferMsg);
   router.registerMessage(SubmitApprovedEthBridgeTransferMsg);
   router.registerMessage(SubmitApprovedWithdrawMsg);
+  router.registerMessage(ApproveConnectInterfaceMsg);
+  router.registerMessage(ConnectInterfaceResponseMsg);
+  router.registerMessage(RevokeConnectionMsg);
 
   router.addHandler(ROUTE, getHandler(service));
 }

--- a/apps/extension/src/background/approvals/messages.ts
+++ b/apps/extension/src/background/approvals/messages.ts
@@ -9,6 +9,8 @@ enum MessageType {
   SubmitApprovedBond = "submit-approved-bond",
   SubmitApprovedUnbond = "submit-approved-unbond",
   SubmitApprovedWithdraw = "submit-approved-withdraw",
+  ConnectInterfaceResponse = "connect-interface-response",
+  RevokeConnection = "revoke-connection",
 }
 
 export class RejectTxMsg extends Message<void> {
@@ -213,5 +215,68 @@ export class SubmitApprovedWithdrawMsg extends Message<void> {
 
   type(): string {
     return SubmitApprovedWithdrawMsg.type();
+  }
+}
+
+export class ConnectInterfaceResponseMsg extends Message<void> {
+  public static type(): MessageType {
+    return MessageType.ConnectInterfaceResponse;
+  }
+
+  constructor(
+    public readonly interfaceTabId: number,
+    public readonly chainId: string,
+    public readonly interfaceOrigin: string,
+    public readonly allowConnection: boolean,
+  ) {
+    super();
+  }
+
+  validate(): void {
+    if (!this.interfaceTabId) {
+      throw new Error("interfaceTabId not set");
+    }
+
+    if (!this.chainId) {
+      throw new Error("chain ID not set");
+    }
+
+    if (!this.interfaceOrigin) {
+      throw new Error("interfaceOrigin not set");
+    }
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return ConnectInterfaceResponseMsg.type();
+  }
+}
+
+export class RevokeConnectionMsg extends Message<void> {
+  public static type(): MessageType {
+    return MessageType.RevokeConnection;
+  }
+
+  constructor(
+    public readonly originToRevoke: string
+  ) {
+    super();
+  }
+
+  validate(): void {
+    if (!this.originToRevoke) {
+      throw new Error("originToRevoke not set");
+    }
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return RevokeConnectionMsg.type();
   }
 }

--- a/apps/extension/src/background/approvals/types.ts
+++ b/apps/extension/src/background/approvals/types.ts
@@ -1,0 +1,1 @@
+export type ApprovedOriginsStore = string[];

--- a/apps/extension/src/background/approvals/utils.ts
+++ b/apps/extension/src/background/approvals/utils.ts
@@ -1,0 +1,27 @@
+import { KVStore } from "@namada/storage";
+
+import { ApprovedOriginsStore } from "./types";
+
+export const APPROVED_ORIGINS_KEY = "namadaExtensionApprovedOrigins";
+
+export const addApprovedOrigin = async (
+  approvedOriginsStore: KVStore<ApprovedOriginsStore>,
+  originToAdd: string,
+): Promise<void> => {
+  const approvedOrigins = await approvedOriginsStore.get(APPROVED_ORIGINS_KEY) || [];
+  await approvedOriginsStore.set(
+    APPROVED_ORIGINS_KEY,
+    [ originToAdd, ...approvedOrigins ]
+  );
+};
+
+export const removeApprovedOrigin = async (
+  approvedOriginsStore: KVStore<ApprovedOriginsStore>,
+  originToRemove: string,
+): Promise<void> => {
+  const approvedOrigins = await approvedOriginsStore.get(APPROVED_ORIGINS_KEY) || [];
+  await approvedOriginsStore.set(
+    APPROVED_ORIGINS_KEY,
+    approvedOrigins.filter(origin => origin !== originToRemove)
+  );
+};

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -44,6 +44,10 @@ const connectedTabsStore = new ExtensionKVStore(KVPrefix.LocalStorage, {
   get: browser.storage.local.get,
   set: browser.storage.local.set,
 });
+const approvedOriginsStore = new ExtensionKVStore(KVPrefix.LocalStorage, {
+  get: browser.storage.local.get,
+  set: browser.storage.local.set,
+});
 const revealedPKStore = new ExtensionKVStore(KVPrefix.RevealedPK, {
   get: browser.storage.local.get,
   set: browser.storage.local.set,
@@ -122,6 +126,7 @@ const init = new Promise<void>(async (resolve) => {
   const approvalsService = new ApprovalsService(
     txStore,
     connectedTabsStore,
+    approvedOriginsStore,
     keyRingService,
     ledgerService
   );

--- a/apps/extension/src/background/keyring/handler.ts
+++ b/apps/extension/src/background/keyring/handler.ts
@@ -20,7 +20,6 @@ import {
   ScanAccountsMsg,
 } from "./messages";
 import {
-  ConnectInterfaceMsg,
   QueryAccountsMsg,
   QueryBalancesMsg,
   FetchAndStoreMaspParamsMsg,
@@ -32,11 +31,6 @@ export const getHandler: (service: KeyRingService) => Handler = (service) => {
     switch (msg.constructor) {
       case CheckIsLockedMsg:
         return handleCheckIsLockedMsg(service)(env, msg as CheckIsLockedMsg);
-      case ConnectInterfaceMsg:
-        return handleConnectInterfaceMsg(service)(
-          env,
-          msg as ConnectInterfaceMsg
-        );
       case LockKeyRingMsg:
         return handleLockKeyRingMsg(service)(env, msg as LockKeyRingMsg);
       case UnlockKeyRingMsg:
@@ -104,14 +98,6 @@ export const getHandler: (service: KeyRingService) => Handler = (service) => {
       default:
         throw new Error("Unknown msg type");
     }
-  };
-};
-
-const handleConnectInterfaceMsg: (
-  service: KeyRingService
-) => InternalHandler<ConnectInterfaceMsg> = (service) => {
-  return async ({ senderTabId }, { chainId }) => {
-    return await service.connect(senderTabId, chainId);
   };
 };
 

--- a/apps/extension/src/background/keyring/init.ts
+++ b/apps/extension/src/background/keyring/init.ts
@@ -19,7 +19,6 @@ import {
   ValidateMnemonicMsg,
 } from "./messages";
 import {
-  ConnectInterfaceMsg,
   QueryAccountsMsg,
   QueryBalancesMsg,
   FetchAndStoreMaspParamsMsg,
@@ -34,7 +33,6 @@ export function init(router: Router, service: KeyRingService): void {
   router.registerMessage(CheckPasswordMsg);
   router.registerMessage(QueryPublicKeyMsg);
   router.registerMessage(CloseOffscreenDocumentMsg);
-  router.registerMessage(ConnectInterfaceMsg);
   router.registerMessage(DeriveAccountMsg);
   router.registerMessage(GenerateMnemonicMsg);
   router.registerMessage(GetActiveAccountMsg);

--- a/apps/extension/src/content/index.ts
+++ b/apps/extension/src/content/index.ts
@@ -25,11 +25,17 @@ const router = new ExtensionRouter(
   extensionStore
 );
 
+const approvedOriginsStore = new ExtensionKVStore(KVPrefix.LocalStorage, {
+  get: browser.storage.local.get,
+  set: browser.storage.local.set,
+});
+
 const init = new Promise<void>(async (resolve) => {
   // Start proxying messages from Namada to InjectedNamada
   const routerId = await getNamadaRouterId(extensionStore);
   Proxy.start(
-    new Namada(manifest.version, new ExtensionRequester(messenger, routerId))
+    new Namada(manifest.version, new ExtensionRequester(messenger, routerId)),
+    approvedOriginsStore
   );
   resolve();
 });

--- a/apps/extension/src/content/injected.ts
+++ b/apps/extension/src/content/injected.ts
@@ -1,4 +1,7 @@
-import { InjectedNamada } from "provider";
+// import needs to be "provider/InjectedNamada" since "provider" will make
+// webpack bundle webextension-polyfill, which causes a runtime crash
+import { InjectedNamada } from "provider/InjectedNamada";
+
 import manifest from "manifest/_base.json";
 
 declare global {

--- a/apps/extension/src/provider/Namada.ts
+++ b/apps/extension/src/provider/Namada.ts
@@ -11,7 +11,7 @@ import {
   ApproveBondMsg,
   ApproveUnbondMsg,
   ApproveWithdrawMsg,
-  ConnectInterfaceMsg,
+  ApproveConnectInterfaceMsg,
   GetChainMsg,
   GetChainsMsg,
   SuggestChainMsg,
@@ -32,7 +32,7 @@ export class Namada implements INamada {
   public async connect(chainId: string): Promise<void> {
     return await this.requester?.sendMessage(
       Ports.Background,
-      new ConnectInterfaceMsg(chainId)
+      new ApproveConnectInterfaceMsg(chainId)
     );
   }
 

--- a/apps/extension/src/provider/messages.ts
+++ b/apps/extension/src/provider/messages.ts
@@ -14,7 +14,7 @@ enum Route {
 }
 
 enum MessageType {
-  ConnectInterface = "connect-interface",
+  ApproveConnectInterface = "approve-connect-interface",
   QueryAccounts = "query-accounts",
   ApproveTransfer = "approve-transfer",
   ApproveIbcTransfer = "approve-ibc-transfer",
@@ -37,9 +37,9 @@ enum MessageType {
  * Messages routed from providers to Chains service
  */
 
-export class ConnectInterfaceMsg extends Message<void> {
+export class ApproveConnectInterfaceMsg extends Message<void> {
   public static type(): MessageType {
-    return MessageType.ConnectInterface;
+    return MessageType.ApproveConnectInterface;
   }
 
   constructor(public readonly chainId: string) {
@@ -53,11 +53,11 @@ export class ConnectInterfaceMsg extends Message<void> {
   }
 
   route(): string {
-    return Route.KeyRing;
+    return Route.Approvals;
   }
 
   type(): string {
-    return ConnectInterfaceMsg.type();
+    return ApproveConnectInterfaceMsg.type();
   }
 }
 

--- a/apps/extension/src/test/init.ts
+++ b/apps/extension/src/test/init.ts
@@ -24,6 +24,7 @@ import {
 import {
   ApprovalsService,
   init as initApprovals,
+  ApprovedOriginsStore
 } from "../background/approvals";
 
 import { Namada } from "provider";
@@ -69,6 +70,9 @@ export const init = async (): Promise<{
   const utilityStore = new KVStoreMock<UtilityStore>(KVPrefix.Utility);
   const connectedTabsStore = new KVStoreMock<TabStore[]>(
     KVPrefix.ConnectedTabs
+  );
+  const approvedOriginsStore = new KVStoreMock<ApprovedOriginsStore>(
+    KVPrefix.LocalStorage
   );
   const revealedPKStore = new KVStoreMock<string[]>(KVPrefix.RevealedPK);
   const namadaRouterId = await getNamadaRouterId(extStore);
@@ -129,6 +133,7 @@ export const init = async (): Promise<{
   const approvalsService = new ApprovalsService(
     txStore,
     connectedTabsStore,
+    approvedOriginsStore,
     keyRingService,
     ledgerService
   );

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -30,7 +30,14 @@ module.exports = {
         "allowExpressions": true
       }
     ],
-    "import/prefer-default-export": "off"
+    "import/prefer-default-export": "off",
+    "no-restricted-globals": [
+      "error",
+      {
+        "name": "browser",
+        "message": "You probably need to import webextension-polyfill."
+      }
+    ]
   },
   "settings": {
     "import/parsers": {

--- a/packages/integrations/src/Namada.ts
+++ b/packages/integrations/src/Namada.ts
@@ -39,7 +39,6 @@ export default class Namada implements Integration<Account, Signer> {
   }
 
   public async accounts(): Promise<readonly Account[] | undefined> {
-    await this.connect();
     const signer = this._namada?.getSigner(this.chain.chainId);
     return await signer?.accounts();
   }


### PR DESCRIPTION
Closes #200.

Expected behaviour
------------------

1. When the interface loads at first nothing happens.
2. When the user clicks on the connect button, an approval pop-up appears in the extension. The interface connect button starts spinning.
   a. If the reject button is clicked, the interface connect button stops spinning and the approval window closes. The extension cannot make any extension requests other than trying to connect again.
3. If the approve button is clicked, the interface account overview is loaded and the approval window closes.
4. The approved origin now exists in the extension local storage and the interface can make any extension requests normally.

### Revoking a connection

1. Open the extension and click the settings icon.
2. Click the 'Connected sites' link.
3. The list of approved origins is listed.
4. Click the 'x' beside an origin to revoke it.
5. When the origin has been revoked, reloading the interface will show the initial connect screen and the interface cannot make any extension requests other than trying to connect again.

---

### Changed
- Make interface wait until connect button is clicked to try to connect

### Added
- Add ability to approve or reject an interface connection in the extension
- Add ability to revoke a previously approved connection in the extension
