### PR TITLE
fix: do not display import with passphrase in pk flow

### DIFF
--- a/apps/extension/src/Setup/ImportAccount/SeedPhraseImport.tsx
+++ b/apps/extension/src/Setup/ImportAccount/SeedPhraseImport.tsx
@@ -262,7 +262,7 @@ export const SeedPhraseImport: React.FC<Props> = ({ onConfirm }) => {
               </Alert>
             </div>
           )}
-          {!showPassphrase && (
+          {!showPassphrase && mnemonicType !== MnemonicTypes.PrivateKey && (
             <LinkButton
               data-testid="setup-import-keys-use-passphrase-button"
               className="text-xs !text-neutral-400"


### PR DESCRIPTION
When clicking on Private Key we do not want to display: "Import with BIP39 Paassphrase" as it's being ignored anyway.

![image](https://github.com/anoma/namada-interface/assets/11858303/beb1aeba-bfb9-48b5-948b-171276353251)
