### PR TITLE
Data fetching fixes

### DIFF
--- a/apps/extension/src/background/approvals/handler.ts
+++ b/apps/extension/src/background/approvals/handler.ts
@@ -2,6 +2,7 @@ import {
   ApproveConnectInterfaceMsg,
   ApproveSignArbitraryMsg,
   ApproveTxMsg,
+  IsConnectionApprovedMsg,
 } from "provider";
 import { Env, Handler, InternalHandler, Message } from "router";
 import {
@@ -25,6 +26,11 @@ export const getHandler: (service: ApprovalsService) => Handler = (service) => {
         return handleSubmitApprovedTxMsg(service)(
           env,
           msg as SubmitApprovedTxMsg
+        );
+      case IsConnectionApprovedMsg:
+        return handleIsConnectionApprovedMsg(service)(
+          env,
+          msg as IsConnectionApprovedMsg
         );
       case ApproveConnectInterfaceMsg:
         return handleApproveConnectInterfaceMsg(service)(
@@ -84,6 +90,14 @@ const handleSubmitApprovedTxMsg: (
 ) => InternalHandler<SubmitApprovedTxMsg> = (service) => {
   return async (_, { msgId }) => {
     return await service.submitTx(msgId);
+  };
+};
+
+const handleIsConnectionApprovedMsg: (
+  service: ApprovalsService
+) => InternalHandler<IsConnectionApprovedMsg> = (service) => {
+  return async (_, { origin }) => {
+    return await service.isConnectionApproved(origin);
   };
 };
 

--- a/apps/extension/src/background/approvals/init.ts
+++ b/apps/extension/src/background/approvals/init.ts
@@ -2,6 +2,7 @@ import {
   ApproveConnectInterfaceMsg,
   ApproveSignArbitraryMsg,
   ApproveTxMsg,
+  IsConnectionApprovedMsg,
 } from "provider";
 import { Router } from "router";
 import {
@@ -24,6 +25,7 @@ export function init(router: Router, service: ApprovalsService): void {
   router.registerMessage(ApproveSignArbitraryMsg);
   router.registerMessage(RejectSignatureMsg);
   router.registerMessage(SubmitApprovedSignatureMsg);
+  router.registerMessage(IsConnectionApprovedMsg);
   router.registerMessage(ApproveConnectInterfaceMsg);
   router.registerMessage(ConnectInterfaceResponseMsg);
   router.registerMessage(RevokeConnectionMsg);

--- a/apps/extension/src/background/approvals/service.test.ts
+++ b/apps/extension/src/background/approvals/service.test.ts
@@ -16,6 +16,7 @@ import { KeyRingService, TabStore } from "background/keyring";
 import { LedgerService } from "background/ledger";
 import { VaultService } from "background/vault";
 import BigNumber from "bignumber.js";
+import { ExtensionBroadcaster } from "extension";
 import createMockInstance from "jest-create-mock-instance";
 import { KVStoreMock } from "test/init";
 import { ApprovalsService } from "./service";
@@ -55,6 +56,8 @@ describe.only("approvals service", () => {
     const vaultService: jest.Mocked<VaultService> = createMockInstance(
       VaultService as any
     );
+    const broadcaster: jest.Mocked<ExtensionBroadcaster> =
+      createMockInstance(ExtensionBroadcaster);
 
     service = new ApprovalsService(
       txStore,
@@ -63,7 +66,8 @@ describe.only("approvals service", () => {
       approvedOriginsStore,
       keyRingService,
       ledgerService,
-      vaultService
+      vaultService,
+      broadcaster
     );
   });
 

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -113,7 +113,8 @@ const init = new Promise<void>(async (resolve) => {
     approvedOriginsStore,
     keyRingService,
     ledgerService,
-    vaultService
+    vaultService,
+    broadcaster
   );
 
   // Initialize messages and handlers

--- a/apps/extension/src/content/events.ts
+++ b/apps/extension/src/content/events.ts
@@ -201,6 +201,26 @@ export class VaultLockedEventMsg extends Message<void> {
   }
 }
 
+export class ConnectionRevokedEventMsg extends Message<void> {
+  public static type(): Events {
+    return Events.ConnectionRevoked;
+  }
+
+  constructor() {
+    super();
+  }
+
+  validate(): void {}
+
+  route(): string {
+    return Routes.InteractionForeground;
+  }
+
+  type(): string {
+    return ConnectionRevokedEventMsg.type();
+  }
+}
+
 export function initEvents(router: Router): void {
   router.registerMessage(AccountChangedEventMsg);
   router.registerMessage(NetworkChangedEventMsg);
@@ -210,6 +230,7 @@ export function initEvents(router: Router): void {
   router.registerMessage(TxStartedEvent);
   router.registerMessage(TxCompletedEvent);
   router.registerMessage(VaultLockedEventMsg);
+  router.registerMessage(ConnectionRevokedEventMsg);
 
   router.addHandler(Routes.InteractionForeground, (_, msg) => {
     const clonedMsg =
@@ -247,6 +268,9 @@ export function initEvents(router: Router): void {
         break;
       case VaultLockedEventMsg:
         window.dispatchEvent(new CustomEvent(Events.ExtensionLocked));
+        break;
+      case ConnectionRevokedEventMsg:
+        window.dispatchEvent(new CustomEvent(Events.ConnectionRevoked));
         break;
       default:
         throw new Error("Unknown msg type");

--- a/apps/extension/src/extension/ExtensionBroadcaster.ts
+++ b/apps/extension/src/extension/ExtensionBroadcaster.ts
@@ -3,6 +3,7 @@ import { KVStore } from "@namada/storage";
 import { TabStore, syncTabs } from "background/keyring";
 import {
   AccountChangedEventMsg,
+  ConnectionRevokedEventMsg,
   NetworkChangedEventMsg,
   ProposalsUpdatedEventMsg,
   TxCompletedEvent,
@@ -57,6 +58,10 @@ export class ExtensionBroadcaster {
 
   async lockExtension(): Promise<void> {
     await this.sendMsgToTabs(new VaultLockedEventMsg());
+  }
+
+  async revokeConnection(): Promise<void> {
+    await this.sendMsgToTabs(new ConnectionRevokedEventMsg());
   }
 
   /**

--- a/apps/extension/src/provider/InjectedNamada.ts
+++ b/apps/extension/src/provider/InjectedNamada.ts
@@ -13,10 +13,14 @@ import { InjectedProxy } from "./InjectedProxy";
 import { Signer } from "./Signer";
 
 export class InjectedNamada implements INamada {
-  constructor(private readonly _version: string) { }
+  constructor(private readonly _version: string) {}
 
   public async connect(): Promise<void> {
     return await InjectedProxy.requestMethod<string, void>("connect");
+  }
+
+  public async isConnected(): Promise<boolean> {
+    return await InjectedProxy.requestMethod<string, boolean>("isConnected");
   }
 
   public async accounts(): Promise<DerivedAccount[]> {

--- a/apps/extension/src/provider/Namada.ts
+++ b/apps/extension/src/provider/Namada.ts
@@ -18,6 +18,7 @@ import {
   FetchAndStoreMaspParamsMsg,
   GetChainMsg,
   HasMaspParamsMsg,
+  IsConnectionApprovedMsg,
   QueryAccountsMsg,
   QueryBalancesMsg,
   QueryDefaultAccountMsg,
@@ -28,12 +29,23 @@ export class Namada implements INamada {
   constructor(
     private readonly _version: string,
     protected readonly requester?: MessageRequester
-  ) { }
+  ) {}
 
   public async connect(): Promise<void> {
     return await this.requester?.sendMessage(
       Ports.Background,
       new ApproveConnectInterfaceMsg()
+    );
+  }
+
+  public async isConnected(): Promise<boolean> {
+    if (!this.requester) {
+      throw new Error("no requester");
+    }
+
+    return await this.requester.sendMessage(
+      Ports.Background,
+      new IsConnectionApprovedMsg()
     );
   }
 

--- a/apps/extension/src/provider/Proxy.ts
+++ b/apps/extension/src/provider/Proxy.ts
@@ -1,5 +1,8 @@
 import { KVStore } from "@namada/storage";
-import { ApprovedOriginsStore, APPROVED_ORIGINS_KEY } from "background/approvals";
+import {
+  APPROVED_ORIGINS_KEY,
+  ApprovedOriginsStore,
+} from "background/approvals";
 
 import { Namada } from "./Namada";
 import { ProxyRequest, ProxyRequestResponse, ProxyRequestTypes } from "./types";
@@ -7,7 +10,7 @@ import { ProxyRequest, ProxyRequestResponse, ProxyRequestTypes } from "./types";
 export class Proxy {
   static start(
     namada: Namada,
-    approvedOriginsStore: KVStore<ApprovedOriginsStore>,
+    approvedOriginsStore: KVStore<ApprovedOriginsStore>
   ): void {
     Proxy.addMessageListener(async (e) => {
       const message = e.data;
@@ -18,8 +21,9 @@ export class Proxy {
 
       const { method, args } = message;
 
-      if (method !== "connect") {
-        const approvedOrigins = await approvedOriginsStore.get(APPROVED_ORIGINS_KEY) || [];
+      if (method !== "connect" && method !== "isConnected") {
+        const approvedOrigins =
+          (await approvedOriginsStore.get(APPROVED_ORIGINS_KEY)) || [];
         if (!approvedOrigins.includes(e.origin)) {
           return;
         }

--- a/apps/extension/src/provider/messages.ts
+++ b/apps/extension/src/provider/messages.ts
@@ -21,6 +21,7 @@ enum Route {
 }
 
 enum MessageType {
+  IsConnectionApproved = "is-connection-approved",
   ApproveConnectInterface = "approve-connect-interface",
   QueryAccounts = "query-accounts",
   QueryDefaultAccount = "query-default-account",
@@ -42,6 +43,27 @@ enum MessageType {
 /**
  * Messages routed from providers to Chains service
  */
+export class IsConnectionApprovedMsg extends Message<boolean> {
+  public static type(): MessageType {
+    return MessageType.IsConnectionApproved;
+  }
+
+  constructor() {
+    super();
+  }
+
+  validate(): void {
+    return;
+  }
+
+  route(): string {
+    return Route.Approvals;
+  }
+
+  type(): string {
+    return IsConnectionApprovedMsg.type();
+  }
+}
 
 export class ApproveConnectInterfaceMsg extends Message<void> {
   public static type(): MessageType {
@@ -74,7 +96,7 @@ export class GetChainMsg extends Message<Chain> {
     super();
   }
 
-  validate(): void { }
+  validate(): void {}
 
   route(): string {
     return Route.Chains;

--- a/apps/extension/src/test/init.ts
+++ b/apps/extension/src/test/init.ts
@@ -43,7 +43,7 @@ const cryptoMemory = require("@namada/crypto").__wasm.memory;
 export class KVStoreMock<T> implements KVStore<T> {
   private storage: { [key: string]: T | null } = {};
 
-  constructor(readonly _prefix: string) { }
+  constructor(readonly _prefix: string) {}
 
   get<U extends T>(key: string): Promise<U | undefined> {
     return new Promise((resolve) => {
@@ -141,7 +141,8 @@ export const init = async (): Promise<{
     approvedOriginsStore,
     keyRingService,
     ledgerService,
-    vaultService
+    vaultService,
+    broadcaster
   );
 
   const init = new Promise<void>(async (resolve) => {

--- a/apps/namada-interface/src/App/fetchEffects.ts
+++ b/apps/namada-interface/src/App/fetchEffects.ts
@@ -1,0 +1,70 @@
+import { useAtomValue, useSetAtom } from "jotai";
+import { loadable } from "jotai/utils";
+
+import { useEffectSkipFirstRender } from "@namada/hooks";
+import {
+  Namada,
+  useIntegration,
+  useUntilIntegrationAttached,
+} from "@namada/integrations";
+import { namadaExtensionConnectedAtom } from "slices/settings";
+
+import { accountsAtom, balancesAtom } from "slices/accounts";
+import { chainAtom } from "slices/chain";
+import { isRevealPkNeededAtom, minimumGasPriceAtom } from "slices/fees";
+
+export const useOnChainChanged = (): void => {
+  const chain = useAtomValue(chainAtom);
+
+  const refreshMinimumGasPrice = useSetAtom(minimumGasPriceAtom);
+  const refreshPublicKeys = useSetAtom(isRevealPkNeededAtom);
+
+  useEffectSkipFirstRender(() => {
+    refreshMinimumGasPrice();
+    refreshPublicKeys();
+  }, [chain]);
+};
+
+export const useOnNamadaExtensionAttached = (): void => {
+  const setNamadaExtensionConnected = useSetAtom(namadaExtensionConnectedAtom);
+  const chain = useAtomValue(chainAtom); // should always be namada
+  const { namada: attachStatus } = useUntilIntegrationAttached(chain);
+  const integration = useIntegration("namada") as Namada;
+
+  useEffectSkipFirstRender(() => {
+    (async () => {
+      if (attachStatus === "attached") {
+        const connected = !!(await integration.isConnected());
+        setNamadaExtensionConnected(connected);
+      }
+    })();
+  }, [attachStatus]);
+};
+
+export const useOnNamadaExtensionConnected = (): void => {
+  const connected = useAtomValue(namadaExtensionConnectedAtom);
+
+  const refreshChain = useSetAtom(chainAtom);
+  const refreshAccounts = useSetAtom(accountsAtom);
+
+  useEffectSkipFirstRender(() => {
+    if (connected) {
+      refreshChain();
+      refreshAccounts();
+    }
+  }, [connected]);
+};
+
+export const useOnAccountsChanged = (): void => {
+  const accountsLoadable = useAtomValue(loadable(accountsAtom));
+
+  const refreshBalances = useSetAtom(balancesAtom);
+  const refreshPublicKeys = useSetAtom(isRevealPkNeededAtom);
+
+  useEffectSkipFirstRender(() => {
+    if (accountsLoadable.state === "hasData") {
+      refreshBalances();
+      refreshPublicKeys();
+    }
+  }, [accountsLoadable]);
+};

--- a/apps/namada-interface/src/index.tsx
+++ b/apps/namada-interface/src/index.tsx
@@ -11,21 +11,23 @@ import reportWebVitals from "./reportWebVitals";
 import "@namada/components/src/base.css";
 import "./tailwind.css";
 
-ReactDOM.render(
-  <React.StrictMode>
-    <IntegrationsProvider>
-      <Provider store={store}>
-        <ExtensionEventsProvider>
-          <RouterProvider router={getRouter()} />
-        </ExtensionEventsProvider>
-      </Provider>
-    </IntegrationsProvider>
-  </React.StrictMode>,
-  document.getElementById("root")
-);
+// TODO: we could show the loading screen while initShared is pending
+initShared().then(() => {
+  ReactDOM.render(
+    <React.StrictMode>
+      <IntegrationsProvider>
+        <Provider store={store}>
+          <ExtensionEventsProvider>
+            <RouterProvider router={getRouter()} />
+          </ExtensionEventsProvider>
+        </Provider>
+      </IntegrationsProvider>
+    </React.StrictMode>,
+    document.getElementById("root")
+  );
+});
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
 reportWebVitals();
-initShared();

--- a/apps/namada-interface/src/services/extensionEvents/handlers/namada.ts
+++ b/apps/namada-interface/src/services/extensionEvents/handlers/namada.ts
@@ -46,8 +46,9 @@ export const NamadaProposalsUpdatedHandler =
   };
 
 export const NamadaUpdatedBalancesHandler =
-  (dispatch: Dispatch<unknown>) => async () => {
+  (dispatch: Dispatch<unknown>, refreshBalances: () => void) => async () => {
     dispatch(fetchBalances());
+    refreshBalances();
   };
 
 export const NamadaUpdatedStakingHandler =
@@ -67,7 +68,8 @@ export const NamadaTxStartedHandler =
   };
 
 export const NamadaTxCompletedHandler =
-  (dispatch: Dispatch<unknown>) => async (event: CustomEventInit) => {
+  (dispatch: Dispatch<unknown>, refreshPublicKeys: () => void) =>
+  async (event: CustomEventInit) => {
     const { msgId, txType, success, payload } = event.detail;
     if (!success) {
       console.warn(`${txType} failed:`, payload);
@@ -80,4 +82,15 @@ export const NamadaTxCompletedHandler =
         error: payload || "",
       })
     );
+    refreshPublicKeys();
+  };
+
+export const NamadaConnectionRevokedHandler =
+  (
+    integration: Namada,
+    setNamadaExtensionConnected: (connected: boolean) => void
+  ) =>
+  async () => {
+    const connected = !!(await integration.isConnected());
+    setNamadaExtensionConnected(connected);
   };

--- a/apps/namada-interface/src/slices/accounts.ts
+++ b/apps/namada-interface/src/slices/accounts.ts
@@ -191,8 +191,7 @@ const balancesAtom = (() => {
         currency: { address: nativeToken },
       } = get(chainAtom);
 
-      // TODO: should we be throwing away old balances here?
-      const balances = get(base);
+      set(base, {});
 
       accounts.forEach(async (account) => {
         const result = await namada.queryBalances(account.address, [
@@ -202,11 +201,7 @@ const balancesAtom = (() => {
           (acc, curr) => ({ ...acc, [curr.token]: new BigNumber(curr.amount) }),
           {} as Balance
         );
-        balances[account.address] = balance;
-        set(
-          base,
-          { ...balances } // object clone ensures jotai realises object has changed
-        );
+        set(base, { ...get(base), [account.address]: balance });
       });
     }
   );

--- a/apps/namada-interface/src/slices/settings.ts
+++ b/apps/namada-interface/src/slices/settings.ts
@@ -1,6 +1,8 @@
 import { ChainKey } from "@namada/types";
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
+import { atom } from "jotai";
+
 const SETTINGS_ACTIONS_BASE = "settings";
 
 export type SettingsState = {
@@ -28,3 +30,11 @@ const { actions, reducer } = settingsSlice;
 export const { setIsConnected } = actions;
 
 export default reducer;
+
+////////////////////////////////////////////////////////////////////////////////
+// JOTAI
+////////////////////////////////////////////////////////////////////////////////
+
+const namadaExtensionConnectedAtom = atom(false);
+
+export { namadaExtensionConnectedAtom };

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./useDebounce";
+export * from "./useEffectSkipFirstRender";
 export * from "./useEvent";
-export * from "./useSanitizedParams";
 export * from "./useSanitizedLocation";
+export * from "./useSanitizedParams";
 export * from "./useUntil";

--- a/packages/hooks/src/useEffectSkipFirstRender.ts
+++ b/packages/hooks/src/useEffectSkipFirstRender.ts
@@ -1,0 +1,16 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * The same as useEffect, but does not run the effect on the first render.
+ */
+export const useEffectSkipFirstRender: typeof useEffect = (effect, deps) => {
+  const firstRender = useRef(true);
+
+  useEffect(() => {
+    if (firstRender.current) {
+      firstRender.current = false;
+    } else {
+      effect();
+    }
+  }, deps);
+};

--- a/packages/integrations/src/Namada.ts
+++ b/packages/integrations/src/Namada.ts
@@ -14,7 +14,7 @@ import { BridgeProps, Integration } from "./types/Integration";
 export default class Namada implements Integration<Account, Signer> {
   private _namada: WindowWithNamada["namada"] | undefined;
 
-  constructor(public readonly chain: Chain) { }
+  constructor(public readonly chain: Chain) {}
 
   public get instance(): INamada | undefined {
     return this._namada;
@@ -33,6 +33,10 @@ export default class Namada implements Integration<Account, Signer> {
 
   public async connect(chainId?: string): Promise<void> {
     await this._namada?.connect(chainId);
+  }
+
+  public async isConnected(): Promise<boolean | undefined> {
+    return await this._namada?.isConnected();
   }
 
   public async getChain(): Promise<Chain | undefined> {

--- a/packages/integrations/src/hooks/useIntegration.ts
+++ b/packages/integrations/src/hooks/useIntegration.ts
@@ -66,10 +66,10 @@ export const useIntegration = (
 export const useIntegrationConnection = <TSuccess, TFail>(
   chainKey: ChainKey
 ): [
-    InstanceType<Integration>,
-    boolean,
-    ExtensionConnection<TSuccess, TFail>,
-  ] => {
+  InstanceType<Integration>,
+  boolean,
+  ExtensionConnection<TSuccess, TFail>,
+] => {
   const integration = useIntegration(chainKey);
   const [isConnectingToExtension, setIsConnectingToExtension] = useState(false);
 
@@ -77,8 +77,8 @@ export const useIntegrationConnection = <TSuccess, TFail>(
     async (onSuccess, onFail) => {
       setIsConnectingToExtension(true);
       try {
-        if (integration?.detect()) {
-          await integration?.connect();
+        if (integration.detect()) {
+          await integration.connect();
           await onSuccess();
         }
       } catch (e) {

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -10,6 +10,7 @@ export enum Events {
   UpdatedStaking = "namada-updated-staking",
   ProposalsUpdated = "namada-proposals-updated",
   ExtensionLocked = "namada-extension-locked",
+  ConnectionRevoked = "namada-connection-revoked",
 }
 
 // Keplr extension events

--- a/packages/types/src/namada.ts
+++ b/packages/types/src/namada.ts
@@ -33,6 +33,7 @@ export interface Namada {
     props: BalancesProps
   ): Promise<{ token: string; amount: string }[] | undefined>;
   connect(chainId?: string): Promise<void>;
+  isConnected(): Promise<boolean | undefined>;
   defaultAccount(chainId?: string): Promise<DerivedAccount | undefined>;
   sign(props: SignArbitraryProps): Promise<SignatureResponse | undefined>;
   verify(props: VerifyArbitraryProps): Promise<void>;


### PR DESCRIPTION
### Changed
- Use setter for fetching public keys to allow more control over when the fetch happens

### Added
- Add isConnected method and revoke event
- Add effects to handle accounts changed, chain changed, extension attached, and extension connected. Replaces fetches interspersed in App and AccountOverview

### Fixed
- Fix balances race condition
- Refresh public keys on Tx completed instead of toast change
- Wait for shared to init before rendering app
- Check for native token early in minimum gas price fetch
- Remove unneeded optional chaining in useIntegration