### PR TITLE
valid tag a

### DIFF
--- a/apps/airdrop/src/App/Common/AcceptTermsCheckbox/AcceptTermsCheckbox.tsx
+++ b/apps/airdrop/src/App/Common/AcceptTermsCheckbox/AcceptTermsCheckbox.tsx
@@ -21,7 +21,11 @@ export const AcceptTermsCheckbox = ({
       {!fullVersion && (
         <span>
           You hereby acknowledge and confirm the{" "}
-          <a href="/terms-and-conditions" target="_blank">
+          <a
+            href="/terms-and-conditions"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Terms and Conditions
           </a>{" "}
           and agree to be bound by them.


### PR DESCRIPTION
Hi teams, I really admire the project
When the rel="noopener noreferrer" attribute is missing in the <a> tag, it can lead to security vulnerabilities, unwanted tracking, and performance issues on the website.