### PR TITLE
Fix web-ext failing to install on CI

### DIFF
--- a/.github/workflows/release-wallet.yml
+++ b/.github/workflows/release-wallet.yml
@@ -113,7 +113,7 @@ jobs:
           version: "v0.10.3"
 
       - name: Install web-ext
-        run: yarn global add web-ext
+        run: yarn global add node-gyp && yarn global add web-ext
 
       - name: Build WASM dependencies
         working-directory: ./apps/extension
@@ -158,7 +158,7 @@ jobs:
           version: "v0.10.3"
 
       - name: Install web-ext
-        run: yarn global add web-ext
+        run: yarn global add node-gyp && yarn global add web-ext
 
       - name: Build WASM dependencies
         working-directory: ./apps/extension


### PR DESCRIPTION
Adds global install of node-gyp before trying to install web-ext, which should fix the failure when trying to release the extension.

 I don't know why this works but it seems to.

I couldn't run this in this repo since it needs to be merged to main first, but it succeeded in my fork:
https://github.com/emccorson/namada-interface/actions/runs/6463924139