### PR TITLE
specs - Add SDK examples

### DIFF
--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -3,8 +3,6 @@
 // Namada extension events
 export enum Events {
   AccountChanged = "namada-account-changed",
-  TransferStarted = "namada-transfer-started",
-  TransferCompleted = "namada-transfer-completed",
   TxStarted = "namada-tx-started",
   TxCompleted = "namada-tx-completed",
   UpdatedBalances = "namada-updated-balances",

--- a/specs/browser-extension/integration.md
+++ b/specs/browser-extension/integration.md
@@ -1,9 +1,10 @@
 # Browser Extension - API & Integration
 
-The extension is able to be integrated with in a similar fasion to Keplr and Metamask. If the extension has been installed (and assuming the user has gone through the process of
+The extension is able to be integrated with in a similar fashion to Keplr and Metamask. If the extension has been installed (and assuming the user has gone through the process of
 setting up an account), we can use the following to integrate with another interface.
 
 For integrating an application with the extension, it is recommended that you import the `@namada/integrations` and `@namada/types` packages.
+
 ## Table of Contents
 - [Detecting the Extension](#detecting-the-extension)
 - [Connecting to the Extension](#connecting-to-the-extension)

--- a/specs/browser-extension/integration.md
+++ b/specs/browser-extension/integration.md
@@ -1,36 +1,80 @@
 # Browser Extension - API & Integration
 
-The extension is able to be integrated with in a similar fasion to Keplr and Metamask. If the extension has been installed (and assuming the user has gone through the process of setting up an account), we can use the following to integrate with another interface.
+The extension is able to be integrated with in a similar fasion to Keplr and Metamask. If the extension has been installed (and assuming the user has gone through the process of
+setting up an account), we can use the following to integrate with another interface.
 
-**NOTE** The user would need to link their `package.json` to `https://github.com/anoma/namada-interface` to import any public packages from this repo - this isn't required for integration, but it provides useful types and utilities.
+For integrating an application with the extension, it is recommended that you import the `@namada/integrations` and `@namada/types` packages.
+## Table of Contents
+- [Detecting the Extension](#detecting-the-extension)
+- [Connecting to the Extension](#connecting-to-the-extension)
+- [Using the Namada Integration](#using-the-namada-integration)
+- [Using the SDK client](#using-the-sdk-client)
+  - [Submitting a Transfer](#submitting-a-transfer)
+- [Handling Extension Events](#handling-extension-events)
 
-## 1. Detecting the extension
+## Detecting the extension
 
 If the extension is installed, and the domain is enabled (currently, all domains are enabled by the extension), detection can be achieved simply by doing the following:
 
-```typescript=
+```typescript
 const isExtensionInstalled = typeof window.namada === 'object';
 ```
 
-## 2. Connecting to the extension
+A better practice would be to use the `Namada` integration, which provides functionality for interacting with the Extension's public API:
 
-To connect your application to the extension, you can invoke the following, providing a `chainId` for which you want to pull accounts from:
+```typescript
+import { Namada } from "@namada/integrations";
 
-```typescript=
-const chainId = 'namada-test.XXXXXXXXXX';
-await namada.connect(chainId);
+// Create integration instance
+const chainId = 'namada-test.XXXXXXXXXX'; // Replace with chain ID
+const namada = new Namada(chainId);
+
+// Detect extension
+const isDetected = namada.detect(); // boolean
 ```
 
-Soon, this will prompt the user to either `Accept` or `Reject` a connection, but this isn't currently implemented.
+The `@namada/integrations` package provides a common interface for interacting with extensions, with Keplr & Metamask currently supported alongside Namada.
 
-## 3. Querying accounts
+[ [Table of Contents](#table-of-contents) ]
 
-To query available accounts in the extension, we first instantiate a signing client:
+## Connecting to the extension
 
-```typescript=
-const client = await namada.getSigner(chainId);
+To connect your application to the extension, you can invoke the following, providing a `chainId`:
 
-const accounts = await client.accounts();
+```typescript
+import { Namada } from "@namada/integrations";
+
+const chainId = 'namada-test.XXXXXXXXXX';
+const namada = new Namada(chainId);
+
+async function myApp(): Promise<void> {
+  await namada.connect(chainId);
+}
+
+myApp();
+```
+
+This will prompt the user to either `Accept` or `Reject` a connection, and a client application can `await` this response and handle it accordingly. 
+
+[ [Table of Contents](#table-of-contents) ]
+
+## Using the Namada Integration
+
+The `Namada` integration provides a convenience method to query all accounts from the extension:
+
+```typescript
+async function myApp(): Promise<void> {
+  // Connect to extension
+  await namada.connect(chainId);
+
+  // Query accounts with integration
+  const accounts = await client.accounts();
+
+  // Alternatively, and as is most often the case, you will be interacting with the SDK client,
+  // which contains this function as well:
+  const client = await namada.signer();
+  console.log(await client.accounts());
+}
 
 // Example accounts results:
 [
@@ -44,81 +88,103 @@ const accounts = await client.accounts();
 ]
 ```
 
-## 4. Encoding and signing transfer transactions
-
-There are two types that can be imported from `namada-interface`:
-
-```typescript=
-import { TxProps, TransferProps } from "@namada/types";
-```
-
-Where the following is defined (for reference - these are the properties we will need to provide to the signing client):
+The `Namada` integration can also be used to query balances for these accounts:
 
 ```typescript
-export type TxProps = {
-  token: string;
-  epoch: number;
-  feeAmount: number;
-  gasLimit: number;
-  txCode: Uint8Array;
-};
-
-export type TransferProps = {
-  source: string;
-  target: string;
-  token: string;
-  amount: number;
-};
+const owner = "atest1d9khqw36xc65xwp3xc6rwsfcxpprssesxsenjs3cxpznqvfkxppnxw2989pnssfkgsenzvphx0u6kj";
+const balances = await client.queryBalances(owner)
 ```
 
-### 4.1 Fetching a pre-built wasm
+[ [Table of Contents](#table-of-contents) ]
 
-We will need to import a pre-built `tx-transfer` wasm file to provide to `TxProps`. There is a utility (see the following) that handles fetching these:
+## Using the SDK client 
 
-```typescript=
-import { fetchWasmCode } from "@namada/utils";
+The SDK client (an instance of the `Signer` class, defined in [Signer.ts](https://github.com/anoma/namada-interface/blob/main/apps/extension/src/provider/Signer.ts)),
+provides the functionality of encoding transactions to be signed and broadcasted by the SDK, passing
+these encoded transactions to the [Namada.ts](https://github.com/anoma/namada-interface/blob/main/apps/extension/src/provider/Namada.ts)
+provider (which is responsible for constructing messages to pass into the extension). The `Signer` represents
+a portion of the public API exposed when the extension is installed. 
 
-(async () {
-    const txCode = await fetchWasmCode('./path/to/tx-transfer.wasm');
-    // Construct transfer transaction...
-})();
+### Submitting a Transfer
+
+In order to submit a `Transfer` transaction via the extension integration, we can make use of the `AccountType`, TransferProps` and `TxProps` type definitions.
+
+```typescript
+import { AccountType, TransferProps, TxProps } from "@namada/types";
 ```
 
-### 4.2 Encoding a transfer tx
+`TxProps` represents the transaction parameters, whereas `TransferProp` represents the details of the transfer itself.
+We use the `AccountType` enum to specify the type of account, which in turn will determine how signing occurs (e.g., if
+the account is of type `AccountType.Ledger`, we will expect signing to occur externally, otherwise, we will 
+query the extension keystore to the keys associated with the `source` address).
 
-```typescript=
-const client = namada.getSigner("namada-test.XXXXXXXXXXX");
+Consider this example:
 
-const address = "atest1v4ehgw368ycryv2z8qcnxv3cxgmrgvjpxs6yg333gym5vv2zxepnj334g4rryvj9xucrgve4x3xvr4";
-// NOTE: Transfer amount is converted to micro-units
-const amount = 1.23 * 1_000_000;
+```typescript
+import { AccountType, TransferProps, TxProps } from "@namada/types";
 
-const transferArgs = {
-  source: address,
-  token: "atest1v4ehgw36x3prswzxggunzv6pxqmnvdj9xvcyzvpsggeyvs3cg9qnywf589qnwvfsg5erg3fkl09rg5",
-  target: "atest1v4ehgw36xvcyyvejgvenxs34g3zygv3jxqunjd6rxyeyys3sxy6rwvfkx4qnj33hg9qnvse4lsfctw",
-  amount,
-};
+const myTransferTx: TransferProps = {
+    source: "atest1d9khqw36g3ryxd29xgmrjsjr89znsse5g5cn2wpsgs6nqv33xguryw2p89znsd2rxqcnzvehcnyzxw",
+    target: "atest1d9khqw36xcmyzve3gvmrqdfexdz5zd2rxu6nv3zp8ym5zwfcgyeygv2x8pzrz3fcgscngs3nchvahj",
+    token: tokenAddress,
+    amount: new BigNumber(1.234),
+    nativeToken: "NAM",
+    // NOTE: tx adheres to the TxProps type
+    tx: {
+        token: tokenAddress,
+        feeAmount: new BigNumber(100),
+        gasLimit: new BigNumber(200),
+        chainId: "namada-devnet.95bcc8eaf0f39f1d3fa27629",
+    }
+}
 
-const encodedTransfer = await client.encodeTransfer(transferArgs);
+async function myApp(): Promise<void> {
+  const namada = new Namada('namada-test.XXXXXXXXXX');
+
+  if (!namada.detect()) {
+    throw new Error("The extension is not installed!")
+  }
+   
+  const client = namada.signer();
+
+  await client.submitTransfer(myTransferTx, AccountType.PrivateKey)
+    .then(() => console.log("Transaction was approved and submitted via the SDK"))
+    .catch((e) => console.error(`Transaction was rejected: ${e}`));
+}
+
+myApp();
 ```
 
-### 4.3 Signing an encoded transfer tx
+In the above example, we define the transfer transaction properties, connect to the extension, and submit
+a transfer transaction. The extension will launch a popup prompting the user for approval. Once the transfer
+is approved, an event is dispatched from the extension indicating that a transaction has started, along with
+the transaction type. When the transaction is completed, another event will fire indicating it's status.
+If the transaction fails in the SDK, the returned error will be dispatched in the completion event.
 
-```typescript=
-// Set up transaction parameters:
-const txProps = {
-    token: "atest1v4ehgw36x3prswzxggunzv6pxqmnvdj9xvcyzvpsggeyvs3cg9qnywf589qnwvfsg5erg3fkl09rg5",
-    // Client will need to fetch the current epoch
-    epoch: 5,
-    feeAmount: 1000,
-    gasLimit: 1000000,
-    // txCode fetched above
-    txCode,
-};
+See [Handling Extension Events](#handling-extension-events) for more information on these events.
 
-// Retrieve tx hash and signed bytes
-const { hash, bytes } = await client.signTx(address, txProps, encodedTx);
+[ [Table of Contents](#table-of-contents) ]
+
+## Handling Extension Events
+
+In the `@namada/types` package, you can import an enum providing the various events you can subscribe to in your interface.
+
+```typscript
+@import { Events } from "@namada/types";
 ```
 
-The resulting `bytes` can now be broadcasted to the ledger, and we can use the `hash` returned to query the status of the transaction.
+The currently dispatched events are as follows:
+
+```typescript
+export enum Events {
+  AccountChanged = "namada-account-changed",
+  TxStarted = "namada-tx-started",
+  TxCompleted = "namada-tx-completed",
+  UpdatedBalances = "namada-updated-balances",
+  UpdatedStaking = "namada-updated-staking",
+}
+```
+
+These events will prove useful when syncronizing the state of the interface with the connected extension.
+
+[ [Table of Contents](#table-of-contents) ]

--- a/specs/browser-extension/integration.md
+++ b/specs/browser-extension/integration.md
@@ -16,13 +16,13 @@ For integrating an application with the extension, it is recommended that you im
 
 If the extension is installed, and the domain is enabled (currently, all domains are enabled by the extension), detection can be achieved simply by doing the following:
 
-```typescript
+```ts
 const isExtensionInstalled = typeof window.namada === 'object';
 ```
 
 A better practice would be to use the `Namada` integration, which provides functionality for interacting with the Extension's public API:
 
-```typescript
+```ts
 import { Namada } from "@namada/integrations";
 
 // Create integration instance
@@ -41,7 +41,7 @@ The `@namada/integrations` package provides a common interface for interacting w
 
 To connect your application to the extension, you can invoke the following, providing a `chainId`:
 
-```typescript
+```ts
 import { Namada } from "@namada/integrations";
 
 const chainId = 'namada-test.XXXXXXXXXX';
@@ -62,7 +62,7 @@ This will prompt the user to either `Accept` or `Reject` a connection, and a cli
 
 The `Namada` integration provides a convenience method to query all accounts from the extension:
 
-```typescript
+```ts
 async function myApp(): Promise<void> {
   // Connect to extension
   await namada.connect(chainId);
@@ -90,7 +90,7 @@ async function myApp(): Promise<void> {
 
 The `Namada` integration can also be used to query balances for these accounts:
 
-```typescript
+```ts
 const owner = "atest1d9khqw36xc65xwp3xc6rwsfcxpprssesxsenjs3cxpznqvfkxppnxw2989pnssfkgsenzvphx0u6kj";
 const balances = await client.queryBalances(owner)
 ```
@@ -109,32 +109,36 @@ a portion of the public API exposed when the extension is installed.
 
 In order to submit a `Transfer` transaction via the extension integration, we can make use of the `AccountType`, TransferProps` and `TxProps` type definitions.
 
-```typescript
+```ts
 import { AccountType, TransferProps, TxProps } from "@namada/types";
 ```
 
 `TxProps` represents the transaction parameters, whereas `TransferProp` represents the details of the transfer itself.
 We use the `AccountType` enum to specify the type of account, which in turn will determine how signing occurs (e.g., if
-the account is of type `AccountType.Ledger`, we will expect signing to occur externally, otherwise, we will 
-query the extension keystore to the keys associated with the `source` address).
+the account is of type `AccountType.Ledger`, we will expect signing to occur externally on the hardware wallet, otherwise,
+the extension will query the keystore for the keys associated with that `source` address, and sign via the SDK).
 
 Consider this example:
 
-```typescript
+```ts
 import { AccountType, TransferProps, TxProps } from "@namada/types";
+
+// Address for NAM token
+const token = "atest1v4ehgw36x3prswzxggunzv6pxqmnvdj9xvcyzvpsggeyvs3cg9qnywf589qnwvfsg5erg3fkl09rg5";
+const chainId = "namada-devnet.95bcc8eaf0f39f1d3fa27629";
 
 const myTransferTx: TransferProps = {
     source: "atest1d9khqw36g3ryxd29xgmrjsjr89znsse5g5cn2wpsgs6nqv33xguryw2p89znsd2rxqcnzvehcnyzxw",
     target: "atest1d9khqw36xcmyzve3gvmrqdfexdz5zd2rxu6nv3zp8ym5zwfcgyeygv2x8pzrz3fcgscngs3nchvahj",
-    token: tokenAddress,
+    token,
     amount: new BigNumber(1.234),
     nativeToken: "NAM",
     // NOTE: tx adheres to the TxProps type
     tx: {
-        token: tokenAddress,
+        token,
         feeAmount: new BigNumber(100),
         gasLimit: new BigNumber(200),
-        chainId: "namada-devnet.95bcc8eaf0f39f1d3fa27629",
+        chainId,
     }
 }
 
@@ -148,7 +152,7 @@ async function myApp(): Promise<void> {
   const client = namada.signer();
 
   await client.submitTransfer(myTransferTx, AccountType.PrivateKey)
-    .then(() => console.log("Transaction was approved and submitted via the SDK"))
+    .then(() => console.log("Transaction was approved by user and submitted via the SDK"))
     .catch((e) => console.error(`Transaction was rejected: ${e}`));
 }
 
@@ -161,7 +165,7 @@ is approved, an event is dispatched from the extension indicating that a transac
 the transaction type. When the transaction is completed, another event will fire indicating it's status.
 If the transaction fails in the SDK, the returned error will be dispatched in the completion event.
 
-See [Handling Extension Events](#handling-extension-events) for more information on these events.
+See [Handling Extension Events](#handling-extension-events) for more information on what extension events may be subscribed to.
 
 [ [Table of Contents](#table-of-contents) ]
 
@@ -175,7 +179,7 @@ In the `@namada/types` package, you can import an enum providing the various eve
 
 The currently dispatched events are as follows:
 
-```typescript
+```ts
 export enum Events {
   AccountChanged = "namada-account-changed",
   TxStarted = "namada-tx-started",
@@ -185,6 +189,6 @@ export enum Events {
 }
 ```
 
-These events will prove useful when syncronizing the state of the interface with the connected extension.
+These events will prove useful when synchronizing the state of the interface with the connected extension.
 
 [ [Table of Contents](#table-of-contents) ]

--- a/specs/packages/examples.md
+++ b/specs/packages/examples.md
@@ -241,17 +241,20 @@ async function myApp(): Promise<void> {
     // NOTE: A helper utility `encodeSignature` exists in the extension utils - this
     // will be moved to a public package in the future. The following is how we encode a signature
     // manually
-    const { pubkey, raw_indices, raw_signature, wrapper_indices, wrapper_signature } = sig;
+    const { pubkey, raw_indices, raw_signature, wrapper_indices, wrapper_signature } = response;
 
     // Due to how data is serialized on the Ledger, we have to coerce the types to
     // get the correct data for now:
-    /* eslint-disable */
-    pubkey: new Uint8Array((pubkey as any).data),
-    rawIndices: new Uint8Array((raw_indices as any).data),
-    rawSignature: new Uint8Array((raw_signature as any).data),
-    wrapperIndices: new Uint8Array((wrapper_indices as any).data),
-    wrapperSignature: new Uint8Array((wrapper_signature as any).data),
-    /* eslint-enable */
+
+    const props = {
+      /* eslint-disable */
+      pubkey: new Uint8Array((pubkey as any).data),
+      rawIndices: new Uint8Array((raw_indices as any).data),
+      rawSignature: new Uint8Array((raw_signature as any).data),
+      wrapperIndices: new Uint8Array((wrapper_indices as any).data),
+      wrapperSignature: new Uint8Array((wrapper_signature as any).data),
+      /* eslint-enable */
+    };
 
     // Encode the signatures for passing into the SDK
     const value = new SignatureMsgValue(props);

--- a/specs/packages/examples.md
+++ b/specs/packages/examples.md
@@ -1,0 +1,155 @@
+# SDK - Examples
+
+## Table of Contents
+
+- [Loading the SDK and Query](#loading-the-sdk-and-query)
+- [Transaction requirements](#transaction-requirements)
+- [Sending a transaction](#sending-a-transaction)
+- [Querying for balance](#querying-for-balance)
+- [Sending a tx with the extension]()
+
+## Loading the SDK and Query from wasm
+
+When using the extension from a TypeScript application, we need to first compile the wasm of the `@namada/shared` package:
+
+```bash
+# If within the namada-interface repo, we can run:
+cd `packages/shared`
+yarn wasm:build
+```
+
+Assuming that the `@namada/shared` package is in the scope of your application, we can instantiate the SDK, as well as the `Query` class (which is needed
+to query the chain for data). This must occur within an `async` function, as we need to `await` the loading of the wasm:
+
+```ts
+import { Query, Sdk } from "@namada/shared";
+// Import wasm initialization function
+import { init as initShared } from "@namada/shared/src/init";
+
+const RPC_URL = "http://127.0.0.1:26657";
+
+async function init() {
+  await initShared();
+
+  const sdk = new Sdk(RPC_URL);
+  const query = new Query(RPC_URL);
+
+  // The SDK & Query are now ready to use
+
+  // Load keys into the SDK:
+  // sdk.add_key(privateKey, password, alias)
+}
+
+init();
+
+```
+[ [Table of Contents](#table-of-contents) ]
+
+## Transaction requirements
+
+The `@namada/types` package contains the [schema](https://github.com/anoma/namada-interface/tree/main/packages/types/src/tx/schema) necessary to serialize transaction data
+before submitting it with the SDK. This serialization is performed by the [@dao-xyz/borsh](https://github.com/dao-xyz/borsh-ts) package. To serialize these values, you need
+to provide the required properites as defined in [types.ts](https://github.com/anoma/namada-interface/blob/main/packages/types/src/tx/types.ts). Following is an example of how
+to serialize a `Transfer` transaction using `borsh-ts`:
+
+```ts
+import { Message, Tokens, TransferProps, TransferMsgValue, TxProps } from `@namada/types`;
+
+const createTransfer = (transferProps: TransferProps): Uint8Array => {
+    const transferMsgValue = new TransferMsgValue(transferProps);
+    const transferMessage = new Message<TransferMsgValue>();
+    const serializedTransfer = transferMessage.encode(transferMsgValue);
+
+    return serializedTransfer;
+}
+
+const tokenAddress = Tokens["NAM"].address;
+
+const transfer = createTransfer({
+    // NOTE: "source" is the signing account in this Tx, and thus must have a corresponding keypair in the SDK
+    source: "atest1d9khqw36g3ryxd29xgmrjsjr89znsse5g5cn2wpsgs6nqv33xguryw2p89znsd2rxqcnzvehcnyzxw",
+    target: "atest1d9khqw36xcmyzve3gvmrqdfexdz5zd2rxu6nv3zp8ym5zwfcgyeygv2x8pzrz3fcgscngs3nchvahj",
+    token: tokenAddress,
+    amount: new BigNumber(1.234),
+    nativeToken: "NAM",
+    // NOTE: tx must adhere to the TxProps type
+    tx: {
+        token: tokenAddress,
+        feeAmount: new BigNumber(100),
+        gasLimit: new BigNumber(200),
+        chainId: "namada-devnet.95bcc8eaf0f39f1d3fa27629",
+    }
+});
+
+```
+
+The serialized `transfer` in the above example is ready to send via the SDK:
+
+```ts
+import { Sdk } from "@namada/shared";
+// Import wasm initialization function
+import { init as initShared } from "@namada/shared/src/init";
+import { Tokens } from "@namada/types";
+import { createTransfer } from "example";
+
+const RPC_URL = "http://127.0.0.1:26657";
+
+// For this example, let's use the following signing account:
+const account = {
+    alias: "My Account",
+    address: "atest1d9khqw36g3ryxd29xgmrjsjr89znsse5g5cn2wpsgs6nqv33xguryw2p89znsd2rxqcnzvehcnyzxw",
+    privateKey: [0, 0, 0, 0, 0, 0, 0...], // Byte array of private key
+};
+
+async function init() {
+  await initShared();
+
+  const sdk = new Sdk(RPC_URL);
+  sdk.add_key(account.privateKey, "secret password", account.alias);
+
+  const tokenAddress = Tokens["NAM"].address;
+
+  const transferMsg = createTransfer({
+    source: account.address,
+    target: "atest1d9khqw36xcmyzve3gvmrqdfexdz5zd2rxu6nv3zp8ym5zwfcgyeygv2x8pzrz3fcgscngs3nchvahj",
+    token: tokenAddress,
+    amount: new BigNumber(1.234),
+    nativeToken: "NAM",
+    // NOTE: tx must adhere to the TxProps type
+    tx: {
+        token: tokenAddress,
+        feeAmount: new BigNumber(100),
+        gasLimit: new BigNumber(200),
+        chainId: "namada-devnet.95bcc8eaf0f39f1d3fa27629",
+    }
+  });
+
+  await sdk.submit_transfer(transferMsg, "secret")
+    .then(() => console.log("Success!"))
+    .catch((e) => console.error(`An error occurred: ${e}`));
+}
+
+init();
+
+```
+
+[ [Table of Contents](#table-of-contents) ]
+
+## Sending a transaction
+
+**TODO**
+
+[ [Table of Contents](#table-of-contents) ]
+
+## Querying for balance
+
+**TODO**
+
+[ [Table of Contents](#table-of-contents) ]
+
+## Sending a transaction with the Extension API
+
+**TODO**
+
+[ [Table of Contents](#table-of-contents) ]
+

--- a/specs/packages/examples.md
+++ b/specs/packages/examples.md
@@ -5,8 +5,8 @@
 - [Loading the SDK and Query](#loading-the-sdk-and-query)
 - [Transaction requirements](#transaction-requirements)
 - [Sending a transaction](#sending-a-transaction)
-- [Querying for balance](#querying-for-balance)
-- [Sending a tx with the extension]()
+- [Querying for data](#querying-for-data)
+- [Sending a tx with the extension](#sending-a-transaction-with-the-extension-api)
 
 ## Loading the SDK and Query from wasm
 
@@ -83,7 +83,13 @@ const transfer = createTransfer({
 
 ```
 
-The serialized `transfer` in the above example is ready to send via the SDK:
+The serialized `transfer` in the above example is ready to send via the SDK.
+
+[ [Table of Contents](#table-of-contents) ]
+
+## Sending a transaction
+
+Building on the previous section, we can send transaction through the SDK as follows:
 
 ```ts
 import { Sdk } from "@namada/shared";
@@ -135,15 +141,46 @@ init();
 
 [ [Table of Contents](#table-of-contents) ]
 
-## Sending a transaction
+## Querying for data
 
-**TODO**
+We make use of the `Query` class instance for querying the chain for data. This is instantiated much like the SDK:
 
-[ [Table of Contents](#table-of-contents) ]
+```ts
+import { Query } from "@namada/shared";
+// Import wasm initialization function
+import { init as initShared } from "@namada/shared/src/init";
 
-## Querying for balance
+const RPC_URL = "http://127.0.0.1:26657";
 
-**TODO**
+async function init() {
+  await initShared();
+
+  const query = new Query(RPC_URL);
+
+  // Query is now ready to use
+
+  const ownerAddress = "atest1d9khqw36g3ryxd29xgmrjsjr89znsse5g5cn2wpsgs6nqv33xguryw2p89znsd2rxqcnzvehcnyzxw";
+  const tokenAddress = "atest1d9khqw36xcmyzve3gvmrqdfexdz5zd2rxu6nv3zp8ym5zwfcgyeygv2x8pzrz3fcgscngs3nchvahj";
+
+  // Balance query
+  // NOTE: `query_balance` contains logic to determine whether this is a "transparent" or "shielded" balance query. The API is simply this:
+  const balance = await query.query_balance(ownerAddress, tokenAddress);
+
+  // Epoch query
+  const epoch = await query.query_epoch();
+
+  // Query all validators
+  const allValidators = await query.query_all_validators();
+
+  // Query my validators - accepts an array of addresses
+  const myValidators = await query.query_my_validators([ownerAddress]);
+
+  // Query public key - used to determine if the public key has been revealed on chain
+  const pk = await query.query_public_key(ownerAddress);
+}
+
+init();
+```
 
 [ [Table of Contents](#table-of-contents) ]
 

--- a/specs/packages/sdk.md
+++ b/specs/packages/sdk.md
@@ -1,6 +1,6 @@
 # Sdk
 
-Sdk is a part of shared package. It's main purpose is to wrap shared logic from the namada crate, so it can be used in the context of the browser.
+Sdk is a part of shared package. It's main purpose is to wrap shared logic from the namada crate, so it can be used in the context of the browser. For examples of usage, see [examples.md](./examples.md).
 
 Modules:
 


### PR DESCRIPTION
Provide developers with better examples of SDK usage from within a TypeScript application.

- [x] Show how to send a transaction, end-to-end, using the SDK
- [x] Show how to send a transaction using Extension API (injected content scripts)