### PR TITLE
feat/449 - Return Mnemonic errors to user

### DIFF
--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -32,6 +32,7 @@ import {
   ActiveAccountStore,
   DeleteAccountError,
   KeyRingStatus,
+  MnemonicValidationResponse,
   SensitiveAccountStoreData,
   UtilityStore,
   AccountSecret,
@@ -74,7 +75,7 @@ export class KeyRing {
     protected readonly sdk: Sdk,
     protected readonly query: Query,
     protected readonly cryptoMemory: WebAssembly.Memory
-  ) {}
+  ) { }
 
   public get status(): KeyRingStatus {
     return this._status;
@@ -97,8 +98,16 @@ export class KeyRing {
     }
   }
 
-  public validateMnemonic(phrase: string): boolean {
-    return Mnemonic.validate(phrase);
+  public validateMnemonic(phrase: string): MnemonicValidationResponse {
+    const isValid = Mnemonic.validate(phrase);
+
+    try {
+      Mnemonic.from_phrase(phrase);
+    } catch (e) {
+      return { isValid, error: `${e}` };
+    }
+
+    return { isValid };
   }
 
   // Return new mnemonic to client for validation

--- a/apps/extension/src/background/keyring/messages.ts
+++ b/apps/extension/src/background/keyring/messages.ts
@@ -7,7 +7,8 @@ import {
   AccountStore,
   DeleteAccountError,
   ParentAccount,
-  AccountSecret
+  AccountSecret,
+  MnemonicValidationResponse,
 } from "./types";
 import { validatePrivateKey } from "utils";
 
@@ -98,7 +99,7 @@ export class RevealAccountMnemonicMsg extends Message<string> {
   }
 }
 
-export class ValidateMnemonicMsg extends Message<boolean> {
+export class ValidateMnemonicMsg extends Message<MnemonicValidationResponse> {
   public static type(): MessageType {
     return MessageType.ValidateMnemonic;
   }

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -24,6 +24,7 @@ import {
   AccountStore,
   ActiveAccountStore,
   DeleteAccountError,
+  MnemonicValidationResponse,
   ParentAccount,
   TabStore,
   UtilityStore,
@@ -84,7 +85,7 @@ export class KeyRingService {
     return await this._keyRing.generateMnemonic(size);
   }
 
-  validateMnemonic(phrase: string): boolean {
+  validateMnemonic(phrase: string): MnemonicValidationResponse {
     return this._keyRing.validateMnemonic(phrase);
   }
 

--- a/apps/extension/src/background/keyring/types.ts
+++ b/apps/extension/src/background/keyring/types.ts
@@ -53,6 +53,11 @@ export enum DeleteAccountError {
   KeyStoreError,
 }
 
-type Mnemonic = { t: "Mnemonic", seedPhrase: string[] };
-type PrivateKey = { t: "PrivateKey", privateKey: string };
+type Mnemonic = { t: "Mnemonic"; seedPhrase: string[] };
+type PrivateKey = { t: "PrivateKey"; privateKey: string };
 export type AccountSecret = Mnemonic | PrivateKey;
+
+export type MnemonicValidationResponse = {
+  isValid: boolean;
+  error?: string;
+};


### PR DESCRIPTION
resolves #449 

- [x] Errors produced by `tiny-bip39` -> `Mnemonic::from_phrase` should be returned to user