### PR TITLE
feat/182 - Private key derivation updates

### DIFF
--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -5,9 +5,11 @@ import { deserialize } from "@dao-xyz/borsh";
 import { chains } from "@namada/chains";
 import {
   HDWallet,
+  ShieldedHDWallet,
   Mnemonic,
   PhraseSize,
-  ShieldedHDWallet,
+  readVecStringPointer,
+  readStringPointer,
   VecU8Pointer,
 } from "@namada/crypto";
 import {
@@ -35,10 +37,6 @@ import {
   UtilityStore,
   AccountStore,
 } from "./types";
-import {
-  readVecStringPointer,
-  readStringPointer,
-} from "@namada/crypto/src/utils";
 import { makeBip44Path, Result } from "@namada/utils";
 
 import { Crypto } from "./crypto";

--- a/apps/extension/src/provider/data.mock.ts
+++ b/apps/extension/src/provider/data.mock.ts
@@ -38,6 +38,7 @@ export const keyStore: KeyStore[] = [
     path: {
       account: 0,
       change: 0,
+      index: 0,
     },
     crypto: {
       cipher: {

--- a/packages/crypto/lib/Cargo.lock
+++ b/packages/crypto/lib/Cargo.lock
@@ -38,6 +38,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+
+[[package]]
 name = "argon2"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +358,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "thiserror",
+ "tiny-bip39",
  "wasm-bindgen",
  "wasm-bindgen-test",
  "zeroize",
@@ -1087,6 +1094,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,6 +1275,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.101",
+]
+
+[[package]]
+name = "tiny-bip39"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62cc94d358b5a1e84a5cb9109f559aa3c4d634d2b1b4de3d0fa4adc7c78e2861"
+dependencies = [
+ "anyhow",
+ "hmac",
+ "once_cell",
+ "pbkdf2 0.11.0",
+ "rand 0.8.5",
+ "rustc-hash",
+ "sha2 0.10.6",
+ "thiserror",
+ "unicode-normalization",
+ "wasm-bindgen",
+ "zeroize",
 ]
 
 [[package]]

--- a/packages/crypto/lib/Cargo.lock
+++ b/packages/crypto/lib/Cargo.lock
@@ -343,7 +343,6 @@ dependencies = [
  "aes-gcm",
  "argon2",
  "base64",
- "bip0039",
  "bip32",
  "borsh",
  "borsh-ext",
@@ -357,6 +356,7 @@ dependencies = [
  "password-hash 0.4.2",
  "rand 0.7.3",
  "serde",
+ "slip10_ed25519",
  "thiserror",
  "tiny-bip39",
  "wasm-bindgen",
@@ -646,6 +646,12 @@ checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.5",
 ]
+
+[[package]]
+name = "hmac-sha512"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e806677ce663d0a199541030c816847b36e8dc095f70dae4a4f4ad63da5383"
 
 [[package]]
 name = "incrementalmerkletree"
@@ -1197,6 +1203,15 @@ checksum = "deb766570a2825fa972bceff0d195727876a9cdf2460ab2e52d455dc2de47fd9"
 dependencies = [
  "digest 0.10.5",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "slip10_ed25519"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be0ff28bf14f9610a342169084e87a4f435ad798ec528dc7579a3678fa9dc9a"
+dependencies = [
+ "hmac-sha512",
 ]
 
 [[package]]

--- a/packages/crypto/lib/Cargo.toml
+++ b/packages/crypto/lib/Cargo.toml
@@ -31,6 +31,7 @@ thiserror = "1.0.30"
 rand = {version = "0.7", features = ["wasm-bindgen"]}
 wasm-bindgen = "0.2.86"
 zeroize = "1.6.0"
+tiny-bip39 = "1.0.0"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"

--- a/packages/crypto/lib/Cargo.toml
+++ b/packages/crypto/lib/Cargo.toml
@@ -15,7 +15,6 @@ aes-gcm = "0.10.1"
 argon2 = "0.4.1"
 base64 = "0.13.0"
 bip32 = { version = "0.4.0", features = ["bip39"] }
-bip0039 = "0.10.1"
 borsh = {version = "1.0.0-alpha.4", features = ["schema", "derive"]}
 borsh-ext = {tag = "v1.0.0-alpha.4", git = "https://github.com/heliaxdev/borsh-ext"}
 ed25519-dalek = {version = "1.0.1", default-features = false, features = ["rand", "u64_backend"]}
@@ -32,6 +31,7 @@ rand = {version = "0.7", features = ["wasm-bindgen"]}
 wasm-bindgen = "0.2.86"
 zeroize = "1.6.0"
 tiny-bip39 = "1.0.0"
+slip10_ed25519 = "0.1.3"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"

--- a/packages/crypto/lib/src/crypto/bip32.rs
+++ b/packages/crypto/lib/src/crypto/bip32.rs
@@ -196,7 +196,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn invalid_derivation_path_should_panic() {
-        let m = Mnemonic::new(PhraseSize::N12).expect("New mnemonic should not fail");
+        let m = Mnemonic::new(PhraseSize::N12);
         let seed = m.to_seed(None).expect("Mnemonic to seed should not fail");
         let b = HDWallet::new(seed).expect("HDWallet from seed should not fail");
 

--- a/packages/crypto/lib/src/crypto/bip32.rs
+++ b/packages/crypto/lib/src/crypto/bip32.rs
@@ -6,15 +6,11 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 
 #[derive(Debug, Error)]
 pub enum HDWalletError {
-    #[error("Unable to parse path")]
-    PathError,
     #[error("Unable to derive keys from path")]
     DerivationError,
-    #[error("Could not create secret key from bytes")]
-    SecretKeyError,
     #[error("Invalid key size")]
     InvalidKeySize,
-    #[error("Invalid seed length")]
+    #[error("Invalid seed")]
     InvalidSeed,
 }
 
@@ -37,30 +33,14 @@ impl Key {
         Ok(Key { bytes })
     }
 
-    pub fn to_bytes(&self) -> VecU8Pointer {
-        VecU8Pointer::new(Vec::from(self.bytes))
+    pub fn to_bytes(&self) -> Vec<u8> {
+        Vec::from(self.bytes)
     }
 
     pub fn to_hex(&self) -> StringPointer {
         let bytes: &[u8] = &self.bytes;
         let string = hex::encode(&bytes);
         StringPointer::new(string)
-    }
-}
-
-/// An ed25519 keypair
-#[wasm_bindgen]
-#[derive(Zeroize, ZeroizeOnDrop)]
-pub struct Keypair {
-    private: Key,
-}
-
-#[wasm_bindgen]
-impl Keypair {
-    pub fn private(&self) -> Key {
-        Key {
-            bytes: self.private.bytes,
-        }
     }
 }
 
@@ -84,11 +64,12 @@ impl HDWallet {
     }
 
     /// Derive account from a seed and a path
-    pub fn derive(&self, path: Vec<u32>) -> Result<Keypair, String> {
+    pub fn derive(&self, path: Vec<u32>) -> Result<Key, String> {
         let key = slip10_ed25519::derive_ed25519_private_key(&self.seed, &path);
-        let private = Key::new(Vec::from(key))?;
+        let private = Key::new(Vec::from(key))
+            .map_err(|err| format!("{}: {:?}", HDWalletError::DerivationError, err))?;
 
-        Ok(Keypair { private })
+        Ok(private)
     }
 }
 
@@ -107,11 +88,14 @@ mod tests {
         let bip44: HDWallet = HDWallet::new(seed).unwrap();
         let path = vec![44, 877, 0, 0, 0];
 
-        let keys = bip44.derive(path).expect("Should derive keys from a path");
-        let secret_hex = &keys.private.to_hex().string;
+        let key = bip44.derive(path).expect("Should derive keys from a path");
+
         assert_eq!(
-            secret_hex,
-            "2493640b28d0ab262451713fdff14d6fb5e5c4d2652f1e3aba301e23fe5c4442"
+            key.to_bytes(),
+            [
+                228, 104, 14, 30, 58, 200, 239, 116, 140, 154, 151, 251, 162, 132, 183, 188, 107,
+                0, 45, 182, 36, 48, 46, 39, 113, 29, 252, 73, 44, 242, 125, 30
+            ]
         );
     }
 

--- a/packages/crypto/lib/src/crypto/bip39.rs
+++ b/packages/crypto/lib/src/crypto/bip39.rs
@@ -3,7 +3,7 @@ use crate::crypto::pointer_types::{
 };
 use bip39::{Language, Mnemonic as M, MnemonicType, Seed};
 use wasm_bindgen::prelude::*;
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::Zeroize;
 
 #[wasm_bindgen]
 #[derive(Copy, Clone)]
@@ -12,7 +12,6 @@ pub enum PhraseSize {
     N24 = 24,
 }
 
-// #[derive(Zeroize, ZeroizeOnDrop)]
 #[wasm_bindgen]
 pub struct Mnemonic {
     mnemonic: M,

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./crypto/crypto";
+export * from "./utils";

--- a/packages/shared/lib/Cargo.lock
+++ b/packages/shared/lib/Cargo.lock
@@ -2863,8 +2863,8 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "namada"
-version = "0.24.0"
-source = "git+https://github.com/anoma/namada#2138c968f07d22714a25a20b30ba8526b2afffd2"
+version = "0.25.0"
+source = "git+https://github.com/anoma/namada#8dcfddc2f1fcd4d8c1ae88f3eb1bc1815f90af3d"
 dependencies = [
  "async-trait",
  "bimap",
@@ -2913,8 +2913,8 @@ dependencies = [
 
 [[package]]
 name = "namada_core"
-version = "0.24.0"
-source = "git+https://github.com/anoma/namada#2138c968f07d22714a25a20b30ba8526b2afffd2"
+version = "0.25.0"
+source = "git+https://github.com/anoma/namada#8dcfddc2f1fcd4d8c1ae88f3eb1bc1815f90af3d"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",
@@ -2966,8 +2966,8 @@ dependencies = [
 
 [[package]]
 name = "namada_ethereum_bridge"
-version = "0.24.0"
-source = "git+https://github.com/anoma/namada#2138c968f07d22714a25a20b30ba8526b2afffd2"
+version = "0.25.0"
+source = "git+https://github.com/anoma/namada#8dcfddc2f1fcd4d8c1ae88f3eb1bc1815f90af3d"
 dependencies = [
  "borsh 1.0.0-alpha.4",
  "borsh-ext",
@@ -2988,8 +2988,8 @@ dependencies = [
 
 [[package]]
 name = "namada_macros"
-version = "0.24.0"
-source = "git+https://github.com/anoma/namada#2138c968f07d22714a25a20b30ba8526b2afffd2"
+version = "0.25.0"
+source = "git+https://github.com/anoma/namada#8dcfddc2f1fcd4d8c1ae88f3eb1bc1815f90af3d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2998,8 +2998,8 @@ dependencies = [
 
 [[package]]
 name = "namada_proof_of_stake"
-version = "0.24.0"
-source = "git+https://github.com/anoma/namada#2138c968f07d22714a25a20b30ba8526b2afffd2"
+version = "0.25.0"
+source = "git+https://github.com/anoma/namada#8dcfddc2f1fcd4d8c1ae88f3eb1bc1815f90af3d"
 dependencies = [
  "borsh 1.0.0-alpha.4",
  "data-encoding",
@@ -3012,8 +3012,8 @@ dependencies = [
 
 [[package]]
 name = "namada_sdk"
-version = "0.24.0"
-source = "git+https://github.com/anoma/namada#2138c968f07d22714a25a20b30ba8526b2afffd2"
+version = "0.25.0"
+source = "git+https://github.com/anoma/namada#8dcfddc2f1fcd4d8c1ae88f3eb1bc1815f90af3d"
 dependencies = [
  "async-trait",
  "bimap",

--- a/packages/shared/lib/Cargo.toml
+++ b/packages/shared/lib/Cargo.toml
@@ -24,7 +24,7 @@ gloo-utils = { version = "0.1.5", features = ["serde"] }
 js-sys = "0.3.60"
 masp_primitives = { git = "https://github.com/anoma/masp", rev = "77e009626f3f52fe83c81ec6ee38fc2547d38da3" }
 masp_proofs = { git = "https://github.com/anoma/masp", rev = "77e009626f3f52fe83c81ec6ee38fc2547d38da3", default-features = false, features = ["local-prover"] }
-namada = { git = "https://github.com/anoma/namada", version = "0.24.0", default-features = false, features = ["abciplus", "namada-sdk"] }
+namada = { git = "https://github.com/anoma/namada", version = "0.25.0", default-features = false, features = ["abciplus", "namada-sdk"] }
 prost = "0.9.0"
 prost-types = "0.9.0"
 rand = "0.8.5"

--- a/packages/shared/lib/src/types/address.rs
+++ b/packages/shared/lib/src/types/address.rs
@@ -1,8 +1,12 @@
-use std::str::FromStr;
 use namada::types::{
     address,
-    key::{self, common::{PublicKey, SecretKey}, RefTo},
+    key::{
+        self,
+        common::{PublicKey, SecretKey},
+        RefTo,
+    },
 };
+use std::str::FromStr;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -18,14 +22,12 @@ impl Address {
     #[wasm_bindgen(constructor)]
     pub fn new(secret: String) -> Address {
         let private = SecretKey::Ed25519(
-            key::ed25519::SecretKey::from_str(&secret).expect("ed25519 encoding should not fail")
+            key::ed25519::SecretKey::from_str(&secret).expect("ed25519 encoding should not fail"),
         );
 
         #[allow(clippy::useless_conversion)]
         let public = PublicKey::from(private.ref_to());
-        let implicit = address::Address::Implicit(
-            address::ImplicitAddress::from(&public),
-        );
+        let implicit = address::Address::Implicit(address::ImplicitAddress::from(&public));
 
         Address {
             implicit,
@@ -53,28 +55,37 @@ mod tests {
 
     #[test]
     fn can_generate_implicit_address() {
-        let secret = String::from("1498b5467a63dffa2dc9d9e069caf075d16fc33fdd4c3b01bfadae6433767d93");
+        let secret =
+            String::from("1498b5467a63dffa2dc9d9e069caf075d16fc33fdd4c3b01bfadae6433767d93");
         let address = Address::new(secret);
         let implicit = address.implicit();
 
-        assert_eq!(implicit, "atest1d9khqw36x5cnvvjpgfzyxsjpgfqnqwf5xpq5zv34gvunswp4g3znww2yxqursdpnxdz5yw2ypna253");
+        assert_eq!(
+            implicit,
+            "atest1d9khqw36x5cnvvjpgfzyxsjpgfqnqwf5xpq5zv34gvunswp4g3znww2yxqursdpnxdz5yw2ypna253"
+        );
         assert_eq!(implicit.len(), address::ADDRESS_LEN);
     }
 
     #[test]
     fn can_return_correct_public_key() {
-        let secret = String::from("1498b5467a63dffa2dc9d9e069caf075d16fc33fdd4c3b01bfadae6433767d93");
+        let secret =
+            String::from("1498b5467a63dffa2dc9d9e069caf075d16fc33fdd4c3b01bfadae6433767d93");
         let address = Address::new(secret);
         let public = address.public();
         let pad = "00";
 
-        assert_eq!(public, format!("{}{}", pad, "b7a3c12dc0c8c748ab07525b701122b88bd78f600c76342d27f25e5f92444cde"));
+        assert_eq!(
+            public,
+            "pktest1qzm68sfdcryvwj9tqaf9kuq3y2ugh4u0vqx8vdpdyle9uhujg3xdurhznu9"
+        );
         assert_eq!(public.len(), pad.len() + 64);
     }
 
     #[test]
     fn can_return_correct_secret_key() {
-        let secret = String::from("1498b5467a63dffa2dc9d9e069caf075d16fc33fdd4c3b01bfadae6433767d93");
+        let secret =
+            String::from("1498b5467a63dffa2dc9d9e069caf075d16fc33fdd4c3b01bfadae6433767d93");
         let address = Address::new(secret.clone());
         let private = address.private();
         let pad = "00";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -27,19 +27,19 @@ const promiseWithTimeout =
     fn: (...args: U) => Promise<T>,
     opts?: TimeoutOpts
   ) =>
-  (...args: U): Promise<T> => {
-    const { timeout, error } = { ...DEFAULT_OPTS, ...opts };
+    (...args: U): Promise<T> => {
+      const { timeout, error } = { ...DEFAULT_OPTS, ...opts };
 
-    return new Promise(async (resolve, reject) => {
-      const t = setTimeout(() => {
-        reject(error(timeout));
-      }, timeout);
+      return new Promise(async (resolve, reject) => {
+        const t = setTimeout(() => {
+          reject(error(timeout));
+        }, timeout);
 
-      const res = await fn(...args);
-      clearTimeout(t);
-      resolve(res);
-    });
-  };
+        const res = await fn(...args);
+        clearTimeout(t);
+        resolve(res);
+      });
+    };
 
 //Fallbacks for rust panics
 export class Query extends RustQuery {

--- a/packages/types/src/account.ts
+++ b/packages/types/src/account.ts
@@ -1,7 +1,7 @@
 export type Bip44Path = {
   account: number;
   change: number;
-  index?: number;
+  index: number;
 };
 
 // Type of account for storage

--- a/packages/utils/src/helpers/index.ts
+++ b/packages/utils/src/helpers/index.ts
@@ -195,6 +195,21 @@ export const makeBip44Path = (
 };
 
 /**
+ * Return a properly formatted BIP-044 path array
+ *
+ * @param {number} coinType - SLIP-044 Coin designation
+ * @param {Bip44Path} path - path object
+ * @returns {string}
+ */
+export const makeBip44PathArray = (
+  coinType: number,
+  path: Bip44Path
+): Uint32Array => {
+  const { account, change, index } = path;
+  return new Uint32Array([44, coinType, account, change, index]);
+};
+
+/**
  * Pick object parameters
  */
 export function pick<T, K extends keyof T>(obj: T, ...keys: K[]): Pick<T, K> {


### PR DESCRIPTION
resolves #182 

This PR is to make use of Namada types & functions for key gen to align with process used in SDK.

- [x] Update `Mnemonic` to use `tiny-bip39`
- [x] Update `HDWallet` to use `slip10_ed25519`
- [x] Update tests
- [x] Verify that derived keys in extension from a given mnemonic are equivalent to those created in CLI

__NOTES__

- `publicKey` is now being used from the `Address` type, and removed from the Key returned in `HDWallet`
- `HDWallet.derive()` now returns a `Key` type, and not `Keypair` (only private key)
- Updated to Namada v0.25.0
- BIP44 Path now requires `index` - type updated. To align with CLI, we derive using all path components including `index`. As `slip10_ed25519` derivation requires an array of path indices, there is a new helper to create this array from a `coinType` and `path`.