### PR TITLE
fix: Correct spelling of GitHub

### DIFF
--- a/apps/airdrop/src/App/AirdropConfirmation.tsx
+++ b/apps/airdrop/src/App/AirdropConfirmation.tsx
@@ -48,7 +48,7 @@ import { ClaimCategory } from "./types";
 import { formatAmount } from "./utils";
 
 const categoryAccountTypeMap: Record<ClaimCategory, string> = {
-  Github: "Github",
+  Github: "GitHub",
   CosmosWallet: "Cosmos Wallet",
   OsmosisWallet: "Osmosis Wallet",
   StargazeWallet: "Stargaze Wallet",


### PR DESCRIPTION
It is correct to capitalize the H in GitHub's brand name.