### PR TITLE
feat/614 - Faucet extension integration

### DIFF
--- a/apps/faucet/package.json
+++ b/apps/faucet/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@cosmjs/encoding": "^0.29.0",
     "@namada/components": "0.2.1",
+    "@namada/integrations": "0.2.1",
     "@namada/utils": "0.2.1",
     "buffer": "^6.0.3",
     "dompurify": "^3.0.2",

--- a/apps/faucet/package.json
+++ b/apps/faucet/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@cosmjs/encoding": "^0.29.0",
     "@namada/components": "0.2.1",
+    "@namada/hooks": "0.2.1",
     "@namada/integrations": "0.2.1",
     "@namada/utils": "0.2.1",
     "buffer": "^6.0.3",

--- a/apps/faucet/src/App/App.components.ts
+++ b/apps/faucet/src/App/App.components.ts
@@ -1,5 +1,5 @@
-import styled, { createGlobalStyle } from "styled-components";
 import { ColorMode, DesignConfiguration } from "@namada/utils";
+import styled, { createGlobalStyle } from "styled-components";
 
 type GlobalStyleProps = {
   colorMode: ColorMode;
@@ -118,6 +118,10 @@ export const BackgroundImage = styled.div<{
   z-index: 0;
   background-image: url(${(props) => props.imageUrl});
   background-size: 120px;
+`;
+
+export const InfoContainer = styled.div`
+  margin: 40px 20px;
 `;
 
 export const ContentContainer = styled.div`

--- a/apps/faucet/src/App/App.tsx
+++ b/apps/faucet/src/App/App.tsx
@@ -14,6 +14,7 @@ import {
   ContentContainer,
   FaucetContainer,
   GlobalStyles,
+  InfoContainer,
   TopSection,
 } from "App/App.components";
 import { FaucetForm } from "App/Faucet";
@@ -206,17 +207,21 @@ export const App: React.FC = () => {
         <AppContainer>
           <ContentContainer>
             <TopSection>
-              <Heading className="uppercase text-black text-5xl" level="h1">
-                Namada Faucet
+              <Heading className="uppercase text-black text-4xl" level="h1">
+                Namada Shielded Expedition Faucet
               </Heading>
             </TopSection>
             <FaucetContainer>
               {extensionAttachStatus ===
                 ExtensionAttachStatus.PendingDetection && (
-                <p>Detecting extension...</p>
+                <InfoContainer>
+                  <Alert type="info">Detecting extension...</Alert>
+                </InfoContainer>
               )}
               {extensionAttachStatus === ExtensionAttachStatus.NotInstalled && (
-                <Alert type="error">You must download the extension!</Alert>
+                <InfoContainer>
+                  <Alert type="error">You must download the extension!</Alert>
+                </InfoContainer>
               )}
               {isExtensionConnected && (
                 <FaucetForm
@@ -227,11 +232,11 @@ export const App: React.FC = () => {
               )}
               {extensionAttachStatus === ExtensionAttachStatus.Installed &&
                 !isExtensionConnected && (
-                  <div>
+                  <InfoContainer>
                     <ActionButton onClick={handleConnectExtensionClick}>
                       Connect to Namada Extension
                     </ActionButton>
-                  </div>
+                  </InfoContainer>
                 )}
             </FaucetContainer>
             <BottomSection>

--- a/apps/faucet/src/App/App.tsx
+++ b/apps/faucet/src/App/App.tsx
@@ -20,7 +20,7 @@ import { FaucetForm } from "App/Faucet";
 
 import { chains } from "@namada/chains";
 import { useUntil } from "@namada/hooks";
-import { Account } from "@namada/types";
+import { Account, AccountType } from "@namada/types";
 import { requestSettings } from "utils";
 import dotsBackground from "../../public/bg-dots.svg";
 import { CallToActionCard } from "./CallToActionCard";
@@ -169,7 +169,12 @@ export const App: React.FC = () => {
         await integration.connect();
         const accounts = await integration.accounts();
         if (accounts) {
-          setAccounts(accounts.filter((account) => !account.isShielded));
+          setAccounts(
+            accounts.filter(
+              (account) =>
+                !account.isShielded && account.type !== AccountType.Ledger
+            )
+          );
         }
         setIsExtensionConnected(true);
       } catch (e) {
@@ -208,13 +213,17 @@ export const App: React.FC = () => {
             <FaucetContainer>
               {extensionAttachStatus ===
                 ExtensionAttachStatus.PendingDetection && (
-                  <p>Detecting extension...</p>
-                )}
+                <p>Detecting extension...</p>
+              )}
               {extensionAttachStatus === ExtensionAttachStatus.NotInstalled && (
                 <Alert type="error">You must download the extension!</Alert>
               )}
               {isExtensionConnected && (
-                <FaucetForm isTestnetLive={isTestnetLive} accounts={accounts} />
+                <FaucetForm
+                  isTestnetLive={isTestnetLive}
+                  accounts={accounts}
+                  integration={integration}
+                />
               )}
               {extensionAttachStatus === ExtensionAttachStatus.Installed &&
                 !isExtensionConnected && (

--- a/apps/faucet/src/App/Faucet.tsx
+++ b/apps/faucet/src/App/Faucet.tsx
@@ -133,7 +133,7 @@ export const FaucetForm: React.FC<Props> = ({
           }
         )) || {};
       if (!tag || !challenge) {
-        throw new Error("WTF");
+        throw new Error("Request challenge did not return a valid response");
       }
 
       const solution = computePowSolution(challenge, difficulty || 0);

--- a/apps/faucet/src/App/Faucet.tsx
+++ b/apps/faucet/src/App/Faucet.tsx
@@ -1,9 +1,14 @@
-import { ActionButton, Alert, AmountInput, Input } from "@namada/components";
+import {
+  ActionButton,
+  Alert,
+  AmountInput,
+  Input,
+  Select,
+} from "@namada/components";
 import BigNumber from "bignumber.js";
 import { sanitize } from "dompurify";
 import React, { useCallback, useContext, useEffect, useState } from "react";
 
-import { useTheme } from "styled-components";
 import {
   TransferResponse,
   computePowSolution,
@@ -18,6 +23,7 @@ import {
   PreFormatted,
 } from "./Faucet.components";
 
+import { Account } from "@namada/types";
 import { bech32mValidation } from "@namada/utils";
 import { AppContext } from "./App";
 
@@ -28,13 +34,13 @@ enum Status {
 }
 
 type Props = {
+  accounts: Account[];
   isTestnetLive: boolean;
 };
 
 const bech32mPrefix = "tnam";
 
-export const FaucetForm: React.FC<Props> = ({ isTestnetLive }) => {
-  const theme = useTheme();
+export const FaucetForm: React.FC<Props> = ({ accounts, isTestnetLive }) => {
   const { difficulty, settingsError, limit, tokens, url } =
     useContext(AppContext);
   const [targetAddress, setTargetAddress] = useState<string>();
@@ -44,6 +50,11 @@ export const FaucetForm: React.FC<Props> = ({ isTestnetLive }) => {
   const [status, setStatus] = useState(Status.Completed);
   const [statusText, setStatusText] = useState<string>();
   const [responseDetails, setResponseDetails] = useState<TransferResponse>();
+
+  const accountsSelectData = accounts.map((account) => ({
+    label: account.alias,
+    value: account.address,
+  }));
 
   useEffect(() => {
     if (tokens?.NAM) {
@@ -156,10 +167,10 @@ export const FaucetForm: React.FC<Props> = ({ isTestnetLive }) => {
     <FaucetFormContainer>
       {settingsError && <Alert type="error">{settingsError}</Alert>}
       <InputContainer>
-        <Input
-          label="Target Address"
+        <Select
+          data={accountsSelectData}
           value={targetAddress}
-          onFocus={handleFocus}
+          label="Account"
           onChange={(e) => setTargetAddress(e.target.value)}
         />
       </InputContainer>

--- a/apps/faucet/src/utils/index.ts
+++ b/apps/faucet/src/utils/index.ts
@@ -45,17 +45,22 @@ export const requestSettings = async (
  * @returns Object
  */
 export const requestChallenge = async (
-  url: string
-): Promise<ChallengeResponse> => {
-  const response = await fetch(new URL(url), {
+  url: string,
+  publicKey: string
+): Promise<ChallengeResponse | undefined> => {
+  const response = await fetch(new URL(`${url}/challenge/${publicKey}`), {
     method: "GET",
   })
     .then((response) => {
       if (response.ok) {
         return response.json() as Promise<ChallengeResponse>;
       }
-      console.warn(response);
-      return Promise.reject(response);
+      const reader = response?.body?.getReader();
+      return reader
+        ?.read()
+        .then(({ value }) =>
+          Promise.reject(JSON.parse(new TextDecoder().decode(value)))
+        );
     })
     .catch((e) => {
       console.error(e);
@@ -75,7 +80,9 @@ export type Data = {
   solution: string;
   tag: string;
   challenge: unknown;
+  challenge_signature: string;
   transfer: TransferDetails;
+  player_id: string;
 };
 
 export type TransferResponse = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7639,6 +7639,7 @@ __metadata:
     "@cosmjs/encoding": "npm:^0.29.0"
     "@namada/components": "npm:0.2.1"
     "@namada/config": "workspace:^"
+    "@namada/hooks": "npm:0.2.1"
     "@namada/integrations": "npm:0.2.1"
     "@namada/utils": "npm:0.2.1"
     "@svgr/webpack": "npm:^6.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7639,6 +7639,7 @@ __metadata:
     "@cosmjs/encoding": "npm:^0.29.0"
     "@namada/components": "npm:0.2.1"
     "@namada/config": "workspace:^"
+    "@namada/integrations": "npm:0.2.1"
     "@namada/utils": "npm:0.2.1"
     "@svgr/webpack": "npm:^6.3.1"
     "@types/dompurify": "npm:^3.0.2"


### PR DESCRIPTION
resolves #614 

- [x] Integrate faucet app with Extension
- [x] Retrieve arbitrary string and invoke `sign()` on extension integration
- [x] Submit signature for verification along with Tx

Also addresses some of https://github.com/anoma/namada-interface/issues/607, but we need more information to finish this, and there may be some style updates we can incorporate later.
