### PR TITLE
Fix/refactor extension events and emit TxCompleted on tx rejected

### DIFF
--- a/apps/extension/src/background/approvals/service.test.ts
+++ b/apps/extension/src/background/approvals/service.test.ts
@@ -529,6 +529,18 @@ describe("approvals service", () => {
 
   describe("rejectTx", () => {
     it("should clear pending tx", async () => {
+      const txType = TxType.Transfer;
+      const txMsg = "txMsg";
+      const specificMsg = "specificMsg";
+
+      jest.spyOn(service["txStore"], "get").mockImplementation(() => {
+        return Promise.resolve({
+          txType,
+          txMsg,
+          specificMsg,
+        });
+      });
+
       jest.spyOn(service as any, "_clearPendingTx");
       await service.rejectTx("msgId");
 

--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -136,21 +136,15 @@ export class ApprovalsService {
     const specificMsgBuffer = Buffer.from(fromBase64(specificMsg));
 
     const getParams =
-      txType === TxType.Bond
-        ? ApprovalsService.getParamsBond
-        : txType === TxType.Unbond
-          ? ApprovalsService.getParamsUnbond
-          : txType === TxType.Withdraw
-            ? ApprovalsService.getParamsWithdraw
-            : txType === TxType.Transfer
-              ? ApprovalsService.getParamsTransfer
-              : txType === TxType.IBCTransfer
-                ? ApprovalsService.getParamsIbcTransfer
-                : txType === TxType.EthBridgeTransfer
-                  ? ApprovalsService.getParamsEthBridgeTransfer
-                  : txType === TxType.VoteProposal
-                    ? ApprovalsService.getParamsVoteProposal
-                    : assertNever(txType);
+      txType === TxType.Bond ? ApprovalsService.getParamsBond
+      : txType === TxType.Unbond ? ApprovalsService.getParamsUnbond
+      : txType === TxType.Withdraw ? ApprovalsService.getParamsWithdraw
+      : txType === TxType.Transfer ? ApprovalsService.getParamsTransfer
+      : txType === TxType.IBCTransfer ? ApprovalsService.getParamsIbcTransfer
+      : txType === TxType.EthBridgeTransfer ?
+        ApprovalsService.getParamsEthBridgeTransfer
+      : txType === TxType.VoteProposal ? ApprovalsService.getParamsVoteProposal
+      : assertNever(txType);
 
     const baseUrl = `${browser.runtime.getURL(
       "approvals.html"
@@ -302,6 +296,18 @@ export class ApprovalsService {
 
   // Remove pending transaction from storage
   async rejectTx(msgId: string): Promise<void> {
+    // Fetch pending transfer tx
+    const tx = await this.txStore.get(msgId);
+
+    if (!tx) {
+      throw new Error("Pending tx not found!");
+    }
+
+    const { txType } = tx;
+    await this.broadcaster.completeTx(msgId, txType, false, {
+      error: { code: "REJECTED" },
+    });
+
     await this._clearPendingTx(msgId);
   }
 
@@ -317,21 +323,15 @@ export class ApprovalsService {
     const { txType, specificMsg, txMsg } = tx;
 
     const submitFn =
-      txType === TxType.Bond
-        ? this.keyRingService.submitBond
-        : txType === TxType.Unbond
-          ? this.keyRingService.submitUnbond
-          : txType === TxType.Transfer
-            ? this.keyRingService.submitTransfer
-            : txType === TxType.IBCTransfer
-              ? this.keyRingService.submitIbcTransfer
-              : txType === TxType.EthBridgeTransfer
-                ? this.keyRingService.submitEthBridgeTransfer
-                : txType === TxType.Withdraw
-                  ? this.keyRingService.submitWithdraw
-                  : txType === TxType.VoteProposal
-                    ? this.keyRingService.submitVoteProposal
-                    : assertNever(txType);
+      txType === TxType.Bond ? this.keyRingService.submitBond
+      : txType === TxType.Unbond ? this.keyRingService.submitUnbond
+      : txType === TxType.Transfer ? this.keyRingService.submitTransfer
+      : txType === TxType.IBCTransfer ? this.keyRingService.submitIbcTransfer
+      : txType === TxType.EthBridgeTransfer ?
+        this.keyRingService.submitEthBridgeTransfer
+      : txType === TxType.Withdraw ? this.keyRingService.submitWithdraw
+      : txType === TxType.VoteProposal ? this.keyRingService.submitVoteProposal
+      : assertNever(txType);
 
     await submitFn.call(this.keyRingService, specificMsg, txMsg, msgId);
 

--- a/apps/extension/src/background/keyring/messages.ts
+++ b/apps/extension/src/background/keyring/messages.ts
@@ -2,7 +2,7 @@ import { PhraseSize } from "@namada/sdk/web";
 import { AccountType, Bip44Path, DerivedAccount } from "@namada/types";
 import { Result } from "@namada/utils";
 import { Message } from "router";
-import { validatePrivateKey } from "utils";
+import { validatePrivateKey, validateProps } from "utils";
 import { ROUTE } from "./constants";
 import {
   AccountSecret,
@@ -405,15 +405,13 @@ export class TransferCompletedEvent extends Message<void> {
   constructor(
     public readonly success: boolean,
     public readonly msgId: string,
-    public readonly payload?: string
+    public readonly payload: string
   ) {
     super();
   }
 
   validate(): void {
-    if (this.success === undefined) {
-      throw new Error("Success is undefined");
-    }
+    validateProps(this, ["success", "msgId", "payload"]);
   }
 
   route(): string {

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -190,12 +190,16 @@ export class KeyRingService {
         bondMsgValue,
         txMsgValue
       );
-      await this.broadcaster.completeTx(msgId, TxType.Bond, true, innerTxHash);
+      await this.broadcaster.completeTx(msgId, TxType.Bond, true, {
+        txHash: innerTxHash,
+      });
       await this.broadcaster.updateStaking();
       await this.broadcaster.updateBalance();
     } catch (e) {
       console.warn(e);
-      await this.broadcaster.completeTx(msgId, TxType.Bond, false, `${e}`);
+      await this.broadcaster.completeTx(msgId, TxType.Bond, false, {
+        error: { code: "UNKNOWN", message: `${e}` },
+      });
       throw new Error(`Unable to submit bond tx! ${e}`);
     }
   }
@@ -217,17 +221,19 @@ export class KeyRingService {
         unbondMsgValue,
         txMsgValue
       );
-      await this.broadcaster.completeTx(
-        msgId,
-        TxType.Unbond,
-        true,
-        innerTxHash
-      );
+      await this.broadcaster.completeTx(msgId, TxType.Unbond, true, {
+        txHash: innerTxHash,
+      });
       await this.broadcaster.updateStaking();
       await this.broadcaster.updateBalance();
     } catch (e) {
       console.warn(e);
-      await this.broadcaster.completeTx(msgId, TxType.Unbond, false, `${e}`);
+      await this.broadcaster.completeTx(msgId, TxType.Unbond, false, {
+        error: {
+          code: "UNKNOWN",
+          message: `${e}`,
+        },
+      });
       throw new Error(`Unable to submit unbond tx! ${e}`);
     }
   }
@@ -249,17 +255,16 @@ export class KeyRingService {
         withdrawMsgValue,
         txMsgValue
       );
-      await this.broadcaster.completeTx(
-        msgId,
-        TxType.Withdraw,
-        true,
-        innerTxHash
-      );
+      await this.broadcaster.completeTx(msgId, TxType.Withdraw, true, {
+        txHash: innerTxHash,
+      });
       await this.broadcaster.updateStaking();
       await this.broadcaster.updateBalance();
     } catch (e) {
       console.warn(e);
-      await this.broadcaster.completeTx(msgId, TxType.Withdraw, false, `${e}`);
+      await this.broadcaster.completeTx(msgId, TxType.Withdraw, false, {
+        error: { code: "UNKNOWN", message: `${e}` },
+      });
       throw new Error(`Unable to submit withdraw tx! ${e}`);
     }
   }
@@ -280,21 +285,15 @@ export class KeyRingService {
         voteProposalMsgValue,
         txMsgValue
       );
-      await this.broadcaster.completeTx(
-        msgId,
-        TxType.VoteProposal,
-        true,
-        innerTxHash
-      );
+      await this.broadcaster.completeTx(msgId, TxType.VoteProposal, true, {
+        txHash: innerTxHash,
+      });
       await this.broadcaster.updateProposals();
     } catch (e) {
       console.warn(e);
-      await this.broadcaster.completeTx(
-        msgId,
-        TxType.VoteProposal,
-        false,
-        `${e}`
-      );
+      await this.broadcaster.completeTx(msgId, TxType.VoteProposal, false, {
+        error: { code: "UNKNOWN", message: `${e}` },
+      });
       throw new Error(`Unable to submit vote proposal tx! ${e}`);
     }
   }
@@ -433,21 +432,15 @@ export class KeyRingService {
         ibcTransferMsgValue,
         txMsgValue
       );
-      await this.broadcaster.completeTx(
-        msgId,
-        TxType.IBCTransfer,
-        true,
-        innerTxHash
-      );
+      await this.broadcaster.completeTx(msgId, TxType.IBCTransfer, true, {
+        txHash: innerTxHash,
+      });
       await this.broadcaster.updateBalance();
     } catch (e) {
       console.warn(e);
-      await this.broadcaster.completeTx(
-        msgId,
-        TxType.IBCTransfer,
-        false,
-        `${e}`
-      );
+      await this.broadcaster.completeTx(msgId, TxType.IBCTransfer, false, {
+        error: { code: "UNKNOWN", message: `${e}` },
+      });
       throw new Error(`Unable to encode IBC transfer! ${e}`);
     }
   }
@@ -469,12 +462,9 @@ export class KeyRingService {
         ethBridgeTransferMsgValue,
         txMsgValue
       );
-      await this.broadcaster.completeTx(
-        msgId,
-        TxType.EthBridgeTransfer,
-        true,
-        innerTxHash
-      );
+      await this.broadcaster.completeTx(msgId, TxType.EthBridgeTransfer, true, {
+        txHash: innerTxHash,
+      });
       await this.broadcaster.updateBalance();
     } catch (e) {
       console.warn(e);
@@ -482,7 +472,7 @@ export class KeyRingService {
         msgId,
         TxType.EthBridgeTransfer,
         false,
-        `${e}`
+        { error: { code: "UNKNOWN", message: `${e}` } }
       );
       throw new Error(`Unable to encode Eth Bridge transfer! ${e}`);
     }
@@ -500,9 +490,13 @@ export class KeyRingService {
   async handleTransferCompleted(
     msgId: string,
     success: boolean,
-    payload?: string
+    payload: string
   ): Promise<void> {
-    await this.broadcaster.completeTx(msgId, TxType.Transfer, success, payload);
+    const options =
+      success ?
+        { txHash: payload }
+      : ({ error: { code: "UNKNOWN", message: payload } } as const);
+    await this.broadcaster.completeTx(msgId, TxType.Transfer, success, options);
     await this.broadcaster.updateBalance();
   }
 

--- a/apps/extension/src/background/ledger/service.ts
+++ b/apps/extension/src/background/ledger/service.ts
@@ -121,7 +121,9 @@ export class LedgerService {
       await this.txStore.set(msgId, null);
 
       // Broadcast update events
-      await this.broadcaster.completeTx(msgId, txType, true, innerTxHash);
+      await this.broadcaster.completeTx(msgId, txType, true, {
+        txHash: innerTxHash,
+      });
       await this.broadcaster.updateBalance();
 
       if ([TxType.Bond, TxType.Unbond, TxType.Withdraw].includes(txType)) {
@@ -129,7 +131,9 @@ export class LedgerService {
       }
     } catch (e) {
       console.warn(e);
-      await this.broadcaster.completeTx(msgId, txType, false, `${e}`);
+      await this.broadcaster.completeTx(msgId, txType, false, {
+        error: { code: "UNKNOWN", message: `${e}` },
+      });
     }
   }
 

--- a/apps/extension/src/background/offscreen/offscreen.ts
+++ b/apps/extension/src/background/offscreen/offscreen.ts
@@ -38,7 +38,7 @@ void (async function init() {
     const transferCompletedHandler = async (
       msgId: string,
       success: boolean,
-      payload?: string
+      payload: string
     ): Promise<void> => {
       // We are sending the message to the background script
       await requester.sendMessage(

--- a/apps/extension/src/background/web-workers/index.ts
+++ b/apps/extension/src/background/web-workers/index.ts
@@ -12,7 +12,7 @@ export const init = (
   transferCompletedHandler: (
     msgId: string,
     success: boolean,
-    payload?: string
+    payload: string
   ) => Promise<void>,
   sendResponse?: (response?: unknown) => void
 ): void => {

--- a/apps/extension/src/background/web-workers/types.ts
+++ b/apps/extension/src/background/web-workers/types.ts
@@ -27,4 +27,4 @@ export type MsgName =
   | typeof TRANSFER_SUCCESSFUL_MSG
   | typeof WEB_WORKER_ERROR_MSG;
 
-export type Msg = { msgName: MsgName; payload?: string };
+export type Msg = { msgName: MsgName; payload: string };

--- a/apps/extension/src/extension/ExtensionBroadcaster.ts
+++ b/apps/extension/src/extension/ExtensionBroadcaster.ts
@@ -28,10 +28,19 @@ export class ExtensionBroadcaster {
     msgId: string,
     txType: TxType,
     success: boolean,
-    payload?: string
+    options?: {
+      txHash?: string;
+      error?: { code: "REJECTED" | "UNKNOWN"; message?: string };
+    }
   ): Promise<void> {
     await this.sendMsgToTabs(
-      new TxCompletedEvent(msgId, txType, success, payload)
+      new TxCompletedEvent(
+        msgId,
+        txType,
+        success,
+        options?.txHash,
+        options?.error
+      )
     );
   }
 

--- a/packages/sdk/src/events.ts
+++ b/packages/sdk/src/events.ts
@@ -1,0 +1,101 @@
+import { TxType } from "@namada/shared";
+import { Events } from "@namada/types";
+
+export type TxStartedDetail = {
+  msgId: string;
+  txType: TxType;
+};
+
+export type TxCompletedErrorCode = "REJECTED" | "UNKNOWN";
+
+// TODO: This could be made more precise with something like:
+// type TxCompletedDetail = { success: true, ... } | { success: false, ... }
+export type TxCompletedDetail = {
+  msgId: string;
+  txType: TxType;
+  success: boolean;
+  txHash?: string;
+  error?: { code: TxCompletedErrorCode; message?: string };
+};
+
+// Specifies the type of the event object's `detail` field
+export type Detail<E extends Events> =
+  E extends Events.TxStarted ? TxStartedDetail
+  : E extends Events.TxCompleted ? TxCompletedDetail
+  : E extends (
+    | Events.AccountChanged
+    | Events.NetworkChanged
+    | Events.UpdatedBalances
+    | Events.UpdatedStaking
+    | Events.ProposalsUpdated
+    | Events.ExtensionLocked
+    | Events.ConnectionRevoked
+  ) ?
+    undefined
+  : never;
+
+export type NamadaEventConstructorParams<E extends Events> =
+  // If we forgot to specify what type of detail an event should have...
+  Detail<E> extends never ?
+    // ...don't allow constructing an event object
+    never
+  : // Otherwise, if the event doesn't require any detail...
+  Detail<E> extends undefined ?
+    // ...make the parameter containing the detail optional
+    [E] | [E, CustomEventInit<Detail<E>> | undefined]
+  : // Otherwise, require that the detail property is present in the second parameter
+    [
+      E,
+      CustomEventInit<Detail<E>> &
+        Required<Pick<CustomEventInit<Detail<E>>, "detail">>,
+    ];
+
+/**
+ * Wrapper around CustomEvent to provide better type safety. An instance of
+ * NamadaEvent can only be constructed by passing the correct type of detail for
+ * a given event.
+ */
+export class NamadaEvent<E extends Events> extends CustomEvent<Detail<E>> {
+  private readonly _type: E;
+
+  // TODO: how do you write JSDocs for this?
+  /* eslint-disable */
+  /**
+   *
+   * @param type - Namada event type e.g. Events.TxCompleted
+   * @param init - Object with detail matching expected detail for the Namada
+   *   event. Otherwise the same as object passed to CustomEvent.
+   */
+  constructor(...[type, init]: NamadaEventConstructorParams<E>) {
+    super(type, init);
+    this._type = type;
+  }
+  /* eslint-enable */
+
+  /**
+   * Needed to override CustomEvent defining type of `type` as `string`.
+   * Prevents problems like:
+   *   const event: NamadaEvent<Events.TxStarted> = { ..., type: "bad type" }
+   * @returns Namada event type
+   */
+  get type(): E {
+    return this._type;
+  }
+}
+
+// Maps events to event objects for all Namada events that have detail defined.
+type EventMap = {
+  [E in Events as Detail<E> extends never ? never : E]: NamadaEvent<E>;
+};
+
+declare global {
+  /**
+   * Provides types to window.addEventListener for Namada events e.g.
+   *
+   *   window.addEventListener(
+   *     Events.TxCompleted,
+   *     (e: NamadaEvent<Events.TxCompleted>) => {}
+   *   );
+   */
+  interface WindowEventMap extends EventMap {}
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,6 +1,8 @@
 // Make Ledger available for direct-import as it is not dependent on Sdk initialization
 export * from "./ledger";
 
+export * from "./events";
+
 // Export types
 export { Argon2Config, KdfType } from "./crypto";
 export type {


### PR DESCRIPTION
Closes #680.

Wraps extension events in new NamadaEvent class to ensure the correct detail is dispatched with an event, and emits TxCompleted event when a tx is rejected.

There's quite a lot of type-level stuff in the first commit, but I've tried to comment it thoroughly so hopefully it's understandable.

I'm also not sure if `packages/sdk/src/events.ts` is the right place to put all the events code.

---

### Changed
- Replace TxCompleted detail `payload` property with `error` on failure and `txHash` on success
- Make transfer completed payload non-optional; return tx hash on success and error message on failure

### Added
- Emit TxCompleted event when tx is rejected
- Add NamadaEvent class which wraps CustomEvent and ensures detail property corresponds to event type
- Add TxCompleted error codes
- Support Namada event types when using `window.addEventListener`

### Fixed
- Remove detail property from AccountChanged event