### PR TITLE
test(e2e): transfer from transparent to shielded address

### DIFF
--- a/e2e/src/partial/index.ts
+++ b/e2e/src/partial/index.ts
@@ -1,0 +1,2 @@
+export * from "./setup";
+export * from "./transfer";

--- a/e2e/src/partial/transfer.ts
+++ b/e2e/src/partial/transfer.ts
@@ -1,0 +1,71 @@
+import * as puppeteer from "puppeteer";
+import { targetPage, waitForXpath, pwdOrAlias } from "../utils";
+
+export type TransferFromOptions = {
+  targetAddress: string;
+  transferTimeout?: number;
+};
+
+export const transferFromTransparent = async (
+  browser: puppeteer.Browser,
+  page: puppeteer.Page,
+  { targetAddress, transferTimeout }: TransferFromOptions
+): Promise<void> => {
+  // Click on send button
+  (
+    await waitForXpath<HTMLButtonElement>(page, "//button[contains(., 'Send')]")
+  ).click();
+
+  // Navigate to transparent transfers
+  (
+    await waitForXpath<HTMLButtonElement>(
+      page,
+      "//button[contains(., 'Transparent')]"
+    )
+  ).click();
+
+  // Fill transfer data
+  const [recipentInput, amountInput] = await page.$$("input");
+  await recipentInput.type(targetAddress);
+  await amountInput.type("10");
+
+  // Continue transfer
+  (
+    await waitForXpath<HTMLButtonElement>(
+      page,
+      "//button[contains(., 'Continue')]"
+    )
+  ).click();
+
+  // Wait for approvals window to show up
+  const approvalsTarget = await browser.waitForTarget((t) =>
+    t.url().includes("approvals.html")
+  );
+  const approvalsPage = await targetPage(approvalsTarget);
+
+  // Click approve button
+  (
+    await waitForXpath<HTMLButtonElement>(
+      approvalsPage,
+      "//button[contains(., 'Approve')]"
+    )
+  ).click();
+
+  (await approvalsPage.$("input"))?.type(pwdOrAlias);
+
+  // Click approve auth button
+  (
+    await waitForXpath<HTMLButtonElement>(
+      approvalsPage,
+      "//button[contains(., 'Authenticate')]"
+    )
+  ).click();
+
+  // Wait for success toast
+  const toast = await page.waitForXPath(
+    "//div[contains(., 'Transaction completed!')]",
+    { timeout: transferTimeout || 60_000 }
+  );
+
+  expect(toast).toBeDefined();
+};

--- a/e2e/src/utils/index.ts
+++ b/e2e/src/utils/index.ts
@@ -1,0 +1,2 @@
+export * from "./values";
+export * from "./helpers";

--- a/e2e/src/utils/values.ts
+++ b/e2e/src/utils/values.ts
@@ -15,4 +15,8 @@ export const mnemonic = [
 
 export const pwdOrAlias = "Asd";
 export const address0Alias = "address0";
+export const address1 =
+  "atest1d9khqw36x9zr2s6pxymrv3z9xcen2s33gvmrxsfjgccnzd2rxez5z3fex5urgsjzg4qnsw2pef6prn";
+export const shieldedAddress0 =
+  "patest1fwnveqn8urtj4j0gckqyw2lfmza5gw7ry4gwah7u05wwkay92eypkjstufj9tt8j8dnswq06yjt";
 export const shieldedAddress0Alias = "shieldedAddress0";


### PR DESCRIPTION
How to run tests:
- go to e2e
- just in case go to `e2e/.namada` and change `.version` file to v0.22.0 - this will retrigger all the downloads during first run
- `./setup-frontend.sh` and wait for both extension and interface  to start
- `yarn test` or` yarn test:watch` - first run will be slow as it will download bunch of stuff like: namada binaries, wasms, masp params
- wait for tests to finish(hopefully successfully :))

I've tested it on WSL/ubuntu. Pretty sure it should work on Mac too.