### PR TITLE
chore - Update to Namada v0.25.0

### DIFF
--- a/e2e/setup-namada.sh
+++ b/e2e/setup-namada.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-VERSION="v0.24.0"
+VERSION="v0.25.0"
 CURRENT_VERSION=""
 NAMADA_DIR=".namada"
 NAMADA_BASE_DIR=".namada/basedir"

--- a/packages/shared/lib/Cargo.lock
+++ b/packages/shared/lib/Cargo.lock
@@ -2863,8 +2863,8 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "namada"
-version = "0.24.0"
-source = "git+https://github.com/anoma/namada#2138c968f07d22714a25a20b30ba8526b2afffd2"
+version = "0.25.0"
+source = "git+https://github.com/anoma/namada#8dcfddc2f1fcd4d8c1ae88f3eb1bc1815f90af3d"
 dependencies = [
  "async-trait",
  "bimap",
@@ -2913,8 +2913,8 @@ dependencies = [
 
 [[package]]
 name = "namada_core"
-version = "0.24.0"
-source = "git+https://github.com/anoma/namada#2138c968f07d22714a25a20b30ba8526b2afffd2"
+version = "0.25.0"
+source = "git+https://github.com/anoma/namada#8dcfddc2f1fcd4d8c1ae88f3eb1bc1815f90af3d"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -2966,8 +2966,8 @@ dependencies = [
 
 [[package]]
 name = "namada_ethereum_bridge"
-version = "0.24.0"
-source = "git+https://github.com/anoma/namada#2138c968f07d22714a25a20b30ba8526b2afffd2"
+version = "0.25.0"
+source = "git+https://github.com/anoma/namada#8dcfddc2f1fcd4d8c1ae88f3eb1bc1815f90af3d"
 dependencies = [
  "borsh 1.0.0-alpha.4",
  "borsh-ext",
@@ -2988,8 +2988,8 @@ dependencies = [
 
 [[package]]
 name = "namada_macros"
-version = "0.24.0"
-source = "git+https://github.com/anoma/namada#2138c968f07d22714a25a20b30ba8526b2afffd2"
+version = "0.25.0"
+source = "git+https://github.com/anoma/namada#8dcfddc2f1fcd4d8c1ae88f3eb1bc1815f90af3d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2998,8 +2998,8 @@ dependencies = [
 
 [[package]]
 name = "namada_proof_of_stake"
-version = "0.24.0"
-source = "git+https://github.com/anoma/namada#2138c968f07d22714a25a20b30ba8526b2afffd2"
+version = "0.25.0"
+source = "git+https://github.com/anoma/namada#8dcfddc2f1fcd4d8c1ae88f3eb1bc1815f90af3d"
 dependencies = [
  "borsh 1.0.0-alpha.4",
  "data-encoding",
@@ -3012,8 +3012,8 @@ dependencies = [
 
 [[package]]
 name = "namada_sdk"
-version = "0.24.0"
-source = "git+https://github.com/anoma/namada#2138c968f07d22714a25a20b30ba8526b2afffd2"
+version = "0.25.0"
+source = "git+https://github.com/anoma/namada#8dcfddc2f1fcd4d8c1ae88f3eb1bc1815f90af3d"
 dependencies = [
  "async-trait",
  "bimap",

--- a/packages/shared/lib/Cargo.toml
+++ b/packages/shared/lib/Cargo.toml
@@ -24,7 +24,7 @@ gloo-utils = { version = "0.1.5", features = ["serde"] }
 js-sys = "0.3.60"
 masp_primitives = { git = "https://github.com/anoma/masp", rev = "77e009626f3f52fe83c81ec6ee38fc2547d38da3" }
 masp_proofs = { git = "https://github.com/anoma/masp", rev = "77e009626f3f52fe83c81ec6ee38fc2547d38da3", default-features = false, features = ["local-prover"] }
-namada = { git = "https://github.com/anoma/namada", version = "0.24.0", default-features = false, features = ["abciplus", "namada-sdk"] }
+namada = { git = "https://github.com/anoma/namada", version = "0.25.0", default-features = false, features = ["abciplus", "namada-sdk"] }
 prost = "0.9.0"
 prost-types = "0.9.0"
 rand = "0.8.5"

--- a/packages/shared/lib/src/types/address.rs
+++ b/packages/shared/lib/src/types/address.rs
@@ -1,8 +1,12 @@
-use std::str::FromStr;
 use namada::types::{
     address,
-    key::{self, common::{PublicKey, SecretKey}, RefTo},
+    key::{
+        self,
+        common::{PublicKey, SecretKey},
+        RefTo,
+    },
 };
+use std::str::FromStr;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -18,14 +22,12 @@ impl Address {
     #[wasm_bindgen(constructor)]
     pub fn new(secret: String) -> Address {
         let private = SecretKey::Ed25519(
-            key::ed25519::SecretKey::from_str(&secret).expect("ed25519 encoding should not fail")
+            key::ed25519::SecretKey::from_str(&secret).expect("ed25519 encoding should not fail"),
         );
 
         #[allow(clippy::useless_conversion)]
         let public = PublicKey::from(private.ref_to());
-        let implicit = address::Address::Implicit(
-            address::ImplicitAddress::from(&public),
-        );
+        let implicit = address::Address::Implicit(address::ImplicitAddress::from(&public));
 
         Address {
             implicit,
@@ -53,28 +55,37 @@ mod tests {
 
     #[test]
     fn can_generate_implicit_address() {
-        let secret = String::from("1498b5467a63dffa2dc9d9e069caf075d16fc33fdd4c3b01bfadae6433767d93");
+        let secret =
+            String::from("1498b5467a63dffa2dc9d9e069caf075d16fc33fdd4c3b01bfadae6433767d93");
         let address = Address::new(secret);
         let implicit = address.implicit();
 
-        assert_eq!(implicit, "atest1d9khqw36x5cnvvjpgfzyxsjpgfqnqwf5xpq5zv34gvunswp4g3znww2yxqursdpnxdz5yw2ypna253");
+        assert_eq!(
+            implicit,
+            "atest1d9khqw36x5cnvvjpgfzyxsjpgfqnqwf5xpq5zv34gvunswp4g3znww2yxqursdpnxdz5yw2ypna253"
+        );
         assert_eq!(implicit.len(), address::ADDRESS_LEN);
     }
 
     #[test]
     fn can_return_correct_public_key() {
-        let secret = String::from("1498b5467a63dffa2dc9d9e069caf075d16fc33fdd4c3b01bfadae6433767d93");
+        let secret =
+            String::from("1498b5467a63dffa2dc9d9e069caf075d16fc33fdd4c3b01bfadae6433767d93");
         let address = Address::new(secret);
         let public = address.public();
         let pad = "00";
 
-        assert_eq!(public, format!("{}{}", pad, "b7a3c12dc0c8c748ab07525b701122b88bd78f600c76342d27f25e5f92444cde"));
+        assert_eq!(
+            public,
+            "pktest1qzm68sfdcryvwj9tqaf9kuq3y2ugh4u0vqx8vdpdyle9uhujg3xdurhznu9"
+        );
         assert_eq!(public.len(), pad.len() + 64);
     }
 
     #[test]
     fn can_return_correct_secret_key() {
-        let secret = String::from("1498b5467a63dffa2dc9d9e069caf075d16fc33fdd4c3b01bfadae6433767d93");
+        let secret =
+            String::from("1498b5467a63dffa2dc9d9e069caf075d16fc33fdd4c3b01bfadae6433767d93");
         let address = Address::new(secret.clone());
         let private = address.private();
         let pad = "00";


### PR DESCRIPTION
Simply updates to use `namada` `v0.25.0`

- Update to 0.25.0
- Fix unit tests