### PR TITLE
feat/457 - Extension: Filter private key prefix if present

### DIFF
--- a/apps/extension/src/Setup/ImportAccount/Steps/SeedPhraseImport/SeedPhraseImport.tsx
+++ b/apps/extension/src/Setup/ImportAccount/Steps/SeedPhraseImport/SeedPhraseImport.tsx
@@ -16,7 +16,7 @@ import { ValidateMnemonicMsg, AccountSecret } from "background/keyring";
 import { Ports } from "router";
 import { Instruction, InstructionList } from "./SeedPhraseImport.components";
 import { useRequester } from "hooks/useRequester";
-import { validatePrivateKey } from "utils";
+import { filterPrivateKeyPrefix, validatePrivateKey } from "utils";
 
 type Props = {
   onConfirm: (accountSecret: AccountSecret) => void;
@@ -48,7 +48,7 @@ export const SeedPhraseImport: React.FC<Props> = ({ onConfirm }) => {
   );
 
   const privateKeyError = (() => {
-    const validation = validatePrivateKey(privateKey);
+    const validation = validatePrivateKey(filterPrivateKeyPrefix(privateKey));
     if (validation.ok) {
       return "";
     } else {
@@ -119,7 +119,10 @@ export const SeedPhraseImport: React.FC<Props> = ({ onConfirm }) => {
   const onSubmit = useCallback(async () => {
     if (mnemonicType === MnemonicTypes.PrivateKey) {
       // TODO: validate here
-      onConfirm({ t: "PrivateKey", privateKey });
+      onConfirm({
+        t: "PrivateKey",
+        privateKey: filterPrivateKeyPrefix(privateKey),
+      });
     } else {
       const actualMnemonics = mnemonics.slice(0, mnemonicType);
       const phrase = actualMnemonics.join(" ");

--- a/apps/extension/src/utils/index.ts
+++ b/apps/extension/src/utils/index.ts
@@ -74,13 +74,19 @@ export const validateProps = <T>(object: T, props: (keyof T)[]): void => {
 const PRIVATE_KEY_MAX_LENGTH = 64;
 
 export type PrivateKeyError =
- | { t: "TooLong", maxLength: number }
- | { t: "BadCharacter" };
+  | { t: "TooLong"; maxLength: number }
+  | { t: "BadCharacter" };
 
 // Very basic private key validation
-export const validatePrivateKey = (privateKey: string): Result<null, PrivateKeyError> =>
-  privateKey.length > PRIVATE_KEY_MAX_LENGTH ?
-    Result.err({ t: "TooLong", maxLength: PRIVATE_KEY_MAX_LENGTH }) :
-  !/^[0-9a-f]*$/.test(privateKey) ?
-    Result.err({ t: "BadCharacter" }) :
-  Result.ok(null);
+export const validatePrivateKey = (
+  privateKey: string
+): Result<null, PrivateKeyError> =>
+  privateKey.length > PRIVATE_KEY_MAX_LENGTH
+    ? Result.err({ t: "TooLong", maxLength: PRIVATE_KEY_MAX_LENGTH })
+    : !/^[0-9a-f]*$/.test(privateKey)
+      ? Result.err({ t: "BadCharacter" })
+      : Result.ok(null);
+
+// Remove prefix from private key, which may be present when exporting keys from CLI
+export const filterPrivateKeyPrefix = (privateKey: string): string =>
+  privateKey.replace(/^00/, "");


### PR DESCRIPTION
resolves #457 

- [x] If user provides private key with the `00` prefix (as exported from CLI), we should handle it correctly
- [x] Keys without this prefix should work as intended