### PR TITLE
feat: airdrop website copies and stuff

### DIFF
--- a/apps/airdrop/src/App/AirdropConfirmation.tsx
+++ b/apps/airdrop/src/App/AirdropConfirmation.tsx
@@ -241,10 +241,16 @@ export const AirdropConfirmation: React.FC = () => {
               </AirdropConfirmationHeading>
               <Text className="fade-in" themeColor={"utility1"}>
                 NAM will be available directly in your wallet
-                <br /> at Namada Mainnet launch, subject to the
-                <br />{" "}
-                <LinkButton href="/terms-of-service" themeColor="utility1">
-                  <b>Terms of Service</b>
+                <br /> in the Namada mainnet genesis block proposal
+                <br /> made by the Anoma Foundation, subject to the
+                <br />
+                <LinkButton
+                  href="/terms-and-conditions"
+                  themeColor="utility1"
+                  target="_blank"
+                  rel="noreferrer nofollow"
+                >
+                  <b>Terms & Conditions</b>
                 </LinkButton>
               </Text>
             </Stack>

--- a/apps/airdrop/src/App/App.components.ts
+++ b/apps/airdrop/src/App/App.components.ts
@@ -30,7 +30,7 @@ body {
       ? color("utility1", "main")(props)
       : color("primary", "main")(props)};
 
-  background-image: url(/images/background.svg);
+  background-image: url(/assets/images/background.svg);
   background-repeat: repeat;
   background-size: 100px 100px;
   background-position-y: 20px;

--- a/apps/airdrop/src/App/App.tsx
+++ b/apps/airdrop/src/App/App.tsx
@@ -32,14 +32,16 @@ export const App: React.FC = () => {
       <GlobalStyles colorMode="dark" />
       <BrowserView>
         <PageHeader
-          showStartOver={pathname !== "/" && pathname !== "/terms-of-service"}
+          showStartOver={
+            pathname !== "/" && pathname !== "/terms-and-conditions"
+          }
           showTermsOfService={pathname === "/"}
           showDomainWarning={pathname === "/"}
-          showBackToClaim={pathname === "/terms-of-service"}
+          showBackToClaim={pathname === "/terms-and-conditions"}
           yellowLogo={
             pathname !== "/" &&
             pathname !== "/claim-confirmed" &&
-            pathname !== "/terms-of-service"
+            pathname !== "/terms-and-conditions"
           }
         />
         <Routes>
@@ -74,7 +76,8 @@ export const App: React.FC = () => {
               )
             }
           />
-          <Route path={`/terms-of-service`} element={<TermsOfService />} />
+          <Route path={`/terms-and-conditions`} element={<TermsOfService />} />
+          <Route path="*" element={<Navigate to="/" replace={true} />}></Route>
         </Routes>
       </BrowserView>
       <MobileView>

--- a/apps/airdrop/src/App/Common/AcceptTermsCheckbox/AcceptTermsCheckbox.tsx
+++ b/apps/airdrop/src/App/Common/AcceptTermsCheckbox/AcceptTermsCheckbox.tsx
@@ -17,8 +17,8 @@ export const AcceptTermsCheckbox = ({
       <Checkbox disabled={disabled} checked={checked} onChange={onChange} />
       <span>
         You agree to the{" "}
-        <a href="/terms-of-service" target="_blank">
-          Terms of Service
+        <a href="/terms-and-conditions" target="_blank">
+          Terms & Conditions
         </a>{" "}
         and are not in the US or any other prohibited jurisdiction
       </span>

--- a/apps/airdrop/src/App/Common/PageHeader/PageHeader.tsx
+++ b/apps/airdrop/src/App/Common/PageHeader/PageHeader.tsx
@@ -107,11 +107,11 @@ export const PageHeader = ({
 
       {showTermsOfService && (
         <PageHeaderLink
-          onClick={() => navigate("/terms-of-service")}
+          href="/terms-and-conditions"
           target="_blank"
           rel="noreferrer nofollow"
         >
-          Terms of Service
+          Terms & Conditions
         </PageHeaderLink>
       )}
     </PageHeaderContainer>

--- a/apps/airdrop/src/App/Layouts/SidebarPage/SidebarPage.tsx
+++ b/apps/airdrop/src/App/Layouts/SidebarPage/SidebarPage.tsx
@@ -32,8 +32,8 @@ export const SidebarPage = ({
     <SidebarPageGrid>
       <aside>
         <SidebarTitle>
-          <TermsLinkWrapper href="/terms-of-service" target="_blank">
-            Terms of Service{" "}
+          <TermsLinkWrapper href="/terms-and-conditions" target="_blank">
+            Terms & Conditions{" "}
             <IconWrap>
               <ExternalPageIcon />
             </IconWrap>

--- a/apps/airdrop/src/App/Main.tsx
+++ b/apps/airdrop/src/App/Main.tsx
@@ -191,7 +191,7 @@ export const Main: React.FC = () => {
                         );
                       }}
                     >
-                      Read annoucement
+                      Read announcement
                       <i className="external-icon">
                         <ExternalPageIcon />
                       </i>
@@ -331,7 +331,7 @@ export const Main: React.FC = () => {
         visible={isGithubFetching}
         variant="full"
         status={"Please wait, we are checking the GitHub claim"}
-        imageUrl="/images/loading.gif"
+        imageUrl="/assets/images/loading.gif"
       />
     </>
   );


### PR DESCRIPTION
- claim confirmation copy
- terms of service -> terms and conditions + always opens in new tab
- redirect for "/" for unknown routes
- fix images links