### PR TITLE
fix: yellow borders on filled action button

### DIFF
--- a/packages/components/src/ActionButton/ActionButton.components.tsx
+++ b/packages/components/src/ActionButton/ActionButton.components.tsx
@@ -32,7 +32,7 @@ export const ButtonText = styled.span`
   z-index: 10;
 `;
 
-export const ButtonContainer = styled(Button)<{
+export const ButtonContainer = styled(Button) <{
   variant: ThemeColor;
   hoverColor?: ThemeColor;
   size: ButtonSize;
@@ -41,6 +41,13 @@ export const ButtonContainer = styled(Button)<{
 }>`
   all: unset;
   background-image: ${(props) => {
+    if (props.disabled && !props.outlined) {
+      return `linear-gradient(${color(
+        "utility1",
+        "main50"
+      )(props)} 50%, ${color("utility1", "main50")(props)} 50%)`;
+    }
+
     if (props.outlined) {
       // main color is transparent, filler color is yellow
       return `linear-gradient(transparent 50%, ${color(
@@ -57,7 +64,7 @@ export const ButtonContainer = styled(Button)<{
       )(props)} 50%, ${color(props.hoverColor, "main")(props)} 50%)`;
     }
 
-     // main color is yellow, filler color is black
+    // main color is yellow, filler color is black
     return `linear-gradient(${color(
       props.variant,
       "main"
@@ -96,21 +103,22 @@ export const ButtonContainer = styled(Button)<{
   transition: color 80ms ease-out, border 450ms ease-out;
   user-select: none;
   width: 100%;
-  transition: background-position 250ms ease-in-out, color 250ms ease-in-out;
+  transition: background-position var(--ease-out-circ) 0.45s,
+    color var(--ease-out-circ) 0.45s;
 
   &:hover:not(:disabled) {
     background-position: 0 100%;
     color: ${(props) => {
-      if (props.outlined) {
-        return color(props.variant, "main20")(props);
-      }
+    if (props.outlined) {
+      return color(props.variant, "main20")(props);
+    }
 
-      if (props.hoverColor) {
-        return color(props.hoverColor, "main20")(props);
-      }
+    if (props.hoverColor) {
+      return color(props.hoverColor, "main20")(props);
+    }
 
-      return color(props.variant, "main")(props);
-    }};
+    return color(props.variant, "main")(props);
+  }};
   }
 
   &:not(:disabled):active {
@@ -118,17 +126,11 @@ export const ButtonContainer = styled(Button)<{
   }
 
   &:disabled {
-    background-color: ${(props) => {
-      if (!props.outlined) {
-        return color("utility1", "main50");
-      }
-    }};
-
     color: ${(props) => {
-      if (!props.outlined) {
-        return color("utility3", "white");
-      }
-    }};
+    if (!props.outlined) {
+      return color("utility3", "white");
+    }
+  }};
 
     cursor: auto;
     opacity: 0.25;

--- a/packages/components/src/ActionButton/ActionButton.components.tsx
+++ b/packages/components/src/ActionButton/ActionButton.components.tsx
@@ -10,7 +10,6 @@ import {
 
 import React from "react";
 import styled from "styled-components";
-import { motion } from "framer-motion";
 
 type ButtonProps = {
   forwardedAs: keyof JSX.IntrinsicElements;
@@ -25,18 +24,6 @@ const Button = ({
 }: ButtonProps): JSX.Element => {
   return React.createElement(forwardedAs, props, children);
 };
-
-export const ButtonHover = styled(motion.i)`
-  display: block;
-  height: 100%;
-  left: 0;
-  position: absolute;
-  top: 0;
-  transform-origin: center center;
-  transform: translateY(calc(100% + 2px));
-  transition: all var(--ease-out-circ) 0.45s;
-  width: 100%;
-`;
 
 export const ButtonText = styled.span`
   color: currentColor;
@@ -53,12 +40,30 @@ export const ButtonContainer = styled(Button)<{
   borderRadius: keyof BorderRadius;
 }>`
   all: unset;
-  background-color: ${(props) => {
+  background-image: ${(props) => {
     if (props.outlined) {
-      return "transparent";
+      // main color is transparent, filler color is yellow
+      return `linear-gradient(transparent 50%, ${color(
+        props.hoverColor || "primary",
+        "main"
+      )(props)} 50%)`;
     }
-    return color(props.variant, "main")(props);
+
+    if (props.hoverColor) {
+      // main color is yellow, filler color is {hoverColor}
+      return `linear-gradient(${color(
+        props.variant,
+        "main"
+      )(props)} 50%, ${color(props.hoverColor, "main")(props)} 50%)`;
+    }
+
+     // main color is yellow, filler color is black
+    return `linear-gradient(${color(
+      props.variant,
+      "main"
+    )(props)} 50%, black 50%)`;
   }};
+  background-size: 100% 220%;
 
   border: ${(props) => {
     if (props.outlined) {
@@ -91,8 +96,10 @@ export const ButtonContainer = styled(Button)<{
   transition: color 80ms ease-out, border 450ms ease-out;
   user-select: none;
   width: 100%;
+  transition: background-position 250ms ease-in-out, color 250ms ease-in-out;
 
   &:hover:not(:disabled) {
+    background-position: 0 100%;
     color: ${(props) => {
       if (props.outlined) {
         return color(props.variant, "main20")(props);
@@ -125,24 +132,6 @@ export const ButtonContainer = styled(Button)<{
 
     cursor: auto;
     opacity: 0.25;
-  }
-
-  ${ButtonHover} {
-    background-color: ${(props) => {
-      if (props.outlined) {
-        return color(props.hoverColor || "primary", "main")(props);
-      }
-
-      if (props.hoverColor) {
-        return color(props.hoverColor, "main")(props);
-      }
-
-      return "black";
-    }};
-  }
-
-  &:hover:not(:disabled) ${ButtonHover} {
-    transform: translateY(0);
   }
 `;
 

--- a/packages/components/src/ActionButton/ActionButton.tsx
+++ b/packages/components/src/ActionButton/ActionButton.tsx
@@ -1,7 +1,6 @@
 import { BorderRadius, ThemeColor } from "@namada/utils";
 import {
   ButtonContainer,
-  ButtonHover,
   ButtonIcon,
   ButtonSize,
   ButtonText,
@@ -40,7 +39,6 @@ export const ActionButton = ({
     >
       {icon && <ButtonIcon>{icon}</ButtonIcon>}
       <ButtonText>{children}</ButtonText>
-      <ButtonHover />
     </ButtonContainer>
   );
 };


### PR DESCRIPTION
# What does this PR do? 
Fix the yellow border when the action button is filled

# Context 
This issue may not exist on all screens, but I see yellow borders when the action button is filled on my retina screen. 
Also, this fix made animation more smooth (IMHO)

# Externals 
## Before fix: 
<img width="696" alt="before" src="https://github.com/anoma/namada-interface/assets/26277721/382410ce-c0d6-4092-917c-7f03aee80bc3">


## After fix: 
<img width="361" alt="after" src="https://github.com/anoma/namada-interface/assets/26277721/4731003f-12a9-410e-b510-5fee93593ade">

