### PR TITLE
fix: blank screen on airdrop page when no metamask installed 

### DIFF
--- a/apps/airdrop/src/App/utils.ts
+++ b/apps/airdrop/src/App/utils.ts
@@ -78,7 +78,7 @@ export const getMetamask = (): MetaMaskInpageProvider | undefined => {
   const provider = (window as MaybeOtherEVMWindow).ethereum;
 
   if (
-    provider.isMetaMask &&
+    provider?.isMetaMask &&
     !Boolean(provider.isRabby) &&
     !Boolean(provider.isEnkrypt)
   ) {


### PR DESCRIPTION
# What does this PR do? 
Fix the issue when you see a blank screen if Metamsk is not installed! 

# UI  before fix
Blank screen: 
<img width="1512" alt="Screenshot 2023-12-08 at 20 07 19" src="https://github.com/anoma/namada-interface/assets/26277721/c6787924-1c70-46c0-aacc-377eca4cf001">
# UI after fix: 
<img width="1510" alt="Screenshot 2023-12-08 at 20 09 28" src="https://github.com/anoma/namada-interface/assets/26277721/ab4bd02f-7f4c-4d9b-8a74-b109349a28c4">
