### PR TITLE
feat: staking gas fee improvements

### DIFF
--- a/apps/namada-interface/src/App/Staking/ValidatorDetails/ValidatorDetails.tsx
+++ b/apps/namada-interface/src/App/Staking/ValidatorDetails/ValidatorDetails.tsx
@@ -19,6 +19,7 @@ import {
   Validator,
   postNewWithdraw,
 } from "slices/StakingAndGovernance";
+import { GAS_LIMIT } from "slices/fees";
 import { RootState, useAppDispatch, useAppSelector } from "store";
 import { ModalState } from "../Staking";
 import {
@@ -28,29 +29,29 @@ import {
 } from "./ValidatorDetails.components";
 
 const validatorDetailsConfigurations: TableConfigurations<KeyValueData, never> =
-{
-  rowRenderer: (rowData: KeyValueData) => {
-    // we have to figure if this is the row for validator homepage, hench an anchor
-    const linkOrText = /^https?:/.test(rowData.value) ? (
-      <a href={rowData.value} target="_blank" rel="noopener noreferrer">
-        {rowData.value}
-      </a>
-    ) : (
-      <span>{rowData.value}</span>
-    );
+  {
+    rowRenderer: (rowData: KeyValueData) => {
+      // we have to figure if this is the row for validator homepage, hench an anchor
+      const linkOrText = /^https?:/.test(rowData.value) ? (
+        <a href={rowData.value} target="_blank" rel="noopener noreferrer">
+          {rowData.value}
+        </a>
+      ) : (
+        <span>{rowData.value}</span>
+      );
 
-    return (
-      <>
-        <td style={{ display: "flex" }}>{rowData.key}</td>
-        <td>{linkOrText}</td>
-      </>
-    );
-  },
-  columns: [
-    { uuid: "1", columnLabel: "", width: "30%" },
-    { uuid: "2", columnLabel: "", width: "70%" },
-  ],
-};
+      return (
+        <>
+          <td style={{ display: "flex" }}>{rowData.key}</td>
+          <td>{linkOrText}</td>
+        </>
+      );
+    },
+    columns: [
+      { uuid: "1", columnLabel: "", width: "30%" },
+      { uuid: "2", columnLabel: "", width: "70%" },
+    ],
+  };
 
 const getMyStakingWithValidatorConfigurations = (
   setModalState: React.Dispatch<React.SetStateAction<ModalState>>,
@@ -118,6 +119,7 @@ type Props = {
   stakingPositionsWithSelectedValidator?: StakingPosition[];
   setModalState: React.Dispatch<React.SetStateAction<ModalState>>;
   navigateToUnbonding: (validatorId: string, owner: string) => void;
+  minimumGasPrice: BigNumber;
 };
 
 // this turns the Validator object to rows that are passed to the table
@@ -148,6 +150,7 @@ export const ValidatorDetails = (props: Props): JSX.Element => {
     setModalState,
     navigateToUnbonding,
     stakingPositionsWithSelectedValidator = [],
+    minimumGasPrice,
   } = props;
 
   const epoch = useAppSelector(
@@ -156,7 +159,14 @@ export const ValidatorDetails = (props: Props): JSX.Element => {
 
   const dispatch = useAppDispatch();
   const dispatchWithdraw = (validatorId: string, owner: string): void => {
-    dispatch(postNewWithdraw({ validatorId, owner }));
+    dispatch(
+      postNewWithdraw({
+        validatorId,
+        owner,
+        gasPrice: minimumGasPrice,
+        gasLimit: GAS_LIMIT,
+      })
+    );
   };
 
   const validatorDetailsData = validatorToDataRows(validator);

--- a/apps/namada-interface/src/App/Token/TokenSend/TokenSend.tsx
+++ b/apps/namada-interface/src/App/Token/TokenSend/TokenSend.tsx
@@ -1,10 +1,13 @@
-import BigNumber from "bignumber.js";
+import { useAtomValue } from "jotai";
+import { loadable } from "jotai/utils";
 import { useEffect, useState } from "react";
 
 import { TransferType } from "App/Token/types";
 import { Account, AccountsState } from "slices/accounts";
+import { isRevealPkNeededAtom, minimumGasPriceAtom } from "slices/fees";
 import { useAppSelector } from "store";
 
+import { chains } from "@namada/chains";
 import {
   Heading,
   NavigationContainer,
@@ -14,10 +17,8 @@ import {
   TabsGroup,
 } from "@namada/components";
 import { useSanitizedParams } from "@namada/hooks";
-import { Query } from "@namada/shared";
-import { Chain, TokenType, Tokens } from "@namada/types";
+import { TokenType, Tokens } from "@namada/types";
 import TokenSendForm from "./TokenSendForm";
-import { chains } from "@namada/chains";
 
 import { TokenSendContainer, TokenSendContent } from "./TokenSend.components";
 import {
@@ -55,13 +56,14 @@ const accountsWithBalanceIntoSelectData = (
     Object.entries(balance)
       .map(([tokenType, amount]) => ({
         value: `${details.address}|${tokenType}`,
-        label: `${details.alias} ${amount} (${Tokens[tokenType as TokenType].symbol})`,
+        label: `${details.alias} ${amount} (${
+          Tokens[tokenType as TokenType].symbol
+        })`,
       }))
   );
 
 const TokenSend = (): JSX.Element => {
   const { derived } = useAppSelector<AccountsState>((state) => state.accounts);
-  const { rpc, currency: { address: nativeToken } } = useAppSelector<Chain>((state) => state.chain.config);
   const { target } = useSanitizedParams<Params>();
 
   const accounts = Object.values(derived[chains.namada.id]);
@@ -113,30 +115,18 @@ const TokenSend = (): JSX.Element => {
 
   const handleTokenChange =
     (selectAccountFn: (accId: string) => void) =>
-      (e: React.ChangeEvent<HTMLSelectElement>): void => {
-        const { value } = e.target;
-        const [accountId, tokenSymbol] = value.split("|");
+    (e: React.ChangeEvent<HTMLSelectElement>): void => {
+      const { value } = e.target;
+      const [accountId, tokenSymbol] = value.split("|");
 
-        selectAccountFn(accountId);
-        setToken(tokenSymbol as TokenType);
-      };
+      selectAccountFn(accountId);
+      setToken(tokenSymbol as TokenType);
+    };
 
-  const [minimumGasPrice, setMinimumGasPrice] = useState<BigNumber>();
-
-  useEffect(() => {
-    (async () => {
-      const query = new Query(rpc);
-      const result = (await query.query_gas_costs()) as [string, string][];
-
-      const namCost = result.find(([token]) => token === nativeToken);
-
-      if (!namCost) {
-        throw new Error("Error querying minimum gas price");
-      }
-
-      setMinimumGasPrice(new BigNumber(namCost[1]));
-    })();
-  }, []);
+  const minimumGasPrice = useAtomValue(loadable(minimumGasPriceAtom));
+  const isRevealPkNeeded = useAtomValue(loadable(isRevealPkNeededAtom));
+  const loadablesReady =
+    minimumGasPrice.state === "hasData" && isRevealPkNeeded.state === "hasData";
 
   return (
     <TokenSendContainer>
@@ -158,7 +148,7 @@ const TokenSend = (): JSX.Element => {
 
       {activeTab === "Shielded" && (
         <TokenSendContent>
-          {shieldedTokenData.length > 0 && minimumGasPrice ? (
+          {shieldedTokenData.length > 0 && loadablesReady ? (
             <>
               <Select
                 data={shieldedTokenData}
@@ -173,7 +163,8 @@ const TokenSend = (): JSX.Element => {
                   defaultTarget={
                     target?.startsWith("znam") ? target : undefined
                   }
-                  minimumGasPrice={minimumGasPrice}
+                  minimumGasPrice={minimumGasPrice.data}
+                  isRevealPkNeededFn={isRevealPkNeeded.data}
                 />
               )}
             </>
@@ -185,7 +176,7 @@ const TokenSend = (): JSX.Element => {
 
       {activeTab === "Transparent" && (
         <TokenSendContent>
-          {transparentTokenData.length > 0 && minimumGasPrice ? (
+          {transparentTokenData.length > 0 && loadablesReady ? (
             <>
               <Select
                 data={transparentTokenData}
@@ -202,7 +193,8 @@ const TokenSend = (): JSX.Element => {
                   defaultTarget={
                     target?.startsWith("tnam") ? target : undefined
                   }
-                  minimumGasPrice={minimumGasPrice}
+                  minimumGasPrice={minimumGasPrice.data}
+                  isRevealPkNeededFn={isRevealPkNeeded.data}
                 />
               )}
             </>

--- a/apps/namada-interface/src/slices/StakingAndGovernance/types.ts
+++ b/apps/namada-interface/src/slices/StakingAndGovernance/types.ts
@@ -83,6 +83,8 @@ export type ChangeInStakingPosition = {
   owner: string;
   amount: BigNumber;
   memo?: string;
+  gasPrice: BigNumber;
+  gasLimit: BigNumber;
 };
 
 export type StakingAndGovernanceState = {

--- a/apps/namada-interface/src/slices/fees.ts
+++ b/apps/namada-interface/src/slices/fees.ts
@@ -1,0 +1,68 @@
+import { Query } from "@namada/shared";
+import BigNumber from "bignumber.js";
+import { atom } from "jotai";
+
+import { accountsAtom } from "slices/accounts";
+import { chainAtom } from "slices/chain";
+
+// TODO: remove harcoding of gas limit
+export const GAS_LIMIT = new BigNumber(20_000);
+
+const minimumGasPriceAtom = (() => {
+  const base = atom(new Promise<BigNumber>(() => {}));
+
+  return atom(
+    (get) => get(base),
+    async (get, set) => {
+      const {
+        rpc,
+        currency: { address: nativeToken },
+      } = get(chainAtom);
+      const query = new Query(rpc);
+
+      const promise = (async () => {
+        const result = (await query.query_gas_costs()) as [string, string][];
+        const nativeTokenCost = result.find(([token]) => token === nativeToken);
+
+        if (!nativeTokenCost) {
+          throw new Error("Error querying minimum gas price");
+        }
+
+        const asBigNumber = new BigNumber(nativeTokenCost[1]);
+
+        if (asBigNumber.isNaN()) {
+          throw new Error("Error converting minimum gas price to BigNumber");
+        }
+
+        return asBigNumber;
+      })();
+
+      set(base, promise);
+    }
+  );
+})();
+
+const isRevealPkNeededAtom = atom(async (get) => {
+  const accounts = await get(accountsAtom);
+  const transparentAccounts = accounts.filter((account) => !account.isShielded);
+
+  const { rpc } = get(chainAtom);
+  const query = new Query(rpc);
+
+  const map: Record<string, string | null> = {};
+  await Promise.all(
+    transparentAccounts.map(async ({ address }) => {
+      const publicKey = await query.query_public_key(address);
+      map[address] = publicKey;
+    })
+  );
+
+  return (address: string): boolean => {
+    if (!(address in map)) {
+      throw new Error("address not found in public key map");
+    }
+    return map[address] === null;
+  };
+});
+
+export { isRevealPkNeededAtom, minimumGasPriceAtom };

--- a/apps/namada-interface/src/slices/notifications/reducers.ts
+++ b/apps/namada-interface/src/slices/notifications/reducers.ts
@@ -1,20 +1,20 @@
 import {
-  PayloadAction,
-  isPending,
-  isFulfilled,
-  isRejected,
   Action,
-  isAsyncThunkAction,
   ActionReducerMapBuilder,
+  PayloadAction,
+  isAsyncThunkAction,
+  isFulfilled,
+  isPending,
+  isRejected,
 } from "@reduxjs/toolkit";
 
+import { TxLabel } from "@namada/shared";
 import {
   CreateToastPayload,
-  ToastId,
   NotificationsState,
+  ToastId,
   ToastTimeout,
 } from "./types";
-import { TxLabel } from "@namada/shared";
 
 export const DEFAULT_TIMEOUT = 2000;
 export const THUNK_MATCH_REGEXP = /^.*(?=\/(pending|fulfilled|rejected)$)/;

--- a/packages/components/src/AmountInput.tsx
+++ b/packages/components/src/AmountInput.tsx
@@ -9,10 +9,15 @@ type BigNumberElement = Omit<HTMLInputElement, "value"> & {
   value?: BigNumber;
 };
 
-type Props = Omit<ComponentProps<typeof Input>, "value" | "onChange"> & {
+type Props = Omit<
+  ComponentProps<typeof Input>,
+  "value" | "onChange" | "min" | "max"
+> & {
   value?: BigNumber;
   onChange?: ChangeEventHandler<BigNumberElement>;
   maxDecimalPlaces?: number;
+  min?: string | number | BigNumber;
+  max?: string | number | BigNumber;
 };
 
 type ValidationError =


### PR DESCRIPTION
Fixes bond, unbond and withdraw in #597.

---

### Changed
- Use minimum gas price instead of hardcoded price for bond, unbond and withdraw
- Account for fees in maximum valid amount in bonding
- Warn the user when bonding too much to allow for future unbonding and withdrawal
- Refresh balances when a transaction completes (specifically when the toasts atom changes)

### Added
- Add max button to new bonding form
- Display gas fee in bonding and unbonding

### Fixed
- Sum all staking positions when calculating total staked amount
- Allow BigNumber for AmountInput min and max props
- Minor styling fixes