### PR TITLE
feat/470 - Prevent duplicate keys from being added

### DIFF
--- a/apps/extension/src/Setup/Common/Completion/Completion.tsx
+++ b/apps/extension/src/Setup/Common/Completion/Completion.tsx
@@ -17,7 +17,7 @@ import {
   DeriveAccountMsg,
   SaveAccountSecretMsg,
   ScanAccountsMsg,
-  AccountSecret
+  AccountSecret,
 } from "background/keyring";
 import { useRequester } from "hooks/useRequester";
 import { useNavigate } from "react-router-dom";
@@ -91,9 +91,11 @@ const Completion: React.FC<Props> = (props) => {
         }
 
         const prettyAccountSecret =
-          accountSecret.t === "Mnemonic" ? "mnemonic" :
-          accountSecret.t === "PrivateKey" ? "private key" :
-          assertNever(accountSecret);
+          accountSecret.t === "Mnemonic"
+            ? "mnemonic"
+            : accountSecret.t === "PrivateKey"
+              ? "private key"
+              : assertNever(accountSecret);
 
         setStatusInfo(`Encrypting and storing ${prettyAccountSecret}.`);
         const account = (await requester.sendMessage<SaveAccountSecretMsg>(
@@ -131,7 +133,7 @@ const Completion: React.FC<Props> = (props) => {
         setMnemonicStatus(Status.Completed);
         setStatusInfo("Done!");
       } catch (e) {
-        setStatusInfo((s) => `Failed while "${s}"`);
+        setStatusInfo((s) => `Failed while "${s}". ${e}`);
         console.error(e);
         setMnemonicStatus(Status.Failed);
       }

--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -38,7 +38,12 @@ import {
   AccountSecret,
 } from "./types";
 
-import { Result, makeBip44PathArray, assertNever } from "@namada/utils";
+import {
+  Result,
+  makeBip44PathArray,
+  assertNever,
+  truncateInMiddle,
+} from "@namada/utils";
 
 import { VaultService } from "background/vault";
 import { generateId } from "utils";
@@ -181,98 +186,98 @@ export class KeyRing {
   public async storeAccountSecret(
     accountSecret: AccountSecret,
     alias: string
-  ): Promise<AccountStore | false> {
+  ): Promise<AccountStore> {
     await this.vaultService.assertIsUnlocked();
 
     const path = { account: 0, change: 0, index: 0 };
 
-    try {
-      const { sk, text, accountType } = ((): {
-        sk: string;
-        text: string;
-        accountType: AccountType;
-      } => {
-        switch (accountSecret.t) {
-          case "Mnemonic":
-            const phrase = accountSecret.seedPhrase.join(" ");
-            const mnemonic = Mnemonic.from_phrase(phrase);
-            const seed = mnemonic.to_seed();
-            const { coinType } = chains[this.chainId].bip44;
-            const bip44Path = makeBip44PathArray(coinType, path);
-            const hdWallet = new HDWallet(seed);
-            const key = hdWallet.derive(new Uint32Array(bip44Path));
-            const privateKeyStringPtr = key.to_hex();
-            const sk = readStringPointer(
-              privateKeyStringPtr,
-              this.cryptoMemory
-            );
+    const { sk, text, accountType } = ((): {
+      sk: string;
+      text: string;
+      accountType: AccountType;
+    } => {
+      switch (accountSecret.t) {
+        case "Mnemonic":
+          const phrase = accountSecret.seedPhrase.join(" ");
+          const mnemonic = Mnemonic.from_phrase(phrase);
+          const seed = mnemonic.to_seed();
+          const { coinType } = chains[this.chainId].bip44;
+          const bip44Path = makeBip44PathArray(coinType, path);
+          const hdWallet = new HDWallet(seed);
+          const key = hdWallet.derive(new Uint32Array(bip44Path));
+          const privateKeyStringPtr = key.to_hex();
+          const sk = readStringPointer(privateKeyStringPtr, this.cryptoMemory);
 
-            mnemonic.free();
-            hdWallet.free();
-            key.free();
-            privateKeyStringPtr.free();
+          mnemonic.free();
+          hdWallet.free();
+          key.free();
+          privateKeyStringPtr.free();
 
-            return { sk, text: phrase, accountType: AccountType.Mnemonic };
+          return { sk, text: phrase, accountType: AccountType.Mnemonic };
 
-          case "PrivateKey":
-            const { privateKey } = accountSecret;
+        case "PrivateKey":
+          const { privateKey } = accountSecret;
 
-            return {
-              sk: privateKey,
-              text: privateKey,
-              accountType: AccountType.PrivateKey,
-            };
+          return {
+            sk: privateKey,
+            text: privateKey,
+            accountType: AccountType.PrivateKey,
+          };
 
-          default:
-            return assertNever(accountSecret);
-        }
-      })();
+        default:
+          return assertNever(accountSecret);
+      }
+    })();
 
-      const addr = new Address(sk);
-      const address = addr.implicit();
-      const publicKey = addr.public();
+    const addr = new Address(sk);
+    const address = addr.implicit();
+    const publicKey = addr.public();
 
-      const { chainId } = this;
-
-      // Generate unique ID for new parent account:
-      const id = generateId(
-        UUID_NAMESPACE,
-        text,
-        await this.vaultService.getLength(KEYSTORE_KEY)
+    // Check whether keys already exist for this account
+    const account = await this.queryAccountByAddress(address);
+    if (account) {
+      throw new Error(
+        `Keys for ${truncateInMiddle(address, 5, 8)} already imported!`
       );
-
-      const accountStore: AccountStore = {
-        id,
-        alias,
-        address,
-        owner: address,
-        chainId,
-        path,
-        publicKey,
-        type: accountType,
-      };
-      const sensitiveData: SensitiveAccountStoreData = { text };
-      await this.vaultService.add<AccountStore, SensitiveAccountStoreData>(
-        KEYSTORE_KEY,
-        accountStore,
-        sensitiveData
-      );
-
-      // When we are adding new top level account we have to clear the storage
-      // to prevent adding top level secret key to existing keys
-      this.sdk.clear_storage();
-      await this.addSecretKey(
-        sk,
-        await this.vaultService.UNSAFE_getPassword(),
-        alias,
-        id
-      );
-      await this.setActiveAccount(id, AccountType.Mnemonic);
-      return accountStore;
-    } catch (e) {
-      console.error(e);
     }
-    return false;
+
+    const { chainId } = this;
+
+    // Generate unique ID for new parent account:
+    const id = generateId(
+      UUID_NAMESPACE,
+      text,
+      await this.vaultService.getLength(KEYSTORE_KEY)
+    );
+
+    const accountStore: AccountStore = {
+      id,
+      alias,
+      address,
+      owner: address,
+      chainId,
+      path,
+      publicKey,
+      type: accountType,
+    };
+    const sensitiveData: SensitiveAccountStoreData = { text };
+    await this.vaultService.add<AccountStore, SensitiveAccountStoreData>(
+      KEYSTORE_KEY,
+      accountStore,
+      sensitiveData
+    );
+
+    // When we are adding new top level account we have to clear the storage
+    // to prevent adding top level secret key to existing keys
+    this.sdk.clear_storage();
+    await this.addSecretKey(
+      sk,
+      await this.vaultService.UNSAFE_getPassword(),
+      alias,
+      id
+    );
+    await this.setActiveAccount(id, AccountType.Mnemonic);
+    return accountStore;
   }
 
   public deriveTransparentAccount(
@@ -524,6 +529,15 @@ export class KeyRing {
 
     const { seed, parentId } = await this.getParentSeed();
     const info = deriveFn(seed, path, parentId);
+
+    // Check whether keys already exist for this account
+    const existingAccount = await this.queryAccountByAddress(info.address);
+    if (existingAccount) {
+      throw new Error(
+        `Keys for ${truncateInMiddle(info.address, 5, 8)} already imported!`
+      );
+    }
+
     const derivedAccount = await this.persistAccount(
       path,
       parentId,
@@ -637,6 +651,14 @@ export class KeyRing {
     } catch (e) {
       throw new Error(`Could not submit bond tx: ${e}`);
     }
+  }
+
+  public async queryAccountByAddress(
+    address: string
+  ): Promise<DerivedAccount | undefined> {
+    return (await this.queryAllAccounts()).find(
+      (account) => account.address === address
+    );
   }
 
   async submitUnbond(unbondMsg: Uint8Array, txMsg: Uint8Array): Promise<void> {

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -4,7 +4,7 @@ import { PhraseSize } from "@namada/crypto";
 import { public_key_to_bech32, Query, Sdk, TxType } from "@namada/shared";
 import { IndexedDBKVStore, KVStore } from "@namada/storage";
 import { AccountType, Bip44Path, DerivedAccount } from "@namada/types";
-import { Result } from "@namada/utils";
+import { Result, truncateInMiddle } from "@namada/utils";
 
 import {
   createOffscreenWithTxWorker,
@@ -96,7 +96,7 @@ export class KeyRingService {
   async saveAccountSecret(
     accountSecret: AccountSecret,
     alias: string
-  ): Promise<AccountStore | false> {
+  ): Promise<AccountStore> {
     const results = await this._keyRing.storeAccountSecret(
       accountSecret,
       alias
@@ -114,6 +114,14 @@ export class KeyRingService {
   ): Promise<AccountStore | false> {
     const publicKeyBytes = fromHex(publicKey);
     const bech32PublicKey = public_key_to_bech32(publicKeyBytes);
+
+    const account = await this._keyRing.queryAccountByAddress(address);
+    if (account) {
+      throw new Error(
+        `Keys for ${truncateInMiddle(address, 5, 8)} already imported!`
+      );
+    }
+
     return await this._keyRing.storeLedger(
       alias,
       address,


### PR DESCRIPTION
resolves #470 

- [x] Prevent duplicate Ledger addreses
- [x] Prevent duplicate keys for mnemonic import
- [x] Prevent duplicate keys for private key import

__NOTE__ I needed to remove and add some `try`/`catch` to get the errors to propagate up to the Setup interface

### Screenshots

#### Ledger - duplicate import
<img width="881" alt="Screen Shot 2023-11-21 at 11 12 59 AM" src="https://github.com/anoma/namada-interface/assets/330911/4b2f9ea4-0541-40c0-b8cb-c504e22bccbe">

### Mnemonic or Private Key - duplicate import
<img width="934" alt="Screen Shot 2023-11-21 at 11 14 16 AM" src="https://github.com/anoma/namada-interface/assets/330911/36b8a418-dce4-4057-ae12-c8e3ea899f43">

