### PR TITLE
feat: strict storage durablity

### DIFF
--- a/apps/extension/src/App/App.components.ts
+++ b/apps/extension/src/App/App.components.ts
@@ -66,6 +66,7 @@ export const Heading = styled.h1`
 `;
 
 export const HeadingLoader = styled.div`
+  display: flex;
   position: relative;
   width: 20px;
   height: 20px;
@@ -81,8 +82,23 @@ export const HeadingLoader = styled.div`
 export const HeadingButtons = styled.div`
   display: flex;
   justify-content: flex-end;
-  width: 100px;
   padding-right: 12px;
+`;
+
+export const Info = styled.div`
+  min-width: 20px;
+  min-height: 20px;
+
+  & svg {
+    display: none;
+  }
+
+  &.visible svg {
+    display: block;
+    min-width: 20px;
+    min-height: 20px;
+    stroke: ${(props) => props.theme.colors.utility3.warning};
+  }
 `;
 
 export const SettingsButton = styled.a`

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -58,7 +58,9 @@ const DEFAULT_URL =
   "https://d3brk13lbhxfdb.cloudfront.net/qc-testnet-5.1.025a61165acd05e";
 const { REACT_APP_PROXY, REACT_APP_NAMADA_URL = DEFAULT_URL } = process.env;
 
-const NamadaRpcEndpoint = REACT_APP_PROXY ? ProxyMappings["namada"] : REACT_APP_NAMADA_URL;
+const NamadaRpcEndpoint = REACT_APP_PROXY
+  ? ProxyMappings["namada"]
+  : REACT_APP_NAMADA_URL;
 
 const messenger = new ExtensionMessenger();
 const router = new ExtensionRouter(

--- a/apps/extension/src/background/keyring/handler.ts
+++ b/apps/extension/src/background/keyring/handler.ts
@@ -24,6 +24,7 @@ import {
   QueryBalancesMsg,
   FetchAndStoreMaspParamsMsg,
   HasMaspParamsMsg,
+  CheckDurabilityMsg,
 } from "provider/messages";
 
 export const getHandler: (service: KeyRingService) => Handler = (service) => {
@@ -95,6 +96,11 @@ export const getHandler: (service: KeyRingService) => Handler = (service) => {
         );
       case HasMaspParamsMsg:
         return handleHasMaspParamsMsg(service)(env, msg as HasMaspParamsMsg);
+      case CheckDurabilityMsg:
+        return handleCheckDurabilityMsg(service)(
+          env,
+          msg as CheckDurabilityMsg
+        );
       default:
         throw new Error("Unknown msg type");
     }
@@ -278,5 +284,13 @@ const handleHasMaspParamsMsg: (
 ) => InternalHandler<HasMaspParamsMsg> = (service) => {
   return async (_, _msg) => {
     return await service.hasMaspParams();
+  };
+};
+
+const handleCheckDurabilityMsg: (
+  service: KeyRingService
+) => InternalHandler<CheckDurabilityMsg> = (service) => {
+  return async (_, _msg) => {
+    return await service.checkDurability();
   };
 };

--- a/apps/extension/src/background/keyring/init.ts
+++ b/apps/extension/src/background/keyring/init.ts
@@ -23,6 +23,7 @@ import {
   QueryBalancesMsg,
   FetchAndStoreMaspParamsMsg,
   HasMaspParamsMsg,
+  CheckDurabilityMsg,
 } from "provider/messages";
 import { ROUTE } from "./constants";
 import { getHandler } from "./handler";
@@ -50,6 +51,7 @@ export function init(router: Router, service: KeyRingService): void {
   router.registerMessage(FetchAndStoreMaspParamsMsg);
   router.registerMessage(HasMaspParamsMsg);
   router.registerMessage(ValidateMnemonicMsg);
+  router.registerMessage(CheckDurabilityMsg);
 
   router.addHandler(ROUTE, getHandler(service));
 }

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -1,7 +1,7 @@
 import { fromBase64 } from "@cosmjs/encoding";
 
 import { PhraseSize } from "@namada/crypto";
-import { KVStore, Store } from "@namada/storage";
+import { IndexedDBKVStore, KVStore, Store } from "@namada/storage";
 import { AccountType, Bip44Path, DerivedAccount } from "@namada/types";
 import { Query, Sdk, TxType } from "@namada/shared";
 import { Result } from "@namada/utils";
@@ -405,5 +405,9 @@ export class KeyRingService {
 
   async queryPublicKey(address: string): Promise<string | undefined> {
     return await this.query.query_public_key(address);
+  }
+
+  async checkDurability(): Promise<boolean> {
+    return await IndexedDBKVStore.durabilityCheck();
   }
 }

--- a/apps/extension/src/background/keyring/types.ts
+++ b/apps/extension/src/background/keyring/types.ts
@@ -74,6 +74,10 @@ export type ActiveAccountStore = {
   type: ParentAccount;
 };
 
+export type DurablityStore = {
+  isDurable: string;
+};
+
 export type UtilityStore = ActiveAccountStore | { [id: string]: CryptoRecord };
 
 export type RevealedPKStore = { [id: string]: string };

--- a/apps/extension/src/provider/Namada.ts
+++ b/apps/extension/src/provider/Namada.ts
@@ -18,6 +18,7 @@ import {
   QueryAccountsMsg,
   FetchAndStoreMaspParamsMsg,
   HasMaspParamsMsg,
+  CheckDurabilityMsg,
   QueryBalancesMsg,
   ApproveIbcTransferMsg,
   ApproveEthBridgeTransferMsg,
@@ -70,6 +71,13 @@ export class Namada implements INamada {
     return await this.requester?.sendMessage(
       Ports.Background,
       new HasMaspParamsMsg()
+    );
+  }
+
+  public async checkDurability(): Promise<boolean | undefined> {
+    return await this.requester?.sendMessage(
+      Ports.Background,
+      new CheckDurabilityMsg()
     );
   }
 

--- a/apps/extension/src/provider/messages.ts
+++ b/apps/extension/src/provider/messages.ts
@@ -31,6 +31,7 @@ enum MessageType {
   FetchAndStoreMaspParams = "fetch-and-store-masp-params",
   HasMaspParams = "has-masp-params",
   ApproveEthBridgeTransfer = "approve-eth-bridge-transfer",
+  CheckDurability = "check-durability",
 }
 
 /**
@@ -393,5 +394,22 @@ export class HasMaspParamsMsg extends Message<boolean> {
 
   type(): string {
     return HasMaspParamsMsg.type();
+  }
+}
+
+export class CheckDurabilityMsg extends Message<boolean> {
+  public static type(): MessageType {
+    return MessageType.CheckDurability;
+  }
+  validate(): void {
+    return;
+  }
+
+  route(): string {
+    return Route.KeyRing;
+  }
+
+  type(): string {
+    return CheckDurabilityMsg.type();
   }
 }

--- a/packages/storage/src/store/IndexedDBKVStore.ts
+++ b/packages/storage/src/store/IndexedDBKVStore.ts
@@ -28,7 +28,11 @@ export class IndexedDBKVStore<T> implements KVStore<T> {
 
   public async set<U extends T>(key: string, data: U | null): Promise<void> {
     if (data === null) {
-      const tx = (await this.getDB()).transaction([this.prefix()], "readwrite");
+      const tx = (await this.getDB()).transaction(
+        [this.prefix()],
+        "readwrite",
+        { durability: "strict" }
+      );
       const store = tx.objectStore(this.prefix());
 
       return new Promise((resolve, reject) => {
@@ -43,7 +47,11 @@ export class IndexedDBKVStore<T> implements KVStore<T> {
         };
       });
     } else {
-      const tx = (await this.getDB()).transaction([this.prefix()], "readwrite");
+      const tx = (await this.getDB()).transaction(
+        [this.prefix()],
+        "readwrite",
+        { durability: "strict" }
+      );
       const store = tx.objectStore(this.prefix());
 
       return new Promise((resolve, reject) => {

--- a/packages/storage/src/store/IndexedDBKVStore.ts
+++ b/packages/storage/src/store/IndexedDBKVStore.ts
@@ -1,5 +1,7 @@
 import { KVStore } from "./types";
 
+let durability: IDBTransactionMode = "readwrite";
+
 export class IndexedDBKVStore<T> implements KVStore<T> {
   protected cachedDB?: IDBDatabase;
 
@@ -28,11 +30,9 @@ export class IndexedDBKVStore<T> implements KVStore<T> {
 
   public async set<U extends T>(key: string, data: U | null): Promise<void> {
     if (data === null) {
-      const tx = (await this.getDB()).transaction(
-        [this.prefix()],
-        "readwrite",
-        { durability: "strict" }
-      );
+      const tx = (await this.getDB()).transaction([this.prefix()], durability, {
+        durability: "strict",
+      });
       const store = tx.objectStore(this.prefix());
 
       return new Promise((resolve, reject) => {
@@ -47,11 +47,9 @@ export class IndexedDBKVStore<T> implements KVStore<T> {
         };
       });
     } else {
-      const tx = (await this.getDB()).transaction(
-        [this.prefix()],
-        "readwrite",
-        { durability: "strict" }
-      );
+      const tx = (await this.getDB()).transaction([this.prefix()], durability, {
+        durability: "strict",
+      });
       const store = tx.objectStore(this.prefix());
 
       return new Promise((resolve, reject) => {
@@ -100,5 +98,49 @@ export class IndexedDBKVStore<T> implements KVStore<T> {
         resolve(request.result);
       };
     });
+  }
+
+  public static async durabilityCheck(): Promise<boolean> {
+    const { TARGET } = process.env;
+    let isDurable: boolean;
+
+    if (TARGET === "chrome") {
+      durability = "readwrite";
+      isDurable = true;
+    } else {
+      const prefix = "durability-check";
+      const db: IDBDatabase = await new Promise((resolve, reject) => {
+        const request = indexedDB.open(prefix);
+        request.onerror = (event) => {
+          event.stopPropagation();
+          reject(event.target);
+        };
+
+        request.onupgradeneeded = (event) => {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          const db = event.target.result;
+
+          db.createObjectStore(prefix, { keyPath: "key" });
+        };
+
+        request.onsuccess = () => {
+          resolve(request.result);
+        };
+      });
+
+      try {
+        db.transaction([prefix], "readwriteflush" as IDBTransactionMode, {
+          durability: "strict",
+        });
+        durability = "readwriteflush" as IDBTransactionMode;
+        isDurable = true;
+      } catch (e) {
+        durability = "readwrite";
+        isDurable = false;
+      }
+    }
+
+    return isDurable;
   }
 }


### PR DESCRIPTION
Resolves #349

### In this PR:
- we set transaction durability option to "strict"
- for firefox we use "readwriteflush" mode if possible. if not we display info icon with warning
### Testing:
In chrome storage should be durable by default,  so there should be no visible info icon

In firefox you should see yellow info icon with information about storage durability. Follow the steps from the icon title. Open extension popup again - info should be gone.

### Caveats
- this solution checks durability every time user opens the popup
- it sets durability options globally(for every storage we use),  we might want to change this in the future if it turns out to be slow