### PR TITLE
fix: action button fill

### DIFF
--- a/packages/components/src/ActionButton.tsx
+++ b/packages/components/src/ActionButton.tsx
@@ -2,31 +2,21 @@ import clsx from "clsx";
 import { createElement } from "react";
 import { tv, type VariantProps } from "tailwind-variants";
 
-const colors = {
-  primary: "yellow",
-  secondary: "cyan",
-  black: "black",
-} as const;
-
-type HoverColor = {
-  hoverColor?: keyof typeof colors;
-};
-
 const actionButton = tv({
   base: clsx(
     `group flex items-center cursor-pointer min-h-[2em] overflow-hidden text-black text-center relative`,
-    `[transition:color_0.1s,background_0.5s] ease-out-circ w-full select-none justify-center font-medium`,
+    `hover-fill w-full select-none justify-center font-medium`,
     `active:top-px`
   ),
 
   variants: {
     color: {
       primary:
-        "bg-100-200 bg-gradient-to-b from-50% to-50% from-yellow to-black hover:bg-bottom hover:text-yellow",
+        "bg-100-200 bg-gradient-to-b from-50% to-50% from-yellow to-black hover:bg-0-99 hover:text-yellow",
       secondary:
-        "bg-100-200 bg-no-repeat bg-gradient-to-b from-50% to-50% from-cyan to-black hover:bg-bottom hover:text-cyan",
+        "bg-100-200 bg-no-repeat bg-gradient-to-b from-50% to-50% from-cyan to-black hover:bg-0-99 hover:text-cyan",
       black:
-        "bg-100-200 bg-no-repeat bg-gradient-to-b from-50% to-50% from-black to-yellow hover:bg-bottom text-yellow hover:text-black",
+        "bg-100-200 bg-no-repeat bg-gradient-to-b from-50% to-50% from-black to-yellow hover:bg-0-99 text-yellow hover:text-black",
     },
 
     size: {
@@ -44,7 +34,7 @@ const actionButton = tv({
     },
 
     outlined: {
-      true: "bg-none bg-transparent border border-current",
+      true: "bg-100-200 bg-gradient-to-b from-50% to-50% from-transparent to-black hover:bg-0-99 hover:text-yellow border border-current",
     },
 
     disabled: {
@@ -53,6 +43,11 @@ const actionButton = tv({
         "bg-neutral-500 text-neutral-100 cursor-auto opacity-25",
         "hover:text-neutral-100 active:top-0"
       ),
+    },
+    hoverColor: {
+      primary: "to-yellow",
+      secondary: "to-cyan",
+      black: "to-black",
     },
   },
 
@@ -91,7 +86,6 @@ export type ActionButtonProps<HtmlTag extends keyof React.ReactHTML> = {
   as?: HtmlTag;
   icon?: React.ReactNode;
 } & React.ComponentPropsWithoutRef<HtmlTag> &
-  HoverColor &
   ActionButtonBaseProps;
 
 export const ActionButton = ({
@@ -106,23 +100,17 @@ export const ActionButton = ({
   hoverColor,
   ...props
 }: ActionButtonProps<keyof React.ReactHTML>): JSX.Element => {
-  // depending on the props, we can conditionally apply a class
-  const hoverColorClass =
-    !disabled && !outlined && hoverColor
-      ? `bg-100-200 bg-gradient-to-b from-50% to-50% from-${
-          colors[color || "primary"]
-        } to-${colors[hoverColor]}`
-      : "";
   return createElement(
     props.as || "button",
     {
       className: actionButton({
-        class: [className, hoverColorClass],
+        class: [className],
         color,
         size,
         borderRadius,
         outlined,
         disabled,
+        hoverColor,
       }),
       disabled,
       ...props,

--- a/packages/components/src/ActionButton.tsx
+++ b/packages/components/src/ActionButton.tsx
@@ -2,18 +2,31 @@ import clsx from "clsx";
 import { createElement } from "react";
 import { tv, type VariantProps } from "tailwind-variants";
 
+const colors = {
+  primary: "yellow",
+  secondary: "cyan",
+  black: "black",
+} as const;
+
+type HoverColor = {
+  hoverColor?: keyof typeof colors;
+};
+
 const actionButton = tv({
   base: clsx(
     `group flex items-center cursor-pointer min-h-[2em] overflow-hidden text-black text-center relative`,
-    `transition-colors duration-100 w-full select-none justify-center font-medium`,
+    `[transition:color_0.1s,background_0.5s] ease-out-circ w-full select-none justify-center font-medium`,
     `active:top-px`
   ),
 
   variants: {
     color: {
-      primary: "bg-yellow hover:text-yellow",
-      secondary: "bg-cyan hover:text-cyan",
-      black: "bg-black text-yellow hover:text-black",
+      primary:
+        "bg-100-200 bg-gradient-to-b from-50% to-50% from-yellow to-black hover:bg-bottom hover:text-yellow",
+      secondary:
+        "bg-100-200 bg-no-repeat bg-gradient-to-b from-50% to-50% from-cyan to-black hover:bg-bottom hover:text-cyan",
+      black:
+        "bg-100-200 bg-no-repeat bg-gradient-to-b from-50% to-50% from-black to-yellow hover:bg-bottom text-yellow hover:text-black",
     },
 
     size: {
@@ -31,11 +44,12 @@ const actionButton = tv({
     },
 
     outlined: {
-      true: "bg-transparent border border-current",
+      true: "bg-none bg-transparent border border-current",
     },
 
     disabled: {
       true: clsx(
+        "bg-none",
         "bg-neutral-500 text-neutral-100 cursor-auto opacity-25",
         "hover:text-neutral-100 active:top-0"
       ),
@@ -71,35 +85,14 @@ const actionButton = tv({
   },
 });
 
-const actionButtonHover = tv({
-  base: clsx(
-    "block absolute h-full w-full left-0 top-0 origin-center translate-y-[calc(100%+2px)]",
-    "transition-all ease-out-circ duration-[0.5s] group-hover:translate-y-0"
-  ),
-  variants: {
-    hoverColor: {
-      primary: "bg-yellow",
-      secondary: "bg-cyan",
-      black: "bg-black",
-    },
-    disabled: {
-      true: "group-hover:translate-y-[calc(100%+2px)]",
-    },
-  },
-
-  defaultVariants: {
-    hoverColor: "black",
-  },
-});
-
 type ActionButtonBaseProps = VariantProps<typeof actionButton>;
-type ActionButtonHoverBaseProps = VariantProps<typeof actionButtonHover>;
+
 export type ActionButtonProps<HtmlTag extends keyof React.ReactHTML> = {
   as?: HtmlTag;
   icon?: React.ReactNode;
 } & React.ComponentPropsWithoutRef<HtmlTag> &
-  ActionButtonBaseProps &
-  ActionButtonHoverBaseProps;
+  HoverColor &
+  ActionButtonBaseProps;
 
 export const ActionButton = ({
   icon,
@@ -113,11 +106,18 @@ export const ActionButton = ({
   hoverColor,
   ...props
 }: ActionButtonProps<keyof React.ReactHTML>): JSX.Element => {
+  // depending on the props, we can conditionally apply a class
+  const hoverColorClass =
+    !disabled && !outlined && hoverColor
+      ? `bg-100-200 bg-gradient-to-b from-50% to-50% from-${
+          colors[color || "primary"]
+        } to-${colors[hoverColor]}`
+      : "";
   return createElement(
     props.as || "button",
     {
       className: actionButton({
-        class: className,
+        class: [className, hoverColorClass],
         color,
         size,
         borderRadius,
@@ -134,7 +134,6 @@ export const ActionButton = ({
         </i>
       )}
       <span className="relative z-10 h-full">{children}</span>
-      <i className={actionButtonHover({ hoverColor, disabled })} />
     </>
   );
 };

--- a/packages/components/src/base.css
+++ b/packages/components/src/base.css
@@ -53,4 +53,9 @@ code {
   .unset {
     all: unset;
   }
+  .hover-fill {
+    transition-property: color, background-position;
+    transition-duration: 0.1s, 0.5s;
+    transition-timing-function: linear, var(--ease-out-circ);
+  }
 }

--- a/packages/components/src/theme.js
+++ b/packages/components/src/theme.js
@@ -1,5 +1,11 @@
 module.exports = {
   theme: {
+    backgroundSize: {
+      "100-200": "100% 220%",
+    },
+    backgroundPosition: {
+      bottom: "0% 99%", // flickering on firefox
+    },
     extend: {
       colors: {
         success: "#15DD89",

--- a/packages/components/src/theme.js
+++ b/packages/components/src/theme.js
@@ -1,10 +1,10 @@
 module.exports = {
   theme: {
     backgroundSize: {
-      "100-200": "100% 220%",
+      "100-200": "100% 203%", // 203% to not leave previous color trace on top when transitioning
     },
     backgroundPosition: {
-      bottom: "0% 99%", // flickering on firefox
+      "0-99": "0% 99%", // with 100% flickering on firefox: on the bottom shows different color for a moment
     },
     extend: {
       colors: {


### PR DESCRIPTION
# What does this PR do? 
Fix the yellow border when the action button is filled

# Context 
This PR is related to this [PR](https://github.com/anoma/namada-interface/pull/517).  Tailwind migration caused a lot of changes to the code base since my last commit, so I decided to create a new PR and close the old one  

# Externals 
## Before fix: 
<img width="696" alt="before" src="https://github.com/anoma/namada-interface/assets/26277721/382410ce-c0d6-4092-917c-7f03aee80bc3">


## After fix: 
<img width="361" alt="after" src="https://github.com/anoma/namada-interface/assets/26277721/4731003f-12a9-410e-b510-5fee93593ade">

