### PR TITLE
feat: make pub key read only input a top one

### DIFF
--- a/packages/components/src/ViewKeys/ViewKeys.tsx
+++ b/packages/components/src/ViewKeys/ViewKeys.tsx
@@ -24,19 +24,19 @@ export const ViewKeys = ({
   return (
     <Stack as="section" gap={GapPatterns.TitleContent}>
       <Stack gap={GapPatterns.FormFields}>
-        {transparentAccountAddress && (
-          <Input
-            label="Your Transparent Address"
-            variant={InputVariants.ReadOnlyCopy}
-            value={transparentAccountAddress}
-            theme={"primary"}
-          />
-        )}
         {publicKeyAddress && (
           <Input
             label="Public Key"
             variant={InputVariants.ReadOnlyCopy}
             value={publicKeyAddress}
+            theme={"primary"}
+          />
+        )}
+        {transparentAccountAddress && (
+          <Input
+            label="Your Transparent Address"
+            variant={InputVariants.ReadOnlyCopy}
+            value={transparentAccountAddress}
             theme={"primary"}
           />
         )}


### PR DESCRIPTION
Context:
> When we were taking a look at website with Chris Holt
 we've noticed that maybe it would make sense to change order of readonly inputs in extension. If we move pubkey up it will be consistent with airdrop website also both transparent and shielded addresses will be next to each other. So it will look like this:
<img width="198" alt="image" src="https://github.com/anoma/namada-interface/assets/11858303/b347d151-44eb-4788-a2a8-54c0355eb483">
