### PR TITLE
Extension: Sign Arbitrary Data

### DIFF
--- a/apps/extension/src/Approvals/Approvals.tsx
+++ b/apps/extension/src/Approvals/Approvals.tsx
@@ -1,15 +1,17 @@
 import React, { useState } from "react";
-import { Routes, Route } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 
 import { Container } from "@namada/components";
 import { TxType } from "@namada/shared";
 
-import { ApproveConnection } from "./ApproveConnection";
+import { AppHeader } from "App/Common/AppHeader";
 import { TopLevelRoute } from "Approvals/types";
+import { ApproveConnection } from "./ApproveConnection";
+import { ApproveSignature } from "./ApproveSignature";
+import { ApproveTx } from "./ApproveTx/ApproveTx";
 import { ConfirmLedgerTx } from "./ApproveTx/ConfirmLedgerTx";
 import { ConfirmTx } from "./ApproveTx/ConfirmTx";
-import { ApproveTx } from "./ApproveTx/ApproveTx";
-import { AppHeader } from "App/Common/AppHeader";
+import { ConfirmSignature } from "./ConfirmSignature";
 
 export enum Status {
   Completed,
@@ -25,8 +27,14 @@ export type ApprovalDetails = {
   target?: string;
 };
 
+export type SignatureDetails = {
+  msgId: string;
+  signer: string;
+};
+
 export const Approvals: React.FC = () => {
   const [details, setDetails] = useState<ApprovalDetails>();
+  const [signatureDetails, setSignatureDetails] = useState<SignatureDetails>();
 
   return (
     <Container
@@ -55,6 +63,16 @@ export const Approvals: React.FC = () => {
         <Route
           path={TopLevelRoute.ApproveConnection}
           element={<ApproveConnection />}
+        />
+        <Route
+          path={`${TopLevelRoute.ApproveSignature}/:signer`}
+          element={
+            <ApproveSignature setSignatureDetails={setSignatureDetails} />
+          }
+        />
+        <Route
+          path={TopLevelRoute.ConfirmSignature}
+          element={<ConfirmSignature details={signatureDetails} />}
         />
       </Routes>
     </Container>

--- a/apps/extension/src/Approvals/ApproveSignature.tsx
+++ b/apps/extension/src/Approvals/ApproveSignature.tsx
@@ -1,0 +1,71 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { ActionButton, Alert, Stack } from "@namada/components";
+import { useSanitizedParams } from "@namada/hooks";
+import { shortenAddress } from "@namada/utils";
+import { SignatureDetails } from "Approvals/Approvals";
+import { TopLevelRoute } from "Approvals/types";
+import { RejectSignatureMsg } from "background/approvals";
+import { useQuery } from "hooks";
+import { useRequester } from "hooks/useRequester";
+import { Ports } from "router";
+import { closeCurrentTab } from "utils";
+
+type Props = {
+  setSignatureDetails: (details: SignatureDetails) => void;
+};
+
+export const ApproveSignature: React.FC<Props> = ({ setSignatureDetails }) => {
+  const navigate = useNavigate();
+  const params = useSanitizedParams();
+  const requester = useRequester();
+  const signer = params?.signer;
+  const query = useQuery();
+  const { msgId } = query.getAll();
+
+  const handleApproveClick = useCallback((): void => {
+    if (signer) {
+      setSignatureDetails({ msgId, signer });
+      navigate(TopLevelRoute.ConfirmSignature);
+    }
+  }, [signer]);
+
+  const handleReject = useCallback(async (): Promise<void> => {
+    try {
+      if (msgId) {
+        await requester.sendMessage(
+          Ports.Background,
+          new RejectSignatureMsg(msgId)
+        );
+        // Close tab
+        return await closeCurrentTab();
+      }
+      throw new Error("msgId was not provided!");
+    } catch (e) {
+      console.warn(e);
+    }
+  }, []);
+
+  return (
+    <Stack className="text-white" gap={4}>
+      {signer && (
+        <Alert type="warning">
+          Approve this signature request for account{" "}
+          {shortenAddress(signer, 24)}?
+        </Alert>
+      )}
+      <Stack gap={2}>
+        {signer && (
+          <p className="text-xs">
+            Signer: <strong>{shortenAddress(signer)}</strong>
+          </p>
+        )}
+      </Stack>
+      <Stack gap={3} direction="horizontal">
+        <ActionButton onClick={handleApproveClick}>Approve</ActionButton>
+        <ActionButton onClick={handleReject}>Reject</ActionButton>
+      </Stack>
+    </Stack>
+  );
+};

--- a/apps/extension/src/Approvals/ConfirmSignature.tsx
+++ b/apps/extension/src/Approvals/ConfirmSignature.tsx
@@ -47,7 +47,7 @@ export const ConfirmSignature: React.FC<Props> = ({ details }) => {
       await requester
         .sendMessage(
           Ports.Background,
-          new SubmitApprovedSignatureMsg(signer, msgId)
+          new SubmitApprovedSignatureMsg(msgId, signer)
         )
         .catch((e) => {
           throw new Error(e);

--- a/apps/extension/src/Approvals/ConfirmSignature.tsx
+++ b/apps/extension/src/Approvals/ConfirmSignature.tsx
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { ActionButton, Alert, Input, Stack } from "@namada/components";
+import { shortenAddress } from "@namada/utils";
+import { SignatureDetails, Status } from "Approvals/Approvals";
+import { SubmitApprovedSignatureMsg } from "background/approvals";
+import { UnlockVaultMsg } from "background/vault";
+import { useRequester } from "hooks/useRequester";
+import { Ports } from "router";
+import { closeCurrentTab } from "utils";
+
+type Props = {
+  details?: SignatureDetails;
+};
+
+export const ConfirmSignature: React.FC<Props> = ({ details }) => {
+  const { msgId, signer } = details || {};
+
+  const navigate = useNavigate();
+  const requester = useRequester();
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string>();
+  const [status, setStatus] = useState<Status>();
+  const [statusInfo, setStatusInfo] = useState("");
+
+  const handleApproveSignature = useCallback(async (): Promise<void> => {
+    if (!msgId || !signer) {
+      throw new Error("Not all required arguments were provided!");
+    }
+
+    setStatus(Status.Pending);
+    setStatusInfo(
+      `Decrypting keys and signing with ${shortenAddress(signer, 24)}`
+    );
+
+    try {
+      const isAuthenticated = await requester.sendMessage(
+        Ports.Background,
+        new UnlockVaultMsg(password)
+      );
+
+      if (!isAuthenticated) {
+        throw new Error("Invalid password!");
+      }
+
+      await requester
+        .sendMessage(
+          Ports.Background,
+          new SubmitApprovedSignatureMsg(signer, msgId)
+        )
+        .catch((e) => {
+          throw new Error(e);
+        });
+      setStatus(Status.Completed);
+    } catch (e) {
+      console.info(e);
+      setError(`${e}`);
+      setStatus(Status.Failed);
+    }
+  }, [password]);
+
+  useEffect(() => {
+    if (status === Status.Completed) {
+      closeCurrentTab();
+    }
+  }, [status]);
+
+  return (
+    <Stack gap={4}>
+      {status === Status.Pending && <Alert type="info">{statusInfo}</Alert>}
+      {status === Status.Failed && (
+        <Alert type="error">
+          {error}
+          <br />
+          Try again
+        </Alert>
+      )}
+      {status !== (Status.Pending || Status.Completed) && signer && (
+        <>
+          <Alert type="warning">
+            Decrypt keys for{" "}
+            <strong className="text-xs">{shortenAddress(signer)}</strong>
+          </Alert>
+          <Input
+            variant="Password"
+            label={"Password"}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <Stack gap={3} direction="horizontal">
+            <ActionButton onClick={handleApproveSignature} disabled={!password}>
+              Authenticate
+            </ActionButton>
+            <ActionButton onClick={() => navigate(-1)}>Back</ActionButton>
+          </Stack>
+        </>
+      )}
+    </Stack>
+  );
+};

--- a/apps/extension/src/Approvals/types.ts
+++ b/apps/extension/src/Approvals/types.ts
@@ -10,7 +10,13 @@ export enum TopLevelRoute {
   ApproveTx = "/approve-tx",
   ConfirmTx = "/confirm-tx",
   ConfirmLedgerTx = "/confirm-ledger-tx",
+
+  // Signing approval
+  ApproveSignature = "/approve-signature",
+  ConfirmSignature = "/confirm-signature",
 }
 
-export type ApproveMsg = new (msgId: string, password: string) => unknown &
-  Message<void>;
+export type ApproveMsg = new (
+  msgId: string,
+  password: string
+) => unknown & Message<void>;

--- a/apps/extension/src/background/approvals/handler.ts
+++ b/apps/extension/src/background/approvals/handler.ts
@@ -1,9 +1,15 @@
-import { ApproveConnectInterfaceMsg, ApproveTxMsg } from "provider";
+import {
+  ApproveConnectInterfaceMsg,
+  ApproveSignArbitraryMsg,
+  ApproveTxMsg,
+} from "provider";
 import { Env, Handler, InternalHandler, Message } from "router";
 import {
   ConnectInterfaceResponseMsg,
+  RejectSignatureMsg,
   RejectTxMsg,
   RevokeConnectionMsg,
+  SubmitApprovedSignatureMsg,
   SubmitApprovedTxMsg,
 } from "./messages";
 import { ApprovalsService } from "./service";
@@ -35,6 +41,22 @@ export const getHandler: (service: ApprovalsService) => Handler = (service) => {
           env,
           msg as RevokeConnectionMsg
         );
+      case ApproveSignArbitraryMsg:
+        return handleApproveSignArbitraryMsg(service)(
+          env,
+          msg as ApproveSignArbitraryMsg
+        );
+      case RejectSignatureMsg:
+        return handleRejectSignatureMsg(service)(
+          env,
+          msg as RejectSignatureMsg
+        );
+      case SubmitApprovedSignatureMsg:
+        return handleSubmitApprovedSignatureMsg(service)(
+          env,
+          msg as SubmitApprovedSignatureMsg
+        );
+
       default:
         throw new Error("Unknown msg type");
     }
@@ -94,5 +116,29 @@ const handleRevokeConnectionMsg: (
 ) => InternalHandler<RevokeConnectionMsg> = (service) => {
   return async (_, { originToRevoke }) => {
     return await service.revokeConnection(originToRevoke);
+  };
+};
+
+const handleApproveSignArbitraryMsg: (
+  service: ApprovalsService
+) => InternalHandler<ApproveSignArbitraryMsg> = (service) => {
+  return async (_, { signer, data }) => {
+    return await service.approveSignature(signer, data);
+  };
+};
+
+const handleRejectSignatureMsg: (
+  service: ApprovalsService
+) => InternalHandler<RejectSignatureMsg> = (service) => {
+  return async ({ senderTabId: popupTabId }, { msgId }) => {
+    return await service.rejectSignature(popupTabId, msgId);
+  };
+};
+
+const handleSubmitApprovedSignatureMsg: (
+  service: ApprovalsService
+) => InternalHandler<SubmitApprovedSignatureMsg> = (service) => {
+  return async ({ senderTabId: popupTabId }, { msgId, signer }) => {
+    return await service.submitSignature(popupTabId, signer, msgId);
   };
 };

--- a/apps/extension/src/background/approvals/handler.ts
+++ b/apps/extension/src/background/approvals/handler.ts
@@ -139,6 +139,6 @@ const handleSubmitApprovedSignatureMsg: (
   service: ApprovalsService
 ) => InternalHandler<SubmitApprovedSignatureMsg> = (service) => {
   return async ({ senderTabId: popupTabId }, { msgId, signer }) => {
-    return await service.submitSignature(popupTabId, signer, msgId);
+    return await service.submitSignature(popupTabId, msgId, signer);
   };
 };

--- a/apps/extension/src/background/approvals/init.ts
+++ b/apps/extension/src/background/approvals/init.ts
@@ -1,20 +1,29 @@
-import { Router } from "router";
-import { ApproveTxMsg, ApproveConnectInterfaceMsg } from "provider";
 import {
-  RejectTxMsg,
-  SubmitApprovedTxMsg,
+  ApproveConnectInterfaceMsg,
+  ApproveSignArbitraryMsg,
+  ApproveTxMsg,
+} from "provider";
+import { Router } from "router";
+import {
   ConnectInterfaceResponseMsg,
+  RejectSignatureMsg,
+  RejectTxMsg,
   RevokeConnectionMsg,
+  SubmitApprovedSignatureMsg,
+  SubmitApprovedTxMsg,
 } from "./messages";
 
 import { ROUTE } from "./constants";
-import { ApprovalsService } from "./service";
 import { getHandler } from "./handler";
+import { ApprovalsService } from "./service";
 
 export function init(router: Router, service: ApprovalsService): void {
   router.registerMessage(ApproveTxMsg);
   router.registerMessage(RejectTxMsg);
   router.registerMessage(SubmitApprovedTxMsg);
+  router.registerMessage(ApproveSignArbitraryMsg);
+  router.registerMessage(RejectSignatureMsg);
+  router.registerMessage(SubmitApprovedSignatureMsg);
   router.registerMessage(ApproveConnectInterfaceMsg);
   router.registerMessage(ConnectInterfaceResponseMsg);
   router.registerMessage(RevokeConnectionMsg);

--- a/apps/extension/src/background/approvals/messages.ts
+++ b/apps/extension/src/background/approvals/messages.ts
@@ -5,8 +5,10 @@ import { ROUTE } from "./constants";
 import { validateProps } from "utils";
 
 enum MessageType {
-  RejectTx = "reject-tx",
   SubmitApprovedTx = "submit-approved-tx",
+  RejectTx = "reject-tx",
+  SubmitApprovedSignature = "submit-approved-signature",
+  RejectSignature = "reject-signature",
   ConnectInterfaceResponse = "connect-interface-response",
   RevokeConnection = "revoke-connection",
 }
@@ -58,6 +60,56 @@ export class SubmitApprovedTxMsg extends Message<void> {
 
   type(): string {
     return SubmitApprovedTxMsg.type();
+  }
+}
+
+export class RejectSignatureMsg extends Message<void> {
+  public static type(): MessageType {
+    return MessageType.RejectSignature;
+  }
+
+  constructor(public readonly msgId: string) {
+    super();
+  }
+
+  validate(): void {
+    if (!this.msgId) {
+      throw new Error("msgId must not be empty!");
+    }
+    return;
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return RejectSignatureMsg.type();
+  }
+}
+
+export class SubmitApprovedSignatureMsg extends Message<void> {
+  public static type(): MessageType {
+    return MessageType.SubmitApprovedSignature;
+  }
+
+  constructor(
+    public readonly msgId: string,
+    public readonly signer: string
+  ) {
+    super();
+  }
+
+  validate(): void {
+    validateProps(this, ["msgId", "signer"]);
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return SubmitApprovedSignatureMsg.type();
   }
 }
 

--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -53,7 +53,7 @@ export class ApprovalsService {
     protected readonly keyRingService: KeyRingService,
     protected readonly ledgerService: LedgerService,
     protected readonly vaultService: VaultService
-  ) {}
+  ) { }
 
   async approveSignature(
     signer: string,
@@ -107,7 +107,6 @@ export class ApprovalsService {
     } catch (e) {
       resolvers.reject(e);
     }
-    resolvers.resolve();
 
     await this._clearPendingSignature(msgId);
   }

--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -10,6 +10,7 @@ import {
   AccountType,
   EthBridgeTransferMsgValue,
   IbcTransferMsgValue,
+  SignatureResponse,
   SubmitBondMsgValue,
   SubmitUnbondMsgValue,
   SubmitVoteProposalMsgValue,
@@ -46,12 +47,81 @@ export class ApprovalsService {
 
   constructor(
     protected readonly txStore: KVStore<TxStore>,
+    protected readonly dataStore: KVStore<string>,
     protected readonly connectedTabsStore: KVStore<TabStore[]>,
     protected readonly approvedOriginsStore: KVStore<ApprovedOriginsStore>,
     protected readonly keyRingService: KeyRingService,
     protected readonly ledgerService: LedgerService,
     protected readonly vaultService: VaultService
-  ) { }
+  ) {}
+
+  async approveSignature(
+    signer: string,
+    data: string
+  ): Promise<SignatureResponse> {
+    const msgId = uuid();
+
+    await this.dataStore.set(msgId, data);
+    const baseUrl = `${browser.runtime.getURL(
+      "approvals.html"
+    )}#/approve-signature/${signer}`;
+
+    const url = paramsToUrl(baseUrl, {
+      msgId,
+    });
+    const approvalWindow = await this._launchApprovalWindow(url);
+    const popupTabId = approvalWindow.tabs?.[0]?.id;
+
+    if (!popupTabId) {
+      throw new Error("no popup tab ID");
+    }
+
+    if (popupTabId in this.resolverMap) {
+      throw new Error(`tab ID ${popupTabId} already exists in promise map`);
+    }
+
+    return await new Promise((resolve, reject) => {
+      this.resolverMap[popupTabId] = { resolve, reject };
+    });
+  }
+
+  async submitSignature(
+    popupTabId: number,
+    msgId: string,
+    signer: string
+  ): Promise<void> {
+    const data = await this.dataStore.get(msgId);
+    const resolvers = this.resolverMap[popupTabId];
+
+    if (!resolvers) {
+      throw new Error(`no resolvers found for tab ID ${popupTabId}`);
+    }
+
+    if (!data) {
+      throw new Error(`Signing data for ${msgId} not found!`);
+    }
+
+    try {
+      const signature = await this.keyRingService.signArbitrary(signer, data);
+      resolvers.resolve(signature);
+    } catch (e) {
+      resolvers.reject(e);
+    }
+    resolvers.resolve();
+
+    await this._clearPendingSignature(msgId);
+  }
+
+  async rejectSignature(popupTabId: number, msgId: string): Promise<void> {
+    const resolvers = this.resolverMap[popupTabId];
+
+    if (!resolvers) {
+      throw new Error(`no resolvers found for tab ID ${popupTabId}`);
+    }
+
+    await this._clearPendingSignature(msgId);
+    resolvers.reject();
+  }
 
   async approveTx(
     txType: SupportedTx,
@@ -331,6 +401,10 @@ export class ApprovalsService {
 
   private async _clearPendingTx(msgId: string): Promise<void> {
     return await this.txStore.set(msgId, null);
+  }
+
+  private async _clearPendingSignature(msgId: string): Promise<void> {
+    return await this.dataStore.set(msgId, null);
   }
 
   private _launchApprovalWindow = (url: string): Promise<Windows.Window> => {

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -50,6 +50,7 @@ const revealedPKStore = new ExtensionKVStore(KVPrefix.RevealedPK, {
   set: browser.storage.local.set,
 });
 const txStore = new MemoryKVStore(KVPrefix.Memory);
+const dataStore = new MemoryKVStore(KVPrefix.Memory);
 
 const messenger = new ExtensionMessenger();
 const router = new ExtensionRouter(
@@ -106,6 +107,7 @@ const init = new Promise<void>(async (resolve) => {
   );
   const approvalsService = new ApprovalsService(
     txStore,
+    dataStore,
     connectedTabsStore,
     approvedOriginsStore,
     keyRingService,

--- a/apps/extension/src/background/keyring/handler.ts
+++ b/apps/extension/src/background/keyring/handler.ts
@@ -5,6 +5,7 @@ import {
   QueryAccountsMsg,
   QueryBalancesMsg,
   QueryDefaultAccountMsg,
+  SignArbitraryMsg,
 } from "provider/messages";
 import { Env, Handler, InternalHandler, Message } from "router";
 import {
@@ -16,13 +17,13 @@ import {
   GetActiveAccountMsg,
   QueryParentAccountsMsg,
   QueryPublicKeyMsg,
+  RenameAccountMsg,
   RevealAccountMnemonicMsg,
   SaveAccountSecretMsg,
   ScanAccountsMsg,
   SetActiveAccountMsg,
   TransferCompletedEvent,
   ValidateMnemonicMsg,
-  RenameAccountMsg,
 } from "./messages";
 import { KeyRingService } from "./service";
 
@@ -110,6 +111,8 @@ export const getHandler: (service: KeyRingService) => Handler = (service) => {
           env,
           msg as AddLedgerAccountMsg
         );
+      case SignArbitraryMsg:
+        return handleSignArbitraryMsg(service)(env, msg as SignArbitraryMsg);
       default:
         throw new Error("Unknown msg type");
     }
@@ -298,5 +301,14 @@ const handleCheckDurabilityMsg: (
 ) => InternalHandler<CheckDurabilityMsg> = (service) => {
   return async (_, _msg) => {
     return await service.checkDurability();
+  };
+};
+
+const handleSignArbitraryMsg: (
+  service: KeyRingService
+) => InternalHandler<SignArbitraryMsg> = (service) => {
+  return async (_, msg) => {
+    const { signer, data } = msg;
+    return await service.signArbitrary(signer, data);
   };
 };

--- a/apps/extension/src/background/keyring/handler.ts
+++ b/apps/extension/src/background/keyring/handler.ts
@@ -5,7 +5,6 @@ import {
   QueryAccountsMsg,
   QueryBalancesMsg,
   QueryDefaultAccountMsg,
-  SignArbitraryMsg,
 } from "provider/messages";
 import { Env, Handler, InternalHandler, Message } from "router";
 import {
@@ -111,8 +110,6 @@ export const getHandler: (service: KeyRingService) => Handler = (service) => {
           env,
           msg as AddLedgerAccountMsg
         );
-      case SignArbitraryMsg:
-        return handleSignArbitraryMsg(service)(env, msg as SignArbitraryMsg);
       default:
         throw new Error("Unknown msg type");
     }
@@ -301,14 +298,5 @@ const handleCheckDurabilityMsg: (
 ) => InternalHandler<CheckDurabilityMsg> = (service) => {
   return async (_, _msg) => {
     return await service.checkDurability();
-  };
-};
-
-const handleSignArbitraryMsg: (
-  service: KeyRingService
-) => InternalHandler<SignArbitraryMsg> = (service) => {
-  return async (_, msg) => {
-    const { signer, data } = msg;
-    return await service.signArbitrary(signer, data);
   };
 };

--- a/apps/extension/src/background/keyring/init.ts
+++ b/apps/extension/src/background/keyring/init.ts
@@ -1,31 +1,32 @@
-import { Router } from "router";
 import {
+  CheckDurabilityMsg,
+  FetchAndStoreMaspParamsMsg,
+  HasMaspParamsMsg,
+  QueryAccountsMsg,
+  QueryBalancesMsg,
+  QueryDefaultAccountMsg,
+  SignArbitraryMsg,
+} from "provider/messages";
+import { Router } from "router";
+import { ROUTE } from "./constants";
+import { getHandler } from "./handler";
+import {
+  AddLedgerAccountMsg,
+  CloseOffscreenDocumentMsg,
+  DeleteAccountMsg,
   DeriveAccountMsg,
-  QueryPublicKeyMsg,
   GenerateMnemonicMsg,
+  GetActiveAccountMsg,
+  QueryParentAccountsMsg,
+  QueryPublicKeyMsg,
+  RenameAccountMsg,
+  RevealAccountMnemonicMsg,
   SaveAccountSecretMsg,
   ScanAccountsMsg,
   SetActiveAccountMsg,
-  GetActiveAccountMsg,
-  QueryParentAccountsMsg,
   TransferCompletedEvent,
-  CloseOffscreenDocumentMsg,
-  DeleteAccountMsg,
   ValidateMnemonicMsg,
-  AddLedgerAccountMsg,
-  RevealAccountMnemonicMsg,
-  RenameAccountMsg,
 } from "./messages";
-import {
-  QueryAccountsMsg,
-  QueryDefaultAccountMsg,
-  QueryBalancesMsg,
-  FetchAndStoreMaspParamsMsg,
-  HasMaspParamsMsg,
-  CheckDurabilityMsg,
-} from "provider/messages";
-import { ROUTE } from "./constants";
-import { getHandler } from "./handler";
 import { KeyRingService } from "./service";
 
 export function init(router: Router, service: KeyRingService): void {
@@ -50,6 +51,7 @@ export function init(router: Router, service: KeyRingService): void {
   router.registerMessage(AddLedgerAccountMsg);
   router.registerMessage(RevealAccountMnemonicMsg);
   router.registerMessage(RenameAccountMsg);
+  router.registerMessage(SignArbitraryMsg);
 
   router.addHandler(ROUTE, getHandler(service));
 }

--- a/apps/extension/src/background/keyring/init.ts
+++ b/apps/extension/src/background/keyring/init.ts
@@ -5,7 +5,6 @@ import {
   QueryAccountsMsg,
   QueryBalancesMsg,
   QueryDefaultAccountMsg,
-  SignArbitraryMsg,
 } from "provider/messages";
 import { Router } from "router";
 import { ROUTE } from "./constants";
@@ -51,7 +50,6 @@ export function init(router: Router, service: KeyRingService): void {
   router.registerMessage(AddLedgerAccountMsg);
   router.registerMessage(RevealAccountMnemonicMsg);
   router.registerMessage(RenameAccountMsg);
-  router.registerMessage(SignArbitraryMsg);
 
   router.addHandler(ROUTE, getHandler(service));
 }

--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -51,6 +51,7 @@ import {
   UtilityStore,
 } from "./types";
 
+import { toHex } from "@cosmjs/encoding";
 import { SdkService } from "background/sdk";
 import { VaultService } from "background/vault";
 import { generateId } from "utils";
@@ -81,7 +82,7 @@ export class KeyRing {
     protected readonly utilityStore: KVStore<UtilityStore>,
     protected readonly extensionStore: KVStore<number>,
     protected readonly cryptoMemory: WebAssembly.Memory
-  ) {}
+  ) { }
 
   public get status(): KeyRingStatus {
     return this._status;
@@ -896,6 +897,6 @@ export class KeyRing {
     const sdk = await this.sdkService.getSdk();
     const [hash, signature] = await sdk.sign_arbitrary(key, data);
 
-    return { hash, signature };
+    return { hash, signature: toHex(signature) };
   }
 }

--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -24,6 +24,7 @@ import {
   DerivedAccount,
   EthBridgeTransferMsgValue,
   IbcTransferMsgValue,
+  SignatureResponse,
   SubmitBondMsgValue,
   SubmitUnbondMsgValue,
   SubmitVoteProposalMsgValue,
@@ -883,5 +884,18 @@ export class KeyRing {
   async queryPublicKey(address: string): Promise<string | undefined> {
     const query = await this.sdkService.getQuery();
     return await query.query_public_key(address);
+  }
+
+  async signArbitrary(
+    signer: string,
+    data: string
+  ): Promise<SignatureResponse | undefined> {
+    await this.vaultService.assertIsUnlocked();
+
+    const key = await this.getSigningKey(signer);
+    const sdk = await this.sdkService.getSdk();
+    const [hash, signature] = await sdk.sign_arbitrary(key, data);
+
+    return { hash, signature };
   }
 }

--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -82,7 +82,7 @@ export class KeyRing {
     protected readonly utilityStore: KVStore<UtilityStore>,
     protected readonly extensionStore: KVStore<number>,
     protected readonly cryptoMemory: WebAssembly.Memory
-  ) { }
+  ) {}
 
   public get status(): KeyRingStatus {
     return this._status;

--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -82,7 +82,7 @@ export class KeyRing {
     protected readonly utilityStore: KVStore<UtilityStore>,
     protected readonly extensionStore: KVStore<number>,
     protected readonly cryptoMemory: WebAssembly.Memory
-  ) {}
+  ) { }
 
   public get status(): KeyRingStatus {
     return this._status;
@@ -890,7 +890,7 @@ export class KeyRing {
   async signArbitrary(
     signer: string,
     data: string
-  ): Promise<SignatureResponse | undefined> {
+  ): Promise<SignatureResponse> {
     await this.vaultService.assertIsUnlocked();
 
     const key = await this.getSigningKey(signer);

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -3,7 +3,12 @@ import { fromBase64, fromHex } from "@cosmjs/encoding";
 import { PhraseSize } from "@namada/crypto";
 import { public_key_to_bech32, Sdk, TxType } from "@namada/shared";
 import { IndexedDBKVStore, KVStore } from "@namada/storage";
-import { AccountType, Bip44Path, DerivedAccount } from "@namada/types";
+import {
+  AccountType,
+  Bip44Path,
+  DerivedAccount,
+  SignatureResponse,
+} from "@namada/types";
 import { Result, truncateInMiddle } from "@namada/utils";
 
 import {
@@ -446,5 +451,12 @@ export class KeyRingService {
 
   async checkDurability(): Promise<boolean> {
     return await IndexedDBKVStore.durabilityCheck();
+  }
+
+  async signArbitrary(
+    signer: string,
+    data: string
+  ): Promise<SignatureResponse | undefined> {
+    return await this._keyRing.signArbitrary(signer, data);
   }
 }

--- a/apps/extension/src/provider/InjectedNamada.ts
+++ b/apps/extension/src/provider/InjectedNamada.ts
@@ -3,6 +3,8 @@ import {
   DerivedAccount,
   Namada as INamada,
   Signer as ISigner,
+  SignArbitraryProps,
+  SignatureResponse,
   TxMsgProps,
 } from "@namada/types";
 import { InjectedProxy } from "./InjectedProxy";
@@ -25,6 +27,15 @@ export class InjectedNamada implements INamada {
     return await InjectedProxy.requestMethod<string, DerivedAccount>(
       "defaultAccount"
     );
+  }
+
+  public async sign(
+    props: SignArbitraryProps
+  ): Promise<SignatureResponse | undefined> {
+    return await InjectedProxy.requestMethod<
+      SignArbitraryProps,
+      SignatureResponse | undefined
+    >("sign", props);
   }
 
   public async balances(

--- a/apps/extension/src/provider/Namada.ts
+++ b/apps/extension/src/provider/Namada.ts
@@ -10,6 +10,7 @@ import { MessageRequester, Ports } from "router";
 
 import {
   ApproveConnectInterfaceMsg,
+  ApproveSignArbitraryMsg,
   ApproveTxMsg,
   CheckDurabilityMsg,
   FetchAndStoreMaspParamsMsg,
@@ -18,7 +19,6 @@ import {
   QueryAccountsMsg,
   QueryBalancesMsg,
   QueryDefaultAccountMsg,
-  SignArbitraryMsg,
 } from "./messages";
 
 export class Namada implements INamada {
@@ -60,7 +60,7 @@ export class Namada implements INamada {
     const { signer, data } = props;
     return await this.requester?.sendMessage(
       Ports.Background,
-      new SignArbitraryMsg(signer, data)
+      new ApproveSignArbitraryMsg(signer, data)
     );
   }
 

--- a/apps/extension/src/provider/Namada.ts
+++ b/apps/extension/src/provider/Namada.ts
@@ -2,6 +2,8 @@ import {
   Chain,
   DerivedAccount,
   Namada as INamada,
+  SignArbitraryProps,
+  SignatureResponse,
   TxMsgProps,
 } from "@namada/types";
 import { MessageRequester, Ports } from "router";
@@ -16,6 +18,7 @@ import {
   QueryAccountsMsg,
   QueryBalancesMsg,
   QueryDefaultAccountMsg,
+  SignArbitraryMsg,
 } from "./messages";
 
 export class Namada implements INamada {
@@ -48,6 +51,16 @@ export class Namada implements INamada {
     return await this.requester?.sendMessage(
       Ports.Background,
       new QueryDefaultAccountMsg()
+    );
+  }
+
+  public async sign(
+    props: SignArbitraryProps
+  ): Promise<SignatureResponse | undefined> {
+    const { signer, data } = props;
+    return await this.requester?.sendMessage(
+      Ports.Background,
+      new SignArbitraryMsg(signer, data)
     );
   }
 

--- a/apps/extension/src/provider/Namada.ts
+++ b/apps/extension/src/provider/Namada.ts
@@ -25,7 +25,7 @@ export class Namada implements INamada {
   constructor(
     private readonly _version: string,
     protected readonly requester?: MessageRequester
-  ) {}
+  ) { }
 
   public async connect(): Promise<void> {
     return await this.requester?.sendMessage(

--- a/apps/extension/src/provider/Signer.ts
+++ b/apps/extension/src/provider/Signer.ts
@@ -28,7 +28,7 @@ import {
 } from "@namada/types";
 
 export class Signer implements ISigner {
-  constructor(private readonly _namada: Namada) {}
+  constructor(private readonly _namada: Namada) { }
 
   public async accounts(): Promise<Account[] | undefined> {
     return (await this._namada.accounts())?.map(

--- a/apps/extension/src/provider/Signer.ts
+++ b/apps/extension/src/provider/Signer.ts
@@ -1,30 +1,31 @@
 import { toBase64 } from "@cosmjs/encoding";
+import { defaultChainId } from "@namada/chains";
+import { SupportedTx, TxType } from "@namada/shared";
 import {
   Account,
-  Namada,
+  AccountType,
+  BridgeTransferProps,
+  EthBridgeTransferMsgValue,
+  Signer as ISigner,
   IbcTransferMsgValue,
   IbcTransferProps,
   Message,
-  Signer as ISigner,
+  Namada,
+  Schema,
+  SignatureResponse,
+  SubmitBondMsgValue,
+  SubmitBondProps,
+  SubmitUnbondMsgValue,
+  SubmitUnbondProps,
+  SubmitVoteProposalMsgValue,
+  SubmitVoteProposalProps,
+  SubmitWithdrawMsgValue,
+  SubmitWithdrawProps,
   TransferMsgValue,
   TransferProps,
-  AccountType,
-  SubmitBondProps,
-  SubmitBondMsgValue,
-  SubmitUnbondProps,
-  SubmitUnbondMsgValue,
-  SubmitWithdrawProps,
-  SubmitWithdrawMsgValue,
-  BridgeTransferProps,
-  EthBridgeTransferMsgValue,
-  TxProps,
   TxMsgValue,
-  Schema,
-  SubmitVoteProposalProps,
-  SubmitVoteProposalMsgValue,
+  TxProps,
 } from "@namada/types";
-import { TxType, SupportedTx } from "@namada/shared";
-import { defaultChainId } from "@namada/chains";
 
 export class Signer implements ISigner {
   constructor(private readonly _namada: Namada) {}
@@ -58,6 +59,14 @@ export class Signer implements ISigner {
       };
     }
   }
+
+  public async sign(
+    signer: string,
+    data: string
+  ): Promise<SignatureResponse | undefined> {
+    return await this._namada.sign({ signer, data });
+  }
+
   private async submitTx<T extends Schema, Args>(
     txType: SupportedTx,
     constructor: new (args: Args) => T,

--- a/apps/extension/src/provider/messages.ts
+++ b/apps/extension/src/provider/messages.ts
@@ -1,5 +1,10 @@
 import { SupportedTx } from "@namada/shared";
-import { AccountType, Chain, DerivedAccount } from "@namada/types";
+import {
+  AccountType,
+  Chain,
+  DerivedAccount,
+  SignatureResponse,
+} from "@namada/types";
 import { Message } from "router";
 import { validateProps } from "utils";
 
@@ -30,6 +35,7 @@ enum MessageType {
   HasMaspParams = "has-masp-params",
   ApproveEthBridgeTransfer = "approve-eth-bridge-transfer",
   CheckDurability = "check-durability",
+  SignArbitrary = "sign-arbitrary",
 }
 
 /**
@@ -67,7 +73,7 @@ export class GetChainMsg extends Message<Chain | undefined> {
     super();
   }
 
-  validate(): void { }
+  validate(): void {}
 
   route(): string {
     return Route.Chains;
@@ -234,5 +240,35 @@ export class CheckDurabilityMsg extends Message<boolean> {
 
   type(): string {
     return CheckDurabilityMsg.type();
+  }
+}
+
+export class SignArbitraryMsg extends Message<SignatureResponse | undefined> {
+  public static type(): MessageType {
+    return MessageType.SignArbitrary;
+  }
+
+  constructor(
+    public readonly signer: string,
+    public readonly data: string
+  ) {
+    super();
+  }
+
+  validate(): void {
+    if (!this.signer) {
+      throw new Error("A signer address is required!");
+    }
+    if (!this.data) {
+      throw new Error("Signing data is required!");
+    }
+  }
+
+  route(): string {
+    return Route.KeyRing;
+  }
+
+  type(): string {
+    return SignArbitraryMsg.type();
   }
 }

--- a/apps/extension/src/provider/messages.ts
+++ b/apps/extension/src/provider/messages.ts
@@ -35,7 +35,7 @@ enum MessageType {
   HasMaspParams = "has-masp-params",
   ApproveEthBridgeTransfer = "approve-eth-bridge-transfer",
   CheckDurability = "check-durability",
-  SignArbitrary = "sign-arbitrary",
+  ApproveSignArbitrary = "approve-sign-arbitrary",
 }
 
 /**
@@ -243,9 +243,9 @@ export class CheckDurabilityMsg extends Message<boolean> {
   }
 }
 
-export class SignArbitraryMsg extends Message<SignatureResponse | undefined> {
+export class ApproveSignArbitraryMsg extends Message<SignatureResponse> {
   public static type(): MessageType {
-    return MessageType.SignArbitrary;
+    return MessageType.ApproveSignArbitrary;
   }
 
   constructor(
@@ -265,10 +265,10 @@ export class SignArbitraryMsg extends Message<SignatureResponse | undefined> {
   }
 
   route(): string {
-    return Route.KeyRing;
+    return Route.Approvals;
   }
 
   type(): string {
-    return SignArbitraryMsg.type();
+    return ApproveSignArbitraryMsg.type();
   }
 }

--- a/apps/extension/src/test/init.ts
+++ b/apps/extension/src/test/init.ts
@@ -87,6 +87,7 @@ export const init = async (): Promise<{
   const namadaRouterId = await getNamadaRouterId(extStore);
   const requester = new ExtensionRequester(messenger, namadaRouterId);
   const txStore = new KVStoreMock<TxStore>(KVPrefix.LocalStorage);
+  const dataStore = new KVStoreMock<string>(KVPrefix.LocalStorage);
   const chainStore = new KVStoreMock<Chain>(KVPrefix.LocalStorage);
   const broadcaster = new ExtensionBroadcaster(connectedTabsStore, requester);
 
@@ -134,6 +135,7 @@ export const init = async (): Promise<{
 
   const approvalsService = new ApprovalsService(
     txStore,
+    dataStore,
     connectedTabsStore,
     approvedOriginsStore,
     keyRingService,

--- a/packages/shared/lib/src/sdk/mod.rs
+++ b/packages/shared/lib/src/sdk/mod.rs
@@ -380,6 +380,21 @@ impl Sdk {
 
         Ok(())
     }
+
+    // Sign arbitrary data with the provided signing key
+    // TODO: Use function from SDK when it is available
+    pub async fn sign_arbitrary(
+        &self,
+        signing_key: String,
+        data: String,
+    ) -> Result<JsValue, JsError> {
+        to_js_result((
+            // Hash
+            String::from(format!("TODO: hash for data: {}", &data)),
+            // Signature
+            String::from(format!("TODO: signature for signing_key: {}", &signing_key)),
+        ))
+    }
 }
 
 #[wasm_bindgen(module = "/src/sdk/mod.js")]

--- a/packages/shared/lib/src/sdk/mod.rs
+++ b/packages/shared/lib/src/sdk/mod.rs
@@ -20,6 +20,8 @@ use namada::namada_sdk::wallet::{Store, Wallet};
 use namada::namada_sdk::{Namada, NamadaImpl};
 use namada::proto::Tx;
 use namada::types::address::Address;
+use namada::types::hash::Hash;
+use namada::types::key::{ed25519, SigScheme};
 use std::str::FromStr;
 use wasm_bindgen::{prelude::wasm_bindgen, JsError, JsValue};
 pub mod io;
@@ -388,11 +390,17 @@ impl Sdk {
         signing_key: String,
         data: String,
     ) -> Result<JsValue, JsError> {
+        let hash = Hash::sha256(&data);
+        let secret = ed25519::SecretKey::from_str(&signing_key)?;
+        let signature: ed25519::Signature = ed25519::SigScheme::sign(&secret, &hash);
+
+        let sig_bytes: &[u8] = &signature.0.to_bytes();
+
         to_js_result((
             // Hash
-            String::from(format!("TODO: hash for data: {}", &data)),
+            &hash.to_string().to_lowercase(),
             // Signature
-            String::from(format!("TODO: signature for signing_key: {}", &signing_key)),
+            &sig_bytes,
         ))
     }
 }

--- a/packages/types/src/namada.ts
+++ b/packages/types/src/namada.ts
@@ -1,6 +1,6 @@
 import { AccountType, DerivedAccount } from "./account";
 import { Chain } from "./chain";
-import { Signer } from "./signer";
+import { SignatureResponse, Signer } from "./signer";
 
 export type TxMsgProps = {
   //TODO: figure out if we can make it better
@@ -11,6 +11,11 @@ export type TxMsgProps = {
   type: AccountType;
 };
 
+export type SignArbitraryProps = {
+  signer: string;
+  data: string;
+};
+
 export interface Namada {
   accounts(chainId?: string): Promise<DerivedAccount[] | undefined>;
   balances(
@@ -18,6 +23,7 @@ export interface Namada {
   ): Promise<{ token: string; amount: string }[] | undefined>;
   connect(chainId?: string): Promise<void>;
   defaultAccount(chainId?: string): Promise<DerivedAccount | undefined>;
+  sign(props: SignArbitraryProps): Promise<SignatureResponse | undefined>;
   submitTx: (props: TxMsgProps) => Promise<void>;
   getChain: () => Promise<Chain | undefined>;
   version: () => string;

--- a/packages/types/src/signer.ts
+++ b/packages/types/src/signer.ts
@@ -10,9 +10,18 @@ import {
   TxProps,
 } from "./tx";
 
+export type SignatureResponse = {
+  hash: string;
+  signature: string;
+};
+
 export interface Signer {
   accounts: (chainId?: string) => Promise<Account[] | undefined>;
   defaultAccount: (chainId?: string) => Promise<Account | undefined>;
+  sign: (
+    signer: string,
+    data: string
+  ) => Promise<SignatureResponse | undefined>;
   submitBond(
     args: SubmitBondProps,
     txArgs: TxProps,


### PR DESCRIPTION
Adding functionality to extension to sign arbitrary data with the extension.

- Added a `.sign(address, data)` function to to `namada.getSigner()` to produce signatures for arbitrary data with our keys. This promise resolves when the user has both approved the signature and successfully authenticated, and is rejected if the user clicks `Reject`
- As the `data` can be of arbitrary size, similar to the Tx approvals, this gets added to a temporary in-memory key store, referenced by `msgId` passed to the approval window. There is a limit to the number of characters we can provide to the Approval popup via query-strings

## Testing

- Install the extension, setup accounts, and copy one of the addresses (make sure it is unlocked before next step)
- In the browser console, do the following (replacing the following address with a real address from your wallet):
  ```
  const signer = namada.getSigner();
  const signature = await signer.sign("tnam1qry3lnk03j965y92np6e25jvadk3kw9u7cvwjclp", "Arbitrary Data!");
  ```
  The resulting output should look something like:
  ```
  {
    "hash": "c5ebe9588ae5b0966977043d94f033d5d729787fdc4df686cf54d0388968df6b",
    "signature": "5f62366e652209586208f5e8b40014b35e1361e1d82dd67bd0609e894fd60a7cdb8ad7c43b7e778bd1e38b5ef259c9e8f3338e5929d4468333a1d46b4706660e"
  }
  ```
- Also, you can test `Reject` behavior - this will invoke `Promise.reject()` so it can be handled in a client, you should just see an error in this case

_NOTE_ You can also invoke it directly on the injected `namada` like this:
```
await namada.sign({ signer: "tnam1qry3lnk03j965y92np6e25jvadk3kw9u7cvwjclp", data: "Arbitrary Data!" });
```

### Screeenshots
Sign-Arbitrary approval:
<img width="391" alt="Screen Shot 2024-01-23 at 8 20 43 AM" src="https://github.com/anoma/namada-interface/assets/330911/c29460ea-d4e8-4fa6-9a07-d22caa99eaaa">

<img width="1115" alt="Screen Shot 2024-01-23 at 8 21 08 AM" src="https://github.com/anoma/namada-interface/assets/330911/86a73a7f-06a2-40b0-a443-933eb7c28bad">

<img width="1117" alt="Screen Shot 2024-01-23 at 8 23 12 AM" src="https://github.com/anoma/namada-interface/assets/330911/e8d99dd9-9daa-45a2-a198-72942169354d">

<img width="724" alt="Screen Shot 2024-01-23 at 8 24 03 AM" src="https://github.com/anoma/namada-interface/assets/330911/82bdc0fb-c038-48dd-bfb7-562868c3df6d">
