### PR TITLE
Update imports, fix signing

### DIFF
--- a/apps/extension/src/background/keyring/handler.ts
+++ b/apps/extension/src/background/keyring/handler.ts
@@ -5,6 +5,7 @@ import {
   QueryAccountsMsg,
   QueryBalancesMsg,
   QueryDefaultAccountMsg,
+  VerifyArbitraryMsg,
 } from "provider/messages";
 import { Env, Handler, InternalHandler, Message } from "router";
 import {
@@ -110,6 +111,8 @@ export const getHandler: (service: KeyRingService) => Handler = (service) => {
           env,
           msg as AddLedgerAccountMsg
         );
+      case VerifyArbitraryMsg:
+        return handleVerifyAbitraryMsg(service)(env, msg as VerifyArbitraryMsg);
       default:
         throw new Error("Unknown msg type");
     }
@@ -298,5 +301,13 @@ const handleCheckDurabilityMsg: (
 ) => InternalHandler<CheckDurabilityMsg> = (service) => {
   return async (_, _msg) => {
     return await service.checkDurability();
+  };
+};
+
+const handleVerifyAbitraryMsg: (
+  service: KeyRingService
+) => InternalHandler<VerifyArbitraryMsg> = (service) => {
+  return async (_, { publicKey, hash, signature }) => {
+    return await service.verifyArbitrary(publicKey, hash, signature);
   };
 };

--- a/apps/extension/src/background/keyring/init.ts
+++ b/apps/extension/src/background/keyring/init.ts
@@ -5,6 +5,7 @@ import {
   QueryAccountsMsg,
   QueryBalancesMsg,
   QueryDefaultAccountMsg,
+  VerifyArbitraryMsg,
 } from "provider/messages";
 import { Router } from "router";
 import { ROUTE } from "./constants";
@@ -50,6 +51,7 @@ export function init(router: Router, service: KeyRingService): void {
   router.registerMessage(AddLedgerAccountMsg);
   router.registerMessage(RevealAccountMnemonicMsg);
   router.registerMessage(RenameAccountMsg);
+  router.registerMessage(VerifyArbitraryMsg);
 
   router.addHandler(ROUTE, getHandler(service));
 }

--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -52,7 +52,6 @@ import {
   UtilityStore,
 } from "./types";
 
-import { toHex } from "@cosmjs/encoding";
 import { SdkService } from "background/sdk";
 import { VaultService } from "background/vault";
 import { generateId } from "utils";
@@ -915,8 +914,8 @@ export class KeyRing {
 
     const key = await this.getSigningKey(signer);
     const sdk = await this.sdkService.getSdk();
-    const [hash, signature] = await sdk.sign_arbitrary(key, data);
+    const [hash, signature] = sdk.sign_arbitrary(key, data);
 
-    return { hash, signature: toHex(signature) };
+    return { hash, signature };
   }
 }

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -462,4 +462,14 @@ export class KeyRingService {
   ): Promise<SignatureResponse | undefined> {
     return await this._keyRing.signArbitrary(signer, data);
   }
+
+  async verifyArbitrary(
+    publicKey: string,
+    hash: string,
+    signature: string
+  ): Promise<void> {
+    const sdk = await this.sdkService.getSdk();
+
+    return sdk.verify_arbitrary(publicKey, hash, signature);
+  }
 }

--- a/apps/extension/src/provider/InjectedNamada.ts
+++ b/apps/extension/src/provider/InjectedNamada.ts
@@ -6,6 +6,7 @@ import {
   SignArbitraryProps,
   SignatureResponse,
   TxMsgProps,
+  VerifyArbitraryProps,
 } from "@namada/types";
 import { InjectedProxy } from "./InjectedProxy";
 import { Signer } from "./Signer";
