### PR TITLE
Fix: Bug related shielded action for transfer

### DIFF
--- a/apps/extension/src/background/approvals/handler.ts
+++ b/apps/extension/src/background/approvals/handler.ts
@@ -72,8 +72,17 @@ export const getHandler: (service: ApprovalsService) => Handler = (service) => {
 const handleApproveTxMsg: (
   service: ApprovalsService
 ) => InternalHandler<ApproveTxMsg> = (service) => {
-  return async (_, { txType, specificMsg, txMsg, accountType }) => {
-    return await service.approveTx(txType, specificMsg, txMsg, accountType);
+  return async (
+    _,
+    { txType, specificMsg, txMsg, accountType, transparentAddress }
+  ) => {
+    return await service.approveTx(
+      txType,
+      specificMsg,
+      txMsg,
+      accountType,
+      transparentAddress
+    );
   };
 };
 

--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -124,10 +124,16 @@ export class ApprovalsService {
     txType: SupportedTx,
     txMsg: string,
     specificMsg: string,
-    type: AccountType
+    type: AccountType,
+    transparentAddress?: string
   ): Promise<void> {
     const msgId = uuid();
-    await this.txStore.set(msgId, { txType, txMsg, specificMsg });
+    await this.txStore.set(msgId, {
+      txType,
+      txMsg,
+      specificMsg,
+      transparentAddress,
+    });
 
     // Decode tx details and launch approval screen
     const txMsgBuffer = Buffer.from(fromBase64(txMsg));
@@ -317,7 +323,7 @@ export class ApprovalsService {
       throw new Error("Pending tx not found!");
     }
 
-    const { txType, specificMsg, txMsg } = tx;
+    const { txType, specificMsg, txMsg, transparentAddress } = tx;
 
     const submitFn =
       txType === TxType.Bond
@@ -336,7 +342,13 @@ export class ApprovalsService {
                     ? this.keyRingService.submitVoteProposal
                     : assertNever(txType);
 
-    await submitFn.call(this.keyRingService, specificMsg, txMsg, msgId);
+    await submitFn.call(
+      this.keyRingService,
+      specificMsg,
+      txMsg,
+      msgId,
+      transparentAddress
+    );
 
     return await this._clearPendingTx(msgId);
   }

--- a/apps/extension/src/background/approvals/types.ts
+++ b/apps/extension/src/background/approvals/types.ts
@@ -6,4 +6,5 @@ export type TxStore = {
   txType: SupportedTx;
   txMsg: string;
   specificMsg: string;
+  transparentAddress?: string;
 };

--- a/apps/extension/src/background/chains/service.ts
+++ b/apps/extension/src/background/chains/service.ts
@@ -26,7 +26,7 @@ export class ChainsService {
       console.warn(`Chain is unreachable: ${e}`);
     }
 
-    await this.localStorage.setChain(chain);
+    await this.localStorage.setChain(chain as any);
     return chain;
   }
 
@@ -59,7 +59,7 @@ export class ChainsService {
       chainId,
       rpc: url,
     };
-    await this.localStorage.setChain(await this._queryNativeToken(chain));
+    await this.localStorage.setChain(await this._queryNativeToken(chain) as any);
     await this.broadcaster.updateNetwork();
   }
 }

--- a/apps/extension/src/provider/Namada.ts
+++ b/apps/extension/src/provider/Namada.ts
@@ -136,7 +136,13 @@ export class Namada implements INamada {
   public async submitTx(props: TxMsgProps): Promise<void> {
     return await this.requester?.sendMessage(
       Ports.Background,
-      new ApproveTxMsg(props.txType, props.specificMsg, props.txMsg, props.type)
+      new ApproveTxMsg(
+        props.txType,
+        props.specificMsg,
+        props.txMsg,
+        props.type,
+        props.transparentAddress
+      )
     );
   }
 

--- a/apps/extension/src/provider/Signer.ts
+++ b/apps/extension/src/provider/Signer.ts
@@ -82,7 +82,8 @@ export class Signer implements ISigner {
     constructor: new (args: Args) => T,
     args: Args,
     txArgs: TxProps,
-    type: AccountType
+    type: AccountType,
+    transparentAddress?: string
   ): Promise<void> {
     const msgValue = new constructor(args);
     const msg = new Message<T>();
@@ -97,6 +98,7 @@ export class Signer implements ISigner {
       specificMsg: toBase64(encoded),
       txMsg: toBase64(txEncoded),
       type,
+      transparentAddress,
     });
   }
 
