### PR TITLE
feat: allow all URLs to interact with extension

### DIFF
--- a/apps/extension/src/manifest/v3/_base.json
+++ b/apps/extension/src/manifest/v3/_base.json
@@ -6,7 +6,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["*://rpgfdrop.namada.net/*"],
+      "matches": ["<all_urls>"],
       "js": ["content.namada.js"]
     }
   ],
@@ -20,7 +20,7 @@
   "web_accessible_resources": [
     {
       "resources": ["injected.namada.js", "assets/app.css"],
-      "matches": ["*://rpgfdrop.namada.net/*"]
+      "matches": ["<all_urls>"]
     }
   ],
   "icons": {


### PR DESCRIPTION
This PR undoes the hard-coding of the airdrop website URL in the Chrome extension manifest.

---

### Changed
- Allow all URLs to interact with the extension