@@ -36,6 +37,13 @@ export class InjectedNamada implements INamada {
       SignArbitraryProps,
       SignatureResponse | undefined
     >("sign", props);
+  }
+
+  public async verify(props: VerifyArbitraryProps): Promise<void> {
+    return await InjectedProxy.requestMethod<VerifyArbitraryProps, void>(
+      "verify",
+      props
+    );
   }
 
   public async balances(

--- a/apps/extension/src/provider/Namada.ts
+++ b/apps/extension/src/provider/Namada.ts
@@ -5,6 +5,7 @@ import {
   SignArbitraryProps,
   SignatureResponse,
   TxMsgProps,
+  VerifyArbitraryProps,
 } from "@namada/types";
 import { MessageRequester, Ports } from "router";
 
@@ -19,6 +20,7 @@ import {
   QueryAccountsMsg,
   QueryBalancesMsg,
   QueryDefaultAccountMsg,
+  VerifyArbitraryMsg,
 } from "./messages";
 
 export class Namada implements INamada {
@@ -61,6 +63,14 @@ export class Namada implements INamada {
     return await this.requester?.sendMessage(
       Ports.Background,
       new ApproveSignArbitraryMsg(signer, data)
+    );
+  }
+
+  public async verify(props: VerifyArbitraryProps): Promise<void> {
+    const { publicKey, hash, signature } = props;
+    return await this.requester?.sendMessage(
+      Ports.Background,
+      new VerifyArbitraryMsg(publicKey, hash, signature)
     );
   }
 

--- a/apps/extension/src/provider/Signer.ts
+++ b/apps/extension/src/provider/Signer.ts
@@ -28,7 +28,7 @@ import {
 } from "@namada/types";
 
 export class Signer implements ISigner {
-  constructor(private readonly _namada: Namada) { }
+  constructor(private readonly _namada: Namada) {}
 
   public async accounts(): Promise<Account[] | undefined> {
     return (await this._namada.accounts())?.map(
@@ -67,6 +67,14 @@ export class Signer implements ISigner {
     data: string
   ): Promise<SignatureResponse | undefined> {
     return await this._namada.sign({ signer, data });
+  }
+
+  public async verify(
+    publicKey: string,
+    hash: string,
+    signature: string
+  ): Promise<void> {
+    return await this._namada.verify({ publicKey, hash, signature });
   }
 
   private async submitTx<T extends Schema, Args>(

--- a/apps/extension/src/provider/messages.ts
+++ b/apps/extension/src/provider/messages.ts
@@ -36,6 +36,7 @@ enum MessageType {
   ApproveEthBridgeTransfer = "approve-eth-bridge-transfer",
   CheckDurability = "check-durability",
   ApproveSignArbitrary = "approve-sign-arbitrary",
+  VerifyArbitrary = "verify-arbitrary",
 }
 
 /**
@@ -270,5 +271,31 @@ export class ApproveSignArbitraryMsg extends Message<SignatureResponse> {
 
   type(): string {
     return ApproveSignArbitraryMsg.type();
+  }
+}
+
+export class VerifyArbitraryMsg extends Message<void> {
+  public static type(): MessageType {
+    return MessageType.VerifyArbitrary;
+  }
+
+  constructor(
+    public readonly publicKey: string,
+    public readonly hash: string,
+    public readonly signature: string
+  ) {
+    super();
+  }
+
+  validate(): void {
+    validateProps(this, ["publicKey", "hash", "signature"]);
+  }
+
+  route(): string {
+    return Route.KeyRing;
+  }
+
+  type(): string {
+    return VerifyArbitraryMsg.type();
   }
 }

--- a/packages/shared/lib/Cargo.lock
+++ b/packages/shared/lib/Cargo.lock
@@ -4456,12 +4456,11 @@ name = "shared"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "borsh",
- "borsh-ext",
  "chrono",
  "console_error_panic_hook",
  "getrandom 0.2.9",
  "gloo-utils",
+ "hex",
  "js-sys",
  "masp_primitives",
  "masp_proofs",

--- a/packages/shared/lib/Cargo.toml
+++ b/packages/shared/lib/Cargo.toml
@@ -17,8 +17,6 @@ multicore = ["wasm-bindgen-rayon", "namada/multicore"]
 [dependencies]
 async-trait = {version = "0.1.51"}
 tiny-bip39 = "0.8.2"
-borsh = {version = "1.2.0", features = ["unstable__schema", "derive"]}
-borsh-ext = { git = "https://github.com/heliaxdev/borsh-ext", tag = "v1.2.0" }
 chrono = "0.4.22"
 getrandom = { version = "0.2.7", features = ["js"] }
 gloo-utils = { version = "0.1.5", features = ["serde"] }
@@ -37,6 +35,7 @@ wasm-bindgen-futures = "0.4.33"
 wasm-bindgen-rayon = { version = "1.0", optional = true }
 console_error_panic_hook = "0.1.6"
 zeroize = "1.6.0"
+hex = "0.4.3"
 
 [dependencies.web-sys]
 version = "0.3.4"

--- a/packages/shared/lib/src/query.rs
+++ b/packages/shared/lib/src/query.rs
@@ -1,8 +1,8 @@
-use borsh::BorshSerialize;
 use js_sys::Uint8Array;
 use masp_primitives::asset_type::AssetType;
 use masp_primitives::transaction::components::ValueSum;
 use masp_primitives::zip32::ExtendedFullViewingKey;
+use namada::core::borsh::BorshSerialize;
 use namada::governance::storage::keys as governance_storage;
 use namada::governance::utils::{compute_proposal_result, ProposalVotes, TallyVote, VotePower};
 use namada::governance::{ProposalType, ProposalVote};

--- a/packages/shared/lib/src/sdk/masp.rs
+++ b/packages/shared/lib/src/sdk/masp.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
-use borsh::{BorshDeserialize, BorshSerialize};
 use gloo_utils::format::JsValueSerdeExt;
 use masp_proofs::prover::LocalTxProver;
+use namada::core::borsh::{BorshDeserialize, BorshSerialize};
 use namada::sdk::masp::{ShieldedContext, ShieldedUtils};
 use rexie::{Error, ObjectStore, Rexie, TransactionMode};
 use wasm_bindgen::JsValue;
@@ -13,6 +13,7 @@ const SHIELDED_CONTEXT_TABLE: &str = "ShieldedContext";
 const SHIELDED_CONTEXT_KEY: &str = "shielded-context";
 
 #[derive(Default, Debug, BorshSerialize, BorshDeserialize, Clone)]
+#[borsh(crate = "namada::core::borsh")]
 pub struct WebShieldedUtils {
     spend_param_bytes: Vec<u8>,
     output_param_bytes: Vec<u8>,

--- a/packages/shared/lib/src/sdk/signature.rs
+++ b/packages/shared/lib/src/sdk/signature.rs
@@ -1,13 +1,13 @@
-use borsh::{BorshDeserialize, BorshSerialize};
+use namada::core::borsh::{BorshDeserialize, BorshSerialize};
 use namada::{
-    ledger::pos::common::Signature,
     tx::{CompressedSignature, Section, Signer, Tx},
-    types::key::common::PublicKey,
+    types::key::common::{PublicKey, Signature},
 };
 use std::collections::BTreeMap;
 use wasm_bindgen::JsError;
 
 #[derive(BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "namada::core::borsh")]
 pub struct SignatureMsg {
     pub pubkey: Vec<u8>,
     pub raw_indices: Vec<u8>,

--- a/packages/shared/lib/src/sdk/tx.rs
+++ b/packages/shared/lib/src/sdk/tx.rs
@@ -1,6 +1,6 @@
 use std::{path::PathBuf, str::FromStr};
 
-use borsh::{BorshDeserialize, BorshSerialize};
+use namada::core::borsh::{BorshDeserialize, BorshSerialize};
 use namada::core::ibc::core::host::types::identifiers::{ChannelId, PortId};
 use namada::tx::data::GasLimit;
 use namada::{
@@ -18,6 +18,7 @@ use tendermint_config::net::Address as TendermintAddress;
 use wasm_bindgen::JsError;
 
 #[derive(BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "namada::core::borsh")]
 pub struct TxMsg {
     token: String,
     fee_amount: String,
@@ -29,6 +30,7 @@ pub struct TxMsg {
 }
 
 #[derive(BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "namada::core::borsh")]
 pub struct SubmitBondMsg {
     source: String,
     validator: String,
@@ -73,6 +75,7 @@ pub fn bond_tx_args(bond_msg: &[u8], tx_msg: &[u8]) -> Result<args::Bond, JsErro
 }
 
 #[derive(BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "namada::core::borsh")]
 pub struct SubmitUnbondMsg {
     source: String,
     validator: String,
@@ -116,6 +119,7 @@ pub fn unbond_tx_args(unbond_msg: &[u8], tx_msg: &[u8]) -> Result<args::Unbond, 
 }
 
 #[derive(BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "namada::core::borsh")]
 pub struct SubmitWithdrawMsg {
     source: String,
     validator: String,
@@ -151,6 +155,7 @@ pub fn withdraw_tx_args(withdraw_msg: &[u8], tx_msg: &[u8]) -> Result<args::With
 }
 
 #[derive(BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "namada::core::borsh")]
 pub struct SubmitVoteProposalMsg {
     signer: String,
     proposal_id: u64,
@@ -195,6 +200,7 @@ pub fn vote_proposal_tx_args(
 }
 
 #[derive(BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "namada::core::borsh")]
 pub struct SubmitTransferMsg {
     source: String,
     target: String,
@@ -269,6 +275,7 @@ pub fn transfer_tx_args(
 }
 
 #[derive(BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "namada::core::borsh")]
 pub struct SubmitIbcTransferMsg {
     source: String,
     receiver: String,
@@ -333,6 +340,7 @@ pub fn ibc_transfer_tx_args(
 }
 
 #[derive(BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "namada::core::borsh")]
 pub struct SubmitEthBridgeTransferMsg {
     nut: bool,
     asset: String,

--- a/packages/shared/lib/src/types/address.rs
+++ b/packages/shared/lib/src/types/address.rs
@@ -1,4 +1,4 @@
-use borsh::BorshDeserialize;
+use namada::core::borsh::BorshDeserialize;
 use namada::types::{
     address,
     key::{

--- a/packages/shared/lib/src/types/masp.rs
+++ b/packages/shared/lib/src/types/masp.rs
@@ -1,7 +1,7 @@
 //! PaymentAddress - Provide wasm_bindgen bindings for shielded addresses
 //! See @namada/crypto for zip32 HD wallet functionality.
-use borsh::BorshDeserialize;
 use masp_primitives::{sapling, zip32};
+use namada::core::borsh::BorshDeserialize;
 use namada::types::masp;
 use thiserror::Error;
 use wasm_bindgen::prelude::*;

--- a/packages/shared/lib/src/types/query.rs
+++ b/packages/shared/lib/src/types/query.rs
@@ -1,6 +1,7 @@
-use borsh::BorshSerialize;
+use namada::core::borsh::BorshSerialize;
 
 #[derive(BorshSerialize)]
+#[borsh(crate = "namada::core::borsh")]
 pub struct ProposalInfo {
     pub id: String,
     pub proposal_type: String,

--- a/packages/types/src/namada.ts
+++ b/packages/types/src/namada.ts
@@ -16,6 +16,12 @@ export type SignArbitraryProps = {
   data: string;
 };
 
+export type VerifyArbitraryProps = {
+  publicKey: string;
+  hash: string;
+  signature: string;
+};
+
 export interface Namada {
   accounts(chainId?: string): Promise<DerivedAccount[] | undefined>;
   balances(
@@ -24,6 +30,7 @@ export interface Namada {
   connect(chainId?: string): Promise<void>;
   defaultAccount(chainId?: string): Promise<DerivedAccount | undefined>;
   sign(props: SignArbitraryProps): Promise<SignatureResponse | undefined>;
+  verify(props: VerifyArbitraryProps): Promise<void>;
   submitTx: (props: TxMsgProps) => Promise<void>;
   getChain: () => Promise<Chain | undefined>;
   version: () => string;

--- a/packages/types/src/signer.ts
+++ b/packages/types/src/signer.ts
@@ -22,6 +22,7 @@ export interface Signer {
     signer: string,
     data: string
   ) => Promise<SignatureResponse | undefined>;
+  verify: (publicKey: string, hash: string, signature: string) => Promise<void>;
   submitBond(
     args: SubmitBondProps,
     txArgs: TxProps,


### PR DESCRIPTION
Updating Rust imports in `@namada/shared`

- Moved `BorshSerialize` `BorshDeserialize` and `BorshSerializeExt` to `namada::core::borsh`
- Fix spots where `SecretKey` was importing from `pos::common`. Switched to `namada::types::key::common`
- Also, import `SigScheme` & `Signature` from `namada::types::key::common`
- Hooked up `verify_arbitrary` to Extension API

### Testing

```
// Change `signer` to address from your wallet:
await namada.sign({ signer: "tnam1qry3lnk03j965y92np6e25jvadk3kw9u7cvwjclp", data: "Arbitrary Data!" });

// Change these to match public key in your wallet for that account, and the hash and signature from the previous response
await namada.verify({
  publicKey: "tpknam1qrxzmeyka3v43jnrhep9stnj3jhtgzq96ku3u6lk8hy8xqmjqgjtw8qu274",
  hash: "c5ebe9588ae5b0966977043d94f033d5d729787fdc4df686cf54d0388968df6b",
  signature: "005f62366e652209586208f5e8b40014b35e1361e1d82dd67bd0609e894fd60a7cdb8ad7c43b7e778bd1e38b5ef259c9e8f3338e5929d4468333a1d46b4706660e",
});

// Expected: Promise resolves with `null`

```

Alternatively, for `verify` you can change some of the characters in the `hash` to view the error state, promise should error out with `Invalid signature`