### PR TITLE
Fix extension manifest permissions, fix approve Tx form

### DIFF
--- a/apps/extension/src/background/approvals/handler.ts
+++ b/apps/extension/src/background/approvals/handler.ts
@@ -1,12 +1,12 @@
-import { Handler, Env, Message, InternalHandler } from "router";
-import { ApprovalsService } from "./service";
-import { ApproveTxMsg, ApproveConnectInterfaceMsg } from "provider";
+import { ApproveConnectInterfaceMsg, ApproveTxMsg } from "provider";
+import { Env, Handler, InternalHandler, Message } from "router";
 import {
-  RejectTxMsg,
   ConnectInterfaceResponseMsg,
+  RejectTxMsg,
   RevokeConnectionMsg,
   SubmitApprovedTxMsg,
 } from "./messages";
+import { ApprovalsService } from "./service";
 
 export const getHandler: (service: ApprovalsService) => Handler = (service) => {
   return (env: Env, msg: Message<unknown>) => {
@@ -60,8 +60,8 @@ const handleRejectTxMsg: (
 const handleSubmitApprovedTxMsg: (
   service: ApprovalsService
 ) => InternalHandler<SubmitApprovedTxMsg> = (service) => {
-  return async (_, { msgId, password }) => {
-    return await service.submitTx(msgId, password);
+  return async (_, { msgId }) => {
+    return await service.submitTx(msgId);
   };
 };
 

--- a/apps/extension/src/background/approvals/messages.ts
+++ b/apps/extension/src/background/approvals/messages.ts
@@ -1,6 +1,6 @@
+import { SupportedTx } from "@namada/shared";
 import { Message } from "router";
 import { ROUTE } from "./constants";
-import { SupportedTx } from "@namada/shared";
 
 import { validateProps } from "utils";
 
@@ -43,14 +43,13 @@ export class SubmitApprovedTxMsg extends Message<void> {
 
   constructor(
     public readonly txType: SupportedTx,
-    public readonly msgId: string,
-    public readonly password: string
+    public readonly msgId: string
   ) {
     super();
   }
 
   validate(): void {
-    validateProps(this, ["txType", "msgId", "password"]);
+    validateProps(this, ["txType", "msgId"]);
   }
 
   route(): string {

--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -1,9 +1,11 @@
-import browser, { Windows } from "webextension-polyfill";
 import { fromBase64 } from "@cosmjs/encoding";
-import { v4 as uuid } from "uuid";
-import BigNumber from "bignumber.js";
 import { deserialize } from "@dao-xyz/borsh";
+import BigNumber from "bignumber.js";
+import { v4 as uuid } from "uuid";
+import browser, { Windows } from "webextension-polyfill";
 
+import { SupportedTx, TxType } from "@namada/shared";
+import { KVStore } from "@namada/storage";
 import {
   AccountType,
   EthBridgeTransferMsgValue,
@@ -15,20 +17,18 @@ import {
   TransferMsgValue,
   TxMsgValue,
 } from "@namada/types";
-import { TxType, SupportedTx } from "@namada/shared";
-import { KVStore } from "@namada/storage";
 
+import { assertNever, paramsToUrl } from "@namada/utils";
 import { KeyRingService, TabStore } from "background/keyring";
 import { LedgerService } from "background/ledger";
-import { paramsToUrl, assertNever } from "@namada/utils";
 
+import { VaultService } from "background/vault";
 import { ApprovedOriginsStore, TxStore } from "./types";
 import {
+  APPROVED_ORIGINS_KEY,
   addApprovedOrigin,
   removeApprovedOrigin,
-  APPROVED_ORIGINS_KEY,
 } from "./utils";
-import { VaultService } from "background/vault";
 
 type GetParams = (
   specificMsg: Uint8Array,
@@ -51,7 +51,7 @@ export class ApprovalsService {
     protected readonly keyRingService: KeyRingService,
     protected readonly ledgerService: LedgerService,
     protected readonly vaultService: VaultService
-  ) {}
+  ) { }
 
   async approveTx(
     txType: SupportedTx,
@@ -72,18 +72,18 @@ export class ApprovalsService {
       txType === TxType.Bond
         ? ApprovalsService.getParamsBond
         : txType === TxType.Unbond
-        ? ApprovalsService.getParamsUnbond
-        : txType === TxType.Withdraw
-        ? ApprovalsService.getParamsWithdraw
-        : txType === TxType.Transfer
-        ? ApprovalsService.getParamsTransfer
-        : txType === TxType.IBCTransfer
-        ? ApprovalsService.getParamsIbcTransfer
-        : txType === TxType.EthBridgeTransfer
-        ? ApprovalsService.getParamsEthBridgeTransfer
-        : txType === TxType.VoteProposal
-        ? ApprovalsService.getParamsVoteProposal
-        : assertNever(txType);
+          ? ApprovalsService.getParamsUnbond
+          : txType === TxType.Withdraw
+            ? ApprovalsService.getParamsWithdraw
+            : txType === TxType.Transfer
+              ? ApprovalsService.getParamsTransfer
+              : txType === TxType.IBCTransfer
+                ? ApprovalsService.getParamsIbcTransfer
+                : txType === TxType.EthBridgeTransfer
+                  ? ApprovalsService.getParamsEthBridgeTransfer
+                  : txType === TxType.VoteProposal
+                    ? ApprovalsService.getParamsVoteProposal
+                    : assertNever(txType);
 
     const baseUrl = `${browser.runtime.getURL(
       "approvals.html"
@@ -235,9 +235,7 @@ export class ApprovalsService {
   }
 
   // Authenticate keyring and submit approved transaction from storage
-  async submitTx(msgId: string, password: string): Promise<void> {
-    await this.vaultService.unlock(password);
-
+  async submitTx(msgId: string): Promise<void> {
     // Fetch pending transfer tx
     const tx = await this.txStore.get(msgId);
 
@@ -251,18 +249,18 @@ export class ApprovalsService {
       txType === TxType.Bond
         ? this.keyRingService.submitBond
         : txType === TxType.Unbond
-        ? this.keyRingService.submitUnbond
-        : txType === TxType.Transfer
-        ? this.keyRingService.submitTransfer
-        : txType === TxType.IBCTransfer
-        ? this.keyRingService.submitIbcTransfer
-        : txType === TxType.EthBridgeTransfer
-        ? this.keyRingService.submitEthBridgeTransfer
-        : txType === TxType.Withdraw
-        ? this.keyRingService.submitWithdraw
-        : txType === TxType.VoteProposal
-        ? this.keyRingService.submitVoteProposal
-        : assertNever(txType);
+          ? this.keyRingService.submitUnbond
+          : txType === TxType.Transfer
+            ? this.keyRingService.submitTransfer
+            : txType === TxType.IBCTransfer
+              ? this.keyRingService.submitIbcTransfer
+              : txType === TxType.EthBridgeTransfer
+                ? this.keyRingService.submitEthBridgeTransfer
+                : txType === TxType.Withdraw
+                  ? this.keyRingService.submitWithdraw
+                  : txType === TxType.VoteProposal
+                    ? this.keyRingService.submitVoteProposal
+                    : assertNever(txType);
 
     await submitFn.call(this.keyRingService, specificMsg, txMsg, msgId);
 

--- a/apps/extension/src/manifest/v3/_base.json
+++ b/apps/extension/src/manifest/v3/_base.json
@@ -13,7 +13,7 @@
   "action": {
     "default_popup": "popup.html"
   },
-  "permissions": ["storage", "notifications", "identity", "offscreen"],
+  "permissions": ["storage", "offscreen"],
   "content_security_policy": {
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
   },


### PR DESCRIPTION
This PR simply updates the following:

- Chrome `manifest.json` permissions removed for `identity` and `notifications`, as they are not used
- Approve Tx form was not properly authenticating users, this is fixed:
  - Removed `password` as a parameter to `SubmitApprovedTxMsg`, and instead am using `UnlockVaultMsg` to validate user credentials - User will now see `Invalid password!` if authentication fails, and will be allowed to try again 