### PR TITLE
feat/455 - Extension: API to return default account

### DIFF
--- a/apps/extension/src/background/keyring/handler.ts
+++ b/apps/extension/src/background/keyring/handler.ts
@@ -4,6 +4,7 @@ import {
   HasMaspParamsMsg,
   QueryAccountsMsg,
   QueryBalancesMsg,
+  QueryDefaultAccountMsg,
 } from "provider/messages";
 import { Env, Handler, InternalHandler, Message } from "router";
 import {
@@ -46,7 +47,10 @@ export const getHandler: (service: KeyRingService) => Handler = (service) => {
           msg as ValidateMnemonicMsg
         );
       case SaveAccountSecretMsg:
-        return handleSaveAccountSecretMsg(service)(env, msg as SaveAccountSecretMsg);
+        return handleSaveAccountSecretMsg(service)(
+          env,
+          msg as SaveAccountSecretMsg
+        );
       case ScanAccountsMsg:
         return handleScanAccountsMsg(service)(env, msg as ScanAccountsMsg);
       case DeriveAccountMsg:
@@ -64,6 +68,11 @@ export const getHandler: (service: KeyRingService) => Handler = (service) => {
         return handleGetActiveAccountMsg(service)(
           env,
           msg as GetActiveAccountMsg
+        );
+      case QueryDefaultAccountMsg:
+        return handleQueryDefaultAccountMsg(service)(
+          env,
+          msg as QueryDefaultAccountMsg
         );
       case QueryParentAccountsMsg:
         return handleQueryParentAccountsMsg(service)(
@@ -205,6 +214,14 @@ const handleQueryAccountsMsg: (
         : await service.queryAccounts();
 
     return output;
+  };
+};
+
+const handleQueryDefaultAccountMsg: (
+  service: KeyRingService
+) => InternalHandler<QueryDefaultAccountMsg> = (service) => {
+  return async () => {
+    return await service.queryDefaultAccount();
   };
 };
 

--- a/apps/extension/src/background/keyring/init.ts
+++ b/apps/extension/src/background/keyring/init.ts
@@ -18,6 +18,7 @@ import {
 } from "./messages";
 import {
   QueryAccountsMsg,
+  QueryDefaultAccountMsg,
   QueryBalancesMsg,
   FetchAndStoreMaspParamsMsg,
   HasMaspParamsMsg,
@@ -34,6 +35,7 @@ export function init(router: Router, service: KeyRingService): void {
   router.registerMessage(GenerateMnemonicMsg);
   router.registerMessage(GetActiveAccountMsg);
   router.registerMessage(QueryAccountsMsg);
+  router.registerMessage(QueryDefaultAccountMsg);
   router.registerMessage(QueryBalancesMsg);
   router.registerMessage(QueryParentAccountsMsg);
   router.registerMessage(SaveAccountSecretMsg);

--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -75,7 +75,7 @@ export class KeyRing {
     protected readonly sdk: Sdk,
     protected readonly query: Query,
     protected readonly cryptoMemory: WebAssembly.Memory
-  ) { }
+  ) {}
 
   public get status(): KeyRingStatus {
     return this._status;
@@ -188,9 +188,9 @@ export class KeyRing {
 
     try {
       const { sk, text, accountType } = ((): {
-        sk: string,
-        text: string,
-        accountType: AccountType
+        sk: string;
+        text: string;
+        accountType: AccountType;
       } => {
         switch (accountSecret.t) {
           case "Mnemonic":
@@ -202,7 +202,10 @@ export class KeyRing {
             const hdWallet = new HDWallet(seed);
             const key = hdWallet.derive(new Uint32Array(bip44Path));
             const privateKeyStringPtr = key.to_hex();
-            const sk = readStringPointer(privateKeyStringPtr, this.cryptoMemory);
+            const sk = readStringPointer(
+              privateKeyStringPtr,
+              this.cryptoMemory
+            );
 
             mnemonic.free();
             hdWallet.free();
@@ -217,7 +220,7 @@ export class KeyRing {
             return {
               sk: privateKey,
               text: privateKey,
-              accountType: AccountType.PrivateKey
+              accountType: AccountType.PrivateKey,
             };
 
           default:
@@ -573,6 +576,15 @@ export class KeyRing {
     }
 
     return [];
+  }
+
+  public async queryDefaultAccount(): Promise<DerivedAccount | undefined> {
+    const accounts = await this.queryAllAccounts();
+    const activeAccount = await this.getActiveAccount();
+
+    if (activeAccount) {
+      return accounts.find((acc) => acc.id === activeAccount.id);
+    }
   }
 
   public async queryAccountByPublicKey(

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -97,7 +97,10 @@ export class KeyRingService {
     accountSecret: AccountSecret,
     alias: string
   ): Promise<AccountStore | false> {
-    const results = await this._keyRing.storeAccountSecret(accountSecret, alias);
+    const results = await this._keyRing.storeAccountSecret(
+      accountSecret,
+      alias
+    );
     this.broadcaster.updateAccounts();
     return results;
   }
@@ -141,6 +144,10 @@ export class KeyRingService {
 
   async queryAccounts(): Promise<DerivedAccount[]> {
     return await this._keyRing.queryAllAccounts();
+  }
+
+  async queryDefaultAccount(): Promise<DerivedAccount | undefined> {
+    return await this._keyRing.queryDefaultAccount();
   }
 
   async queryParentAccounts(): Promise<DerivedAccount[]> {

--- a/apps/extension/src/provider/InjectedNamada.ts
+++ b/apps/extension/src/provider/InjectedNamada.ts
@@ -9,7 +9,7 @@ import { InjectedProxy } from "./InjectedProxy";
 import { Signer } from "./Signer";
 
 export class InjectedNamada implements INamada {
-  constructor(private readonly _version: string) {}
+  constructor(private readonly _version: string) { }
 
   public async connect(chainId: string): Promise<void> {
     return await InjectedProxy.requestMethod<string, void>("connect", chainId);
@@ -33,6 +33,13 @@ export class InjectedNamada implements INamada {
   public async accounts(chainId: string): Promise<DerivedAccount[]> {
     return await InjectedProxy.requestMethod<string, DerivedAccount[]>(
       "accounts",
+      chainId
+    );
+  }
+
+  public async defaultAccount(chainId: string): Promise<DerivedAccount> {
+    return await InjectedProxy.requestMethod<string, DerivedAccount>(
+      "defaultAccount",
       chainId
     );
   }

--- a/apps/extension/src/provider/Namada.ts
+++ b/apps/extension/src/provider/Namada.ts
@@ -17,13 +17,14 @@ import {
   HasMaspParamsMsg,
   CheckDurabilityMsg,
   QueryBalancesMsg,
+  QueryDefaultAccountMsg,
 } from "./messages";
 
 export class Namada implements INamada {
   constructor(
     private readonly _version: string,
     protected readonly requester?: MessageRequester
-  ) {}
+  ) { }
 
   public async connect(chainId: string): Promise<void> {
     return await this.requester?.sendMessage(
@@ -55,6 +56,12 @@ export class Namada implements INamada {
     );
   }
 
+  public async defaultAccount(): Promise<DerivedAccount | undefined> {
+    return await this.requester?.sendMessage(
+      Ports.Background,
+      new QueryDefaultAccountMsg()
+    );
+  }
   public async fetchAndStoreMaspParams(): Promise<void> {
     return await this.requester?.sendMessage(
       Ports.Background,

--- a/apps/extension/src/provider/Signer.ts
+++ b/apps/extension/src/provider/Signer.ts
@@ -30,7 +30,7 @@ export class Signer implements ISigner {
   constructor(
     protected readonly chainId: string,
     private readonly _namada: Namada
-  ) {}
+  ) { }
 
   public async accounts(): Promise<Account[] | undefined> {
     return (await this._namada.accounts(this.chainId))?.map(
@@ -45,6 +45,22 @@ export class Signer implements ISigner {
     );
   }
 
+  public async defaultAccount(): Promise<Account | undefined> {
+    const account = await this._namada.defaultAccount(this.chainId);
+
+    if (account) {
+      const { alias, address, chainId, type, publicKey } = account;
+
+      return {
+        alias,
+        address,
+        chainId,
+        type,
+        publicKey,
+        isShielded: type === AccountType.ShieldedKeys,
+      };
+    }
+  }
   private async submitTx<T extends Schema, Args>(
     txType: SupportedTx,
     constructor: new (args: Args) => T,

--- a/apps/extension/src/provider/messages.ts
+++ b/apps/extension/src/provider/messages.ts
@@ -17,6 +17,7 @@ enum Route {
 enum MessageType {
   ApproveConnectInterface = "approve-connect-interface",
   QueryAccounts = "query-accounts",
+  QueryDefaultAccount = "query-default-account",
   ApproveTx = "approve-tx",
   QueryBalances = "query-balances",
   SubmitIbcTransfer = "submit-ibc-transfer",
@@ -183,6 +184,30 @@ export class QueryBalancesMsg extends Message<
 
   type(): string {
     return QueryBalancesMsg.type();
+  }
+}
+
+export class QueryDefaultAccountMsg extends Message<
+  DerivedAccount | undefined
+> {
+  public static type(): MessageType {
+    return MessageType.QueryDefaultAccount;
+  }
+
+  constructor() {
+    super();
+  }
+
+  validate(): void {
+    return;
+  }
+
+  route(): string {
+    return Route.KeyRing;
+  }
+
+  type(): string {
+    return QueryDefaultAccountMsg.type();
   }
 }
 

--- a/packages/integrations/src/Namada.ts
+++ b/packages/integrations/src/Namada.ts
@@ -43,6 +43,11 @@ export default class Namada implements Integration<Account, Signer> {
     return await signer?.accounts();
   }
 
+  public async defaultAccount(): Promise<Account | undefined> {
+    const signer = this._namada?.getSigner(this.chain.chainId);
+    return await signer?.defaultAccount();
+  }
+
   public signer(): Signer | undefined {
     return this._namada?.getSigner(this.chain.chainId);
   }
@@ -53,9 +58,17 @@ export default class Namada implements Integration<Account, Signer> {
   ): Promise<void> {
     const signer = this._namada?.getSigner(this.chain.chainId);
     if (props.ibcProps) {
-      return await signer?.submitIbcTransfer(props.ibcProps, props.txProps, type);
+      return await signer?.submitIbcTransfer(
+        props.ibcProps,
+        props.txProps,
+        type
+      );
     } else if (props.bridgeProps) {
-      return await signer?.submitEthBridgeTransfer(props.bridgeProps, props.txProps, type);
+      return await signer?.submitEthBridgeTransfer(
+        props.bridgeProps,
+        props.txProps,
+        type
+      );
     }
 
     return Promise.reject("Invalid bridge transfer props!");

--- a/packages/types/src/namada.ts
+++ b/packages/types/src/namada.ts
@@ -13,6 +13,7 @@ export type TxMsgProps = {
 export interface Namada {
   connect(chainId: string): Promise<void>;
   accounts(chainId: string): Promise<DerivedAccount[] | undefined>;
+  defaultAccount(chainId: string): Promise<DerivedAccount | undefined>;
   balances(
     owner: string
   ): Promise<{ token: string; amount: string }[] | undefined>;

--- a/packages/types/src/signer.ts
+++ b/packages/types/src/signer.ts
@@ -12,6 +12,7 @@ import {
 
 export interface Signer {
   accounts: () => Promise<Account[] | undefined>;
+  defaultAccount: () => Promise<Account | undefined>;
   submitBond(
     args: SubmitBondProps,
     txArgs: TxProps,


### PR DESCRIPTION
resolves #455 

## Testing

1 - Install this version of the extension
2 - Launch `namada-interface`:
  ```bash
  # In namada-interface/apps/namada-interface
  yarn dev:local
  ```
3 - Create/Import at least 2 accounts in extension (to test that default account gets updated)
4 - In `namada-interface`, connect to extension, then open the console, and enter the following:
```
await namada.defaultAccount()
```

This should give you a result like:
```
{
    "id": "9f318429-3627-50e2-b5f5-26f861b00d13",
    "alias": "tester",
    "address": "tnam1qz4sdx5jlh909j44uz46pf29ty0ztftfzc98s8dx",
    "owner": "tnam1qz4sdx5jlh909j44uz46pf29ty0ztftfzc98s8dx",
    "chainId": "localnet.aa8b11f87ddde352c2-0",
    "path": {
        "account": 0,
        "change": 0,
        "index": 0
    },
    "publicKey": "tpknam1qptrn64myunqr4847yq4cn0uwek5ecwc7eeexjfc5npmd5kmg6ex563n5as",
    "type": "mnemonic"
}
```

You can switch the selected account in the extension, then re-run `await namada.defaultAccount()` in the console, and the account should be updated.

## Events

I had wanted to make a specific event that fires when the default accounts changed, but wanted to keep this simple for the release. For now, we can subscribe to `Events.AccountChanged`, and re-issue the `await namada.defaultAccount()` if we need event handling for any reason.