### PR TITLE
fix: Chain service improvements for token

### DIFF
--- a/apps/extension/src/background/chains/service.ts
+++ b/apps/extension/src/background/chains/service.ts
@@ -31,7 +31,7 @@ export class ChainsService {
           const nativeToken = await query.query_native_token();
           defaultChain.currency.address = nativeToken || tokenAddress;
         } catch (e) {
-          console.warn(`Chain is not reachable: ${e}`);
+          console.warn(`Chain is unreachable: ${e}`);
         }
       }
 
@@ -46,15 +46,17 @@ export class ChainsService {
     if (!chain) {
       throw new Error("No chain found!");
     }
-    let {
-      currency: { address },
-    } = chain;
+
+    // If query fails, leave address undefined so it will be caught when chain is available
+    let address: string | undefined;
 
     // Attempt to fetch native token, fallback to env
-    if (!address) {
+    try {
       const query = new Query(chain.rpc);
       const nativeToken = await query.query_native_token();
       address = nativeToken || tokenAddress;
+    } catch (e) {
+      console.warn(`Chain is unreachable: ${e}`);
     }
 
     await this.chainsStore.set(CHAINS_KEY, {

--- a/apps/extension/src/background/chains/service.ts
+++ b/apps/extension/src/background/chains/service.ts
@@ -4,70 +4,61 @@ import { KVStore } from "@namada/storage";
 import { Chain } from "@namada/types";
 import { ExtensionBroadcaster } from "extension";
 
-const {
-  NAMADA_INTERFACE_NAMADA_TOKEN:
-  tokenAddress = "tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e",
-} = process.env;
-
 export const CHAINS_KEY = "chains";
 
 export class ChainsService {
   constructor(
     protected readonly chainsStore: KVStore<Chain>,
     protected readonly broadcaster: ExtensionBroadcaster
-  ) { }
+  ) {
+    this._initChain();
+  }
+
+  private async _queryNativeToken(chain: Chain): Promise<Chain> {
+    const query = new Query(chain.rpc);
+    try {
+      const nativeToken = await query.query_native_token();
+      if (nativeToken) {
+        chain.currency.address = nativeToken;
+      }
+    } catch (e) {
+      console.warn(`Chain is unreachable: ${e}`);
+    }
+
+    await this.chainsStore.set(CHAINS_KEY, chain);
+    return chain;
+  }
+
+  private async _initChain(): Promise<void> {
+    // Initialize default chain in storage
+    const chain = (await this.chainsStore.get(CHAINS_KEY)) || chains.namada;
+    // Default chain config does not have a token address, so we query:
+    if (!chain.currency.address) {
+      this._queryNativeToken(chain);
+    }
+  }
 
   async getChain(): Promise<Chain> {
-    const chain = await this.chainsStore.get(CHAINS_KEY);
-    if (!chain) {
-      // Initialize default chain in storage
-      const defaultChain = chains.namada;
-      const {
-        currency: { address },
-      } = defaultChain;
-      if (!address) {
-        const query = new Query(defaultChain.rpc);
-        try {
-          const nativeToken = await query.query_native_token();
-          defaultChain.currency.address = nativeToken || tokenAddress;
-        } catch (e) {
-          console.warn(`Chain is unreachable: ${e}`);
-        }
-      }
-
-      await this.chainsStore.set(CHAINS_KEY, defaultChain);
-      return defaultChain;
+    let chain = (await this.chainsStore.get(CHAINS_KEY)) || chains.namada;
+    // If a previous query for native token failed, attempt again:
+    if (!chain.currency.address) {
+      chain = await this._queryNativeToken(chain);
     }
     return chain;
   }
 
   async updateChain(chainId: string, url: string): Promise<void> {
-    const chain = await this.getChain();
+    let chain = await this.getChain();
     if (!chain) {
       throw new Error("No chain found!");
     }
-
-    // If query fails, leave address undefined so it will be caught when chain is available
-    let address: string | undefined;
-
-    // Attempt to fetch native token, fallback to env
-    try {
-      const query = new Query(chain.rpc);
-      const nativeToken = await query.query_native_token();
-      address = nativeToken || tokenAddress;
-    } catch (e) {
-      console.warn(`Chain is unreachable: ${e}`);
-    }
-
-    await this.chainsStore.set(CHAINS_KEY, {
+    // Update RPC & Chain ID, then query for native token
+    chain = {
       ...chain,
       chainId,
       rpc: url,
-      currency: {
-        ...chain.currency,
-        address,
-      },
-    });
+    };
+    await this.chainsStore.set(CHAINS_KEY, await this._queryNativeToken(chain));
     this.broadcaster.updateNetwork();
   }
 }


### PR DESCRIPTION
The logic for query native token was a bit incorrect in the `ChainsService` - this has been fixed! The goal of this feature is that the native token will always match the chain that the extension is pointed to, assuming that chain is up and responding, and users should be able to remedy any issue related to this without restarting or upgrading the extension.

### Testing

- Build the extension & interface with pointed to a local node (if you have balances, even better, as it's easier to see it working)
- If your node requires proxying, point the extension to `http://localhost:8010/proxy`
- You should see balances, and you can also inspect the Redux state to confirm the token address, which should be: `tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e`
- In the Extension, in `Network`, set the values to look like this:
```
shielded-expedition.88f17d1d14
https://proxy.heliax.click/shielded-expedition.88f17d1d14/
```
- Clicking submit, then inspect Redux state, and the `chain.currency.address` should be `tnam1qxvg64psvhwumv3mwrrjfcz0h3t3274hwggyzcee`

You may also test error states, like setting the URL to something that's invalid so that the query fails, and then update with a correct value. An error should result in a chain config that either has an unset `address` or the previous `address`, but upon a successful query, this should always be correct.

**NOTE** The interface is a little buggy, even though the `getChain()`is correct, you will sometimes have to refresh for balances - there are some inefficiencies there, but this PR is to fix the extension