### PR TITLE
fix: Extension release version should read from extension package.json

### DIFF
--- a/.github/workflows/release-wallet.yml
+++ b/.github/workflows/release-wallet.yml
@@ -54,7 +54,7 @@ jobs:
         id: set-environment-variables
         run: |
           COMMIT_HASH=$(git rev-parse --short $SHA)
-          BASE_VERSION=$(node -e 'console.log(require("./package.json").version)')
+          BASE_VERSION=$(node -e 'console.log(require("./apps/extension/package.json").version)')
           echo "VERSION=v$BASE_VERSION-$COMMIT_HASH" >> "$GITHUB_OUTPUT"
         env:
           SHA: ${{ github.sha }}

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@namada/extension",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Namada Browser Extension",
   "repository": "https://github.com/anoma/namada-interface/",
   "author": "Heliax Dev <info@heliax.dev>",

--- a/apps/namada-interface/webpack.config.js
+++ b/apps/namada-interface/webpack.config.js
@@ -26,7 +26,7 @@ const copyPatterns = [
   },
   {
     from: "./public/_redirects",
-    to: "./_redirects",
+    to: "./",
   },
 ];
 
@@ -159,7 +159,7 @@ module.exports = {
     hints: "warning",
     maxAssetSize: 200000,
     maxEntrypointSize: 400000,
-    assetFilter: function (assetFilename) {
+    assetFilter: function(assetFilename) {
       assetFilename.endsWith(".wasm");
     },
   },


### PR DESCRIPTION
- [x] Bump extension version to match last submitted version
- [x] Extension build asset reads version from `apps/extension/package.json`
- [x] Also fixed issue with `_redirects` being copied into a folder and not picked up by Netlify
