### PR TITLE
feat/634: Faucet - Catch rate limiting error code, provide specific message

### DIFF
--- a/apps/faucet/src/utils/types.ts
+++ b/apps/faucet/src/utils/types.ts
@@ -33,6 +33,6 @@ export type TransferResponse = {
 };
 
 export type ErrorResponse = {
-  code: string;
+  code: number;
   message: string;
 };


### PR DESCRIPTION
Resolves #634 

- Added specific message to display in the case of rate limiting errors (code `429`)

**NOTE** When deploying, set the faucet limit to 10 (instead of the default 1000) as it has been changed!