### PR TITLE
bug/480 - Add optional chainId to accounts

### DIFF
--- a/apps/extension/src/provider/Namada.ts
+++ b/apps/extension/src/provider/Namada.ts
@@ -25,14 +25,18 @@ export class Namada implements INamada {
     );
   }
 
-  public async accounts(): Promise<DerivedAccount[] | undefined> {
+  public async accounts(
+    _chainId?: string
+  ): Promise<DerivedAccount[] | undefined> {
     return await this.requester?.sendMessage(
       Ports.Background,
       new QueryAccountsMsg()
     );
   }
 
-  public async defaultAccount(): Promise<DerivedAccount | undefined> {
+  public async defaultAccount(
+    _chainId?: string
+  ): Promise<DerivedAccount | undefined> {
     return await this.requester?.sendMessage(
       Ports.Background,
       new QueryDefaultAccountMsg()

--- a/packages/integrations/src/Namada.ts
+++ b/packages/integrations/src/Namada.ts
@@ -37,14 +37,16 @@ export default class Namada implements Integration<Account, Signer> {
     await this._namada?.connect(chainId);
   }
 
-  public async accounts(): Promise<readonly Account[] | undefined> {
+  public async accounts(
+    chainId?: string
+  ): Promise<readonly Account[] | undefined> {
     const signer = this._namada?.getSigner();
-    return await signer?.accounts();
+    return await signer?.accounts(chainId);
   }
 
-  public async defaultAccount(): Promise<Account | undefined> {
+  public async defaultAccount(chainId?: string): Promise<Account | undefined> {
     const signer = this._namada?.getSigner();
-    return await signer?.defaultAccount();
+    return await signer?.defaultAccount(chainId);
   }
 
   public signer(): Signer | undefined {

--- a/packages/types/src/namada.ts
+++ b/packages/types/src/namada.ts
@@ -11,8 +11,8 @@ export type TxMsgProps = {
 
 export interface Namada {
   connect(chainId?: string): Promise<void>;
-  accounts(): Promise<DerivedAccount[] | undefined>;
-  defaultAccount(): Promise<DerivedAccount | undefined>;
+  accounts(chainId?: string): Promise<DerivedAccount[] | undefined>;
+  defaultAccount(chainId?: string): Promise<DerivedAccount | undefined>;
   balances(
     owner: string
   ): Promise<{ token: string; amount: string }[] | undefined>;

--- a/packages/types/src/signer.ts
+++ b/packages/types/src/signer.ts
@@ -11,8 +11,8 @@ import {
 } from "./tx";
 
 export interface Signer {
-  accounts: () => Promise<Account[] | undefined>;
-  defaultAccount: () => Promise<Account | undefined>;
+  accounts: (chainId?: string) => Promise<Account[] | undefined>;
+  defaultAccount: (chainId?: string) => Promise<Account | undefined>;
   submitBond(
     args: SubmitBondProps,
     txArgs: TxProps,


### PR DESCRIPTION
Relates to #480

- [x] Optional chain ID for accounts & default account in extension integration