### PR TITLE
chore: fix main CI workflow broken by #456 and rename

### DIFF
--- a/.github/workflows/deploy-wallet-at-merge-to-main.yml
+++ b/.github/workflows/deploy-wallet-at-merge-to-main.yml
@@ -1,4 +1,4 @@
-name: Deploy wallet preview to netlify at PR and pushes to it
+name: Build interface and caches at push to main
 on:
   push:
     branches:
@@ -64,6 +64,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Install yarn dependencies
+        uses: ./.github/actions/yarn-cache
+
       - name: Restore Rust cache
         uses: ./.github/actions/rust-cache
         with:
@@ -85,6 +88,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Install yarn dependencies
+        uses: ./.github/actions/yarn-cache
 
       - name: Restore Rust cache
         uses: ./.github/actions/rust-cache


### PR DESCRIPTION
Fixes main CI workflow that I broke in #456.

CI run on my fork to show that the fix works (fails at Slack notification as expected since it's a fork):
https://github.com/emccorson/namada-interface/actions/runs/6924320288

---

### Changed
- Rename main CI workflow

### Fixed
- Fix main CI workflow broken by yarn file not being present