### PR TITLE
feat/721: Return and display invalid word in mnemonic phrase

### DIFF
--- a/apps/extension/src/Setup/Common/SeedPhraseList.tsx
+++ b/apps/extension/src/Setup/Common/SeedPhraseList.tsx
@@ -7,6 +7,7 @@ type SeedPhraseListProps = {
   words: string[];
   sensitive?: boolean;
   columns?: number;
+  invalidIdx?: number;
   onChange?: (index: number, value: string) => void;
   onPaste?: (index: number, e: React.ClipboardEvent<HTMLInputElement>) => void;
 };
@@ -17,6 +18,7 @@ export const SeedPhraseList = ({
   onPaste,
   columns = 3,
   sensitive = true,
+  invalidIdx,
 }: SeedPhraseListProps): JSX.Element => {
   const list = (
     <ol
@@ -29,6 +31,7 @@ export const SeedPhraseList = ({
           key={`seed-phrase-list-${idx}`}
           word={word}
           idx={idx}
+          invalidIdx={invalidIdx}
           onChange={onChange}
           onPaste={onPaste}
         />

--- a/apps/extension/src/Setup/Common/SeedPhraseList.tsx
+++ b/apps/extension/src/Setup/Common/SeedPhraseList.tsx
@@ -7,7 +7,7 @@ type SeedPhraseListProps = {
   words: string[];
   sensitive?: boolean;
   columns?: number;
-  invalidIdx?: number;
+  invalidWordIndex?: number;
   onChange?: (index: number, value: string) => void;
   onPaste?: (index: number, e: React.ClipboardEvent<HTMLInputElement>) => void;
 };
@@ -18,7 +18,7 @@ export const SeedPhraseList = ({
   onPaste,
   columns = 3,
   sensitive = true,
-  invalidIdx,
+  invalidWordIndex,
 }: SeedPhraseListProps): JSX.Element => {
   const list = (
     <ol
@@ -31,7 +31,7 @@ export const SeedPhraseList = ({
           key={`seed-phrase-list-${idx}`}
           word={word}
           idx={idx}
-          invalidIdx={invalidIdx}
+          invalidWordIndex={invalidWordIndex}
           onChange={onChange}
           onPaste={onPaste}
         />

--- a/apps/extension/src/Setup/Common/SeedPhraseListItem.tsx
+++ b/apps/extension/src/Setup/Common/SeedPhraseListItem.tsx
@@ -3,6 +3,7 @@ import clsx from "clsx";
 
 type SeedPhraseListItemProps = {
   idx: number;
+  invalidIdx?: number;
   word: string;
   onChange?: (index: number, value: string) => void;
   onPaste?: (idx: number, e: React.ClipboardEvent<HTMLInputElement>) => void;
@@ -10,10 +11,12 @@ type SeedPhraseListItemProps = {
 
 export const SeedPhraseListItem = ({
   idx,
+  invalidIdx,
   word,
   onChange,
   onPaste,
 }: SeedPhraseListItemProps): JSX.Element => {
+  const hasError = idx === invalidIdx;
   return (
     <li
       className={clsx(
@@ -21,7 +24,7 @@ export const SeedPhraseListItem = ({
         "px-1 py-3 h-[48px]"
       )}
     >
-      {onChange ? (
+      {onChange ?
         <span
           className={clsx(
             "flex items-center absolute left-0 top-0 w-full h-full",
@@ -35,21 +38,21 @@ export const SeedPhraseListItem = ({
           <Input
             label=""
             className="-mt-2 ml-1"
-            variant="PasswordOnBlur"
+            variant={hasError ? "Text" : "PasswordOnBlur"}
             hideIcon={true}
             onChange={(e) => onChange(idx, e.target.value)}
             onPaste={(e) => onPaste && onPaste(idx, e)}
             value={word}
+            error={hasError}
           />
         </span>
-      ) : (
-        <span
+        : <span
           className={clsx("absolute font-light left-2.5 top-[1em] select-none")}
         >
           <i className="not-italic">{idx + 1} </i>
           <span className="text-white font-bold ml-1">{word}</span>
         </span>
-      )}
+      }
     </li>
   );
 };

--- a/apps/extension/src/Setup/Common/SeedPhraseListItem.tsx
+++ b/apps/extension/src/Setup/Common/SeedPhraseListItem.tsx
@@ -3,7 +3,7 @@ import clsx from "clsx";
 
 type SeedPhraseListItemProps = {
   idx: number;
-  invalidIdx?: number;
+  invalidWordIndex?: number;
   word: string;
   onChange?: (index: number, value: string) => void;
   onPaste?: (idx: number, e: React.ClipboardEvent<HTMLInputElement>) => void;
@@ -11,12 +11,12 @@ type SeedPhraseListItemProps = {
 
 export const SeedPhraseListItem = ({
   idx,
-  invalidIdx,
+  invalidWordIndex,
   word,
   onChange,
   onPaste,
 }: SeedPhraseListItemProps): JSX.Element => {
-  const hasError = idx === invalidIdx;
+  const hasError = idx === invalidWordIndex;
   return (
     <li
       className={clsx(
@@ -46,7 +46,7 @@ export const SeedPhraseListItem = ({
             error={hasError}
           />
         </span>
-        : <span
+      : <span
           className={clsx("absolute font-light left-2.5 top-[1em] select-none")}
         >
           <i className="not-italic">{idx + 1} </i>

--- a/apps/extension/src/Setup/ImportAccount/SeedPhraseImport.tsx
+++ b/apps/extension/src/Setup/ImportAccount/SeedPhraseImport.tsx
@@ -33,6 +33,7 @@ export const SeedPhraseImport: React.FC<Props> = ({ onConfirm }) => {
   const requester = useRequester();
   const [privateKey, setPrivateKey] = useState("");
   const [passphrase, setPassphrase] = useState("");
+  const [invalidIdx, setInvalidIdx] = useState<number>();
   const [showPassphrase, setShowPassphrase] = useState(false);
   const [mnemonicType, setMnemonicType] = useState<MnemonicTypes>(
     MnemonicTypes.TwelveWords
@@ -65,8 +66,8 @@ export const SeedPhraseImport: React.FC<Props> = ({ onConfirm }) => {
   })();
 
   const isSubmitButtonDisabled =
-    mnemonicType === MnemonicTypes.PrivateKey
-      ? privateKey === "" || privateKeyError !== ""
+    mnemonicType === MnemonicTypes.PrivateKey ?
+      privateKey === "" || privateKeyError !== ""
       : mnemonics.slice(0, mnemonicType).some((mnemonic) => !mnemonic);
 
   const onPaste = useCallback(
@@ -136,6 +137,14 @@ export const SeedPhraseImport: React.FC<Props> = ({ onConfirm }) => {
         onConfirm({ t: "Mnemonic", seedPhrase: actualMnemonics, passphrase });
       } else {
         setMnemonicError(error);
+        const isInvalidWord = /^invalid word in phrase with index \d+$/.test(
+          `${error}`
+        );
+        if (isInvalidWord) {
+          // get index from error
+          const matches = error?.match(/\d+$/);
+          setInvalidIdx(matches ? parseInt(matches[0]) : undefined);
+        }
       }
     }
   }, [mnemonics, mnemonicType, privateKey, passphrase, showPassphrase]);
@@ -210,6 +219,7 @@ export const SeedPhraseImport: React.FC<Props> = ({ onConfirm }) => {
 
           {mnemonicType !== MnemonicTypes.PrivateKey && (
             <SeedPhraseList
+              invalidIdx={invalidIdx}
               sensitive={false}
               columns={mnemonicType === MnemonicTypes.TwentyFourWords ? 4 : 3}
               words={fillArray(mnemonics.slice(0, mnemonicType), mnemonicType)}

--- a/apps/extension/src/Setup/ImportAccount/SeedPhraseImport.tsx
+++ b/apps/extension/src/Setup/ImportAccount/SeedPhraseImport.tsx
@@ -33,7 +33,7 @@ export const SeedPhraseImport: React.FC<Props> = ({ onConfirm }) => {
   const requester = useRequester();
   const [privateKey, setPrivateKey] = useState("");
   const [passphrase, setPassphrase] = useState("");
-  const [invalidIdx, setInvalidIdx] = useState<number>();
+  const [invalidWordIndex, setInvalidWordIndex] = useState<number>();
   const [showPassphrase, setShowPassphrase] = useState(false);
   const [mnemonicType, setMnemonicType] = useState<MnemonicTypes>(
     MnemonicTypes.TwelveWords
@@ -136,14 +136,19 @@ export const SeedPhraseImport: React.FC<Props> = ({ onConfirm }) => {
         setMnemonicError(undefined);
         onConfirm({ t: "Mnemonic", seedPhrase: actualMnemonics, passphrase });
       } else {
-        setMnemonicError(error);
         const isInvalidWord = /^invalid word in phrase with index \d+$/.test(
           `${error}`
         );
         if (isInvalidWord) {
           // get index from error
           const matches = error?.match(/\d+$/);
-          setInvalidIdx(matches ? parseInt(matches[0]) : undefined);
+          const invalidWordIndex = matches ? parseInt(matches[0]) : undefined;
+          setInvalidWordIndex(invalidWordIndex);
+          typeof invalidWordIndex === "number" ?
+            setMnemonicError(`Word #${invalidWordIndex + 1} is invalid!`)
+            : setMnemonicError(error);
+        } else {
+          setMnemonicError(error);
         }
       }
     }
@@ -219,7 +224,7 @@ export const SeedPhraseImport: React.FC<Props> = ({ onConfirm }) => {
 
           {mnemonicType !== MnemonicTypes.PrivateKey && (
             <SeedPhraseList
-              invalidIdx={invalidIdx}
+              invalidWordIndex={invalidWordIndex}
               sensitive={false}
               columns={mnemonicType === MnemonicTypes.TwentyFourWords ? 4 : 3}
               words={fillArray(mnemonics.slice(0, mnemonicType), mnemonicType)}

--- a/packages/crypto/lib/Cargo.lock
+++ b/packages/crypto/lib/Cargo.lock
@@ -1259,8 +1259,7 @@ dependencies = [
 [[package]]
 name = "tiny-bip39"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62cc94d358b5a1e84a5cb9109f559aa3c4d634d2b1b4de3d0fa4adc7c78e2861"
+source = "git+https://github.com/anoma/tiny-bip39?branch=invalid-word-index#24df8522308416ce611371bfb33a9d897ea5c046"
 dependencies = [
  "anyhow",
  "hmac",

--- a/packages/crypto/lib/Cargo.lock
+++ b/packages/crypto/lib/Cargo.lock
@@ -1259,7 +1259,7 @@ dependencies = [
 [[package]]
 name = "tiny-bip39"
 version = "1.0.0"
-source = "git+https://github.com/anoma/tiny-bip39?branch=invalid-word-index#24df8522308416ce611371bfb33a9d897ea5c046"
+source = "git+https://github.com/anoma/tiny-bip39?rev=743d537349c8deab14409ce726b868dcde90fd8e#743d537349c8deab14409ce726b868dcde90fd8e"
 dependencies = [
  "anyhow",
  "hmac",

--- a/packages/crypto/lib/Cargo.toml
+++ b/packages/crypto/lib/Cargo.toml
@@ -29,7 +29,7 @@ thiserror = "1.0.30"
 rand = {version = "0.7", features = ["wasm-bindgen"]}
 wasm-bindgen = "0.2.86"
 zeroize = "1.6.0"
-tiny-bip39 = { git = "https://github.com/anoma/tiny-bip39", branch = "invalid-word-index" }
+tiny-bip39 = { git = "https://github.com/anoma/tiny-bip39", rev = "743d537349c8deab14409ce726b868dcde90fd8e" }
 slip10_ed25519 = "0.1.3"
 
 [dev-dependencies]

--- a/packages/crypto/lib/Cargo.toml
+++ b/packages/crypto/lib/Cargo.toml
@@ -29,7 +29,7 @@ thiserror = "1.0.30"
 rand = {version = "0.7", features = ["wasm-bindgen"]}
 wasm-bindgen = "0.2.86"
 zeroize = "1.6.0"
-tiny-bip39 = "1.0.0"
+tiny-bip39 = { git = "https://github.com/anoma/tiny-bip39", branch = "invalid-word-index" }
 slip10_ed25519 = "0.1.3"
 
 [dev-dependencies]

--- a/packages/crypto/lib/src/crypto/bip39.rs
+++ b/packages/crypto/lib/src/crypto/bip39.rs
@@ -43,6 +43,9 @@ impl Mnemonic {
     }
 
     pub fn from_phrase(mut phrase: String) -> Result<Mnemonic, String> {
+        // First validate phrase, provide error to client if this fails
+        M::validate(&phrase, Language::English).map_err(|e| format!("{}", e))?;
+
         let mnemonic = M::from_phrase(&phrase, Language::English)
             .map_err(|e| format!("{}: {:?}", Bip39Error::InvalidPhrase, e))?;
 


### PR DESCRIPTION
Resolves #721 

- [x] `@namada/crypto` should return error containing index of invalid word when validating mnemonic
- [x] Mnemonic phrase import should validate mnemonic and highlight invalid word if found

NOTE: Checked with Chris Holt - we'll be keeping this design for now.

### Screenshot

In addition to returning the error message containing the invalid index, the word input is highlighted for the user to fix:

<img width="577" alt="Screen Shot 2024-04-17 at 11 26 13 AM" src="https://github.com/anoma/namada-interface/assets/330911/a397c1a7-ccf6-4a71-b96a-033be4086cd9">
