### PR TITLE
bug - Fix private key validation

### DIFF
--- a/apps/extension/src/utils/index.ts
+++ b/apps/extension/src/utils/index.ts
@@ -89,4 +89,6 @@ export const validatePrivateKey = (
 
 // Remove prefix from private key, which may be present when exporting keys from CLI
 export const filterPrivateKeyPrefix = (privateKey: string): string =>
-  privateKey.replace(/^00/, "");
+  privateKey.length === PRIVATE_KEY_MAX_LENGTH + 2
+    ? privateKey.replace(/^00/, "")
+    : privateKey;


### PR DESCRIPTION
This is a simple fix that adds a check to the `filterPrivateKeyPrefix` which ensure the length must be 66 for it to strip the prefix, otherwise, it may strip leading zeros that are actually part of the key.

### Testing

These keys should work on import:

```
59f0d21f1c7375697275d8fe6ef58b06505f5a073aeca5c5b05e0dda24bd6324

0059f0d21f1c7375697275d8fe6ef58b06505f5a073aeca5c5b05e0dda24bd6324

000000000000000000000000000000000000000000000000000000000000000000

00000000000000000000000000000000000000000000000000000000000000000
```