### PR TITLE
feat: support notification when ibc transfer from cosmos

### DIFF
--- a/apps/namada-interface/src/services/extensionEvents/handlers/keplr.ts
+++ b/apps/namada-interface/src/services/extensionEvents/handlers/keplr.ts
@@ -4,6 +4,8 @@ import { Keplr } from "@namada/integrations";
 
 import { addAccounts, fetchBalances } from "slices/accounts";
 
+import { actions as notificationsActions } from "slices/notifications";
+
 export const KeplrAccountChangedHandler =
   (dispatch: Dispatch<unknown>, integration: Keplr) => async () => {
     const accounts = await integration.accounts();
@@ -12,4 +14,18 @@ export const KeplrAccountChangedHandler =
       dispatch(addAccounts(accounts));
       dispatch(fetchBalances());
     }
+  };
+
+export const KeplrBridgeTransferCompletedHandler =
+  (dispatch: Dispatch<unknown>) => async (event: CustomEventInit) => {
+    const msgId = (Math.random() + 1).toString(36).substring(7);
+    const success = true;
+    dispatch(
+      notificationsActions.txCompletedToast({
+        id: msgId,
+        txTypeLabel: "IBC Transfer",
+        success,
+        error: "",
+      })
+    );
   };

--- a/apps/namada-interface/src/services/extensionEvents/provider.tsx
+++ b/apps/namada-interface/src/services/extensionEvents/provider.tsx
@@ -7,6 +7,7 @@ import { Events, KeplrEvents, MetamaskEvents } from "@namada/types";
 import { useAppDispatch } from "store";
 import {
   KeplrAccountChangedHandler,
+  KeplrBridgeTransferCompletedHandler,
   MetamaskAccountChangedHandler,
   MetamaskBridgeTransferCompletedHandler,
   NamadaAccountChangedHandler,
@@ -72,6 +73,9 @@ export const ExtensionEventsProvider: React.FC = (props): JSX.Element => {
     keplrIntegration as Keplr
   );
 
+  const keplrBridgeTransferCompletedHandler =
+    KeplrBridgeTransferCompletedHandler(dispatch);
+
   // Metamask handlers
   const metamaskAccountChangedHandler = MetamaskAccountChangedHandler(
     dispatch,
@@ -115,6 +119,10 @@ export const ExtensionEventsProvider: React.FC = (props): JSX.Element => {
     metamaskBridgeTransferCompletedHandler
   );
 
+  useEventListenerOnce(
+    KeplrEvents.BridgeTransferCompleted,
+    keplrBridgeTransferCompletedHandler
+  );
   return (
     <ExtensionEventsContext.Provider value={{}}>
       {props.children}

--- a/packages/integrations/src/Keplr.ts
+++ b/packages/integrations/src/Keplr.ts
@@ -24,6 +24,7 @@ import {
   CosmosTokens,
   TokenBalances,
   tokenByMinDenom,
+  KeplrEvents
 } from "@namada/types";
 import { BridgeProps, Integration } from "./types/Integration";
 
@@ -210,7 +211,7 @@ class Keplr implements Integration<Account, OfflineSigner, CosmosTokenType> {
           `Transaction failed with code ${response.code}! Message: ${response.rawLog}`
         );
       }
-
+      window.dispatchEvent(new Event(KeplrEvents.BridgeTransferCompleted));
       return;
     }
 

--- a/packages/types/src/events.ts
+++ b/packages/types/src/events.ts
@@ -16,6 +16,7 @@ export enum Events {
 // Keplr extension events
 export enum KeplrEvents {
   AccountChanged = "keplr_keystorechange",
+  BridgeTransferCompleted = "readystatechange",
 }
 
 // Metamask extension window.ethereum events


### PR DESCRIPTION
- Implementing an event listener to capture events when a user submits an IBC transfer from Cosmos to Namada.
- Display a notification when the transaction is successfully sent using the Keplr wallet.