### PR TITLE
fix: await connect message send before closing tab

### DIFF
--- a/apps/extension/src/Approvals/ApproveConnection.tsx
+++ b/apps/extension/src/Approvals/ApproveConnection.tsx
@@ -11,9 +11,9 @@ export const ApproveConnection: React.FC = () => {
   const interfaceOrigin = params.get("interfaceOrigin");
   const interfaceTabId = params.get("interfaceTabId");
 
-  const handleResponse = (allowConnection: boolean): void => {
+  const handleResponse = async (allowConnection: boolean): Promise<void> => {
     if (interfaceTabId && interfaceOrigin) {
-      requester.sendMessage(
+      await requester.sendMessage(
         Ports.Background,
         new ConnectInterfaceResponseMsg(
           parseInt(interfaceTabId),


### PR DESCRIPTION
This should fix connections to the extension from intermittently failing when the approval window closes before the connection message has sent.