### PR TITLE
bug/480 - Make chainId optional to support released extension

### DIFF
--- a/apps/extension/src/provider/Namada.ts
+++ b/apps/extension/src/provider/Namada.ts
@@ -18,7 +18,7 @@ export class Namada implements INamada {
     protected readonly requester?: MessageRequester
   ) { }
 
-  public async connect(): Promise<void> {
+  public async connect(_chainId?: string): Promise<void> {
     return await this.requester?.sendMessage(
       Ports.Background,
       new ApproveConnectInterfaceMsg()

--- a/packages/integrations/src/Namada.ts
+++ b/packages/integrations/src/Namada.ts
@@ -33,9 +33,8 @@ export default class Namada implements Integration<Account, Signer> {
     return !!this._namada;
   }
 
-  public async connect(): Promise<void> {
-    this._init();
-    await this._namada?.connect();
+  public async connect(chainId?: string): Promise<void> {
+    await this._namada?.connect(chainId);
   }
 
   public async accounts(): Promise<readonly Account[] | undefined> {

--- a/packages/types/src/namada.ts
+++ b/packages/types/src/namada.ts
@@ -10,7 +10,7 @@ export type TxMsgProps = {
 };
 
 export interface Namada {
-  connect(): Promise<void>;
+  connect(chainId?: string): Promise<void>;
   accounts(): Promise<DerivedAccount[] | undefined>;
   defaultAccount(): Promise<DerivedAccount | undefined>;
   balances(


### PR DESCRIPTION
Relates to #480 

- [x] Make `chainId` optional to support released extension (`Namada` interface, `Namada` provider and integration)