### PR TITLE
bug/591 - Staking should use correct chain ID

### DIFF
--- a/apps/extension/src/App/Settings/Network.tsx
+++ b/apps/extension/src/App/Settings/Network.tsx
@@ -105,7 +105,7 @@ export const Network = (): JSX.Element => {
           type="text"
           value={chainId}
           onChange={(e) => setChainId(e.target.value)}
-          error={chainId.length === 0 ? "URL is required!" : ""}
+          error={chainId.length === 0 ? "Chain ID required!" : ""}
         />
         <Input
           label="URL"

--- a/apps/namada-interface/src/App/Token/EthereumBridge/EthereumBridge.tsx
+++ b/apps/namada-interface/src/App/Token/EthereumBridge/EthereumBridge.tsx
@@ -5,7 +5,7 @@ import {
   Select,
 } from "@namada/components";
 import { chains } from "@namada/chains";
-import { TokenType, Tokens } from "@namada/types";
+import { Chain, TokenType, Tokens } from "@namada/types";
 import BigNumber from "bignumber.js";
 import { useState } from "react";
 import { Account, AccountsState } from "slices/accounts";
@@ -45,6 +45,7 @@ const toTokenData = (
 
 export const EthereumBridge = (): JSX.Element => {
   const { derived } = useAppSelector<AccountsState>((state) => state.accounts);
+  const { id, chainId } = useAppSelector<Chain>((state) => state.chain.config);
   const [recipient, setRecipient] = useState("");
   const [amount, setAmount] = useState<BigNumber>(new BigNumber(0));
   const [feeAmount, setFeeAmount] = useState<BigNumber>(new BigNumber(0));
@@ -75,7 +76,7 @@ export const EthereumBridge = (): JSX.Element => {
       (account) => account?.details?.address === accountId
     ) as Account;
 
-    const integration = getIntegration(chains.namada.id);
+    const integration = getIntegration(id);
     await integration.submitBridgeTransfer(
       {
         bridgeProps: {
@@ -92,7 +93,7 @@ export const EthereumBridge = (): JSX.Element => {
           feeAmount: new BigNumber(0),
           gasLimit: new BigNumber(20_000),
           publicKey: account.details.publicKey,
-          chainId: chains.namada.chainId,
+          chainId,
         },
       },
       account.details.type

--- a/apps/namada-interface/src/slices/StakingAndGovernance/actions.ts
+++ b/apps/namada-interface/src/slices/StakingAndGovernance/actions.ts
@@ -236,10 +236,10 @@ export const postNewBonding = createAsyncThunk<
   { state: RootState }
 >(POST_NEW_STAKING, async (change, thunkApi) => {
   const { derived } = thunkApi.getState().accounts;
+  const { id, chainId } = thunkApi.getState().chain.config;
   const integration = getIntegration(chains.namada.id);
   const signer = integration.signer() as Signer;
   const { owner: source, validatorId: validator, amount } = change;
-  const { id, chainId } = chains.namada;
   const account = derived[id][source];
   const { type, publicKey } = account.details;
 
@@ -272,7 +272,8 @@ export const postNewUnbonding = createAsyncThunk<
   { state: RootState }
 >(POST_UNSTAKING, async (change, thunkApi) => {
   const { derived } = thunkApi.getState().accounts;
-  const { chainId, id } = chains.namada
+  const { id, chainId } = thunkApi.getState().chain.config;
+
   const integration = getIntegration(id);
   const signer = integration.signer() as Signer;
   const { owner: source, validatorId: validator, amount } = change;
@@ -303,7 +304,8 @@ export const postNewWithdraw = createAsyncThunk<
   { state: RootState }
 >(POST_UNSTAKING, async ({ owner, validatorId }, thunkApi) => {
   const { derived } = thunkApi.getState().accounts;
-  const { id, chainId } = chains.namada
+  const { id, chainId } = thunkApi.getState().chain.config;
+
   const integration = getIntegration(id);
   const signer = integration.signer() as Signer;
   const {

--- a/apps/namada-interface/src/slices/channels.ts
+++ b/apps/namada-interface/src/slices/channels.ts
@@ -3,7 +3,7 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 export type Channel = string;
 
 type ChannelsByChain = {
-  [chainId: string]: Record<string, Channel[]>;
+  [chainKey: string]: Record<string, Channel[]>;
 };
 
 export type ChannelsState = {


### PR DESCRIPTION
resolves #591 

Fixes an issue where `chainId` was not using the updated configuration from extension for all staking requests.

Also fixed validation message on extension `Network` form (was incorrectly referencing "URL" in the Chain ID field)

## Testing

- Similar to the original testing process for Network settings: Build the extension with one chain ID / RPC url (which will set default), then change them in the extension. Staking (and all other Tx) should succeed. 
- Alternatively, just change it to something other than what is already there (pointing to a node that is working and has balances for these accounts) - should contain correct `chainId` in Tx