### PR TITLE
Handle "Error: unreachable" message when importing short private key

### DIFF
--- a/apps/extension/src/Setup/ImportAccount/SeedPhraseImport.tsx
+++ b/apps/extension/src/Setup/ImportAccount/SeedPhraseImport.tsx
@@ -47,27 +47,28 @@ export const SeedPhraseImport: React.FC<Props> = ({ onConfirm }) => {
     Array.from(mnemonicsRange)
   );
 
-  const privateKeyError = (() => {
-    const validation = validatePrivateKey(filterPrivateKeyPrefix(privateKey));
+  const validatePkAndFormatErrorMessage = (key: string): string => {
+    const validation = validatePrivateKey(filterPrivateKeyPrefix(key));
     if (validation.ok) {
       return "";
     } else {
       switch (validation.error.t) {
-        case "TooLong":
-          return `Private key must be no more than
-             ${validation.error.maxLength} characters long`;
+        case "WrongLength":
+          return `Private key must be ${validation.error.length} characters long`;
         case "BadCharacter":
           return "Private key may only contain characters 0-9, a-f";
         default:
           return assertNever(validation.error);
       }
     }
-  })();
+  };
+
+  const privateKeyError = validatePkAndFormatErrorMessage(privateKey);
 
   const isSubmitButtonDisabled =
-    mnemonicType === MnemonicTypes.PrivateKey
-      ? privateKey === "" || privateKeyError !== ""
-      : mnemonics.slice(0, mnemonicType).some((mnemonic) => !mnemonic);
+    mnemonicType === MnemonicTypes.PrivateKey ?
+      privateKey === "" || privateKeyError !== ""
+    : mnemonics.slice(0, mnemonicType).some((mnemonic) => !mnemonic);
 
   const onPaste = useCallback(
     (index: number, e: React.ClipboardEvent<HTMLInputElement>) => {

--- a/apps/extension/src/Setup/ImportAccount/SeedPhraseImport.tsx
+++ b/apps/extension/src/Setup/ImportAccount/SeedPhraseImport.tsx
@@ -119,11 +119,16 @@ export const SeedPhraseImport: React.FC<Props> = ({ onConfirm }) => {
 
   const onSubmit = useCallback(async () => {
     if (mnemonicType === MnemonicTypes.PrivateKey) {
-      // TODO: validate here
-      onConfirm({
-        t: "PrivateKey",
-        privateKey: filterPrivateKeyPrefix(privateKey),
-      });
+      const privateKeyError = validatePkAndFormatErrorMessage(privateKey);
+      if (privateKeyError) {
+        setMnemonicError(privateKeyError);
+      } else {
+        setMnemonicError(undefined);
+        onConfirm({
+          t: "PrivateKey",
+          privateKey: filterPrivateKeyPrefix(privateKey),
+        });
+      }
     } else {
       const actualMnemonics = mnemonics.slice(0, mnemonicType);
       const phrase = actualMnemonics.join(" ");

--- a/apps/extension/src/Setup/ImportAccount/SeedPhraseImport.tsx
+++ b/apps/extension/src/Setup/ImportAccount/SeedPhraseImport.tsx
@@ -54,7 +54,10 @@ export const SeedPhraseImport: React.FC<Props> = ({ onConfirm }) => {
     } else {
       switch (validation.error.t) {
         case "WrongLength":
-          return `Private key must be ${validation.error.length} characters long`;
+          return (
+            `Private key must be ${validation.error.length} characters long. ` +
+            `You provided a key of length ${key.length}.`
+          );
         case "BadCharacter":
           return "Private key may only contain characters 0-9, a-f";
         default:

--- a/apps/extension/src/utils/index.ts
+++ b/apps/extension/src/utils/index.ts
@@ -81,24 +81,27 @@ export const validateProps = <T>(object: T, props: (keyof T)[]): void => {
   });
 };
 
-const PRIVATE_KEY_MAX_LENGTH = 64;
+const PRIVATE_KEY_LENGTH = 64;
 
 export type PrivateKeyError =
-  | { t: "TooLong"; maxLength: number }
+  | { t: "WrongLength"; length: number }
   | { t: "BadCharacter" };
 
 // Very basic private key validation
 export const validatePrivateKey = (
   privateKey: string
-): Result<null, PrivateKeyError> =>
-  privateKey.length > PRIVATE_KEY_MAX_LENGTH
-    ? Result.err({ t: "TooLong", maxLength: PRIVATE_KEY_MAX_LENGTH })
-    : !/^[0-9a-f]*$/.test(privateKey)
-      ? Result.err({ t: "BadCharacter" })
-      : Result.ok(null);
+): Result<null, PrivateKeyError> => {
+  if (privateKey.length != PRIVATE_KEY_LENGTH) {
+    return Result.err({ t: "WrongLength", length: PRIVATE_KEY_LENGTH });
+  } else if (!/^[0-9a-f]*$/.test(privateKey)) {
+    return Result.err({ t: "BadCharacter" });
+  } else {
+    return Result.ok(null);
+  }
+};
 
 // Remove prefix from private key, which may be present when exporting keys from CLI
 export const filterPrivateKeyPrefix = (privateKey: string): string =>
-  privateKey.length === PRIVATE_KEY_MAX_LENGTH + 2
-    ? privateKey.replace(/^00/, "")
-    : privateKey;
+  privateKey.length === PRIVATE_KEY_LENGTH + 2 ?
+    privateKey.replace(/^00/, "")
+  : privateKey;


### PR DESCRIPTION
If user attempts to import private key of length less than 64 symbols namada extension continues with the import process but in the end throws `Failed while "Encrypting and storing private key.". Error: unreachable` to the user. While it is unlikelly someone will be importing private key of value `123` it is possible to trim few characters from your private key when you copy it and receive error which is not very informative. ( Which happened to me and thought there is something wrong with extension )

Changes:
Validation for private key minimum length and error message in case wrong length was provided.
Validation before submitting private key to extension background.

Tests:
Built and imported extension to my browser and tested that it is not possible to proceed with short key and meaningfull validation error message is presented to the user.
Also checked the normal flow with proper key.
