### PR TITLE
test(e2e): bond, unbond, withdraw, add to bridge pool

### DIFF
--- a/apps/namada-interface/src/App/Token/EthereumBridge/EthereumBridge.tsx
+++ b/apps/namada-interface/src/App/Token/EthereumBridge/EthereumBridge.tsx
@@ -166,7 +166,7 @@ export const EthereumBridge = (): JSX.Element => {
         </GeneralSection>
 
         {extensionKey == "namada" && (
-          <FeeSection>
+          <FeeSection data-testid="eth-bridge-fee">
             <InputContainer>
               <Select
                 data={tokenData}

--- a/e2e/genesis.toml
+++ b/e2e/genesis.toml
@@ -185,10 +185,10 @@ max_signatures_per_transaction = 15
 max_validator_slots = 128
 # Pipeline length (in epochs). Any change in the validator set made in
 # epoch 'n' will become active in epoch 'n + pipeline_len'.
-pipeline_len = 2
+pipeline_len = 0
 # Unbonding length (in epochs). Validators may have their stake slashed
 # for a fault in epoch 'n' up through epoch 'n + unbonding_len'.
-unbonding_len = 3
+unbonding_len = 0
 # Votes per fundamental staking token (namnam) - for testnets this should be 1. For e2e toml, a decimal is used for testing purposes.
 tm_votes_per_token = "0.1"
 # Reward for proposing a block.

--- a/e2e/genesis.toml
+++ b/e2e/genesis.toml
@@ -24,6 +24,11 @@ max_commission_rate_change = "0.01"
 net_address = "127.0.0.1:27656"
 
 # Some tokens present at genesis.
+[token.TestERC20]
+address = "atest1v46xsw368psnwwf3xcerqeryxcervvpsxuukye3cxsukgce4x5mrwctyvvekvvnxv33nxvfc0kmacx"
+denom = 6
+[token.TestERC20.balances]
+TestA = "1000"
 
 [token.NAM]
 address = "atest1v4ehgw36x3prswzxggunzv6pxqmnvdj9xvcyzvpsggeyvs3cg9qnywf589qnwvfsg5erg3fkl09rg5"

--- a/e2e/setup-frontend.sh
+++ b/e2e/setup-frontend.sh
@@ -6,16 +6,18 @@ cd ../apps/extension && \
     yarn clean:chrome && \
     export NODE_ENV=development; \
     export TARGET=chrome; \
+    export MASP_PARAMS_PATH=http://localhost:8080/assets/; \
     export REACT_APP_NAMADA_CHAIN_ID=${CHAIN_ID}; \
-    export REACT_APP_NAMADA_URL=http://127.0.0.1:27657 && \
+    export REACT_APP_NAMADA_URL=http://localhost:27657 && \
     npx webpack --watch &
 
 # Run the interface
 cd ../namada-interface && \
     export NODE_ENV=development; \
     export REACT_APP_LOCAL=true; \
+    export MASP_PARAMS_PATH=http://localhost:8080/assets/; \
     export REACT_APP_NAMADA_CHAIN_ID=${CHAIN_ID}; \
-    export REACT_APP_NAMADA_URL=http://127.0.0.1:27657 && \
+    export REACT_APP_NAMADA_URL=http://localhost:27657 && \
     npx webpack --watch &
 
 cd ../../e2e

--- a/e2e/setup-namada.sh
+++ b/e2e/setup-namada.sh
@@ -84,3 +84,5 @@ else
     find ../apps/extension/build/chrome -type f -name "*.js" -exec sed -i -E "s/dev-test\..{21}/$CHAIN_ID/g" {} +
     find ../apps/namada-interface/build -type f -name "*.js" -exec sed -i -E "s/dev-test\..{21}/$CHAIN_ID/g" {} +
 fi
+
+find .namada/basedir -type f -name "config.toml" -exec sed -i -E "s/cors_allowed_origins[[:space:]]=[[:space:]]\[\]/cors_allowed_origins = [\"*\"]/g" {} +

--- a/e2e/setup-namada.sh
+++ b/e2e/setup-namada.sh
@@ -32,6 +32,12 @@ if [ "$CURRENT_VERSION" != "$VERSION" ]; then
     curl --location --remote-header-name --remote-name https://raw.githubusercontent.com/anoma/namada/${VERSION}/wasm/checksums.json
     mv checksums.json "${NAMADA_DIR}/checksums.json"
 
+    #  Download masp params
+    curl --location --remote-header-name --remote-name https://github.com/anoma/masp-mpc/releases/download/namada-trusted-setup/masp-output.params 
+    curl --location --remote-header-name --remote-name https://github.com/anoma/masp-mpc/releases/download/namada-trusted-setup/masp-convert.params 
+    curl --location --remote-header-name --remote-name https://github.com/anoma/masp-mpc/releases/download/namada-trusted-setup/masp-spend.params
+    mv masp-*.params "${NAMADA_DIR}"
+
     # Download wasms
     CHECKSUMS="${NAMADA_DIR}/checksums.json"
     WASM=""
@@ -85,4 +91,8 @@ else
     find ../apps/namada-interface/build -type f -name "*.js" -exec sed -i -E "s/dev-test\..{21}/$CHAIN_ID/g" {} +
 fi
 
+echo "Fixing CORS"
 find .namada/basedir -type f -name "config.toml" -exec sed -i -E "s/cors_allowed_origins[[:space:]]=[[:space:]]\[\]/cors_allowed_origins = [\"*\"]/g" {} +
+
+echo "Moving MASP params"
+cp .namada/masp-*.params ../apps/namada-interface/build/assets

--- a/e2e/src/index.test.ts
+++ b/e2e/src/index.test.ts
@@ -324,7 +324,16 @@ describe("Namada", () => {
       expect(unbondCompletedToast).toBeDefined();
 
       // Wait for new epoch
-      await new Promise((resolve) => setTimeout(resolve, 60000));
+      page.on("dialog", async (dialog) => {
+        await new Promise((resolve) => setTimeout(resolve, 60000));
+        await dialog.accept();
+      });
+
+      await page.evaluate(() =>
+        alert(
+          'E2E info: We need to wait a minute before we can withdraw funds :|\n[do not touch "Ok" :), this window will close automatically]'
+        )
+      );
 
       // Click on send button
       (

--- a/e2e/src/index.test.ts
+++ b/e2e/src/index.test.ts
@@ -5,24 +5,27 @@ import * as puppeteer from "puppeteer";
 import { ChildProcess } from "child_process";
 
 import {
-  address0Alias,
-  address1,
-  shieldedAddress0,
-  shieldedAddress0Alias,
+  approveTransaction,
+  approveConnection,
+  createAccount,
+  importAccount,
+  transferFromTransparent,
+} from "./partial";
+import {
   launchPuppeteer,
   openPopup,
   setupNamada,
   startNamada,
   stopNamada,
-  targetPage,
   waitForInputValue,
   waitForXpath,
-} from "./utils";
+} from "./utils/helpers";
 import {
-  createAccount,
-  importAccount,
-  transferFromTransparent,
-} from "./partial";
+  address0Alias,
+  address1,
+  shieldedAddress0,
+  shieldedAddress0Alias,
+} from "./utils/values";
 
 jest.setTimeout(240000);
 
@@ -39,7 +42,7 @@ describe("Namada extension", () => {
   });
 
   afterEach(async function () {
-    await browser.close();
+    // await browser.close();
   });
 
   afterAll(async () => {
@@ -149,33 +152,12 @@ describe("Namada extension", () => {
     });
   });
 
-  describe("send transfer (transparent->transparent)", () => {
-    test("should send transfer", async () => {
+  describe("transfer", () => {
+    test("(transparent->transparent)", async () => {
       const nam = startNamada(namRefs);
 
       await importAccount(browser, page);
-
-      // Click on connect to extension
-      (
-        await waitForXpath<HTMLButtonElement>(
-          page,
-          "//button[contains(., 'Connect to')]"
-        )
-      ).click();
-
-      // Wait for approvals window to show up
-      const at = await browser.waitForTarget((t) =>
-        t.url().includes("approvals.html")
-      );
-      const ap = await targetPage(at);
-
-      // Click approve button
-      (
-        await waitForXpath<HTMLButtonElement>(
-          ap,
-          "//button[contains(., 'Approve')]"
-        )
-      ).click();
+      await approveConnection(browser, page);
 
       await transferFromTransparent(browser, page, {
         targetAddress: address1,
@@ -183,40 +165,102 @@ describe("Namada extension", () => {
 
       await stopNamada(nam);
     });
-  });
 
-  describe("send transfer (transparent->shielded)", () => {
-    test("should send transfer", async () => {
+    test("(transparent->shielded)", async () => {
       const nam = startNamada(namRefs);
 
       await importAccount(browser, page);
-
-      // Click on connect to extension
-      (
-        await waitForXpath<HTMLButtonElement>(
-          page,
-          "//button[contains(., 'Connect to')]"
-        )
-      ).click();
-
-      // Wait for approvals window to show up
-      const at = await browser.waitForTarget((t) =>
-        t.url().includes("approvals.html")
-      );
-      const ap = await targetPage(at);
-
-      // Click approve button
-      (
-        await waitForXpath<HTMLButtonElement>(
-          ap,
-          "//button[contains(., 'Approve')]"
-        )
-      ).click();
+      await approveConnection(browser, page);
 
       await transferFromTransparent(browser, page, {
         targetAddress: shieldedAddress0,
         transferTimeout: 120000,
       });
+
+      await stopNamada(nam);
+    });
+  });
+
+  describe("staking", () => {
+    test("bond and unbond", async () => {
+      const nam = startNamada(namRefs);
+
+      await importAccount(browser, page);
+      await approveConnection(browser, page);
+
+      // Click on send button
+      (
+        await waitForXpath<HTMLButtonElement>(
+          page,
+          "//button[contains(., 'Staking')]"
+        )
+      ).click();
+
+      // Click on validator
+      (
+        await waitForXpath<HTMLSpanElement>(
+          page,
+          "//span[contains(., 'atest1v4')]"
+        )
+      ).click();
+
+      // Click on stake button
+      (
+        await waitForXpath<HTMLButtonElement>(
+          page,
+          "//button[contains(., 'Stake')]"
+        )
+      ).click();
+
+      // Type staking amount
+      const [stakeInput] = await page.$$("input");
+      await stakeInput.type("100");
+
+      // Click confirm
+      (
+        await waitForXpath<HTMLButtonElement>(
+          page,
+          "//button[contains(., 'Confirm')]"
+        )
+      ).click();
+
+      await approveTransaction(browser);
+
+      // Wait for success toast
+      const bondCompletedToast = await page.waitForXPath(
+        "//div[contains(., 'Transaction completed!')]"
+      );
+
+      expect(bondCompletedToast).toBeDefined();
+
+      // Click on unstake
+      (
+        await waitForXpath<HTMLSpanElement>(
+          page,
+          "//span[contains(., 'unstake')]"
+        )
+      ).click();
+
+      await page.waitForNavigation();
+      const [unstakeInput] = await page.$$("input");
+      await unstakeInput.type("100");
+
+      // Click confirm
+      (
+        await waitForXpath<HTMLButtonElement>(
+          page,
+          "//button[contains(., 'Confirm')]"
+        )
+      ).click();
+
+      await approveTransaction(browser);
+
+      // Wait for success toast
+      const unbondCompletedToast = await page.waitForXPath(
+        "//div[contains(., 'Transaction completed!')]"
+      );
+
+      expect(unbondCompletedToast).toBeDefined();
 
       await stopNamada(nam);
     });

--- a/e2e/src/partial/approvals.ts
+++ b/e2e/src/partial/approvals.ts
@@ -1,0 +1,58 @@
+import * as puppeteer from "puppeteer";
+import { targetPage, waitForXpath } from "../utils/helpers";
+import { pwdOrAlias } from "../utils/values";
+
+export const approveConnection = async (
+  browser: puppeteer.Browser,
+  page: puppeteer.Page
+): Promise<void> => {
+  // Click on connect to extension
+  (
+    await waitForXpath<HTMLButtonElement>(
+      page,
+      "//button[contains(., 'Connect to')]"
+    )
+  ).click();
+
+  // Wait for approvals window to show up
+  const approvalsTarget = await browser.waitForTarget((t) =>
+    t.url().includes("approvals.html")
+  );
+  const approvalsPage = await targetPage(approvalsTarget);
+
+  // Click approve button
+  (
+    await waitForXpath<HTMLButtonElement>(
+      approvalsPage,
+      "//button[contains(., 'Approve')]"
+    )
+  ).click();
+};
+
+export const approveTransaction = async (
+  browser: puppeteer.Browser
+): Promise<void> => {
+  // Wait for approvals window to show up
+  const approvalsTarget = await browser.waitForTarget((t) =>
+    t.url().includes("approvals.html")
+  );
+  const approvalsPage = await targetPage(approvalsTarget);
+
+  // Click approve button
+  (
+    await waitForXpath<HTMLButtonElement>(
+      approvalsPage,
+      "//button[contains(., 'Approve')]"
+    )
+  ).click();
+
+  (await approvalsPage.$("input"))?.type(pwdOrAlias);
+
+  // Click approve auth button
+  (
+    await waitForXpath<HTMLButtonElement>(
+      approvalsPage,
+      "//button[contains(., 'Authenticate')]"
+    )
+  ).click();
+};

--- a/e2e/src/partial/index.ts
+++ b/e2e/src/partial/index.ts
@@ -1,2 +1,3 @@
 export * from "./setup";
 export * from "./transfer";
+export * from "./approvals";

--- a/e2e/src/partial/setup.ts
+++ b/e2e/src/partial/setup.ts
@@ -4,8 +4,9 @@ import {
   openInterface,
   openSetup,
   waitForXpath,
-  allowClipboardRead,
   $x,
+  pasteValueInto,
+  allowClipboardRead,
 } from "../utils/helpers";
 import { mnemonic, pwdOrAlias } from "../utils/values";
 
@@ -32,13 +33,10 @@ export const importAccount = async (
   const mnemonicH1 = await page.$eval("h1", (e) => e.innerText);
   expect(mnemonicH1).toEqual("Import Account");
 
-  // Fill mnemonic
   const wordInputs = await page.$$("input");
-  let index = 0;
-  for await (const input of wordInputs) {
-    await input.type(mnemonic[index]);
-    index++;
-  }
+
+  // Fill mnemonic
+  await pasteValueInto(page, wordInputs[5], mnemonic.join(" "));
 
   // Click on import account
   (

--- a/e2e/src/partial/transfer.ts
+++ b/e2e/src/partial/transfer.ts
@@ -1,6 +1,6 @@
 import * as puppeteer from "puppeteer";
 import { approveTransaction } from "./approvals";
-import { waitForXpath } from "../utils/helpers";
+import { pasteValueInto, waitForXpath } from "../utils/helpers";
 
 export type TransferFromOptions = {
   targetAddress: string;
@@ -27,7 +27,9 @@ export const transferFromTransparent = async (
 
   // Fill transfer data
   const [recipentInput, amountInput] = await page.$$("input");
-  await recipentInput.type(targetAddress);
+
+  await pasteValueInto(page, recipentInput, targetAddress);
+
   await amountInput.type("10");
 
   // Continue transfer

--- a/e2e/src/partial/transfer.ts
+++ b/e2e/src/partial/transfer.ts
@@ -1,5 +1,6 @@
 import * as puppeteer from "puppeteer";
-import { targetPage, waitForXpath, pwdOrAlias } from "../utils";
+import { approveTransaction } from "./approvals";
+import { waitForXpath } from "../utils/helpers";
 
 export type TransferFromOptions = {
   targetAddress: string;
@@ -37,29 +38,7 @@ export const transferFromTransparent = async (
     )
   ).click();
 
-  // Wait for approvals window to show up
-  const approvalsTarget = await browser.waitForTarget((t) =>
-    t.url().includes("approvals.html")
-  );
-  const approvalsPage = await targetPage(approvalsTarget);
-
-  // Click approve button
-  (
-    await waitForXpath<HTMLButtonElement>(
-      approvalsPage,
-      "//button[contains(., 'Approve')]"
-    )
-  ).click();
-
-  (await approvalsPage.$("input"))?.type(pwdOrAlias);
-
-  // Click approve auth button
-  (
-    await waitForXpath<HTMLButtonElement>(
-      approvalsPage,
-      "//button[contains(., 'Authenticate')]"
-    )
-  ).click();
+  await approveTransaction(browser);
 
   // Wait for success toast
   const toast = await page.waitForXPath(

--- a/e2e/src/utils/helpers.ts
+++ b/e2e/src/utils/helpers.ts
@@ -144,3 +144,16 @@ export const waitForInputValue = async <T>(
     input,
     value
   );
+
+export const pasteValueInto = async (
+  page: puppeteer.Page,
+  input: puppeteer.ElementHandle<HTMLInputElement>,
+  value: string
+): Promise<void> => {
+  await page.evaluate((value) => navigator.clipboard.writeText(value), value);
+
+  input.focus();
+  await page.keyboard.down("Control");
+  await page.keyboard.press("V");
+  await page.keyboard.up("Control");
+};

--- a/e2e/src/utils/helpers.ts
+++ b/e2e/src/utils/helpers.ts
@@ -110,6 +110,10 @@ export const launchPuppeteer = async (): Promise<puppeteer.Browser> => {
     headless: false,
     slowMo: 50,
     args: puppeteerArgs,
+    defaultViewport: {
+      width: 1200,
+      height: 800,
+    },
   });
 
   return browser;

--- a/e2e/src/utils/index.ts
+++ b/e2e/src/utils/index.ts
@@ -1,2 +1,0 @@
-export * from "./values";
-export * from "./helpers";

--- a/e2e/src/utils/values.ts
+++ b/e2e/src/utils/values.ts
@@ -14,9 +14,13 @@ export const mnemonic = [
 ];
 
 export const pwdOrAlias = "Asd";
+
 export const address0Alias = "address0";
 export const address1 =
   "atest1d9khqw36x9zr2s6pxymrv3z9xcen2s33gvmrxsfjgccnzd2rxez5z3fex5urgsjzg4qnsw2pef6prn";
+
 export const shieldedAddress0 =
   "patest1fwnveqn8urtj4j0gckqyw2lfmza5gw7ry4gwah7u05wwkay92eypkjstufj9tt8j8dnswq06yjt";
 export const shieldedAddress0Alias = "shieldedAddress0";
+
+export const ethAddress0 = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";

--- a/packages/shared/lib/src/sdk/mod.js
+++ b/packages/shared/lib/src/sdk/mod.js
@@ -30,9 +30,11 @@ async function fetchAndStore(params) {
 }
 
 async function fetchParams(params) {
-  return fetch(
-    `https://github.com/anoma/masp-mpc/releases/download/namada-trusted-setup/${params}`
-  )
+  const path =
+    process.env.MASP_PARAMS_PATH ||
+    "https://github.com/anoma/masp-mpc/releases/download/namada-trusted-setup/";
+
+  return fetch(`${path}${params}`)
     .then((response) => response.arrayBuffer())
     .then((ab) => new Uint8Array(ab));
 }


### PR DESCRIPTION
How to run tests:
- go to e2e
- just in case go to `e2e/.namada` and change `.version` file to v0.22.0 - this will retrigger all the downloads during first run
- `./setup-frontend.sh` and wait for both extension and interface  to start
- `yarn test` or` yarn test:watch` - first run will be slow as it will download bunch of stuff like: namada binaries, wasms, masp params
- wait for tests to finish(hopefully successfully :))

I've tested it on WSL/ubuntu. Pretty sure it should work on Mac too.