### PR TITLE
Un-nest common tx args and refactor tx code

### DIFF
--- a/apps/extension/src/Approvals/ApproveTx/ConfirmTx.tsx
+++ b/apps/extension/src/Approvals/ApproveTx/ConfirmTx.tsx
@@ -9,6 +9,7 @@ import {
 } from "@namada/components";
 import { shortenAddress } from "@namada/utils";
 import { TxType, TxTypeLabel } from "@namada/shared";
+import { SupportedTx } from "@namada/types";
 
 import { ApprovalDetails, Status } from "Approvals/Approvals";
 import {
@@ -22,7 +23,7 @@ import { useRequester } from "hooks/useRequester";
 import { Address } from "App/Accounts/AccountListing.components";
 import { closeCurrentTab } from "utils";
 import { FetchAndStoreMaspParamsMsg, HasMaspParamsMsg } from "provider";
-import { ApproveMsg, SupportedTx, txMap } from "Approvals/types";
+import { SubmitApprovedTxMsg } from "background/approvals";
 
 const { REACT_APP_NAMADA_FAUCET_ADDRESS: faucetAddress } = process.env;
 
@@ -48,12 +49,8 @@ export const ConfirmTx: React.FC<Props> = ({ details }) => {
     );
 
     try {
-      const Msg: ApproveMsg | undefined = txMap.get(txType as SupportedTx);
       if (!msgId) {
         throw new Error("msgId was not provided!");
-      }
-      if (!Msg) {
-        throw new Error("Unsupported transaction!");
       }
 
       const hasMaspParams = await requester.sendMessage(
@@ -74,7 +71,10 @@ export const ConfirmTx: React.FC<Props> = ({ details }) => {
         }
       }
 
-      requester.sendMessage(Ports.Background, new Msg(msgId, password));
+      requester.sendMessage(
+        Ports.Background,
+        new SubmitApprovedTxMsg(txType as SupportedTx, msgId, password)
+      );
       setStatus(Status.Completed);
     } catch (e) {
       console.info(e);

--- a/apps/extension/src/Approvals/types.ts
+++ b/apps/extension/src/Approvals/types.ts
@@ -1,12 +1,3 @@
-import { TxType } from "@namada/shared";
-import {
-  SubmitApprovedBondMsg,
-  SubmitApprovedTransferMsg,
-  SubmitApprovedIbcTransferMsg,
-  SubmitApprovedUnbondMsg,
-  SubmitApprovedWithdrawMsg,
-  SubmitApprovedEthBridgeTransferMsg,
-} from "background/approvals";
 import { Message } from "router";
 
 export enum TopLevelRoute {
@@ -21,24 +12,5 @@ export enum TopLevelRoute {
   ConfirmLedgerTx = "/confirm-ledger-tx",
 }
 
-export type SupportedTx = Extract<
-  TxType,
-  | TxType.Bond
-  | TxType.Unbond
-  | TxType.Transfer
-  | TxType.IBCTransfer
-  | TxType.EthBridgeTransfer
-  | TxType.Withdraw
->;
-
 export type ApproveMsg = new (msgId: string, password: string) => unknown &
   Message<void>;
-
-export const txMap: Map<SupportedTx, ApproveMsg> = new Map([
-  [TxType.Bond, SubmitApprovedBondMsg],
-  [TxType.Unbond, SubmitApprovedUnbondMsg],
-  [TxType.Transfer, SubmitApprovedTransferMsg],
-  [TxType.IBCTransfer, SubmitApprovedIbcTransferMsg],
-  [TxType.EthBridgeTransfer, SubmitApprovedEthBridgeTransferMsg],
-  [TxType.Withdraw, SubmitApprovedWithdrawMsg],
-]);

--- a/apps/extension/src/background/approvals/handler.ts
+++ b/apps/extension/src/background/approvals/handler.ts
@@ -1,22 +1,12 @@
 import { Handler, Env, Message, InternalHandler } from "router";
 import { ApprovalsService } from "./service";
 import {
-  ApproveBondMsg,
-  ApproveUnbondMsg,
-  ApproveTransferMsg,
-  ApproveIbcTransferMsg,
-  ApproveWithdrawMsg,
-  ApproveEthBridgeTransferMsg,
+  ApproveTxMsg,
   ApproveConnectInterfaceMsg,
 } from "provider";
 import {
   RejectTxMsg,
-  SubmitApprovedTransferMsg,
-  SubmitApprovedIbcTransferMsg,
-  SubmitApprovedEthBridgeTransferMsg,
-  SubmitApprovedBondMsg,
-  SubmitApprovedUnbondMsg,
-  SubmitApprovedWithdrawMsg,
+  SubmitApprovedTxMsg,
   ConnectInterfaceResponseMsg,
   RevokeConnectionMsg,
 } from "./messages";
@@ -24,62 +14,17 @@ import {
 export const getHandler: (service: ApprovalsService) => Handler = (service) => {
   return (env: Env, msg: Message<unknown>) => {
     switch (msg.constructor) {
-      case ApproveTransferMsg:
-        return handleApproveTransferMsg(service)(
+      case ApproveTxMsg:
+        return handleApproveTxMsg(service)(
           env,
-          msg as ApproveTransferMsg
-        );
-      case ApproveIbcTransferMsg:
-        return handleApproveIbcTransferMsg(service)(
-          env,
-          msg as ApproveIbcTransferMsg
-        );
-      case ApproveEthBridgeTransferMsg:
-        return handleApproveEthBridgeTransferMsg(service)(
-          env,
-          msg as ApproveEthBridgeTransferMsg
-        );
-      case ApproveBondMsg:
-        return handleApproveBondMsg(service)(env, msg as ApproveBondMsg);
-      case ApproveUnbondMsg:
-        return handleApproveUnbondMsg(service)(env, msg as ApproveUnbondMsg);
-      case ApproveWithdrawMsg:
-        return handleApproveWithdrawMsg(service)(
-          env,
-          msg as ApproveWithdrawMsg
+          msg as ApproveTxMsg
         );
       case RejectTxMsg:
         return handleRejectTxMsg(service)(env, msg as RejectTxMsg);
-      case SubmitApprovedTransferMsg:
-        return handleSubmitApprovedTransferMsg(service)(
+      case SubmitApprovedTxMsg:
+        return handleSubmitApprovedTxMsg(service)(
           env,
-          msg as SubmitApprovedTransferMsg
-        );
-      case SubmitApprovedIbcTransferMsg:
-        return handleSubmitApprovedIBCTransferMsg(service)(
-          env,
-          msg as SubmitApprovedIbcTransferMsg
-        );
-      case SubmitApprovedEthBridgeTransferMsg:
-        return handleSubmitApprovedEthBridgeTransferMsg(service)(
-          env,
-          msg as SubmitApprovedEthBridgeTransferMsg
-        );
-
-      case SubmitApprovedBondMsg:
-        return handleSubmitApprovedBondMsg(service)(
-          env,
-          msg as SubmitApprovedBondMsg
-        );
-      case SubmitApprovedUnbondMsg:
-        return handleSubmitApprovedUnbondMsg(service)(
-          env,
-          msg as SubmitApprovedUnbondMsg
-        );
-      case SubmitApprovedWithdrawMsg:
-        return handleSubmitApprovedWithdrawMsg(service)(
-          env,
-          msg as SubmitApprovedUnbondMsg
+          msg as SubmitApprovedTxMsg
         );
       case ApproveConnectInterfaceMsg:
         return handleApproveConnectInterfaceMsg(service)(
@@ -102,27 +47,11 @@ export const getHandler: (service: ApprovalsService) => Handler = (service) => {
   };
 };
 
-const handleApproveTransferMsg: (
+const handleApproveTxMsg: (
   service: ApprovalsService
-) => InternalHandler<ApproveTransferMsg> = (service) => {
-  return async (_, { txMsg, accountType }) => {
-    return await service.approveTransfer(txMsg, accountType);
-  };
-};
-
-const handleApproveIbcTransferMsg: (
-  service: ApprovalsService
-) => InternalHandler<ApproveIbcTransferMsg> = (service) => {
-  return async (_, { txMsg, accountType }) => {
-    return await service.approveIbcTransfer(txMsg, accountType);
-  };
-};
-
-const handleApproveEthBridgeTransferMsg: (
-  service: ApprovalsService
-) => InternalHandler<ApproveEthBridgeTransferMsg> = (service) => {
-  return async (_, { txMsg, accountType }) => {
-    return await service.approveEthBridgeTransfer(txMsg, accountType);
+) => InternalHandler<ApproveTxMsg> = (service) => {
+  return async (_, { txType, specificMsg, txMsg, accountType }) => {
+    return await service.approveTx(txType, specificMsg, txMsg, accountType);
   };
 };
 
@@ -134,75 +63,11 @@ const handleRejectTxMsg: (
   };
 };
 
-const handleSubmitApprovedTransferMsg: (
+const handleSubmitApprovedTxMsg: (
   service: ApprovalsService
-) => InternalHandler<SubmitApprovedTransferMsg> = (service) => {
+) => InternalHandler<SubmitApprovedTxMsg> = (service) => {
   return async (_, { msgId, password }) => {
-    return await service.submitTransfer(msgId, password);
-  };
-};
-
-const handleSubmitApprovedIBCTransferMsg: (
-  service: ApprovalsService
-) => InternalHandler<SubmitApprovedIbcTransferMsg> = (service) => {
-  return async (_, { msgId, password }) => {
-    return await service.submitIbcTransfer(msgId, password);
-  };
-};
-
-const handleSubmitApprovedEthBridgeTransferMsg: (
-  service: ApprovalsService
-) => InternalHandler<SubmitApprovedEthBridgeTransferMsg> = (service) => {
-  return async (_, { msgId, password }) => {
-    return await service.submitEthBridgeTransfer(msgId, password);
-  };
-};
-
-const handleApproveBondMsg: (
-  service: ApprovalsService
-) => InternalHandler<ApproveBondMsg> = (service) => {
-  return async (_, { txMsg, accountType }) => {
-    return await service.approveBond(txMsg, accountType);
-  };
-};
-
-const handleApproveUnbondMsg: (
-  service: ApprovalsService
-) => InternalHandler<ApproveUnbondMsg> = (service) => {
-  return async (_, { txMsg, accountType }) => {
-    return await service.approveUnbond(txMsg, accountType);
-  };
-};
-
-const handleApproveWithdrawMsg: (
-  service: ApprovalsService
-) => InternalHandler<ApproveWithdrawMsg> = (service) => {
-  return async (_, { txMsg, accountType }) => {
-    return await service.approveWithdraw(txMsg, accountType);
-  };
-};
-
-const handleSubmitApprovedBondMsg: (
-  service: ApprovalsService
-) => InternalHandler<SubmitApprovedBondMsg> = (service) => {
-  return async (_, { msgId, password }) => {
-    return await service.submitBond(msgId, password);
-  };
-};
-
-const handleSubmitApprovedUnbondMsg: (
-  service: ApprovalsService
-) => InternalHandler<SubmitApprovedUnbondMsg> = (service) => {
-  return async (_, { msgId, password }) => {
-    return await service.submitUnbond(msgId, password);
-  };
-};
-
-const handleSubmitApprovedWithdrawMsg: (
-  service: ApprovalsService
-) => InternalHandler<SubmitApprovedWithdrawMsg> = (service) => {
-  return async (_, { msgId, password }) => {
-    return await service.submitWithdraw(msgId, password);
+    return await service.submitTx(msgId, password);
   };
 };
 

--- a/apps/extension/src/background/approvals/init.ts
+++ b/apps/extension/src/background/approvals/init.ts
@@ -1,21 +1,11 @@
 import { Router } from "router";
 import {
-  ApproveBondMsg,
-  ApproveTransferMsg,
-  ApproveIbcTransferMsg,
-  ApproveEthBridgeTransferMsg,
-  ApproveUnbondMsg,
-  ApproveWithdrawMsg,
+  ApproveTxMsg,
   ApproveConnectInterfaceMsg,
 } from "provider";
 import {
   RejectTxMsg,
-  SubmitApprovedBondMsg,
-  SubmitApprovedUnbondMsg,
-  SubmitApprovedTransferMsg,
-  SubmitApprovedIbcTransferMsg,
-  SubmitApprovedEthBridgeTransferMsg,
-  SubmitApprovedWithdrawMsg,
+  SubmitApprovedTxMsg,
   ConnectInterfaceResponseMsg,
   RevokeConnectionMsg,
 } from "./messages";
@@ -25,19 +15,9 @@ import { ApprovalsService } from "./service";
 import { getHandler } from "./handler";
 
 export function init(router: Router, service: ApprovalsService): void {
-  router.registerMessage(ApproveBondMsg);
-  router.registerMessage(ApproveTransferMsg);
-  router.registerMessage(ApproveIbcTransferMsg);
-  router.registerMessage(ApproveEthBridgeTransferMsg);
-  router.registerMessage(ApproveUnbondMsg);
-  router.registerMessage(ApproveWithdrawMsg);
+  router.registerMessage(ApproveTxMsg);
   router.registerMessage(RejectTxMsg);
-  router.registerMessage(SubmitApprovedBondMsg);
-  router.registerMessage(SubmitApprovedUnbondMsg);
-  router.registerMessage(SubmitApprovedTransferMsg);
-  router.registerMessage(SubmitApprovedIbcTransferMsg);
-  router.registerMessage(SubmitApprovedEthBridgeTransferMsg);
-  router.registerMessage(SubmitApprovedWithdrawMsg);
+  router.registerMessage(SubmitApprovedTxMsg);
   router.registerMessage(ApproveConnectInterfaceMsg);
   router.registerMessage(ConnectInterfaceResponseMsg);
   router.registerMessage(RevokeConnectionMsg);

--- a/apps/extension/src/background/approvals/messages.ts
+++ b/apps/extension/src/background/approvals/messages.ts
@@ -1,14 +1,12 @@
 import { Message } from "router";
 import { ROUTE } from "./constants";
+import { SupportedTx } from "@namada/types";
+
+import { validateProps } from "utils";
 
 enum MessageType {
   RejectTx = "reject-tx",
-  SubmitApprovedTransfer = "submit-approved-transfer",
-  SubmitApprovedIbcTransfer = "submit-approved-ibc-transfer",
-  SubmitApprovedEthBridgeTransferMsg = "submit-approved-eth-bridge-transfer",
-  SubmitApprovedBond = "submit-approved-bond",
-  SubmitApprovedUnbond = "submit-approved-unbond",
-  SubmitApprovedWithdraw = "submit-approved-withdraw",
+  SubmitApprovedTx = "submit-approved-tx",
   ConnectInterfaceResponse = "connect-interface-response",
   RevokeConnection = "revoke-connection",
 }
@@ -38,26 +36,21 @@ export class RejectTxMsg extends Message<void> {
   }
 }
 
-export class SubmitApprovedTransferMsg extends Message<void> {
+export class SubmitApprovedTxMsg extends Message<void> {
   public static type(): MessageType {
-    return MessageType.SubmitApprovedTransfer;
+    return MessageType.SubmitApprovedTx;
   }
 
-  constructor(public readonly msgId: string, public readonly password: string) {
+  constructor(
+    public readonly txType: SupportedTx,
+    public readonly msgId: string,
+    public readonly password: string
+  ) {
     super();
   }
 
   validate(): void {
-    if (!this.msgId) {
-      throw new Error("msgId must not be empty!");
-    }
-    if (!this.password) {
-      throw new Error(
-        "Password is required to submitTx for this type of account!"
-      );
-    }
-
-    return;
+    validateProps(this, ["txType", "msgId", "password"]);
   }
 
   route(): string {
@@ -65,156 +58,7 @@ export class SubmitApprovedTransferMsg extends Message<void> {
   }
 
   type(): string {
-    return SubmitApprovedTransferMsg.type();
-  }
-}
-
-export class SubmitApprovedIbcTransferMsg extends Message<void> {
-  public static type(): MessageType {
-    return MessageType.SubmitApprovedIbcTransfer;
-  }
-
-  constructor(public readonly msgId: string, public readonly password: string) {
-    super();
-  }
-
-  validate(): void {
-    if (!this.msgId) {
-      throw new Error("msgId must not be empty!");
-    }
-    if (!this.password) {
-      throw new Error(
-        "Password is required to submitTx for this type of account!"
-      );
-    }
-
-    return;
-  }
-
-  route(): string {
-    return ROUTE;
-  }
-
-  type(): string {
-    return SubmitApprovedIbcTransferMsg.type();
-  }
-}
-
-export class SubmitApprovedEthBridgeTransferMsg extends Message<void> {
-  public static type(): MessageType {
-    return MessageType.SubmitApprovedEthBridgeTransferMsg;
-  }
-
-  constructor(public readonly msgId: string, public readonly password: string) {
-    super();
-  }
-
-  validate(): void {
-    if (!this.msgId) {
-      throw new Error("msgId must not be empty!");
-    }
-    if (!this.password) {
-      throw new Error(
-        "Password is required to submitTx for this type of account!"
-      );
-    }
-
-    return;
-  }
-
-  route(): string {
-    return ROUTE;
-  }
-
-  type(): string {
-    return SubmitApprovedEthBridgeTransferMsg.type();
-  }
-}
-
-export class SubmitApprovedBondMsg extends Message<void> {
-  public static type(): MessageType {
-    return MessageType.SubmitApprovedBond;
-  }
-
-  constructor(public readonly msgId: string, public readonly password: string) {
-    super();
-  }
-
-  validate(): void {
-    if (!this.msgId) {
-      throw new Error("msgId must not be empty!");
-    }
-    if (!this.password) {
-      throw new Error("Password is required to submit bond tx!");
-    }
-
-    return;
-  }
-
-  route(): string {
-    return ROUTE;
-  }
-
-  type(): string {
-    return SubmitApprovedBondMsg.type();
-  }
-}
-
-export class SubmitApprovedUnbondMsg extends Message<void> {
-  public static type(): MessageType {
-    return MessageType.SubmitApprovedUnbond;
-  }
-
-  constructor(public readonly msgId: string, public readonly password: string) {
-    super();
-  }
-
-  validate(): void {
-    if (!this.msgId) {
-      throw new Error("msgId must not be empty!");
-    }
-    if (!this.password) {
-      throw new Error("Password is required to submit unbond tx!");
-    }
-
-    return;
-  }
-
-  route(): string {
-    return ROUTE;
-  }
-
-  type(): string {
-    return SubmitApprovedUnbondMsg.type();
-  }
-}
-
-export class SubmitApprovedWithdrawMsg extends Message<void> {
-  public static type(): MessageType {
-    return MessageType.SubmitApprovedWithdraw;
-  }
-
-  constructor(public readonly msgId: string, public readonly password: string) {
-    super();
-  }
-
-  validate(): void {
-    if (!this.msgId) {
-      throw new Error("msgId must not be empty!");
-    }
-    if (!this.password) {
-      throw new Error("Password is required to submit unbond tx!");
-    }
-
-    return;
-  }
-
-  route(): string {
-    return ROUTE;
-  }
-
-  type(): string {
-    return SubmitApprovedWithdrawMsg.type();
+    return SubmitApprovedTxMsg.type();
   }
 }
 

--- a/apps/extension/src/background/approvals/types.ts
+++ b/apps/extension/src/background/approvals/types.ts
@@ -1,1 +1,5 @@
+import { SupportedTx } from "@namada/types";
+
 export type ApprovedOriginsStore = string[];
+
+export type TxStore = { txType: SupportedTx, txMsg: string, specificMsg: string };

--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -595,44 +595,50 @@ export class KeyRing {
     return getAccountValuesFromStore(accounts);
   }
 
-  async submitBond(txMsg: Uint8Array): Promise<void> {
+  async submitBond(bondMsg: Uint8Array, txMsg: Uint8Array): Promise<void> {
     if (!this._password) {
       throw new Error("Not authenticated!");
     }
 
     try {
-      await this.sdk.submit_bond(txMsg, this._password);
+      const builtTx = await this.sdk.build_bond(bondMsg, txMsg, this._password);
+      const [txBytes, revealPkTxBytes] = await this.sdk.sign_tx(builtTx, txMsg);
+      await this.sdk.process_tx(txBytes, txMsg, revealPkTxBytes);
     } catch (e) {
       throw new Error(`Could not submit bond tx: ${e}`);
     }
   }
 
-  async submitUnbond(txMsg: Uint8Array): Promise<void> {
+  async submitUnbond(unbondMsg: Uint8Array, txMsg: Uint8Array): Promise<void> {
     if (!this._password) {
       throw new Error("Not authenticated!");
     }
 
     try {
-      await this.sdk.submit_unbond(txMsg, this._password);
+      const builtTx = await this.sdk.build_unbond(unbondMsg, txMsg, this._password);
+      const [txBytes, revealPkTxBytes] = await this.sdk.sign_tx(builtTx, txMsg);
+      await this.sdk.process_tx(txBytes, txMsg, revealPkTxBytes);
     } catch (e) {
       throw new Error(`Could not submit unbond tx: ${e}`);
     }
   }
 
-  async submitWithdraw(txMsg: Uint8Array): Promise<void> {
+  async submitWithdraw(withdrawMsg: Uint8Array, txMsg: Uint8Array): Promise<void> {
     if (!this._password) {
       throw new Error("Not authenticated!");
     }
 
     try {
-      await this.sdk.submit_withdraw(txMsg, this._password);
+      const builtTx = await this.sdk.build_withdraw(withdrawMsg, txMsg, this._password);
+      const [txBytes, revealPkTxBytes] = await this.sdk.sign_tx(builtTx, txMsg);
+      await this.sdk.process_tx(txBytes, txMsg, revealPkTxBytes);
     } catch (e) {
       throw new Error(`Could not submit withdraw tx: ${e}`);
     }
   }
 
   async submitTransfer(
-    txMsg: Uint8Array,
+    transferMsg: Uint8Array,
     submit: (password: string, xsk?: string) => Promise<void>
   ): Promise<void> {
     if (!this._password) {
@@ -642,7 +648,7 @@ export class KeyRing {
     // We need to get the source address in case it is shielded one, so we can
     // decrypt the extended spending key for a transfer.
     const { source, target } = deserialize(
-      Buffer.from(txMsg),
+      Buffer.from(transferMsg),
       TransferMsgValue
     );
 
@@ -667,25 +673,31 @@ export class KeyRing {
     await submit(this._password, extendedSpendingKey);
   }
 
-  async submitIbcTransfer(txMsg: Uint8Array): Promise<void> {
+  async submitIbcTransfer(ibcTransferMsg: Uint8Array, txMsg: Uint8Array): Promise<void> {
     if (!this._password) {
       throw new Error("Not authenticated!");
     }
 
     try {
-      await this.sdk.submit_ibc_transfer(txMsg, this._password);
+      const builtTx =
+        await this.sdk.build_ibc_transfer(ibcTransferMsg, txMsg, this._password);
+      const [txBytes, revealPkTxBytes] = await this.sdk.sign_tx(builtTx, txMsg);
+      await this.sdk.process_tx(txBytes, txMsg, revealPkTxBytes);
     } catch (e) {
       throw new Error(`Could not submit ibc transfer tx: ${e}`);
     }
   }
 
-  async submitEthBridgeTransfer(txMsg: Uint8Array): Promise<void> {
+  async submitEthBridgeTransfer(ethBridgeTransferMsg: Uint8Array, txMsg: Uint8Array): Promise<void> {
     if (!this._password) {
       throw new Error("Not authenticated!");
     }
 
     try {
-      await this.sdk.submit_eth_bridge_transfer(txMsg, this._password);
+      const builtTx =
+        await this.sdk.build_eth_bridge_transfer(ethBridgeTransferMsg, txMsg, this._password);
+      const [txBytes, revealPkTxBytes] = await this.sdk.sign_tx(builtTx, txMsg);
+      await this.sdk.process_tx(txBytes, txMsg, revealPkTxBytes);
     } catch (e) {
       throw new Error(`Could not submit submit_eth_bridge_transfer tx: ${e}`);
     }

--- a/apps/extension/src/background/web-workers/types.ts
+++ b/apps/extension/src/background/web-workers/types.ts
@@ -6,6 +6,7 @@ export type SubmitTransferMessage = {
 };
 
 export type SubmitTransferMessageData = {
+  transferMsg: string;
   txMsg: string;
   msgId: string;
   password: string;

--- a/apps/extension/src/provider/InjectedNamada.ts
+++ b/apps/extension/src/provider/InjectedNamada.ts
@@ -1,5 +1,4 @@
 import {
-  AccountType,
   Chain,
   DerivedAccount,
   Namada as INamada,
@@ -51,73 +50,11 @@ export class InjectedNamada implements INamada {
     return new Signer(chainId, this);
   }
 
-  public async submitBond(props: TxMsgProps): Promise<void> {
-    const { txMsg, type } = props;
+  public async submitTx(props: TxMsgProps): Promise<void> {
     return await InjectedProxy.requestMethod<
-      { txMsg: string; type: AccountType },
+      TxMsgProps,
       void
-    >("submitBond", {
-      txMsg,
-      type,
-    });
-  }
-
-  public async submitUnbond(props: TxMsgProps): Promise<void> {
-    const { txMsg, type } = props;
-    return await InjectedProxy.requestMethod<
-      { txMsg: string; type: AccountType },
-      void
-    >("submitUnbond", { txMsg, type });
-  }
-
-  public async submitWithdraw(props: TxMsgProps): Promise<void> {
-    const { txMsg, type } = props;
-    return await InjectedProxy.requestMethod<
-      { txMsg: string; type: AccountType },
-      void
-    >("submitWithdraw", { txMsg, type });
-  }
-
-  public async submitTransfer(props: {
-    txMsg: string;
-    type: AccountType;
-  }): Promise<void> {
-    const { txMsg, type } = props;
-    return await InjectedProxy.requestMethod<
-      { txMsg: string; type: AccountType },
-      void
-    >("submitTransfer", {
-      txMsg,
-      type,
-    });
-  }
-
-  public async submitIbcTransfer(props: {
-    txMsg: string;
-    type: AccountType;
-  }): Promise<void> {
-    const { txMsg, type } = props;
-    return await InjectedProxy.requestMethod<
-      { txMsg: string; type: AccountType },
-      void
-    >("submitIbcTransfer", {
-      txMsg,
-      type,
-    });
-  }
-
-  public async submitEthBridgeTransfer(props: {
-    txMsg: string;
-    type: AccountType;
-  }): Promise<void> {
-    const { txMsg, type } = props;
-    return await InjectedProxy.requestMethod<
-      { txMsg: string; type: AccountType },
-      void
-    >("submitEthBridgeTransfer", {
-      txMsg,
-      type,
-    });
+    >("submitTx", props);
   }
 
   public version(): string {

--- a/apps/extension/src/provider/Namada.ts
+++ b/apps/extension/src/provider/Namada.ts
@@ -1,16 +1,13 @@
 import {
-  AccountType,
   Namada as INamada,
   Chain,
   DerivedAccount,
+  TxMsgProps,
 } from "@namada/types";
 import { Ports, MessageRequester } from "router";
 
 import {
-  ApproveTransferMsg,
-  ApproveBondMsg,
-  ApproveUnbondMsg,
-  ApproveWithdrawMsg,
+  ApproveTxMsg,
   ApproveConnectInterfaceMsg,
   GetChainMsg,
   GetChainsMsg,
@@ -20,8 +17,6 @@ import {
   HasMaspParamsMsg,
   CheckDurabilityMsg,
   QueryBalancesMsg,
-  ApproveIbcTransferMsg,
-  ApproveEthBridgeTransferMsg,
 } from "./messages";
 
 export class Namada implements INamada {
@@ -97,69 +92,15 @@ export class Namada implements INamada {
     );
   }
 
-  public async submitBond(props: {
-    txMsg: string;
-    type: AccountType;
-  }): Promise<void> {
-    const { txMsg, type } = props;
+  public async submitTx(props: TxMsgProps): Promise<void> {
     return await this.requester?.sendMessage(
       Ports.Background,
-      new ApproveBondMsg(txMsg, type)
-    );
-  }
-
-  public async submitUnbond(props: {
-    txMsg: string;
-    type: AccountType;
-  }): Promise<void> {
-    const { txMsg, type } = props;
-    return await this.requester?.sendMessage(
-      Ports.Background,
-      new ApproveUnbondMsg(txMsg, type)
-    );
-  }
-
-  public async submitWithdraw(props: {
-    txMsg: string;
-    type: AccountType;
-  }): Promise<void> {
-    const { txMsg, type } = props;
-    return await this.requester?.sendMessage(
-      Ports.Background,
-      new ApproveWithdrawMsg(txMsg, type)
-    );
-  }
-
-  public async submitTransfer(props: {
-    txMsg: string;
-    type: AccountType;
-  }): Promise<void> {
-    const { txMsg, type } = props;
-    return await this.requester?.sendMessage(
-      Ports.Background,
-      new ApproveTransferMsg(txMsg, type)
-    );
-  }
-
-  public async submitIbcTransfer(props: {
-    txMsg: string;
-    type: AccountType;
-  }): Promise<void> {
-    const { txMsg, type } = props;
-    return await this.requester?.sendMessage(
-      Ports.Background,
-      new ApproveIbcTransferMsg(txMsg, type)
-    );
-  }
-
-  public async submitEthBridgeTransfer(props: {
-    txMsg: string;
-    type: AccountType;
-  }): Promise<void> {
-    const { txMsg, type } = props;
-    return await this.requester?.sendMessage(
-      Ports.Background,
-      new ApproveEthBridgeTransferMsg(txMsg, type)
+      new ApproveTxMsg(
+        props.txType,
+        props.specificMsg,
+        props.txMsg,
+        props.type
+      )
     );
   }
 

--- a/apps/extension/src/provider/messages.ts
+++ b/apps/extension/src/provider/messages.ts
@@ -1,5 +1,11 @@
-import { AccountType, Chain, DerivedAccount } from "@namada/types";
+import {
+  AccountType,
+  Chain,
+  DerivedAccount,
+  SupportedTx
+} from "@namada/types";
 import { Message } from "router";
+import { validateProps } from "utils";
 
 /**
  * Message for use with providers: These messages are called outside of the
@@ -16,11 +22,7 @@ enum Route {
 enum MessageType {
   ApproveConnectInterface = "approve-connect-interface",
   QueryAccounts = "query-accounts",
-  ApproveTransfer = "approve-transfer",
-  ApproveIbcTransfer = "approve-ibc-transfer",
-  ApproveBond = "approve-bond",
-  ApproveUnbond = "approve-unbond",
-  ApproveWithdraw = "approve-withdraw",
+  ApproveTx = "approve-tx",
   QueryBalances = "query-balances",
   SubmitIbcTransfer = "submit-ibc-transfer",
   SubmitLedgerTransfer = "submit-ledger-transfer",
@@ -184,23 +186,22 @@ export class QueryBalancesMsg extends Message<
   }
 }
 
-export class ApproveTransferMsg extends Message<void> {
+export class ApproveTxMsg extends Message<void> {
   public static type(): MessageType {
-    return MessageType.ApproveTransfer;
+    return MessageType.ApproveTx;
   }
 
   constructor(
+    public readonly txType: SupportedTx,
     public readonly txMsg: string,
+    public readonly specificMsg: string,
     public readonly accountType: AccountType
   ) {
     super();
   }
 
   validate(): void {
-    if (!this.txMsg) {
-      throw new Error("txMsg was not provided!");
-    }
-    return;
+    validateProps(this, ["txType", "txMsg", "specificMsg", "accountType"]);
   }
 
   route(): string {
@@ -208,158 +209,7 @@ export class ApproveTransferMsg extends Message<void> {
   }
 
   type(): string {
-    return ApproveTransferMsg.type();
-  }
-}
-
-export class ApproveIbcTransferMsg extends Message<void> {
-  public static type(): MessageType {
-    return MessageType.ApproveIbcTransfer;
-  }
-
-  constructor(
-    public readonly txMsg: string,
-    public readonly accountType: AccountType
-  ) {
-    super();
-  }
-
-  validate(): void {
-    if (!this.txMsg) {
-      throw new Error("txMsg was not provided!");
-    }
-    return;
-  }
-
-  route(): string {
-    return Route.Approvals;
-  }
-
-  type(): string {
-    return ApproveIbcTransferMsg.type();
-  }
-}
-
-export class ApproveEthBridgeTransferMsg extends Message<void> {
-  public static type(): MessageType {
-    return MessageType.ApproveEthBridgeTransfer;
-  }
-
-  constructor(
-    public readonly txMsg: string,
-    public readonly accountType: AccountType
-  ) {
-    super();
-  }
-
-  validate(): void {
-    if (!this.txMsg) {
-      throw new Error("txMsg was not provided!");
-    }
-    return;
-  }
-
-  route(): string {
-    return Route.Approvals;
-  }
-
-  type(): string {
-    return ApproveEthBridgeTransferMsg.type();
-  }
-}
-
-export class ApproveBondMsg extends Message<void> {
-  public static type(): MessageType {
-    return MessageType.ApproveBond;
-  }
-
-  constructor(
-    public readonly txMsg: string,
-    public readonly accountType: AccountType
-  ) {
-    super();
-  }
-
-  validate(): void {
-    if (!this.txMsg) {
-      throw new Error("txMsg was not provided!");
-    }
-    if (!this.accountType) {
-      throw new Error("accountType was not provided!");
-    }
-    return;
-  }
-
-  route(): string {
-    return Route.Approvals;
-  }
-
-  type(): string {
-    return ApproveBondMsg.type();
-  }
-}
-
-export class ApproveUnbondMsg extends Message<void> {
-  public static type(): MessageType {
-    return MessageType.ApproveUnbond;
-  }
-
-  constructor(
-    public readonly txMsg: string,
-    public readonly accountType: AccountType
-  ) {
-    super();
-  }
-
-  validate(): void {
-    if (!this.txMsg) {
-      throw new Error("txMsg was not provided!");
-    }
-    if (!this.accountType) {
-      throw new Error("accountType was not provided!");
-    }
-
-    return;
-  }
-
-  route(): string {
-    return Route.Approvals;
-  }
-
-  type(): string {
-    return ApproveUnbondMsg.type();
-  }
-}
-
-export class ApproveWithdrawMsg extends Message<void> {
-  public static type(): MessageType {
-    return MessageType.ApproveWithdraw;
-  }
-
-  constructor(
-    public readonly txMsg: string,
-    public readonly accountType: AccountType
-  ) {
-    super();
-  }
-
-  validate(): void {
-    if (!this.txMsg) {
-      throw new Error("An encoded txMsg is required!");
-    }
-    if (!this.accountType) {
-      throw new Error("accountType was not provided!");
-    }
-
-    return;
-  }
-
-  route(): string {
-    return Route.Approvals;
-  }
-
-  type(): string {
-    return ApproveWithdrawMsg.type();
+    return ApproveTxMsg.type();
   }
 }
 

--- a/apps/extension/src/test/init.ts
+++ b/apps/extension/src/test/init.ts
@@ -24,7 +24,8 @@ import {
 import {
   ApprovalsService,
   init as initApprovals,
-  ApprovedOriginsStore
+  ApprovedOriginsStore,
+  TxStore,
 } from "../background/approvals";
 
 import { Namada } from "provider";
@@ -77,7 +78,7 @@ export const init = async (): Promise<{
   const revealedPKStore = new KVStoreMock<string[]>(KVPrefix.RevealedPK);
   const namadaRouterId = await getNamadaRouterId(extStore);
   const requester = new ExtensionRequester(messenger, namadaRouterId);
-  const txStore = new KVStoreMock<string>(KVPrefix.LocalStorage);
+  const txStore = new KVStoreMock<TxStore>(KVPrefix.LocalStorage);
   const broadcaster = new ExtensionBroadcaster(
     connectedTabsStore,
     chainId,

--- a/apps/extension/src/utils/index.ts
+++ b/apps/extension/src/utils/index.ts
@@ -5,20 +5,12 @@ import {
   DerivedAccount,
   Message,
   SignatureMsgValue,
-  SubmitBondMsgValue,
-  SubmitUnbondMsgValue,
-  SubmitWithdrawMsgValue,
-  TransferMsgValue,
   TxProps,
   TxMsgValue,
-  IbcTransferMsgValue,
 } from "@namada/types";
 import { pick } from "@namada/utils";
 import { AccountStore } from "background/keyring";
 import { ISignature } from "@namada/ledger-namada";
-import { TxType } from "@namada/shared";
-import { deserialize } from "@dao-xyz/borsh";
-import { fromBase64 } from "@cosmjs/encoding";
 
 /**
  * Query the current extension tab and close it
@@ -94,35 +86,10 @@ export const encodeTx = (tx: TxProps): Uint8Array => {
   return msg.encode(txMsgValue);
 };
 
-/**
- * Helper to get encoded Tx information by TxType
- */
-export const getEncodedTxByType = (
-  txType: TxType,
-  txMsg: string
-): Uint8Array => {
-  switch (txType) {
-    case TxType.Transfer: {
-      const { tx } = deserialize(fromBase64(txMsg), TransferMsgValue);
-      return encodeTx(tx);
+export const validateProps = <T,>(object: T, props: (keyof T)[]): void => {
+  props.forEach(prop => {
+    if (!object[prop]) {
+      throw new Error(`${String(prop)} was not provided!`);
     }
-    case TxType.IBCTransfer: {
-      const { tx } = deserialize(fromBase64(txMsg), IbcTransferMsgValue);
-      return encodeTx(tx);
-    }
-    case TxType.Bond: {
-      const { tx } = deserialize(fromBase64(txMsg), SubmitBondMsgValue);
-      return encodeTx(tx);
-    }
-    case TxType.Unbond: {
-      const { tx } = deserialize(fromBase64(txMsg), SubmitUnbondMsgValue);
-      return encodeTx(tx);
-    }
-    case TxType.Withdraw: {
-      const { tx } = deserialize(fromBase64(txMsg), SubmitWithdrawMsgValue);
-      return encodeTx(tx);
-    }
-    default:
-      throw new Error("Valid txType not provided!");
-  }
-};
+  });
+}

--- a/apps/namada-interface/src/App/Token/EthereumBridge/EthereumBridge.tsx
+++ b/apps/namada-interface/src/App/Token/EthereumBridge/EthereumBridge.tsx
@@ -84,19 +84,19 @@ export const EthereumBridge = (): JSX.Element => {
       {
         bridgeProps: {
           nut: Boolean(Tokens[tokenSymbol as TokenType]?.isNut),
-          tx: {
-            token: Tokens.NAM.address || "",
-            feeAmount: new BigNumber(0),
-            gasLimit: new BigNumber(20_000),
-            publicKey: account.details.publicKey,
-            chainId,
-          },
           asset: Tokens[tokenSymbol as TokenType]?.nativeAddress || "",
           recipient,
           sender: account.details.address,
           amount,
           feeAmount,
           feeToken: Tokens[feeTokenSymbol as TokenType]?.address || "",
+        },
+        txProps: {
+          token: Tokens.NAM.address || "",
+          feeAmount: new BigNumber(0),
+          gasLimit: new BigNumber(20_000),
+          publicKey: account.details.publicKey,
+          chainId,
         },
       },
       account.details.type

--- a/apps/namada-interface/src/App/Token/IBCTransfer/IBCTransfer.tsx
+++ b/apps/namada-interface/src/App/Token/IBCTransfer/IBCTransfer.tsx
@@ -58,19 +58,19 @@ export const submitIbcTransfer = async (
   await integration.submitBridgeTransfer(
     {
       ibcProps: {
-        tx: {
-          token: Tokens.NAM.address || "",
-          feeAmount: new BigNumber(0),
-          gasLimit: new BigNumber(20_000),
-          publicKey,
-          chainId,
-        },
         source: address,
         receiver: target,
         token,
         amount,
         portId,
         channelId,
+      },
+      txProps: {
+        token: Tokens.NAM.address || "",
+        feeAmount: new BigNumber(0),
+        gasLimit: new BigNumber(20_000),
+        publicKey,
+        chainId,
       },
     },
     type

--- a/apps/namada-interface/src/App/Token/TokenSend/TokenSendForm.tsx
+++ b/apps/namada-interface/src/App/Token/TokenSend/TokenSendForm.tsx
@@ -60,7 +60,7 @@ const getColor = (
 };
 
 export const submitTransferTransaction = async (
-  txArgs: TxTransferArgs
+  txTransferArgs: TxTransferArgs
 ): Promise<void> => {
   const {
     account: { address, chainId, publicKey, type },
@@ -68,19 +68,11 @@ export const submitTransferTransaction = async (
     faucet,
     target,
     token,
-  } = txArgs;
+  } = txTransferArgs;
   const integration = getIntegration(chainId);
   const signer = integration.signer() as Signer;
 
   const transferArgs = {
-    tx: {
-      token: Tokens.NAM.address || "",
-      feeAmount: new BigNumber(0),
-      gasLimit: new BigNumber(20_000),
-      chainId,
-      publicKey: publicKey,
-      signer: faucet ? target : undefined,
-    },
     source: faucet || address,
     target,
     token: Tokens[token].address || Tokens.NAM.address || "",
@@ -88,7 +80,16 @@ export const submitTransferTransaction = async (
     nativeToken: Tokens.NAM.address || "",
   };
 
-  await signer.submitTransfer(transferArgs, type);
+  const txArgs = {
+    token: Tokens.NAM.address || "",
+    feeAmount: new BigNumber(0),
+    gasLimit: new BigNumber(20_000),
+    chainId,
+    publicKey: publicKey,
+    signer: faucet ? target : undefined,
+  };
+
+  await signer.submitTransfer(transferArgs, txArgs, type);
 };
 
 type Props = {

--- a/apps/namada-interface/src/slices/StakingAndGovernance/actions.ts
+++ b/apps/namada-interface/src/slices/StakingAndGovernance/actions.ts
@@ -246,13 +246,13 @@ export const postNewBonding = createAsyncThunk<
       validator,
       amount: new BigNumber(amount),
       nativeToken: Tokens.NAM.address || "",
-      tx: {
-        token: Tokens.NAM.address || "",
-        feeAmount: new BigNumber(0),
-        gasLimit: new BigNumber(20_000),
-        chainId,
-        publicKey,
-      },
+    },
+    {
+      token: Tokens.NAM.address || "",
+      feeAmount: new BigNumber(0),
+      gasLimit: new BigNumber(20_000),
+      chainId,
+      publicKey,
     },
     type
   );
@@ -282,13 +282,13 @@ export const postNewUnbonding = createAsyncThunk<
       source,
       validator,
       amount: new BigNumber(amount),
-      tx: {
-        token: Tokens.NAM.address || "",
-        feeAmount: new BigNumber(0),
-        gasLimit: new BigNumber(20_000),
-        chainId,
-        publicKey,
-      },
+    },
+    {
+      token: Tokens.NAM.address || "",
+      feeAmount: new BigNumber(0),
+      gasLimit: new BigNumber(20_000),
+      chainId,
+      publicKey,
     },
     type
   );
@@ -311,13 +311,13 @@ export const postNewWithdraw = createAsyncThunk<
     {
       source: owner,
       validator: validatorId,
-      tx: {
-        token: Tokens.NAM.address || "",
-        feeAmount: new BigNumber(0),
-        gasLimit: new BigNumber(20_000),
-        chainId,
-        publicKey,
-      },
+    },
+    {
+      token: Tokens.NAM.address || "",
+      feeAmount: new BigNumber(0),
+      gasLimit: new BigNumber(20_000),
+      chainId,
+      publicKey,
     },
     type
   );

--- a/packages/integrations/src/Keplr.ts
+++ b/packages/integrations/src/Keplr.ts
@@ -148,8 +148,8 @@ class Keplr implements Integration<Account, OfflineSigner> {
         amount,
         portId = "transfer",
         channelId,
-        tx: { feeAmount }
       } = props.ibcProps;
+      const { feeAmount } = props.txProps;
 
       const client = await SigningStargateClient.connectWithSigner(
         this.chain.rpc,

--- a/packages/integrations/src/Namada.ts
+++ b/packages/integrations/src/Namada.ts
@@ -53,9 +53,9 @@ export default class Namada implements Integration<Account, Signer> {
   ): Promise<void> {
     const signer = this._namada?.getSigner(this.chain.chainId);
     if (props.ibcProps) {
-      return await signer?.submitIbcTransfer(props.ibcProps, type);
+      return await signer?.submitIbcTransfer(props.ibcProps, props.txProps, type);
     } else if (props.bridgeProps) {
-      return await signer?.submitEthBridgeTransfer(props.bridgeProps, type);
+      return await signer?.submitEthBridgeTransfer(props.bridgeProps, props.txProps, type);
     }
 
     return Promise.reject("Invalid bridge transfer props!");

--- a/packages/integrations/src/types/Integration.ts
+++ b/packages/integrations/src/types/Integration.ts
@@ -3,11 +3,13 @@ import {
   BridgeTransferProps,
   IbcTransferProps,
   TokenBalance,
+  TxProps,
 } from "@namada/types";
 
 export type BridgeProps = {
   ibcProps?: IbcTransferProps;
   bridgeProps?: BridgeTransferProps;
+  txProps: TxProps;
 };
 
 export interface Integration<T, S> {

--- a/packages/shared/lib/src/sdk/mod.rs
+++ b/packages/shared/lib/src/sdk/mod.rs
@@ -39,6 +39,20 @@ pub enum TxType {
     RevealPK = 7,
 }
 
+#[wasm_bindgen]
+pub struct BuiltTx {
+    tx: Tx,
+    signing_data: SigningTxData,
+    is_faucet_transfer: bool
+}
+
+#[wasm_bindgen]
+impl BuiltTx {
+    pub fn tx_bytes(&self) -> Result<Vec<u8>, JsError> {
+        Ok(self.tx.try_to_vec()?)
+    }
+}
+
 /// Represents the Sdk public API.
 #[wasm_bindgen]
 pub struct Sdk {
@@ -112,14 +126,19 @@ impl Sdk {
         wallet::add_spending_key(&mut self.wallet, xsk, password, alias)
     }
 
-    /// Sign and submit transactions
-    async fn sign_and_process_tx(
+    pub async fn sign_tx(
         &mut self,
-        args: args::Tx,
-        mut tx: Tx,
-        signing_data: SigningTxData,
-        is_faucet_transfer: bool,
-    ) -> Result<(), JsError> {
+        built_tx: BuiltTx,
+        tx_msg: &[u8]
+    ) -> Result<JsValue, JsError> {
+        let BuiltTx {
+            mut tx,
+            signing_data,
+            is_faucet_transfer
+        } = built_tx;
+
+        let args = tx::tx_args_from_slice(tx_msg)?;
+
         // We are revealing the signer of this transaction(if needed)
         // We only support one signer(for now)
         let pk = &signing_data
@@ -131,7 +150,7 @@ impl Sdk {
 
         let address = Address::from(pk);
 
-        if !is_faucet_transfer && is_reveal_pk_needed(&self.client, &address, false).await? {
+        let reveal_pk_tx_bytes = if !is_faucet_transfer && is_reveal_pk_needed(&self.client, &address, false).await? {
             let (mut tx, _) = build_reveal_pk::<_, _, _, WebIo>(
                 &self.client,
                 &mut self.wallet,
@@ -145,154 +164,69 @@ impl Sdk {
 
             sign_tx(&mut self.wallet, &args, &mut tx, signing_data.clone())?;
 
-            process_tx::<_, _, WebIo>(&self.client, &mut self.wallet, &args, tx).await?;
-        }
+            let bytes = tx.try_to_vec()?;
+
+            Some(bytes)
+        } else {
+            None
+        };
 
         // Sign tx
         sign_tx(&mut self.wallet, &args, &mut tx, signing_data.clone())?;
 
-        // Submit tx
+        to_js_result((tx.try_to_vec()?, reveal_pk_tx_bytes))
+    }
+
+    pub async fn process_tx(
+        &mut self,
+        tx_bytes: &[u8],
+        tx_msg: &[u8],
+        reveal_pk_tx_bytes: Option<Vec<u8>>
+    ) -> Result<(), JsError> {
+        let args = tx::tx_args_from_slice(tx_msg)?;
+
+        if let Some(bytes) = reveal_pk_tx_bytes {
+            let reveal_pk_tx = Tx::try_from_slice(bytes.as_slice())?;
+            process_tx::<_, _, WebIo>(&self.client, &mut self.wallet, &args, reveal_pk_tx).await?;
+        }
+
+        let tx = Tx::try_from_slice(tx_bytes)?;
         process_tx::<_, _, WebIo>(&self.client, &mut self.wallet, &args, tx).await?;
 
         Ok(())
     }
 
-    /// Submit signed reveal pk tx
-    pub async fn submit_signed_reveal_pk(
-        &mut self,
-        tx_msg: &[u8],
-        tx_bytes: &[u8],
-        sig_msg_bytes: &[u8],
-    ) -> Result<(), JsError> {
-        let reveal_pk_tx = self.sign_tx(tx_bytes, sig_msg_bytes)?;
-        let args = tx::tx_args_from_slice(&tx_msg)?;
-
-        process_tx::<_, _, WebIo>(&self.client, &mut self.wallet, &args, reveal_pk_tx).await?;
-
-        Ok(())
-    }
 
     /// Build transaction for specified type, return bytes to client
     pub async fn build_tx(
         &mut self,
         tx_type: TxType,
+        specific_msg: &[u8],
         tx_msg: &[u8],
         gas_payer: String,
     ) -> Result<JsValue, JsError> {
-        //TODO: verify if this works
-        // We prefix 00 because PublicKey is an enum. TODO: fix when ledger is updated to handle
-        // payment addresses
-        let gas_payer = PublicKey::from_str(&format!("00{}", gas_payer))?;
-
         let tx = match tx_type {
-            TxType::Bond => {
-                let (args, _) = tx::bond_tx_args(tx_msg, None)?;
-                let (bond, _) = build_bond::<_, _, _, WebIo>(
-                    &self.client,
-                    &mut self.wallet,
-                    &mut self.shielded_ctx,
-                    args.clone(),
-                    gas_payer,
-                )
-                .await
-                .map_err(JsError::from)?;
-                bond
-            }
-            TxType::RevealPK => {
-                let args = tx::tx_args_from_slice(tx_msg)?;
-
-                let public_key = match args.verification_key.clone() {
-                    Some(v) => PublicKey::from(v),
-                    _ => {
-                        return Err(JsError::new(
-                            "verification_key is required in this context!",
-                        ))
-                    }
-                };
-
-                let address = Address::from(&public_key);
-
-                let (reveal_pk, _) = build_reveal_pk::<_, _, _, WebIo>(
-                    &self.client,
-                    &mut self.wallet,
-                    &mut self.shielded_ctx,
-                    &args.clone(),
-                    &address,
-                    &public_key,
-                    &gas_payer,
-                )
-                .await?;
-                reveal_pk
-            }
-            TxType::Transfer => {
-                let (args, _faucet_signer) = tx::transfer_tx_args(tx_msg, None, None)?;
-                let (tx, _) = build_transfer::<_, _, _, WebIo>(
-                    &self.client,
-                    &mut self.wallet,
-                    &mut self.shielded_ctx,
-                    args.clone(),
-                    gas_payer,
-                )
-                .await?;
-                tx
-            }
-            TxType::IBCTransfer => {
-                let (args, _faucet_signer) = tx::ibc_transfer_tx_args(tx_msg, None)?;
-
-                let (tx, _) = build_ibc_transfer::<_, _, _, WebIo>(
-                    &self.client,
-                    &mut self.wallet,
-                    &mut self.shielded_ctx,
-                    args.clone(),
-                    gas_payer,
-                )
-                .await?;
-                tx
-            }
-            TxType::EthBridgeTransfer => {
-                let (args, _faucet_signer) = tx::eth_bridge_transfer_tx_args(tx_msg, None)?;
-
-                let (tx, _) = build_bridge_pool_tx::<_, _, _, WebIo>(
-                    &self.client,
-                    &mut self.wallet,
-                    &mut self.shielded_ctx,
-                    args.clone(),
-                    gas_payer,
-                )
-                .await?;
-                tx
-            }
-            TxType::Unbond => {
-                let (args, _faucet_signer) = tx::unbond_tx_args(tx_msg, None)?;
-                let (tx, _, _) = build_unbond::<_, _, _, WebIo>(
-                    &self.client,
-                    &mut self.wallet,
-                    &mut self.shielded_ctx,
-                    args.clone(),
-                    gas_payer,
-                )
-                .await?;
-                tx
-            }
-            TxType::Withdraw => {
-                let (args, _faucet_signer) = tx::withdraw_tx_args(tx_msg, None)?;
-                let (withdraw, _) = build_withdraw::<_, _, _, WebIo>(
-                    &self.client,
-                    &mut self.wallet,
-                    &mut self.shielded_ctx,
-                    args.clone(),
-                    gas_payer,
-                )
-                .await?;
-                withdraw
-            }
+            TxType::Bond =>
+                self.build_bond(specific_msg, tx_msg, None, Some(gas_payer)).await?.tx,
+            TxType::Unbond =>
+                self.build_unbond(specific_msg, tx_msg, None, Some(gas_payer)).await?.tx,
+            TxType::Withdraw =>
+                self.build_withdraw(specific_msg, tx_msg, None, Some(gas_payer)).await?.tx,
+            TxType::Transfer =>
+                self.build_transfer(specific_msg, tx_msg, None, None, Some(gas_payer)).await?.tx,
+            TxType::IBCTransfer =>
+                self.build_ibc_transfer(specific_msg, tx_msg, None, Some(gas_payer)).await?.tx,
+            TxType::EthBridgeTransfer =>
+                self.build_eth_bridge_transfer(specific_msg, tx_msg, None, Some(gas_payer)).await?.tx,
+            TxType::RevealPK =>
+                self.build_reveal_pk(tx_msg, gas_payer).await?,
         };
 
         to_js_result(tx.try_to_vec()?)
     }
 
     // Append signatures and return tx bytes
-    fn sign_tx(&self, tx_bytes: &[u8], sig_msg_bytes: &[u8]) -> Result<Tx, JsError> {
+    pub fn append_signature(&self, tx_bytes: &[u8], sig_msg_bytes: &[u8]) -> Result<JsValue, JsError> {
         let mut tx: Tx = Tx::try_from_slice(tx_bytes)?;
         let signature::SignatureMsg {
             pubkey,
@@ -316,221 +250,291 @@ impl Sdk {
 
         tx.protocol_filter();
 
-        Ok(tx)
+        to_js_result(tx.try_to_vec()?)
     }
 
-    /// Submit signed tx
-    pub async fn submit_signed_tx(
+    async fn signing_data_and_fee_payer(
         &mut self,
-        tx_msg: &[u8],
-        tx_bytes: &[u8],
-        sig_msg_bytes: &[u8],
-    ) -> Result<(), JsError> {
-        let transfer_tx = self.sign_tx(tx_bytes, sig_msg_bytes)?;
-        let args = tx::tx_args_from_slice(tx_msg)?;
-
-        process_tx::<_, _, WebIo>(&self.client, &mut self.wallet, &args, transfer_tx).await?;
-
-        Ok(())
-    }
-
-    pub async fn submit_transfer(
-        &mut self,
-        tx_msg: &[u8],
-        password: Option<String>,
-        xsk: Option<String>,
-    ) -> Result<(), JsError> {
-        let (args, faucet_signer) = tx::transfer_tx_args(tx_msg, password, xsk)?;
-        let effective_address = args.source.effective_address();
-        let default_signer = faucet_signer.clone().or(Some(effective_address.clone()));
-
+        args: &args::Tx,
+        owner: Option<Address>,
+        default_signer: Option<Address>,
+        gas_payer: Option<String>
+    ) -> Result<(SigningTxData, PublicKey), JsError> {
         let signing_data = aux_signing_data::<_, _, WebIo>(
             &self.client,
             &mut self.wallet,
-            &args.tx.clone(),
-            Some(effective_address.clone()),
+            args,
+            owner,
             default_signer,
         )
         .await?;
+
+        let fee_payer = match gas_payer {
+            Some(gas_payer) =>
+                //TODO: verify if this works
+                // We prefix 00 because PublicKey is an enum.
+                // TODO: fix when ledger is updated to handle payment addresses
+                PublicKey::from_str(&format!("00{}", gas_payer))?,
+            None =>
+                signing_data.fee_payer.clone()
+        };
+
+        Ok((signing_data, fee_payer))
+    }
+
+    pub async fn build_transfer(
+        &mut self,
+        transfer_msg: &[u8],
+        tx_msg: &[u8],
+        password: Option<String>,
+        xsk: Option<String>,
+        gas_payer: Option<String>
+    ) -> Result<BuiltTx, JsError> {
+        let (args, faucet_signer) =
+            tx::transfer_tx_args(transfer_msg, tx_msg, password, xsk)?;
+
+        let effective_address = args.source.effective_address();
+        let default_signer = faucet_signer.clone().or(Some(effective_address.clone()));
+
+        let (signing_data, fee_payer) = self.signing_data_and_fee_payer(
+            &args.tx,
+            Some(effective_address.clone()),
+            default_signer,
+            gas_payer
+        ).await?;
 
         let (tx, _) = build_transfer::<_, _, _, WebIo>(
             &self.client,
             &mut self.wallet,
             &mut self.shielded_ctx,
             args.clone(),
-            signing_data.fee_payer.clone(),
+            fee_payer,
         )
         .await?;
 
-        self.sign_and_process_tx(args.tx, tx, signing_data, faucet_signer.is_some())
-            .await?;
-
-        Ok(())
+        Ok(BuiltTx {
+            tx,
+            signing_data,
+            is_faucet_transfer: faucet_signer.is_some()
+        })
     }
 
-    pub async fn submit_ibc_transfer(
+    pub async fn build_ibc_transfer(
         &mut self,
+        ibc_transfer_msg: &[u8],
         tx_msg: &[u8],
         password: Option<String>,
-    ) -> Result<(), JsError> {
-        let (args, faucet_signer) = tx::ibc_transfer_tx_args(tx_msg, password)?;
+        gas_payer: Option<String>
+    ) -> Result<BuiltTx, JsError> {
+        let (args, faucet_signer) =
+            tx::ibc_transfer_tx_args(ibc_transfer_msg, tx_msg, password)?;
+
         let source = args.source.clone();
         let default_signer = faucet_signer.clone().or(Some(source.clone()));
 
-        let signing_data = aux_signing_data::<_, _, WebIo>(
-            &self.client,
-            &mut self.wallet,
-            &args.tx.clone(),
-            Some(source.clone()),
+        let (signing_data, fee_payer) = self.signing_data_and_fee_payer(
+            &args.tx,
+            Some(source),
             default_signer,
-        )
-        .await?;
+            gas_payer
+        ).await?;
 
         let (tx, _) = build_ibc_transfer::<_, _, _, WebIo>(
             &self.client,
             &mut self.wallet,
             &mut self.shielded_ctx,
             args.clone(),
-            signing_data.fee_payer.clone(),
+            fee_payer
         )
         .await?;
 
-        self.sign_and_process_tx(args.tx, tx, signing_data, faucet_signer.is_some())
-            .await?;
-
-        Ok(())
+        Ok(BuiltTx {
+            tx,
+            signing_data,
+            is_faucet_transfer: faucet_signer.is_some()
+        })
     }
 
-    pub async fn submit_eth_bridge_transfer(
+    pub async fn build_eth_bridge_transfer(
         &mut self,
+        eth_bridge_transfer_msg: &[u8],
         tx_msg: &[u8],
         password: Option<String>,
-    ) -> Result<(), JsError> {
-        let (args, faucet_signer) = tx::eth_bridge_transfer_tx_args(tx_msg, password)?;
+        gas_payer: Option<String>
+    ) -> Result<BuiltTx, JsError> {
+        let (args, faucet_signer) =
+            tx::eth_bridge_transfer_tx_args(eth_bridge_transfer_msg, tx_msg, password)?;
+
         let sender = args.sender.clone();
         let default_signer = faucet_signer.clone().or(Some(sender.clone()));
 
-        let signing_data = aux_signing_data::<_, _, WebIo>(
-            &self.client,
-            &mut self.wallet,
-            &args.tx.clone(),
-            Some(sender.clone()),
+        let (signing_data, fee_payer) = self.signing_data_and_fee_payer(
+            &args.tx,
+            Some(sender),
             default_signer,
-        )
-        .await?;
+            gas_payer
+        ).await?;
 
         let (tx, _) =
-            namada::ledger::eth_bridge::bridge_pool::build_bridge_pool_tx::<_, _, _, WebIo>(
+            build_bridge_pool_tx::<_, _, _, WebIo>(
                 &self.client,
                 &mut self.wallet,
                 &mut self.shielded_ctx,
                 args.clone(),
-                signing_data.fee_payer.clone(),
+                fee_payer,
             )
             .await?;
 
-        self.sign_and_process_tx(args.tx, tx, signing_data, faucet_signer.is_some())
-            .await?;
-
-        Ok(())
+        Ok(BuiltTx {
+            tx,
+            signing_data,
+            is_faucet_transfer: faucet_signer.is_some()
+        })
     }
 
-    pub async fn submit_bond(
+    pub async fn build_bond(
         &mut self,
+        bond_msg: &[u8],
         tx_msg: &[u8],
         password: Option<String>,
-    ) -> Result<(), JsError> {
-        let (args, faucet_signer) = tx::bond_tx_args(tx_msg, password)?;
+        gas_payer: Option<String>
+    ) -> Result<BuiltTx, JsError> {
+        let (args, faucet_signer) =
+            tx::bond_tx_args(bond_msg, tx_msg, password)?;
+
         let source = args.source.clone();
         let default_signer = faucet_signer.clone().or(source.clone());
 
-        let signing_data = aux_signing_data::<_, _, WebIo>(
-            &self.client,
-            &mut self.wallet,
-            &args.tx.clone(),
+        let (signing_data, fee_payer) = self.signing_data_and_fee_payer(
+            &args.tx,
             source,
             default_signer,
-        )
-        .await?;
+            gas_payer
+        ).await?;
 
         let (tx, _) = build_bond::<_, _, _, WebIo>(
             &mut self.client,
             &mut self.wallet,
             &mut self.shielded_ctx,
             args.clone(),
-            signing_data.fee_payer.clone(),
+            fee_payer,
         )
         .await?;
 
-        self.sign_and_process_tx(args.tx, tx, signing_data, faucet_signer.is_some())
-            .await?;
-
-        Ok(())
+        Ok(BuiltTx {
+            tx,
+            signing_data,
+            is_faucet_transfer: faucet_signer.is_some()
+        })
     }
 
-    /// Submit unbond
-    pub async fn submit_unbond(
+    pub async fn build_unbond(
         &mut self,
+        unbond_msg: &[u8],
         tx_msg: &[u8],
         password: Option<String>,
-    ) -> Result<(), JsError> {
-        let (args, faucet_signer) = tx::unbond_tx_args(tx_msg, password)?;
+        gas_payer: Option<String>
+    ) -> Result<BuiltTx, JsError> {
+        let (args, faucet_signer) =
+            tx::unbond_tx_args(unbond_msg, tx_msg, password)?;
+
         let source = args.source.clone();
         let default_signer = faucet_signer.clone().or(source.clone());
-        let signing_data = aux_signing_data::<_, _, WebIo>(
-            &self.client,
-            &mut self.wallet,
-            &args.tx.clone(),
+
+        let (signing_data, fee_payer) = self.signing_data_and_fee_payer(
+            &args.tx,
             source,
             default_signer,
-        )
-        .await?;
+            gas_payer
+        ).await?;
 
         let (tx, _, _) = build_unbond::<_, _, _, WebIo>(
             &mut self.client,
             &mut self.wallet,
             &mut self.shielded_ctx,
             args.clone(),
-            signing_data.fee_payer.clone(),
+            fee_payer,
         )
         .await?;
 
-        self.sign_and_process_tx(args.tx, tx, signing_data, faucet_signer.is_some())
-            .await?;
-
-        Ok(())
+        Ok(BuiltTx {
+            tx,
+            signing_data,
+            is_faucet_transfer: faucet_signer.is_some()
+        })
     }
 
-    pub async fn submit_withdraw(
+    pub async fn build_withdraw(
         &mut self,
+        withdraw_msg: &[u8],
         tx_msg: &[u8],
         password: Option<String>,
-    ) -> Result<(), JsError> {
-        let (args, faucet_signer) = tx::withdraw_tx_args(tx_msg, password)?;
+        gas_payer: Option<String>
+    ) -> Result<BuiltTx, JsError> {
+        let (args, faucet_signer) =
+            tx::withdraw_tx_args(withdraw_msg, tx_msg, password)?;
+
         let source = args.source.clone();
         let default_signer = faucet_signer.clone().or(source.clone());
-        let signing_data = aux_signing_data::<_, _, WebIo>(
-            &self.client,
-            &mut self.wallet,
-            &args.tx.clone(),
+
+        let (signing_data, fee_payer) = self.signing_data_and_fee_payer(
+            &args.tx,
             source,
             default_signer,
-        )
-        .await?;
+            gas_payer
+        ).await?;
 
         let (tx, _) = build_withdraw::<_, _, _, WebIo>(
             &mut self.client,
             &mut self.wallet,
             &mut self.shielded_ctx,
             args.clone(),
-            signing_data.fee_payer.clone(),
+            fee_payer,
         )
         .await?;
 
-        self.sign_and_process_tx(args.tx, tx, signing_data, faucet_signer.is_some())
-            .await?;
+        Ok(BuiltTx {
+            tx,
+            signing_data,
+            is_faucet_transfer: faucet_signer.is_some()
+        })
+    }
 
-        Ok(())
+    async fn build_reveal_pk(
+        &mut self,
+        tx_msg: &[u8],
+        gas_payer: String,
+    ) -> Result<Tx, JsError> {
+         //TODO: verify if this works
+         // We prefix 00 because PublicKey is an enum.
+         // TODO: fix when ledger is updated to handle payment addresses
+        let gas_payer = PublicKey::from_str(&format!("00{}", gas_payer))?;
+
+        let args = tx::tx_args_from_slice(tx_msg)?;
+
+        let public_key = match args.verification_key.clone() {
+            Some(v) => PublicKey::from(v),
+            _ => {
+                return Err(JsError::new(
+                    "verification_key is required in this context!",
+                ))
+            }
+        };
+
+        let address = Address::from(&public_key);
+
+        let (reveal_pk, _) = build_reveal_pk::<_, _, _, WebIo>(
+            &self.client,
+            &mut self.wallet,
+            &mut self.shielded_ctx,
+            &args.clone(),
+            &address,
+            &public_key,
+            &gas_payer,
+        )
+        .await?;
+
+        Ok(reveal_pk)
     }
 }
 

--- a/packages/shared/lib/src/sdk/tx.rs
+++ b/packages/shared/lib/src/sdk/tx.rs
@@ -33,7 +33,6 @@ pub struct SubmitBondMsg {
     validator: String,
     amount: String,
     native_token: String,
-    tx: TxMsg,
 }
 
 /// Maps serialized tx_msg into BondTx args.
@@ -48,24 +47,24 @@ pub struct SubmitBondMsg {
 /// Returns JsError if the tx_msg can't be deserialized or
 /// Rust structs can't be created.
 pub fn bond_tx_args(
+    bond_msg: &[u8],
     tx_msg: &[u8],
     password: Option<String>,
 ) -> Result<(args::Bond, Option<Address>), JsError> {
-    let tx_msg = SubmitBondMsg::try_from_slice(tx_msg)?;
+    let bond_msg = SubmitBondMsg::try_from_slice(bond_msg)?;
 
     let SubmitBondMsg {
         native_token,
         source,
         validator,
         amount,
-        tx,
-    } = tx_msg;
+    } = bond_msg;
 
     let source = Address::from_str(&source)?;
     let native_token = Address::from_str(&native_token)?;
     let validator = Address::from_str(&validator)?;
     let amount = Amount::from_str(&amount, NATIVE_MAX_DECIMAL_PLACES)?;
-    let (tx, faucet_signer) = tx_msg_into_args(tx, password)?;
+    let (tx, faucet_signer) = tx_msg_into_args(tx_msg, password)?;
 
     let args = args::Bond {
         tx,
@@ -84,7 +83,6 @@ pub struct SubmitUnbondMsg {
     source: String,
     validator: String,
     amount: String,
-    tx: TxMsg,
 }
 
 /// Maps serialized tx_msg into UnbondTx args.
@@ -99,23 +97,23 @@ pub struct SubmitUnbondMsg {
 /// Returns JsError if the tx_msg can't be deserialized or
 /// Rust structs can't be created.
 pub fn unbond_tx_args(
+    unbond_msg: &[u8],
     tx_msg: &[u8],
     password: Option<String>,
 ) -> Result<(args::Unbond, Option<Address>), JsError> {
-    let tx_msg = SubmitUnbondMsg::try_from_slice(tx_msg)?;
+    let unbond_msg = SubmitUnbondMsg::try_from_slice(unbond_msg)?;
 
     let SubmitUnbondMsg {
         source,
         validator,
         amount,
-        tx,
-    } = tx_msg;
+    } = unbond_msg;
 
     let source = Address::from_str(&source)?;
     let validator = Address::from_str(&validator)?;
 
     let amount = Amount::from_str(&amount, NATIVE_MAX_DECIMAL_PLACES)?;
-    let (tx, faucet_signer) = tx_msg_into_args(tx, password)?;
+    let (tx, faucet_signer) = tx_msg_into_args(tx_msg, password)?;
 
     let args = args::Unbond {
         tx,
@@ -132,7 +130,6 @@ pub fn unbond_tx_args(
 pub struct SubmitWithdrawMsg {
     source: String,
     validator: String,
-    tx: TxMsg,
 }
 
 /// Maps serialized tx_msg into WithdrawTx args.
@@ -147,20 +144,20 @@ pub struct SubmitWithdrawMsg {
 /// Returns JsError if the tx_msg can't be deserialized or
 /// Rust structs can't be created.
 pub fn withdraw_tx_args(
+    withdraw_msg: &[u8],
     tx_msg: &[u8],
     password: Option<String>,
 ) -> Result<(args::Withdraw, Option<Address>), JsError> {
-    let tx_msg = SubmitWithdrawMsg::try_from_slice(tx_msg)?;
+    let withdraw_msg = SubmitWithdrawMsg::try_from_slice(withdraw_msg)?;
 
     let SubmitWithdrawMsg {
         source,
         validator,
-        tx,
-    } = tx_msg;
+    } = withdraw_msg;
 
     let source = Address::from_str(&source)?;
     let validator = Address::from_str(&validator)?;
-    let (tx, faucet_signer) = tx_msg_into_args(tx, password)?;
+    let (tx, faucet_signer) = tx_msg_into_args(tx_msg, password)?;
 
     let args = args::Withdraw {
         tx,
@@ -174,7 +171,6 @@ pub fn withdraw_tx_args(
 
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct SubmitTransferMsg {
-    tx: TxMsg,
     source: String,
     target: String,
     token: String,
@@ -194,19 +190,19 @@ pub struct SubmitTransferMsg {
 /// Returns JsError if the tx_msg can't be deserialized or
 /// Rust structs can't be created.
 pub fn transfer_tx_args(
+    transfer_msg: &[u8],
     tx_msg: &[u8],
     password: Option<String>,
     xsk: Option<String>,
 ) -> Result<(args::TxTransfer, Option<Address>), JsError> {
-    let tx_msg = SubmitTransferMsg::try_from_slice(tx_msg)?;
+    let transfer_msg = SubmitTransferMsg::try_from_slice(transfer_msg)?;
     let SubmitTransferMsg {
-        tx,
         source,
         target,
         token,
         amount,
         native_token,
-    } = tx_msg;
+    } = transfer_msg;
 
     let source = match Address::from_str(&source) {
         Ok(v) => Ok(TransferSource::Address(v)),
@@ -236,7 +232,7 @@ pub fn transfer_tx_args(
     let token = Address::from_str(&token)?;
     let denom_amount = DenominatedAmount::from_str(&amount).expect("Amount to be valid.");
     let amount = InputAmount::Unvalidated(denom_amount);
-    let (tx, faucet_signer) = tx_msg_into_args(tx, password)?;
+    let (tx, faucet_signer) = tx_msg_into_args(tx_msg, password)?;
 
     let args = args::TxTransfer {
         tx,
@@ -253,7 +249,6 @@ pub fn transfer_tx_args(
 
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct SubmitIbcTransferMsg {
-    tx: TxMsg,
     source: String,
     receiver: String,
     token: String,
@@ -276,12 +271,12 @@ pub struct SubmitIbcTransferMsg {
 /// Returns JsError if the tx_msg can't be deserialized or
 /// Rust structs can't be created.
 pub fn ibc_transfer_tx_args(
+    ibc_transfer_msg: &[u8],
     tx_msg: &[u8],
     password: Option<String>,
 ) -> Result<(args::TxIbcTransfer, Option<Address>), JsError> {
-    let tx_msg = SubmitIbcTransferMsg::try_from_slice(tx_msg)?;
+    let ibc_transfer_msg = SubmitIbcTransferMsg::try_from_slice(ibc_transfer_msg)?;
     let SubmitIbcTransferMsg {
-        tx,
         source,
         receiver,
         token,
@@ -290,7 +285,7 @@ pub fn ibc_transfer_tx_args(
         channel_id,
         timeout_height,
         timeout_sec_offset,
-    } = tx_msg;
+    } = ibc_transfer_msg;
 
     let source = Address::from_str(&source)?;
     let token = Address::from_str(&token)?;
@@ -298,7 +293,7 @@ pub fn ibc_transfer_tx_args(
     let amount = InputAmount::Unvalidated(denom_amount);
     let port_id = PortId::from_str(&port_id).expect("Port id to be valid");
     let channel_id = ChannelId::from_str(&channel_id).expect("Channel id to be valid");
-    let (tx, faucet_signer) = tx_msg_into_args(tx, password)?;
+    let (tx, faucet_signer) = tx_msg_into_args(tx_msg, password)?;
 
     let args = args::TxIbcTransfer {
         tx,
@@ -320,7 +315,6 @@ pub fn ibc_transfer_tx_args(
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct SubmitEthBridgeTransferMsg {
     nut: bool,
-    tx: TxMsg,
     asset: String,
     recipient: String,
     sender: String,
@@ -331,13 +325,13 @@ pub struct SubmitEthBridgeTransferMsg {
 }
 
 pub fn eth_bridge_transfer_tx_args(
+    eth_bridge_transfer_msg: &[u8],
     tx_msg: &[u8],
     password: Option<String>,
 ) -> Result<(args::EthereumBridgePool, Option<Address>), JsError> {
-    let tx_msg = SubmitEthBridgeTransferMsg::try_from_slice(tx_msg)?;
+    let eth_bridge_transfer_msg = SubmitEthBridgeTransferMsg::try_from_slice(eth_bridge_transfer_msg)?;
     let SubmitEthBridgeTransferMsg {
         nut,
-        tx,
         asset,
         recipient,
         sender,
@@ -345,9 +339,9 @@ pub fn eth_bridge_transfer_tx_args(
         fee_amount,
         fee_payer,
         fee_token,
-    } = tx_msg;
+    } = eth_bridge_transfer_msg;
 
-    let (tx, faucet_signer) = tx_msg_into_args(tx, password)?;
+    let (tx, faucet_signer) = tx_msg_into_args(tx_msg, password)?;
     let asset = EthAddress::from_str(&asset).map_err(|e| JsError::new(&format!("{}", e)))?;
     let recipient =
         EthAddress::from_str(&recipient).map_err(|e| JsError::new(&format!("{}", e)))?;
@@ -377,8 +371,7 @@ pub fn eth_bridge_transfer_tx_args(
 }
 
 pub fn tx_args_from_slice(tx_msg_bytes: &[u8]) -> Result<args::Tx, JsError> {
-    let tx_msg = TxMsg::try_from_slice(tx_msg_bytes)?;
-    let (args, _) = tx_msg_into_args(tx_msg, None)?;
+    let (args, _) = tx_msg_into_args(tx_msg_bytes, None)?;
 
     Ok(args)
 }
@@ -395,9 +388,10 @@ pub fn tx_args_from_slice(tx_msg_bytes: &[u8]) -> Result<args::Tx, JsError> {
 ///
 /// Returns JsError if token address is invalid.
 fn tx_msg_into_args(
-    tx_msg: TxMsg,
+    tx_msg: &[u8],
     password: Option<String>,
 ) -> Result<(args::Tx, Option<Address>), JsError> {
+    let tx_msg = TxMsg::try_from_slice(tx_msg)?;
     let TxMsg {
         token,
         fee_amount,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,14 +5,14 @@ type TimeoutOpts = {
   // Timeout in miliseconds
   timeout?: number;
   // Error message
-  error?: string;
+  error?: (timeout: number) => string;
 };
 
 const DEFAULT_TIMEOUT = 60000;
 
-const DEFAULT_OPTS: TimeoutOpts = {
+const DEFAULT_OPTS: Required<TimeoutOpts> = {
   timeout: DEFAULT_TIMEOUT,
-  error: `Promise timed out after ${DEFAULT_TIMEOUT} ms.`,
+  error: timeout => `Promise timed out after ${timeout} ms.`,
 };
 
 /**
@@ -28,7 +28,7 @@ const promiseWithTimeout =
 
       return new Promise(async (resolve, reject) => {
         const t = setTimeout(() => {
-          reject(error);
+          reject(error(timeout));
         }, timeout);
 
         const res = await fn(...args);

--- a/packages/types/src/namada.ts
+++ b/packages/types/src/namada.ts
@@ -1,8 +1,14 @@
+import { SupportedTx } from "@namada/types";
 import { AccountType, DerivedAccount } from "./account";
 import { Chain } from "./chain";
 import { Signer } from "./signer";
 
-export type TxMsgProps = { txMsg: string; type: AccountType };
+export type TxMsgProps = {
+  txType: SupportedTx,
+  specificMsg: string;
+  txMsg: string;
+  type: AccountType
+};
 
 export interface Namada {
   connect(chainId: string): Promise<void>;
@@ -13,12 +19,7 @@ export interface Namada {
   suggestChain(chainConfig: Chain): Promise<void>;
   chain: (chainId: string) => Promise<Chain | undefined>;
   chains: () => Promise<Chain[] | undefined>;
-  submitBond: (props: TxMsgProps) => Promise<void>;
-  submitUnbond: (props: TxMsgProps) => Promise<void>;
-  submitWithdraw: (props: TxMsgProps) => Promise<void>;
-  submitTransfer: (props: TxMsgProps) => Promise<void>;
-  submitIbcTransfer: (props: TxMsgProps) => Promise<void>;
-  submitEthBridgeTransfer: (props: TxMsgProps) => Promise<void>;
+  submitTx: (props: TxMsgProps) => Promise<void>;
   version: () => string;
 }
 

--- a/packages/types/src/signer.ts
+++ b/packages/types/src/signer.ts
@@ -6,17 +6,19 @@ import {
   SubmitUnbondProps,
   SubmitWithdrawProps,
   TransferProps,
+  TxProps,
 } from "./tx";
 
 export interface Signer {
   accounts: () => Promise<Account[] | undefined>;
-  submitBond(args: SubmitBondProps, type: AccountType): Promise<void>;
-  submitUnbond(args: SubmitUnbondProps, type: AccountType): Promise<void>;
-  submitWithdraw(args: SubmitWithdrawProps, type: AccountType): Promise<void>;
-  submitTransfer(args: TransferProps, type: AccountType): Promise<void>;
-  submitIbcTransfer(args: IbcTransferProps, type: AccountType): Promise<void>;
+  submitBond(args: SubmitBondProps, txArgs: TxProps, type: AccountType): Promise<void>;
+  submitUnbond(args: SubmitUnbondProps, txArgs: TxProps, type: AccountType): Promise<void>;
+  submitWithdraw(args: SubmitWithdrawProps, txArgs: TxProps, type: AccountType): Promise<void>;
+  submitTransfer(args: TransferProps, txArgs: TxProps, type: AccountType): Promise<void>;
+  submitIbcTransfer(args: IbcTransferProps, txArgs: TxProps, type: AccountType): Promise<void>;
   submitEthBridgeTransfer(
     args: BridgeTransferProps,
+    txArgs: TxProps,
     type: AccountType
   ): Promise<void>;
 }

--- a/packages/types/src/tx/schema/bond.ts
+++ b/packages/types/src/tx/schema/bond.ts
@@ -18,11 +18,7 @@ export class SubmitBondMsgValue {
   @field({ type: "string" })
   nativeToken!: string;
 
-  @field({ type: TxMsgValue })
-  tx!: InstanceType<typeof TxMsgValue>;
-
   constructor(data: SubmitBondProps) {
     Object.assign(this, data);
-    this.tx = new TxMsgValue(data.tx);
   }
 }

--- a/packages/types/src/tx/schema/ethBridgeTransfer.ts
+++ b/packages/types/src/tx/schema/ethBridgeTransfer.ts
@@ -9,9 +9,6 @@ export class EthBridgeTransferMsgValue {
   @field({ type: "bool" })
   nut!: boolean;
 
-  @field({ type: TxMsgValue })
-  tx!: InstanceType<typeof TxMsgValue>;
-
   @field({ type: "string" })
   asset!: string;
 
@@ -35,6 +32,5 @@ export class EthBridgeTransferMsgValue {
 
   constructor(data: BridgeTransferProps) {
     Object.assign(this, data);
-    this.tx = new TxMsgValue(data.tx);
   }
 }

--- a/packages/types/src/tx/schema/ibcTransfer.ts
+++ b/packages/types/src/tx/schema/ibcTransfer.ts
@@ -6,9 +6,6 @@ import { TxMsgValue } from "./tx";
 import { IbcTransferProps } from "../types";
 
 export class IbcTransferMsgValue {
-  @field({ type: TxMsgValue })
-  tx!: InstanceType<typeof TxMsgValue>;
-
   @field({ type: "string" })
   source!: string;
 
@@ -36,6 +33,5 @@ export class IbcTransferMsgValue {
   constructor(data: IbcTransferProps) {
     Object.assign(this, data);
     this.token = data.token.address
-    this.tx = new TxMsgValue(data.tx);
   }
 }

--- a/packages/types/src/tx/schema/transfer.ts
+++ b/packages/types/src/tx/schema/transfer.ts
@@ -6,9 +6,6 @@ import { BigNumberSerializer } from "./utils";
 import { TransferProps } from "../types";
 
 export class TransferMsgValue {
-  @field({ type: TxMsgValue })
-  tx!: InstanceType<typeof TxMsgValue>;
-
   @field({ type: "string" })
   source!: string;
 
@@ -26,6 +23,5 @@ export class TransferMsgValue {
 
   constructor(data: TransferProps) {
     Object.assign(this, data);
-    this.tx = new TxMsgValue(data.tx);
   }
 }

--- a/packages/types/src/tx/schema/unbond.ts
+++ b/packages/types/src/tx/schema/unbond.ts
@@ -15,11 +15,7 @@ export class SubmitUnbondMsgValue {
   @field(BigNumberSerializer)
   amount!: BigNumber;
 
-  @field({ type: TxMsgValue })
-  tx!: InstanceType<typeof TxMsgValue>;
-
   constructor(data: SubmitUnbondProps) {
     Object.assign(this, data);
-    this.tx = new TxMsgValue(data.tx);
   }
 }

--- a/packages/types/src/tx/schema/withdraw.ts
+++ b/packages/types/src/tx/schema/withdraw.ts
@@ -10,11 +10,7 @@ export class SubmitWithdrawMsgValue {
   @field({ type: "string" })
   validator!: string;
 
-  @field({ type: TxMsgValue })
-  tx!: TxMsgValue;
-
   constructor(data: SubmitWithdrawProps) {
     Object.assign(this, data);
-    this.tx = new TxMsgValue({ ...data.tx, publicKey: data.tx.publicKey });
   }
 }

--- a/packages/types/src/tx/types.ts
+++ b/packages/types/src/tx/types.ts
@@ -1,52 +1,39 @@
 import BigNumber from "bignumber.js";
 import { TokenInfo } from "./tokens";
+import { TxType } from "@namada/shared";
 
-export type SubmitBondProps = {
-  validator: string;
-  amount: BigNumber;
-  source: string;
-  nativeToken: string;
-  tx: TxProps;
-};
+import {
+  TxMsgValue,
+  SubmitBondMsgValue,
+  SubmitUnbondMsgValue,
+  SubmitWithdrawMsgValue,
+  TransferMsgValue,
+  EthBridgeTransferMsgValue,
+  SignatureMsgValue,
+} from "./schema";
 
-export type SubmitUnbondProps = {
-  validator: string;
-  amount: BigNumber;
-  source: string;
-  tx: TxProps;
-};
+export type SupportedTx = Extract<
+  TxType,
+  | TxType.Bond
+  | TxType.Unbond
+  | TxType.Transfer
+  | TxType.IBCTransfer
+  | TxType.EthBridgeTransfer
+  | TxType.Withdraw
+>;
 
-export type SubmitWithdrawProps = {
-  validator: string;
-  source: string;
-  tx: TxProps;
-};
-
-export type TxProps = {
-  token: string;
-  feeAmount: BigNumber;
-  gasLimit: BigNumber;
-  chainId: string;
-  publicKey?: string;
-  signer?: string;
-};
-
-export type RevealPKProps = {
-  publicKey: string;
-  tx: TxProps;
-};
-
-export type TransferProps = {
-  tx: TxProps;
-  source: string;
-  target: string;
-  token: string;
-  amount: BigNumber;
-  nativeToken: string;
-};
+// TODO: These could probably be removed altogether, but maybe they're useful to
+// distinguish between values created as plain object literals and values
+// created using a class constructor.
+export type TxProps = TxMsgValue;
+export type SubmitBondProps = SubmitBondMsgValue;
+export type SubmitUnbondProps = SubmitUnbondMsgValue;
+export type SubmitWithdrawProps = SubmitWithdrawMsgValue;
+export type TransferProps = TransferMsgValue;
+export type BridgeTransferProps = EthBridgeTransferMsgValue;
+export type SignatureProps = SignatureMsgValue;
 
 export type IbcTransferProps = {
-  tx: TxProps;
   source: string;
   receiver: string;
   token: TokenInfo;
@@ -55,24 +42,4 @@ export type IbcTransferProps = {
   channelId: string;
   timeoutHeight?: bigint;
   timeoutSecOffset?: bigint;
-};
-
-export type BridgeTransferProps = {
-  nut: boolean;
-  tx: TxProps;
-  asset: string;
-  recipient: string;
-  sender: string;
-  amount: BigNumber;
-  feeAmount: BigNumber;
-  feePayer?: string;
-  feeToken: string;
-};
-
-export type SignatureProps = {
-  pubkey: Uint8Array;
-  rawIndices: Uint8Array;
-  rawSignature: Uint8Array;
-  wrapperIndices: Uint8Array;
-  wrapperSignature: Uint8Array;
 };


### PR DESCRIPTION
This PR refactors the transfer and SDK code to un-nest the common TX args and separate TX submission into separate build, sign, and process steps, as well as remove duplicate code and fix a bug in the query timeout message.

Notes:
- I've tested transparent->transparent transfers, bond, unbond and withdraw. I couldn't test the other transaction types since I don't have the local setup/hardware.
- I don't particularly like the name `specificMsg` to refer to transaction type-specific args (e.g. transfer args, bond args), so suggestions welcome for anything better.

---

### Changed
- Separate SDK submit functions into build functions, sign_tx function and process_tx function
- Make Ledger build_tx function reuse non-Ledger build_ functions
- Rename Ledger sign_tx function to append_signature
- Remove Tx arg from schemas and pass Tx as separate argument
- Replace Props types with type alias to equivalent MsgValue types
- Replace separate submit and approve functions/messages with single Tx function/message covering all supported Tx types
- Move SupportedTx type to @namada/types

### Fixed
- Fix wrong timeout value being printed in query error message
