### PR TITLE
fix: fix balances not displaying on initial connection

### DIFF
--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -82,8 +82,8 @@ const init = new Promise<void>(async (resolve) => {
     cryptoMemory,
     broadcaster
   );
-  const sdkService = new SdkService(chainStore);
   const chainsService = new ChainsService(chainStore, broadcaster);
+  const sdkService = new SdkService(chainsService);
   const keyRingService = new KeyRingService(
     vaultService,
     sdkService,

--- a/apps/extension/src/background/sdk/service.ts
+++ b/apps/extension/src/background/sdk/service.ts
@@ -1,14 +1,12 @@
 import { Query, Sdk } from "@namada/shared";
-import { KVStore } from "@namada/storage";
-import { Chain } from "@namada/types";
-import { CHAINS_KEY } from "background/chains";
+import { ChainsService } from "background/chains";
 
 export class SdkService {
-  constructor(protected readonly chainStore: KVStore<Chain>) { }
+  constructor(protected readonly chainsService: ChainsService) {}
 
   private async _getRpc(): Promise<string> {
     // Pull chain config from store, as the RPC value may have changed:
-    const chain = await this.chainStore.get(CHAINS_KEY);
+    const chain = await this.chainsService.getChain();
 
     if (!chain) {
       throw new Error("No chain found!");

--- a/apps/extension/src/test/init.ts
+++ b/apps/extension/src/test/init.ts
@@ -31,6 +31,7 @@ import {
   init as initApprovals,
 } from "../background/approvals";
 
+import { ChainsService } from "background/chains";
 import { LedgerService } from "background/ledger";
 import { SdkService } from "background/sdk";
 import { Namada } from "provider";
@@ -42,7 +43,7 @@ const cryptoMemory = require("@namada/crypto").__wasm.memory;
 export class KVStoreMock<T> implements KVStore<T> {
   private storage: { [key: string]: T | null } = {};
 
-  constructor(readonly _prefix: string) { }
+  constructor(readonly _prefix: string) {}
 
   get<U extends T>(key: string): Promise<U | undefined> {
     return new Promise((resolve) => {
@@ -106,7 +107,8 @@ export const init = async (): Promise<{
     sessionStore,
     cryptoMemory
   );
-  const sdkService = new SdkService(chainStore);
+  const chainsService = new ChainsService(chainStore, broadcaster);
+  const sdkService = new SdkService(chainsService);
 
   const keyRingService = new KeyRingService(
     vaultService,


### PR DESCRIPTION
It was failing because there was no chain config present in the store.

Fixes #575.