### PR TITLE
feat/410 - Auto generate build URL for setting download link

### DIFF
--- a/.github/workflows/release-wallet.yml
+++ b/.github/workflows/release-wallet.yml
@@ -2,6 +2,10 @@ name: Deploy interface and release extension
 on:
   workflow_dispatch:
     inputs:
+      REF:
+        required: true
+        type: string
+        default: "main"
       REACT_APP_NAMADA_ALIAS:
         required: true
         type: string
@@ -43,6 +47,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.REF }}
 
       - name: Set environment variables
         id: set-environment-variables
@@ -81,6 +87,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.REF }}
 
       - name: Install yarn dependencies
         uses: ./.github/actions/yarn-cache
@@ -106,6 +114,7 @@ jobs:
           REACT_APP_ETH_ALIAS: ${{ inputs.REACT_APP_ETH_ALIAS }}
           REACT_APP_ETH_CHAIN_ID: ${{ inputs.REACT_APP_ETH_CHAIN_ID }}
           REACT_APP_ETH_URL: ${{ inputs.REACT_APP_ETH_URL }}
+          REACT_APP_EXTENSION_URL: https://github.com/anoma/namada-interface/releases/tag/${{ needs.setup.outputs.VERSION }}/
 
       - uses: actions/upload-artifact@v3
         with:
@@ -118,6 +127,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.REF }}
 
       - name: Install yarn dependencies
         uses: ./.github/actions/yarn-cache
@@ -162,6 +173,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.REF }}
 
       - name: Install yarn dependencies
         uses: ./.github/actions/yarn-cache
@@ -201,7 +214,8 @@ jobs:
           path: ./apps/extension/build/firefox/namada_extension-*.zip
 
   release:
-    needs: [setup, build-interface, build-extension-chrome, build-extension-firefox]
+    needs:
+      [setup, build-interface, build-extension-chrome, build-extension-firefox]
     runs-on: ubuntu-latest
     steps:
       - name: Download interface build

--- a/packages/types/src/chain.ts
+++ b/packages/types/src/chain.ts
@@ -1,5 +1,10 @@
 import { TokenType } from "./tx";
 
+const {
+  // Load extension download URL from env
+  REACT_APP_EXTENSION_URL: extensionUrl,
+} = process.env;
+
 export type Currency = {
   token: string;
   symbol: TokenType;
@@ -30,7 +35,7 @@ export const Extensions: Record<ExtensionKey, ExtensionInfo> = {
     alias: "Namada",
     id: "namada",
     // TODO: Update to most recent release
-    url: "https://github.com/anoma/namada-interface/releases/tag/v0.1.0-48adf43",
+    url: extensionUrl || "https://namada.me",
   },
   keplr: {
     alias: "Keplr",


### PR DESCRIPTION
resolves #410 

- [x] Generates asset link to specify in `namada-interface` build env vars, so deployed interface will link user to Github assets correctly
- [x] Adds `REF` input to CI so we can test with any branch/tag/commit

## Testing

I did a test deployment from this branch to here: https://652e6081e80443191bd26347--wallet-preview-heliax-dev.netlify.app/

If you load this in a browser _without_ the extension, it should link you to the assets, both of which you can install (in development mode on Chrome or temporarily if on FF).

### Running CI on this branch for testing

1. Go to `namada-interface` repo, click on `Actions`, then `Deploy Interface and Release Extension`
2. Click the arrow on `Run Workflow`, then `Use Workflow from`, and enter `feat/410-update-download-link`
3. You should see the `REF` field, also paste `feat/410-update-download-link` into that (FYI, this can take a branch, tag, or commit hash)
4. Use the following values:

```
REACT_APP_NAMADA_CHAIN_ID=public-testnet-14.5d79b6958580
REACT_APP_NAMADA_URL=https://proxy.heliax.click/public-testnet-14.5d79b6958580/
# Can ignore the remaining settings as we're just testing Namada
```

5. Then `Run` the workflow

Once CI is complete, a new release should be present with the assets. We then need to check the Netlify _preview_ link for that deployment. 

1. Log in to Netlify, look for `namada.me`, then check the most recent deployment. (It should look something like https://652e6081e80443191bd26347--wallet-preview-heliax-dev.netlify.app/)
2. In a browser where the extension is _not_ installed, click the Download link for the Namada extension - This should direct you to the build assets for the most recent release
3. You can go one step further and install the built assets for your browser - this should work for both Chrome & Firefox