### PR TITLE
Setup: Removing return button from last step

### DIFF
--- a/apps/extension/src/Setup/Common/ContainerHeader/ContainerHeader.tsx
+++ b/apps/extension/src/Setup/Common/ContainerHeader/ContainerHeader.tsx
@@ -27,13 +27,16 @@ export const ContainerHeader = ({
       )}
       {totalSteps > 0 && (
         <>
-          <ReturnIcon onClick={() => navigate(-1)}>
-            <Icon
-              strokeColorOverride="currentColor"
-              fillColorOverride="currentColor"
-              iconName={IconName.ArrowLeft}
-            />
-          </ReturnIcon>
+          {/* Don't show return button in the last step */}
+          {currentStep < totalSteps && (
+            <ReturnIcon onClick={() => navigate(-1)}>
+              <Icon
+                strokeColorOverride="currentColor"
+                fillColorOverride="currentColor"
+                iconName={IconName.ArrowLeft}
+              />
+            </ReturnIcon>
+          )}
           <ProgressIndicator
             keyName="setup"
             totalSteps={totalSteps}

--- a/apps/extension/src/Setup/Setup.tsx
+++ b/apps/extension/src/Setup/Setup.tsx
@@ -64,6 +64,7 @@ export const Setup: React.FC = () => {
       alias: "",
     });
   const [seedPhrase, setSeedPhrase] = useState<string[]>();
+  const [selectedSeedPhrase, setSelectedSeedPhrase] = useState<string[]>([]);
   const [currentStep, setCurrentStep] = useState(0);
   const [totalSteps, setTotalSteps] = useState(0);
 
@@ -145,7 +146,16 @@ export const Setup: React.FC = () => {
                         seedPhrase={seedPhrase || []}
                         passwordRequired={!passwordInitialized}
                         onConfirm={(accountCreationDetails: AccountDetails) => {
+                          if (!seedPhrase?.length) {
+                            formatRouterPath([
+                              TopLevelRoute.AccountCreation,
+                              AccountCreationRoute.SeedPhraseConfirmation,
+                            ]);
+                            return;
+                          }
                           setAccountCreationDetails(accountCreationDetails);
+                          setSelectedSeedPhrase(Array.from(seedPhrase));
+                          setSeedPhrase(undefined);
                           navigate(
                             formatRouterPath([
                               TopLevelRoute.AccountCreation,
@@ -166,7 +176,7 @@ export const Setup: React.FC = () => {
                         pageTitle="Namada Keys Created"
                         pageSubtitle="Here are the accounts generated from your keys"
                         alias={accountCreationDetails.alias || ""}
-                        mnemonic={seedPhrase || []}
+                        mnemonic={selectedSeedPhrase || []}
                         password={accountCreationDetails.password || ""}
                         scanAccounts={false}
                       />
@@ -211,6 +221,17 @@ export const Setup: React.FC = () => {
                         accountCreationDetails={accountCreationDetails}
                         seedPhrase={seedPhrase}
                         onConfirm={(accountCreationDetails: AccountDetails) => {
+                          if (!seedPhrase) {
+                            navigate(
+                              formatRouterPath([
+                                TopLevelRoute.ImportAccount,
+                                AccountImportRoute.SeedPhrase,
+                              ])
+                            );
+                            return;
+                          }
+
+                          setSelectedSeedPhrase(Array.from(seedPhrase));
                           setAccountCreationDetails(accountCreationDetails);
                           navigate(
                             formatRouterPath([
@@ -232,7 +253,7 @@ export const Setup: React.FC = () => {
                         pageTitle="Namada Keys Imported"
                         pageSubtitle="Here are the accounts generated from your keys"
                         alias={accountCreationDetails.alias || ""}
-                        mnemonic={seedPhrase || []}
+                        mnemonic={selectedSeedPhrase || []}
                         password={accountCreationDetails.password || ""}
                         scanAccounts={false}
                       />


### PR DESCRIPTION
When users reached the end of the Setup flow (confirmation), they could return to the previous step. This PR removes this possibility and also ensures that the seedPhrase gets deleted before moving forward to the next step.