### PR TITLE
fix: make publicKey a required field in the TxMsgValue class.

### DIFF
--- a/packages/types/src/tx/schema/tx.ts
+++ b/packages/types/src/tx/schema/tx.ts
@@ -17,8 +17,8 @@ export class TxMsgValue {
   @field({ type: "string" })
   chainId!: string;
 
-  @field({ type: option("string") })
-  publicKey?: string;
+  @field({ type: "string" })
+  publicKey!: string;
 
   @field({ type: option("bool") })
   disposableSigningKey?: boolean;


### PR DESCRIPTION
Hi again!

As I was working on #658 I couldn't seem to understand why the transactions weren't resolving. Checking the console of the extension I realized I didn't pass a publicKey value to my `sendIbcTransfer` causing the extension to panic! I thus made it a required field in the TxMsgValue class. This way it doesn't even get to the extension when a transaction doesn't contain this.