@@ -168,9 +170,17 @@ export class Signer implements ISigner {
   public async submitTransfer(
     args: TransferProps,
     txArgs: TxProps,
-    type: AccountType
+    type: AccountType,
+    transparentAddress?: string
   ): Promise<void> {
-    return this.submitTx(TxType.Transfer, TransferMsgValue, args, txArgs, type);
+    return this.submitTx(
+      TxType.Transfer,
+      TransferMsgValue,
+      args,
+      txArgs,
+      type,
+      transparentAddress
+    );
   }
 
   /**
@@ -179,14 +189,16 @@ export class Signer implements ISigner {
   public async submitIbcTransfer(
     args: IbcTransferProps,
     txArgs: TxProps,
-    type: AccountType
+    type: AccountType,
+    transparentAddress?: string
   ): Promise<void> {
-    return this.submitTx(
+    return await this.submitTx(
       TxType.IBCTransfer,
       IbcTransferMsgValue,
       args,
       txArgs,
-      type
+      type,
+      transparentAddress,
     );
   }
 

--- a/apps/extension/src/provider/messages.ts
+++ b/apps/extension/src/provider/messages.ts
@@ -221,7 +221,8 @@ export class ApproveTxMsg extends Message<void> {
     public readonly txType: SupportedTx,
     public readonly txMsg: string,
     public readonly specificMsg: string,
-    public readonly accountType: AccountType
+    public readonly accountType: AccountType,
+    public readonly transparentAddress?: string
   ) {
     super();
   }

--- a/apps/namada-interface/src/App/Token/TokenSend/TokenSendForm.tsx
+++ b/apps/namada-interface/src/App/Token/TokenSend/TokenSendForm.tsx
@@ -29,7 +29,7 @@ export const submitTransferTransaction = async (
   txTransferArgs: TxTransferArgs
 ): Promise<void> => {
   const {
-    account: { address, publicKey, type },
+    account: { address, publicKey, type,transparentAddress },
     amount,
     chainId,
     target,
@@ -62,13 +62,13 @@ export const submitTransferTransaction = async (
     feeAmount,
     gasLimit,
     chainId,
-    publicKey: publicKey,
+    publicKey,
     signer: undefined,
     disposableSigningKey,
     memo,
   };
 
-  await signer.submitTransfer(transferArgs, txArgs, type);
+  await signer.submitTransfer(transferArgs, txArgs, type,transparentAddress);
 };
 
 type Props = {
@@ -224,7 +224,7 @@ const TokenSendForm = ({
         gasLimit,
         disposableSigningKey: isShieldedSource,
         memo,
-        nativeToken: chain.currency.address || tokenAddress,
+        nativeToken: chain.currency.address || tokenAddress
       });
     }
   };

--- a/apps/namada-interface/src/store/mocks.ts
+++ b/apps/namada-interface/src/store/mocks.ts
@@ -27,6 +27,7 @@ export const mockAppState: RootState = {
       },
       cosmos: {},
       ethereum: {},
+      osmosis: {},
     },
   },
   chain: { config: chains.namada },

--- a/packages/chains/src/chains/osmosis.ts
+++ b/packages/chains/src/chains/osmosis.ts
@@ -1,0 +1,34 @@
+import { BridgeType, Chain, Extensions } from "@namada/types";
+import { ProxyMappings } from "../types";
+
+const DEFAULT_ALIAS = "Osmosis";
+const DEFAULT_CHAIN_ID = "osmosis-5";
+const DEFAULT_RPC = "https://rpc.osmotest5.osmosis.zone";
+
+const rpc = DEFAULT_RPC;
+const chainId = DEFAULT_CHAIN_ID;
+const alias = DEFAULT_ALIAS;
+const isProxied = false;
+
+const cosmos: Chain = {
+  id: "osmosis",
+  alias,
+  bech32Prefix: "osmosis",
+  bip44: {
+    coinType: 118,
+  },
+  bridgeType: [BridgeType.IBC],
+  rpc: isProxied ? ProxyMappings["osmosis"] : rpc,
+  chainId,
+  currency: {
+    token: "osmo",
+    symbol: "OSMO",
+    gasPriceStep: { low: 0.01, average: 0.025, high: 0.03 },
+  },
+  extension: Extensions["keplr"],
+  ibc: {
+    portId: "transfer",
+  },
+};
+
+export default cosmos;

--- a/packages/chains/src/index.ts
+++ b/packages/chains/src/index.ts
@@ -2,11 +2,13 @@ import { Chain, ChainKey } from "@namada/types";
 import cosmos from "./chains/cosmos";
 import ethereum from "./chains/ethereum";
 import namada from "./chains/namada";
+import osmosis from "./chains/osmosis";
 
 export const chains: Record<ChainKey, Chain> = {
   cosmos,
   namada,
   ethereum,
+  osmosis
 };
 
 export * from "./types";

--- a/packages/chains/src/types.ts
+++ b/packages/chains/src/types.ts
@@ -7,4 +7,5 @@ export const ProxyMappings: Record<ChainKey, string> = {
   namada: getProxyURL(8010),
   cosmos: getProxyURL(8011),
   ethereum: getProxyURL(8012),
+  osmosis: getProxyURL(8013),
 };

--- a/packages/integrations/src/Namada.ts
+++ b/packages/integrations/src/Namada.ts
@@ -61,14 +61,16 @@ export default class Namada implements Integration<Account, Signer> {
 
   public async submitBridgeTransfer(
     props: BridgeProps,
-    type: AccountType
+    type: AccountType,
+    transparentAddress?: string
   ): Promise<void> {
     const signer = this._namada?.getSigner();
     if (props.ibcProps) {
       return await signer?.submitIbcTransfer(
         props.ibcProps,
         props.txProps,
-        type
+        type,
+        transparentAddress
       );
     } else if (props.bridgeProps) {
       return await signer?.submitEthBridgeTransfer(

--- a/packages/shared/lib/src/sdk/masp.rs
+++ b/packages/shared/lib/src/sdk/masp.rs
@@ -3,8 +3,10 @@ use gloo_utils::format::JsValueSerdeExt;
 use namada::core::borsh::{BorshDeserialize, BorshSerialize};
 use namada::sdk::masp::{ContextSyncStatus, ShieldedContext, ShieldedUtils};
 use namada::sdk::masp_proofs::prover::LocalTxProver;
+use namada::tendermint::node::info;
 use rexie::{Error, ObjectStore, Rexie, TransactionMode};
 use wasm_bindgen::{JsError, JsValue};
+use crate::utils::to_js_result;
 
 use crate::utils::to_bytes;
 

--- a/packages/types/src/account.ts
+++ b/packages/types/src/account.ts
@@ -36,4 +36,5 @@ export type Account = Pick<
   chainId: string;
   isShielded: boolean;
   chainKey: ChainKey;
+  transparentAddress?: string;
 };

--- a/packages/types/src/chain.ts
+++ b/packages/types/src/chain.ts
@@ -18,7 +18,7 @@ export enum BridgeType {
 export type ExtensionKey = "namada" | "keplr" | "metamask";
 
 // Define keys for supported chains
-export type ChainKey = "namada" | "cosmos" | "ethereum";
+export type ChainKey = "namada" | "cosmos" | "ethereum" | "osmosis";
 
 export type ExtensionInfo = {
   alias: string;

--- a/packages/types/src/namada.ts
+++ b/packages/types/src/namada.ts
@@ -9,6 +9,7 @@ export type TxMsgProps = {
   specificMsg: string;
   txMsg: string;
   type: AccountType;
+  transparentAddress?: string;
 };
 
 export type SignArbitraryProps = {

--- a/packages/types/src/signer.ts
+++ b/packages/types/src/signer.ts
@@ -41,12 +41,14 @@ export interface Signer {
   submitTransfer(
     args: TransferProps,
     txArgs: TxProps,
-    type: AccountType
+    type: AccountType,
+    transparentAddress?: string
   ): Promise<void>;
   submitIbcTransfer(
     args: IbcTransferProps,
     txArgs: TxProps,
-    type: AccountType
+    type: AccountType,
+    transparentAddress?: string
   ): Promise<void>;
   submitVoteProposal(
     args: SubmitVoteProposalProps,


### PR DESCRIPTION
### Bug 1: Wrong chain id passing for shielded IBC transfer ( only IBC shielded )
- Currently in IBC transfer function get chain ID from account like image below
![image](https://github.com/anoma/namada-interface/assets/44290296/83ec9546-b1eb-43ba-8d9a-d2777e3f3033)
- The chain id in the account is always taken from the .env file. It will not be updated according to the chain ID extension. That's why the chain ID is wrong
- Solution: Chain id should be get from redux: const chain = useAppSelector<Chain>((state) => state.chain.config). This is the correct chain ID same as chain id of extension

### Bug 2: Private key is not passing into shielded action ( both IBC shielded and internal shielded transfer )
- At present, the private key is not being passed for shielded actions. The private key must be passed along with the transaction to serve as the payer for fees and to process the transaction. Failure to include the private key results in this bug.
- Solution: We propose adding a parameter called transparentAddress specifically for shielded transfers. This transparentAddress parameter would facilitate the generation of the private key required for signing and paying for transactions. By including this parameter, ensuring that the necessary private key is provided, thus enabling seamless signing and payment for transactions.

### Bug 3: Public key is missing in txArgs when execute shielded transfer ( both ibc shielded and internal shielded transfer )
- Same as bug 2, the public key should be passed as an argument in the build_transfer function. This argument is crucial for determining the payer of the transaction fees.
- Solution: Because the account don't have public key, so will mapping in redux to add public key into shielded account

### Bug 4: disposable_signing_key should be false when using shielded transfer ( only internal shielded transfer )
- The current flag disposableSigningKey is set based on isShieldedSource. From my understanding, this flag indicates whether the signing key is disposable, and the validator is responsible for paying the transaction fee. Therefore, it's advisable to enable this flag only for voting proposal transactions.
- Solution: Remove this flag in transfer transaction
![image](https://github.com/anoma/namada-interface/assets/44290296/5f6c74c6-82e8-4dbb-a984-d405a0686584)

