### PR TITLE
feat: Add ability to import an account from a private key

### DIFF
--- a/apps/extension/src/Setup/ImportAccount/Steps/SeedPhraseSetup/SeedPhraseSetup.tsx
+++ b/apps/extension/src/Setup/ImportAccount/Steps/SeedPhraseSetup/SeedPhraseSetup.tsx
@@ -8,9 +8,10 @@ import { useNavigate } from "react-router-dom";
 import { formatRouterPath } from "@namada/utils";
 import { TopLevelRoute } from "App/types";
 import { Footer } from "./SeedPhraseSetup.components";
+import { AccountSecret } from "background/keyring";
 
 type SeedPhraseSetupProps = {
-  seedPhrase?: string[];
+  accountSecret?: AccountSecret;
   accountCreationDetails?: AccountDetails;
   onConfirm: (accountCreationDetails: AccountDetails) => void;
   passwordRequired: boolean | undefined;
@@ -18,20 +19,18 @@ type SeedPhraseSetupProps = {
 
 export const SeedPhraseSetup = (props: SeedPhraseSetupProps): JSX.Element => {
   const navigate = useNavigate();
-  const { seedPhrase, accountCreationDetails, onConfirm, passwordRequired } =
+  const { accountSecret, accountCreationDetails, onConfirm, passwordRequired } =
     props;
 
   const [password, setPassword] = useState<string | undefined>();
   const [accountName, setAccountName] = useState<string>("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const seedPhraseLength = seedPhrase ? seedPhrase.length : 0;
   const notVerified = (passwordRequired && !password) || !accountName;
 
   useEffect(() => {
-    if (seedPhraseLength === 0) {
+    if (!accountSecret) {
       navigate(formatRouterPath([TopLevelRoute.AddAccount]));
-      return;
     }
   }, []);
 

--- a/apps/extension/src/background/keyring/handler.ts
+++ b/apps/extension/src/background/keyring/handler.ts
@@ -16,7 +16,7 @@ import {
   QueryParentAccountsMsg,
   QueryPublicKeyMsg,
   RevealAccountMnemonicMsg,
-  SaveMnemonicMsg,
+  SaveAccountSecretMsg,
   ScanAccountsMsg,
   SetActiveAccountMsg,
   TransferCompletedEvent,
@@ -45,8 +45,8 @@ export const getHandler: (service: KeyRingService) => Handler = (service) => {
           env,
           msg as ValidateMnemonicMsg
         );
-      case SaveMnemonicMsg:
-        return handleSaveMnemonicMsg(service)(env, msg as SaveMnemonicMsg);
+      case SaveAccountSecretMsg:
+        return handleSaveAccountSecretMsg(service)(env, msg as SaveAccountSecretMsg);
       case ScanAccountsMsg:
         return handleScanAccountsMsg(service)(env, msg as ScanAccountsMsg);
       case DeriveAccountMsg:
@@ -155,13 +155,13 @@ const handleValidateMnemonicMsg: (
   };
 };
 
-const handleSaveMnemonicMsg: (
+const handleSaveAccountSecretMsg: (
   service: KeyRingService
-) => InternalHandler<SaveMnemonicMsg> = (service) => {
+) => InternalHandler<SaveAccountSecretMsg> = (service) => {
   return async (_, msg) => {
-    const { words, alias } = msg;
-    if (words) {
-      return await service.saveMnemonic(words, alias);
+    const { accountSecret, alias } = msg;
+    if (accountSecret) {
+      return await service.saveAccountSecret(accountSecret, alias);
     }
     return false;
   };

--- a/apps/extension/src/background/keyring/init.ts
+++ b/apps/extension/src/background/keyring/init.ts
@@ -3,7 +3,7 @@ import {
   DeriveAccountMsg,
   QueryPublicKeyMsg,
   GenerateMnemonicMsg,
-  SaveMnemonicMsg,
+  SaveAccountSecretMsg,
   ScanAccountsMsg,
   SetActiveAccountMsg,
   GetActiveAccountMsg,
@@ -36,7 +36,7 @@ export function init(router: Router, service: KeyRingService): void {
   router.registerMessage(QueryAccountsMsg);
   router.registerMessage(QueryBalancesMsg);
   router.registerMessage(QueryParentAccountsMsg);
-  router.registerMessage(SaveMnemonicMsg);
+  router.registerMessage(SaveAccountSecretMsg);
   router.registerMessage(ScanAccountsMsg);
   router.registerMessage(SetActiveAccountMsg);
   router.registerMessage(TransferCompletedEvent);

--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -34,9 +34,10 @@ import {
   KeyRingStatus,
   SensitiveAccountStoreData,
   UtilityStore,
+  AccountSecret,
 } from "./types";
 
-import { Result, makeBip44PathArray } from "@namada/utils";
+import { Result, makeBip44PathArray, assertNever } from "@namada/utils";
 
 import { VaultService } from "background/vault";
 import { generateId } from "utils";
@@ -167,27 +168,54 @@ export class KeyRing {
     return sensitiveData.text;
   }
 
-  // Store validated mnemonic
-  public async storeMnemonic(
-    mnemonic: string[],
+  // Store validated mnemonic or private key
+  public async storeAccountSecret(
+    accountSecret: AccountSecret,
     alias: string
   ): Promise<AccountStore | false> {
     await this.vaultService.assertIsUnlocked();
-    const phrase = mnemonic.join(" ");
+
+    const path = { account: 0, change: 0, index: 0 };
+
     try {
-      const mnemonic = Mnemonic.from_phrase(phrase);
-      const seed = mnemonic.to_seed();
-      const { coinType } = chains[this.chainId].bip44;
-      const path = {
-        account: 0,
-        change: 0,
-        index: 0,
-      };
-      const bip44Path = makeBip44PathArray(coinType, path);
-      const hdWallet = new HDWallet(seed);
-      const key = hdWallet.derive(new Uint32Array(bip44Path));
-      const privateKeyStringPtr = key.to_hex();
-      const sk = readStringPointer(privateKeyStringPtr, this.cryptoMemory);
+      const { sk, text, accountType } = ((): {
+        sk: string,
+        text: string,
+        accountType: AccountType
+      } => {
+        switch (accountSecret.t) {
+          case "Mnemonic":
+            const phrase = accountSecret.seedPhrase.join(" ");
+            const mnemonic = Mnemonic.from_phrase(phrase);
+            const seed = mnemonic.to_seed();
+            const { coinType } = chains[this.chainId].bip44;
+            const bip44Path = makeBip44PathArray(coinType, path);
+            const hdWallet = new HDWallet(seed);
+            const key = hdWallet.derive(new Uint32Array(bip44Path));
+            const privateKeyStringPtr = key.to_hex();
+            const sk = readStringPointer(privateKeyStringPtr, this.cryptoMemory);
+
+            mnemonic.free();
+            hdWallet.free();
+            key.free();
+            privateKeyStringPtr.free();
+
+            return { sk, text: phrase, accountType: AccountType.Mnemonic };
+
+          case "PrivateKey":
+            const { privateKey } = accountSecret;
+
+            return {
+              sk: privateKey,
+              text: privateKey,
+              accountType: AccountType.PrivateKey
+            };
+
+          default:
+            return assertNever(accountSecret);
+        }
+      })();
+
       const addr = new Address(sk);
       const address = addr.implicit();
       const publicKey = addr.public();
@@ -197,14 +225,9 @@ export class KeyRing {
       // Generate unique ID for new parent account:
       const id = generateId(
         UUID_NAMESPACE,
-        phrase,
+        text,
         await this.vaultService.getLength(KEYSTORE_KEY)
       );
-
-      mnemonic.free();
-      hdWallet.free();
-      key.free();
-      privateKeyStringPtr.free();
 
       const accountStore: AccountStore = {
         id,
@@ -214,9 +237,9 @@ export class KeyRing {
         chainId,
         path,
         publicKey,
-        type: AccountType.Mnemonic,
+        type: accountType,
       };
-      const sensitiveData: SensitiveAccountStoreData = { text: phrase };
+      const sensitiveData: SensitiveAccountStoreData = { text };
       await this.vaultService.add<AccountStore, SensitiveAccountStoreData>(
         KEYSTORE_KEY,
         accountStore,

--- a/apps/extension/src/background/keyring/messages.ts
+++ b/apps/extension/src/background/keyring/messages.ts
@@ -3,7 +3,13 @@ import { AccountType, Bip44Path, DerivedAccount } from "@namada/types";
 import { Result } from "@namada/utils";
 import { Message } from "router";
 import { ROUTE } from "./constants";
-import { AccountStore, DeleteAccountError, ParentAccount } from "./types";
+import {
+  AccountStore,
+  DeleteAccountError,
+  ParentAccount,
+  AccountSecret
+} from "./types";
+import { validatePrivateKey } from "utils";
 
 enum MessageType {
   QueryPublicKey = "query-public-key",
@@ -13,7 +19,7 @@ enum MessageType {
   GenerateMnemonic = "generate-mnemonic",
   GetActiveAccount = "get-active-account",
   QueryParentAccounts = "query-parent-accounts",
-  SaveMnemonic = "save-mnemonic",
+  SaveAccountSecret = "save-account-secret",
   ScanAccounts = "scan-accounts",
   SetActiveAccount = "set-active-account",
   TransferCompletedEvent = "transfer-completed-event",
@@ -141,25 +147,41 @@ export class RenameAccountMsg extends Message<DerivedAccount> {
   }
 }
 
-export class SaveMnemonicMsg extends Message<AccountStore | false> {
+export class SaveAccountSecretMsg extends Message<AccountStore | false> {
   public static type(): MessageType {
-    return MessageType.SaveMnemonic;
+    return MessageType.SaveAccountSecret;
   }
 
-  constructor(public readonly words: string[], public readonly alias: string) {
+  constructor(
+    public readonly accountSecret: AccountSecret,
+    public readonly alias: string
+  ) {
     super();
   }
 
   validate(): void {
-    if (!this.words) {
-      throw new Error("A wordlist is required to save a mnemonic!");
+    if (!this.accountSecret) {
+      throw new Error("A wordlist or private key is required!");
     }
 
-    if (
-      this.words.length !== PhraseSize.N12 &&
-      this.words.length !== PhraseSize.N24
-    ) {
-      throw new Error("Invalid wordlist length! Not a valid mnemonic.");
+    switch (this.accountSecret.t) {
+      case "Mnemonic":
+        if (
+          this.accountSecret.seedPhrase.length !== PhraseSize.N12 &&
+          this.accountSecret.seedPhrase.length !== PhraseSize.N24
+        ) {
+          throw new Error("Invalid wordlist length! Not a valid mnemonic.");
+        }
+        break;
+
+      case "PrivateKey":
+        if (!validatePrivateKey(this.accountSecret.privateKey).ok) {
+          throw new Error("Invalid private key!");
+        }
+        break;
+
+      default:
+        throw new Error("Unknown account secret type");
     }
   }
 
@@ -168,7 +190,7 @@ export class SaveMnemonicMsg extends Message<AccountStore | false> {
   }
 
   type(): string {
-    return SaveMnemonicMsg.type();
+    return SaveAccountSecretMsg.type();
   }
 }
 

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -27,6 +27,7 @@ import {
   ParentAccount,
   TabStore,
   UtilityStore,
+  AccountSecret,
 } from "./types";
 import { syncTabs, updateTabStorage } from "./utils";
 
@@ -91,11 +92,11 @@ export class KeyRingService {
     return await this._keyRing.revealMnemonic(accountId);
   }
 
-  async saveMnemonic(
-    words: string[],
+  async saveAccountSecret(
+    accountSecret: AccountSecret,
     alias: string
   ): Promise<AccountStore | false> {
-    const results = await this._keyRing.storeMnemonic(words, alias);
+    const results = await this._keyRing.storeAccountSecret(accountSecret, alias);
     this.broadcaster.updateAccounts();
     return results;
   }

--- a/apps/extension/src/background/keyring/types.ts
+++ b/apps/extension/src/background/keyring/types.ts
@@ -52,3 +52,7 @@ export enum DeleteAccountError {
   BadPassword,
   KeyStoreError,
 }
+
+type Mnemonic = { t: "Mnemonic", seedPhrase: string[] };
+type PrivateKey = { t: "PrivateKey", privateKey: string };
+export type AccountSecret = Mnemonic | PrivateKey;

--- a/apps/extension/src/utils/index.ts
+++ b/apps/extension/src/utils/index.ts
@@ -3,6 +3,7 @@ import browser from "webextension-polyfill";
 
 import { ISignature } from "@namada/ledger-namada";
 import { Message, SignatureMsgValue, TxMsgValue, TxProps } from "@namada/types";
+import { Result } from "@namada/utils";
 
 /**
  * Query the current extension tab and close it
@@ -69,3 +70,17 @@ export const validateProps = <T>(object: T, props: (keyof T)[]): void => {
     }
   });
 };
+
+const PRIVATE_KEY_MAX_LENGTH = 64;
+
+export type PrivateKeyError =
+ | { t: "TooLong", maxLength: number }
+ | { t: "BadCharacter" };
+
+// Very basic private key validation
+export const validatePrivateKey = (privateKey: string): Result<null, PrivateKeyError> =>
+  privateKey.length > PRIVATE_KEY_MAX_LENGTH ?
+    Result.err({ t: "TooLong", maxLength: PRIVATE_KEY_MAX_LENGTH }) :
+  !/^[0-9a-f]*$/.test(privateKey) ?
+    Result.err({ t: "BadCharacter" }) :
+  Result.ok(null);


### PR DESCRIPTION
Notes:
- Private key validation currently checks that the key is not more than 64 characters. I'm not sure if that should be *exactly* 64 characters.
- I'm not 100% sure I'm doing the right thing in the replacement of `selectedSeedPhrase` which is supposed to be used to allow deleting the seed phrase from `seedPhrase ` in `Setup.tsx`.