### PR TITLE
feat: begin replacing redux with jotai

### DIFF
--- a/apps/namada-interface/package.json
+++ b/apps/namada-interface/package.json
@@ -20,6 +20,8 @@
     "ethers": "^6.7.1",
     "fp-ts": "^2.16.1",
     "framer-motion": "^6.2.8",
+    "jotai": "^2.6.3",
+    "jotai-redux": "^0.2.1",
     "next-qrcode": "^2.0.0",
     "path": "^0.12.7",
     "react": "^17.0.2",

--- a/apps/namada-interface/src/App/AccountOverview/DerivedAccounts/DerivedAccounts.tsx
+++ b/apps/namada-interface/src/App/AccountOverview/DerivedAccounts/DerivedAccounts.tsx
@@ -1,45 +1,43 @@
 import { useContext, useEffect, useState } from "react";
 import { ThemeContext } from "styled-components";
-import BigNumber from "bignumber.js";
 
 import { chains } from "@namada/chains";
 import { TokenType, Tokens } from "@namada/types";
 import { formatCurrency } from "@namada/utils";
 
 import {
+  DerivedAccountAlias,
+  DerivedAccountBalance,
+  DerivedAccountContainer,
+  DerivedAccountInfo,
+  DerivedAccountItem,
+  DerivedAccountType,
   DerivedAccountsContainer,
   DerivedAccountsList,
-  DerivedAccountItem,
-  DerivedAccountBalance,
-  DerivedAccountType,
-  DerivedAccountInfo,
-  DerivedAccountAlias,
-  DerivedAccountContainer,
-  TokenIcon,
-  TokenBalance,
-  TransparentLabel,
-  ShieldedLabel,
   NoTokens,
-  TokenTotals,
+  ShieldedLabel,
+  TokenBalance,
   TokenBalances,
+  TokenIcon,
+  TokenTotals,
+  TransparentLabel,
 } from "./DerivedAccounts.components";
 
 // Import PNG images assets
-import AssetNamadaNamLight from "./assets/asset-namada-nam-light.png";
-import AssetNamadaNamDark from "./assets/asset-namada-nam-dark.png";
-import AssetEthereumEther from "./assets/asset-ethereum-ether.png";
 import AssetBitcoin from "./assets/asset-bitcoin-btc.png";
+import AssetEthereumEther from "./assets/asset-ethereum-ether.png";
+import AssetNamadaNamDark from "./assets/asset-namada-nam-dark.png";
+import AssetNamadaNamLight from "./assets/asset-namada-nam-light.png";
 import AssetPolkadot from "./assets/asset-polkadot-dot.png";
 
-import { useAppDispatch, useAppSelector } from "store";
-import { AccountsState, Balance } from "slices/accounts";
-import { CoinsState, fetchConversionRates } from "slices/coins";
+import { Balance } from "slices/accounts";
+import { balanceToFiatAtom, coinsAtom } from "slices/coins";
 import { SettingsState } from "slices/settings";
-import Config from "config";
+import { useAppSelector } from "store";
 
-type Props = {
-  setTotal: (total: BigNumber) => void;
-};
+import { useAtomValue, useSetAtom } from "jotai";
+import { loadable } from "jotai/utils";
+import { accountsAtom, balancesAtom } from "slices/accounts";
 
 const assetIconByToken: Record<TokenType, { light: string; dark: string }> = {
   ["NAM"]: {
@@ -56,7 +54,7 @@ const assetIconByToken: Record<TokenType, { light: string; dark: string }> = {
   },
   ["DOT"]: {
     light: AssetPolkadot,
-    dark: AssetPolkadot
+    dark: AssetPolkadot,
   },
   ["SCH"]: {
     light: AssetNamadaNamLight,
@@ -72,23 +70,38 @@ const assetIconByToken: Record<TokenType, { light: string; dark: string }> = {
   },
 };
 
-const DerivedAccounts = ({ setTotal }: Props): JSX.Element => {
-  const dispatch = useAppDispatch();
-  const themeContext = useContext(ThemeContext);
-  const { derived } = useAppSelector<AccountsState>((state) => state.accounts);
-  const [activeAccountAddress, setActiveAccountAddress] = useState("");
-
+const FiatBalanceDisplay: React.FC<{
+  balance?: Balance;
+}> = ({ balance }) => {
   const { fiatCurrency } = useAppSelector<SettingsState>(
     (state) => state.settings
   );
-  const { rates, timestamp } = useAppSelector<CoinsState>(
-    (state) => state.coins
-  );
-  const { api } = Config;
+
+  const balanceToFiat = useAtomValue(loadable(balanceToFiatAtom));
+
+  const displayString =
+    typeof balance !== "undefined" && balanceToFiat.state === "hasData"
+      ? formatCurrency(fiatCurrency, balanceToFiat.data(balance, fiatCurrency))
+      : `${fiatCurrency} -`;
+
+  return <DerivedAccountBalance>{displayString}</DerivedAccountBalance>;
+};
+
+const DerivedAccounts = (): JSX.Element => {
+  const accountsLoadable = useAtomValue(loadable(accountsAtom));
+  const accounts =
+    accountsLoadable.state === "hasData" ? accountsLoadable.data : [];
+
+  const balances = useAtomValue(balancesAtom);
+
+  const themeContext = useContext(ThemeContext);
+  const [activeAccountAddress, setActiveAccountAddress] = useState("");
+
+  const fetchConversionRates = useSetAtom(coinsAtom);
+
   const chain = chains.namada;
   const { alias } = chain || {};
 
-  const accounts = derived[chain.id] ? Object.values(derived[chain.id]) : [];
   const { colorMode } = themeContext.themeConfigurations;
 
   const getAssetIconByTheme = (symbol: TokenType): string => {
@@ -101,33 +114,13 @@ const DerivedAccounts = ({ setTotal }: Props): JSX.Element => {
     setActiveAccountAddress(address === activeAccountAddress ? "" : address);
   };
 
-  const balanceToFiat = (balance: Balance): BigNumber => {
-    return Object.entries(balance).reduce((acc, [token, value]) => {
-
-      return acc.plus(
-        rates[token] && rates[token][fiatCurrency]
-          ? value.multipliedBy(rates[token][fiatCurrency].rate)
-          : value
-      );
-    }, new BigNumber(0));
-  };
+  useEffect(() => {
+    setActiveAccountAddress(accounts[0]?.address);
+  }, [accounts]);
 
   useEffect(() => {
-    const total = accounts.reduce((acc, { balance }) => {
-      return acc.plus(balanceToFiat(balance));
-    }, new BigNumber(0));
-    setTotal(total);
-    setActiveAccountAddress(accounts[0]?.details.address);
-  }, [derived[chain.id]]);
-
-  useEffect(() => {
-    const currentTimestamp = Math.floor(Date.now() / 1000);
-    const timeSinceUpdate = currentTimestamp - (timestamp || 0);
-
-    if (!timestamp || timeSinceUpdate > api.cacheTTL) {
-      dispatch(fetchConversionRates());
-    }
-  }, [timestamp]);
+    fetchConversionRates();
+  }, []);
 
   return (
     <DerivedAccountsContainer>
@@ -137,10 +130,11 @@ const DerivedAccounts = ({ setTotal }: Props): JSX.Element => {
         </NoTokens>
       )}
       <DerivedAccountsList>
-        {accounts
-          .sort(({ details }) => (details.isShielded ? -1 : 1))
-          .map(({ details, balance }) => {
-            const { alias, address, isShielded } = details;
+        {[...accounts] // cloning because can't call sort on readonly array
+          .sort(({ isShielded }) => (isShielded ? -1 : 1))
+          .map((account) => {
+            const { alias, address, isShielded } = account;
+            const balance = balances[address];
 
             return (
               <DerivedAccountItem key={address}>
@@ -157,37 +151,35 @@ const DerivedAccounts = ({ setTotal }: Props): JSX.Element => {
                       )}
                     </DerivedAccountType>
                   </DerivedAccountInfo>
-                  <DerivedAccountBalance>
-                    {formatCurrency(fiatCurrency, balanceToFiat(balance))}
-                  </DerivedAccountBalance>
+                  <FiatBalanceDisplay balance={balance} />
                 </DerivedAccountContainer>
-                <TokenTotals
-                  className={
-                    (address === activeAccountAddress && "active") || ""
-                  }
-                >
-                  <TokenBalances>
-                    {Object.entries(balance)
-                      .sort(([tokenType]) => {
-                        // Show native token first
-                        return tokenType === chain.currency.token
-                          ? 1
-                          : -1;
-                      })
-                      .filter(([_, amount]) => amount.isGreaterThan(0))
-                      .map(([token, amount]) => {
-                        return (
-                          <TokenBalance key={`${address}-${token}`}>
-                            <TokenIcon
-                              src={getAssetIconByTheme(token as TokenType)}
-                            />
-                            {amount.toString()}{" "}
-                            {Tokens[token as TokenType].symbol}
-                          </TokenBalance>
-                        );
-                      })}
-                  </TokenBalances>
-                </TokenTotals>
+                {balance && (
+                  <TokenTotals
+                    className={
+                      (address === activeAccountAddress && "active") || ""
+                    }
+                  >
+                    <TokenBalances>
+                      {Object.entries(balance)
+                        .sort(([tokenType]) => {
+                          // Show native token first
+                          return tokenType === chain.currency.token ? 1 : -1;
+                        })
+                        .filter(([_, amount]) => amount.isGreaterThan(0))
+                        .map(([token, amount]) => {
+                          return (
+                            <TokenBalance key={`${address}-${token}`}>
+                              <TokenIcon
+                                src={getAssetIconByTheme(token as TokenType)}
+                              />
+                              {amount.toString()}{" "}
+                              {Tokens[token as TokenType].symbol}
+                            </TokenBalance>
+                          );
+                        })}
+                    </TokenBalances>
+                  </TokenTotals>
+                )}
               </DerivedAccountItem>
             );
           })}

--- a/apps/namada-interface/src/services/extensionEvents/handlers/namada.ts
+++ b/apps/namada-interface/src/services/extensionEvents/handlers/namada.ts
@@ -10,7 +10,14 @@ import { actions as notificationsActions } from "slices/notifications";
 import { fetchProposals } from "slices/proposals";
 
 export const NamadaAccountChangedHandler =
-  (dispatch: Dispatch<unknown>, integration: Namada) => async () => {
+  (
+    dispatch: Dispatch<unknown>,
+    integration: Namada,
+    refreshAccounts: () => Promise<void>
+  ) =>
+  async () => {
+    refreshAccounts();
+
     const accounts = (await integration.accounts()) || [];
 
     dispatch(addAccounts(accounts));
@@ -18,7 +25,14 @@ export const NamadaAccountChangedHandler =
   };
 
 export const NamadaNetworkChangedHandler =
-  (dispatch: Dispatch<unknown>, integration: Namada) => async () => {
+  (
+    dispatch: Dispatch<unknown>,
+    integration: Namada,
+    refreshChain: () => Promise<void>
+  ) =>
+  async () => {
+    refreshChain();
+
     const chain = await integration.getChain();
     if (chain) {
       dispatch(setChain(chain));

--- a/apps/namada-interface/src/services/extensionEvents/provider.tsx
+++ b/apps/namada-interface/src/services/extensionEvents/provider.tsx
@@ -18,6 +18,10 @@ import {
   NamadaUpdatedStakingHandler,
 } from "./handlers";
 
+import { useSetAtom } from "jotai";
+import { accountsAtom } from "slices/accounts";
+import { chainAtom } from "slices/chain";
+
 export const ExtensionEventsContext = createContext({});
 
 export const ExtensionEventsProvider: React.FC = (props): JSX.Element => {
@@ -26,14 +30,19 @@ export const ExtensionEventsProvider: React.FC = (props): JSX.Element => {
   const keplrIntegration = useIntegration("cosmos");
   const metamaskIntegration = useIntegration("ethereum");
 
+  const refreshAccounts = useSetAtom(accountsAtom);
+  const refreshChain = useSetAtom(chainAtom);
+
   // Instantiate handlers:
   const namadaAccountChangedHandler = NamadaAccountChangedHandler(
     dispatch,
-    namadaIntegration as Namada
+    namadaIntegration as Namada,
+    refreshAccounts
   );
   const namadaNetworkChangedHandler = NamadaNetworkChangedHandler(
     dispatch,
-    namadaIntegration as Namada
+    namadaIntegration as Namada,
+    refreshChain
   );
   const namadaTxStartedHandler = NamadaTxStartedHandler(dispatch);
   const namadaTxCompletedHandler = NamadaTxCompletedHandler(dispatch);

--- a/apps/namada-interface/src/slices/chain.ts
+++ b/apps/namada-interface/src/slices/chain.ts
@@ -2,6 +2,9 @@ import { chains } from "@namada/chains";
 import { Chain } from "@namada/types";
 import { PayloadAction, createSlice } from "@reduxjs/toolkit";
 
+import { getIntegration } from "@namada/integrations";
+import { atom } from "jotai";
+
 export type ChainState = {
   config: Chain;
 };
@@ -24,3 +27,25 @@ const { actions, reducer } = chainSlice;
 export const { setChain } = actions;
 
 export default reducer;
+
+////////////////////////////////////////////////////////////////////////////////
+// JOTAI
+////////////////////////////////////////////////////////////////////////////////
+
+const chainAtom = (() => {
+  const base = atom(chains.namada);
+
+  return atom(
+    (get) => get(base),
+    async (_get, set) => {
+      const namada = getIntegration("namada");
+      const chain = await namada.getChain();
+      if (typeof chain === "undefined") {
+        throw new Error("chain was undefined!");
+      }
+      set(base, chain);
+    }
+  );
+})();
+
+export { chainAtom };

--- a/apps/namada-interface/src/slices/coins.ts
+++ b/apps/namada-interface/src/slices/coins.ts
@@ -1,12 +1,13 @@
-import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
-
 import { Symbols, Tokens } from "@namada/types";
 import { getTimeStamp } from "@namada/utils";
 
 import Config from "config";
 import { Currencies } from "currencies";
 
-const COINS_ACTIONS_BASE = "coins";
+import { Balance } from "slices/accounts";
+
+import BigNumber from "bignumber.js";
+import { atom } from "jotai";
 
 export type ConversionRate = {
   currency: string;
@@ -18,110 +19,95 @@ export type CoinGeckoIds = Record<string, { coinGeckoId: string }>;
 export type RateByToken = Record<string, ConversionRate>;
 export type CoinsState = {
   rates: Record<string, RateByToken>;
-  timestamp?: number;
-};
-
-const initialState: CoinsState = {
-  rates: {},
-};
-
-type RatesResponse = {
-  data: {
-    [token: string]: {
-      [currency: string]: number;
-    };
-  };
   timestamp: number;
 };
 
-enum CoinsThunkActions {
-  FetchRates = "fetchRates",
-}
+const fetchConversionRates = async (): Promise<CoinsState> => {
+  const { api } = Config;
+  const apiBase = api.url;
+  const apiKey = api.key;
 
-export const fetchConversionRates = createAsyncThunk(
-  `${COINS_ACTIONS_BASE}/${CoinsThunkActions.FetchRates}`,
-  async (): Promise<RatesResponse> => {
-    const { api } = Config;
-    const apiBase = api.url;
-    const apiKey = api.key;
+  const baseUrl = `${apiBase}/simple/price`;
 
-    const baseUrl = `${apiBase}/simple/price`;
+  const coinsQuery = Symbols.filter((symbol) => Tokens[symbol]?.coinGeckoId)
+    .map((symbol) => {
+      const token = Tokens[symbol];
+      const { coinGeckoId } = token;
+      return coinGeckoId;
+    })
+    .join(",");
+  const currenciesQuery = Currencies.map((currency) => currency.currency).join(
+    ","
+  );
 
-    const coinsQuery = Symbols.filter((symbol) => Tokens[symbol]?.coinGeckoId)
-      .map((symbol) => {
-        const token = Tokens[symbol];
-        const { coinGeckoId } = token;
-        return coinGeckoId;
-      })
-      .join(",");
-    const currenciesQuery = Currencies.map(
-      (currency) => currency.currency
-    ).join(",");
-
-    const headers = apiKey
-      ? {
-          "X-Api-Key": apiKey,
-        }
-      : undefined;
-
-    const url = `${baseUrl}?ids=${coinsQuery}&vs_currencies=${currenciesQuery}`;
-
-    const response = await fetch(url, {
-      method: "GET",
-      headers,
-    });
-
-    const json = await response.json();
-    const data = json;
-
-    return {
-      data,
-      timestamp: getTimeStamp(),
-    };
-  }
-);
-
-const coinsSlice = createSlice({
-  name: COINS_ACTIONS_BASE,
-  initialState,
-  reducers: {},
-  extraReducers: (builder) => {
-    builder.addCase(
-      fetchConversionRates.fulfilled,
-      (state, action: PayloadAction<RatesResponse>) => {
-        const { data, timestamp } = action.payload;
-        const keys = Object.keys(data);
-        state.rates = {};
-        state.timestamp = timestamp;
-
-        keys.forEach((key) => {
-          const token = Object.values(Tokens).find(
-            (token) => token?.coinGeckoId === key
-          );
-          const symbol = token?.symbol;
-
-          if (symbol) {
-            if (!state.rates[symbol]) {
-              state.rates[symbol] = {};
-            }
-            const currencies = Object.keys(data[key]);
-
-            currencies.forEach((currencyKey) => {
-              const currency = currencyKey.toUpperCase();
-              const rate = data[key][currencyKey] || 1;
-
-              state.rates[symbol][currency] = {
-                currency,
-                rate,
-              };
-            });
-          }
-        });
+  const headers = apiKey
+    ? {
+        "X-Api-Key": apiKey,
       }
+    : undefined;
+
+  const url = `${baseUrl}?ids=${coinsQuery}&vs_currencies=${currenciesQuery}`;
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers,
+  });
+
+  const data = await response.json();
+
+  const timestamp = getTimeStamp();
+
+  const keys = Object.keys(data);
+  const rates = {} as Record<string, RateByToken>;
+
+  keys.forEach((key) => {
+    const token = Object.values(Tokens).find(
+      (token) => token?.coinGeckoId === key
     );
-  },
+    const symbol = token?.symbol;
+
+    if (symbol) {
+      if (!rates[symbol]) {
+        rates[symbol] = {};
+      }
+      const currencies = Object.keys(data[key]);
+
+      currencies.forEach((currencyKey) => {
+        const currency = currencyKey.toUpperCase();
+        const rate = data[key][currencyKey] || 1;
+
+        rates[symbol][currency] = {
+          currency,
+          rate,
+        };
+      });
+    }
+  });
+
+  return { rates, timestamp };
+};
+
+const coinsAtom = (() => {
+  const base = atom(new Promise<CoinsState>(() => {}));
+
+  return atom(
+    (get) => get(base),
+    (_get, set) => set(base, fetchConversionRates())
+  );
+})();
+
+const balanceToFiatAtom = atom(async (get) => {
+  const { rates } = await get(coinsAtom);
+
+  return (balance: Balance, fiatCurrency: string) => {
+    return Object.entries(balance).reduce((acc, [token, value]) => {
+      return acc.plus(
+        rates[token] && rates[token][fiatCurrency]
+          ? value.multipliedBy(rates[token][fiatCurrency].rate)
+          : value
+      );
+    }, new BigNumber(0));
+  };
 });
 
-const { reducer } = coinsSlice;
-
-export default reducer;
+export { balanceToFiatAtom, coinsAtom };

--- a/apps/namada-interface/src/slices/index.ts
+++ b/apps/namada-interface/src/slices/index.ts
@@ -2,7 +2,6 @@ export { stakingAndGovernanceReducers } from "./StakingAndGovernance";
 export { default as accountsReducer } from "./accounts";
 export { default as chainReducer } from "./chain";
 export { default as channelsReducer } from "./channels";
-export { default as coinsReducer } from "./coins";
 export { notificationsReducer } from "./notifications";
 export { default as proposalsReducers } from "./proposals";
 export { default as settingsReducer } from "./settings";

--- a/apps/namada-interface/src/slices/settings.ts
+++ b/apps/namada-interface/src/slices/settings.ts
@@ -1,5 +1,8 @@
 import { ChainKey } from "@namada/types";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { reduxStoreAtom } from "store";
+
+import { atom } from "jotai";
 
 const SETTINGS_ACTIONS_BASE = "settings";
 
@@ -33,3 +36,9 @@ const { actions, reducer } = settingsSlice;
 export const { setFiatCurrency, setIsConnected } = actions;
 
 export default reducer;
+
+const fiatCurrencyAtom = atom(
+  (get) => get(reduxStoreAtom).settings.fiatCurrency
+);
+
+export { fiatCurrencyAtom };

--- a/apps/namada-interface/src/store/index.ts
+++ b/apps/namada-interface/src/store/index.ts
@@ -1,3 +1,3 @@
-export { store, persistor } from "./store";
-export type { RootState } from "./store";
 export { useAppDispatch, useAppSelector } from "./hooks";
+export { persistor, reduxStoreAtom, store } from "./store";
+export type { RootState } from "./store";

--- a/apps/namada-interface/src/store/mocks.ts
+++ b/apps/namada-interface/src/store/mocks.ts
@@ -44,9 +44,6 @@ export const mockAppState: RootState = {
     fiatCurrency: "USD",
     connectedChains: [],
   },
-  coins: {
-    rates: {},
-  },
   stakingAndGovernance: {
     validators: [],
     validatorAssets: {},

--- a/apps/namada-interface/src/store/store.ts
+++ b/apps/namada-interface/src/store/store.ts
@@ -8,13 +8,14 @@ import {
   accountsReducer,
   chainReducer,
   channelsReducer,
-  coinsReducer,
   notificationsReducer,
   proposalsReducers,
   settingsReducer,
   stakingAndGovernanceReducers,
 } from "slices";
 import { SettingsState } from "slices/settings";
+
+import { atomWithStore } from "jotai-redux";
 
 const { NAMADA_INTERFACE_LOCAL, NODE_ENV } = process.env;
 const POSTFIX =
@@ -39,7 +40,6 @@ const reducers = combineReducers({
   chain: chainReducer,
   channels: channelsReducer,
   settings: settingsReducer,
-  coins: coinsReducer,
   notifications: notificationsReducer,
   stakingAndGovernance: stakingAndGovernanceReducers,
   proposals: proposalsReducers,
@@ -73,4 +73,6 @@ export type AppThunk<ReturnType = void> = ThunkAction<
 >;
 export type AppDispatch = ReturnType<AppStore["dispatch"]>;
 
-export { persistor, store };
+const reduxStoreAtom = atomWithStore(store);
+
+export { persistor, reduxStoreAtom, store };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7770,6 +7770,8 @@ __metadata:
     html-webpack-plugin: "npm:^5.5.0"
     jest: "npm:^29.4.1"
     jest-fetch-mock: "npm:^3.0.3"
+    jotai: "npm:^2.6.3"
+    jotai-redux: "npm:^0.2.1"
     local-cors-proxy: "npm:^1.1.0"
     next-qrcode: "npm:^2.0.0"
     path: "npm:^0.12.7"
@@ -22989,6 +22991,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jotai-redux@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "jotai-redux@npm:0.2.1"
+  peerDependencies:
+    jotai: ">=1.11.0"
+  checksum: 36c4696fa7c983b10f125e3851267c74b8a728cf766bfb8bcb16d75ed74068fc52b2a1f08ae280293b5a40556db80d7ac5e6472fbdc1adbff754137d1ccfb8fa
+  languageName: node
+  linkType: hard
+
 "jotai@npm:^2.5.1":
   version: 2.5.1
   resolution: "jotai@npm:2.5.1"
@@ -23001,6 +23012,21 @@ __metadata:
     react:
       optional: true
   checksum: af2c86e16e4dd4baad31e8ad5127db8ee07712a6f852c86049f915efc71c6a099661f28a910ecef2e7da0b7868f74477712161e3717d050c1131bd521754c562
+  languageName: node
+  linkType: hard
+
+"jotai@npm:^2.6.3":
+  version: 2.6.4
+  resolution: "jotai@npm:2.6.4"
+  peerDependencies:
+    "@types/react": ">=17.0.0"
+    react: ">=17.0.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    react:
+      optional: true
+  checksum: 2cda03cccff7f6509d5733412194543634dc496a01a88da4e81d6bf1c46c27383833e8bd9462ecbcd4b745316b54edf5aa403b42c098900561cc08a0f5fcaa54
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR is the first part of replacing redux with jotai in the interface. There are different ways we could handle the data fetching depending on the UI requirements, but it should be easy to change and overall I'm happy enough with how jotai is to use compared to redux.

Currently redux has only been removed for the coins slice, so everywhere else jotai has been added, the existing redux code is still there. Data being fetched through jotai is still being fetched for redux too, so the work is duplicated but I'll fix that in a later PR.

---

### Changed
- Fetch accounts, balances etc. for jotai as well as redux (currently duplicating fetching work but will be fixed later)
- Use jotai instead of redux for displaying data in DerivedAccounts
- Calculate total balance in AccountOverview instead of DerivedAccounts
- Display "-" instead of "0" when balance for an account is loading
- Refactor DerivedAccounts with smaller FiatBalanceDisplay component

### Added
- Add jotai atoms for Namada accounts, balances and chain config
- Add jotai atoms for fiat rates and balanceToFiat function
- Add jotai atom for fiatCurrency setting
- Add temporary jotai atom for reading from redux store

### Removed
- Remove redux coins slice

### Fixed
- Only fetch fiat rates when DerivedAccounts is first mounted and remove apparently broken timestamp code