### PR TITLE
feat/677 - Support querying pending Tx within extension

### DIFF
--- a/apps/extension/src/Approvals/Approvals.tsx
+++ b/apps/extension/src/Approvals/Approvals.tsx
@@ -20,7 +20,6 @@ export enum Status {
   Failed,
 }
 
-// TODO: Handle array of ApprovalDetails
 export type ApprovalDetails = {
   msgId: string;
   txType: TxType;

--- a/apps/extension/src/Approvals/Approvals.tsx
+++ b/apps/extension/src/Approvals/Approvals.tsx
@@ -19,6 +19,7 @@ export enum Status {
   Failed,
 }
 
+// TODO: Handle array of ApprovalDetails
 export type ApprovalDetails = {
   source: string;
   msgId: string;
@@ -26,6 +27,9 @@ export type ApprovalDetails = {
   publicKey?: string;
   target?: string;
   nativeToken?: string;
+  tokenAddress?: string;
+  amount?: string;
+  validator?: string;
 };
 
 export type SignatureDetails = {
@@ -50,8 +54,8 @@ export const Approvals: React.FC = () => {
     >
       <Routes>
         <Route
-          path={`${TopLevelRoute.ApproveTx}/:type`}
-          element={<ApproveTx setDetails={setDetails} />}
+          path={`${TopLevelRoute.ApproveTx}/:msgId/:type/:accountType`}
+          element={<ApproveTx setDetails={setDetails} details={details} />}
         />
         <Route
           path={TopLevelRoute.ConfirmTx}

--- a/apps/extension/src/Approvals/Approvals.tsx
+++ b/apps/extension/src/Approvals/Approvals.tsx
@@ -6,6 +6,7 @@ import { Container } from "@namada/components";
 
 import { AppHeader } from "App/Common/AppHeader";
 import { TopLevelRoute } from "Approvals/types";
+import { PendingTxDetails } from "background/approvals";
 import { ApproveConnection } from "./ApproveConnection";
 import { ApproveSignature } from "./ApproveSignature";
 import { ApproveTx } from "./ApproveTx/ApproveTx";
@@ -21,15 +22,9 @@ export enum Status {
 
 // TODO: Handle array of ApprovalDetails
 export type ApprovalDetails = {
-  source: string;
   msgId: string;
   txType: TxType;
-  publicKey?: string;
-  target?: string;
-  nativeToken?: string;
-  tokenAddress?: string;
-  amount?: string;
-  validator?: string;
+  tx: PendingTxDetails[];
 };
 
 export type SignatureDetails = {

--- a/apps/extension/src/Approvals/ApproveTx/ApproveTx.tsx
+++ b/apps/extension/src/Approvals/ApproveTx/ApproveTx.tsx
@@ -36,19 +36,12 @@ const fetchPendingTxDetails = async (
 export const ApproveTx: React.FC<Props> = ({ details, setDetails }) => {
   const navigate = useNavigate();
   const requester = useRequester();
-  const { amount, source, target, publicKey, tokenAddress, validator } =
-    details || {};
-
   // Parse URL params
   const params = useSanitizedParams();
   const txType = parseInt(params?.type || "0");
   const accountType =
     (params?.accountType as AccountType) || AccountType.PrivateKey;
   const msgId = params?.msgId || "0";
-
-  const tokenType =
-    Object.values(Tokens).find((token) => token.address === tokenAddress)
-      ?.symbol || "NAM";
 
   useEffect(() => {
     fetchPendingTxDetails(requester, msgId)
@@ -59,32 +52,16 @@ export const ApproveTx: React.FC<Props> = ({ details, setDetails }) => {
           );
         }
         // TODO: Handle array of approval details
-        const {
-          amount,
-          source,
-          publicKey,
-          target,
-          nativeToken,
-          tokenAddress,
-          validator,
-        } = details[0];
-
         setDetails({
-          amount,
-          source,
           txType,
           msgId,
-          publicKey,
-          target,
-          nativeToken,
-          tokenAddress,
-          validator,
+          tx: details,
         });
       })
       .catch((e) => {
         console.error(`Could not fetch pending Tx with msgId = ${msgId}: ${e}`);
       });
-  }, [source, publicKey, txType, target, msgId]);
+  }, [txType, msgId]);
 
   const handleApproveClick = useCallback((): void => {
     if (accountType === AccountType.Ledger) {
@@ -114,25 +91,45 @@ export const ApproveTx: React.FC<Props> = ({ details, setDetails }) => {
         <strong>{TxTypeLabel[txType as TxType]}</strong> transaction?
       </Alert>
       <Stack gap={2}>
-        {source && (
-          <p className="text-xs">
-            Source: <strong>{shortenAddress(source)}</strong>
-          </p>
-        )}
-        {target && (
-          <p className="text-xs">
-            Target:
-            <strong>{shortenAddress(target)}</strong>
-          </p>
-        )}
-        {amount && (
-          <p className="text-xs">
-            Amount: {amount} {tokenType}
-          </p>
-        )}
-        {validator && (
-          <p className="text-xs">Validator: {shortenAddress(validator)}</p>
-        )}
+        {details?.tx.map((txDetails, i) => {
+          const { amount, source, target, publicKey, tokenAddress, validator } =
+            txDetails || {};
+          const tokenType =
+            Object.values(Tokens).find(
+              (token) => token.address === tokenAddress
+            )?.symbol || "NAM";
+
+          return (
+            <div key={i}>
+              {source && (
+                <p className="text-xs">
+                  Source: <strong>{shortenAddress(source)}</strong>
+                </p>
+              )}
+              {target && (
+                <p className="text-xs">
+                  Target:
+                  <strong>{shortenAddress(target)}</strong>
+                </p>
+              )}
+              {amount && (
+                <p className="text-xs">
+                  Amount: {amount} {tokenType}
+                </p>
+              )}
+              {publicKey && (
+                <p className="text-xs">
+                  Public key: {shortenAddress(publicKey)}
+                </p>
+              )}
+              {validator && (
+                <p className="text-xs">
+                  Validator: {shortenAddress(validator)}
+                </p>
+              )}
+            </div>
+          );
+        })}
       </Stack>
       <Stack gap={3} direction="horizontal">
         <ActionButton onClick={handleApproveClick}>Approve</ActionButton>

--- a/apps/extension/src/Approvals/ApproveTx/ConfirmLedgerTx.tsx
+++ b/apps/extension/src/Approvals/ApproveTx/ConfirmLedgerTx.tsx
@@ -135,11 +135,13 @@ export const ConfirmLedgerTx: React.FC<Props> = ({ details }) => {
       throw new Error("msgId was not provided!");
     }
 
-    const { bytes, path } = await requester
-      .sendMessage(Ports.Background, new GetTxBytesMsg(txType, msgId, source))
-      .catch((e) => {
-        throw new Error(`Requester error: ${e}`);
-      });
+    const { bytes, path } = (
+      await requester
+        .sendMessage(Ports.Background, new GetTxBytesMsg(txType, msgId, source))
+        .catch((e) => {
+          throw new Error(`Requester error: ${e}`);
+        })
+    )[0];
 
     setStatusInfo(`Review and approve ${txLabel} transaction on your Ledger`);
 

--- a/apps/extension/src/Approvals/ApproveTx/ConfirmLedgerTx.tsx
+++ b/apps/extension/src/Approvals/ApproveTx/ConfirmLedgerTx.tsx
@@ -31,7 +31,8 @@ export const ConfirmLedgerTx: React.FC<Props> = ({ details }) => {
   const [error, setError] = useState<string>();
   const [status, setStatus] = useState<Status>();
   const [statusInfo, setStatusInfo] = useState("");
-  const { source, msgId, publicKey, txType, nativeToken } = details || {};
+  const { msgId, txType } = details || {};
+  const { source, publicKey, nativeToken } = details?.tx[0] || {};
 
   useEffect(() => {
     if (status === Status.Completed) {

--- a/apps/extension/src/Approvals/ApproveTx/ConfirmTx.tsx
+++ b/apps/extension/src/Approvals/ApproveTx/ConfirmTx.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { SupportedTx, TxType, TxTypeLabel } from "@heliax/namada-sdk/web";
+import { SupportedTx, TxTypeLabel } from "@heliax/namada-sdk/web";
 import { ActionButton, Alert, Input, Stack } from "@namada/components";
 import { shortenAddress } from "@namada/utils";
 import { ApprovalDetails, Status } from "Approvals/Approvals";
@@ -17,7 +17,8 @@ type Props = {
 };
 
 export const ConfirmTx: React.FC<Props> = ({ details }) => {
-  const { source, msgId, txType } = details || {};
+  const { msgId, txType } = details || {};
+  const { source } = details?.tx[0] || {};
 
   const navigate = useNavigate();
   const requester = useRequester();
@@ -27,10 +28,12 @@ export const ConfirmTx: React.FC<Props> = ({ details }) => {
   const [statusInfo, setStatusInfo] = useState("");
 
   const handleApproveTx = useCallback(async (): Promise<void> => {
+    if (!txType) {
+      // TODO: What would be a better handling of this? txType should be defined
+      throw new Error("txType should be defined");
+    }
     setStatus(Status.Pending);
-    setStatusInfo(
-      `Decrypting keys and submitting ${TxTypeLabel[txType as TxType]}...`
-    );
+    setStatusInfo(`Decrypting keys and submitting ${TxTypeLabel[txType]}...`);
 
     try {
       if (!msgId) {

--- a/apps/extension/src/Approvals/ApproveTx/ConfirmTx.tsx
+++ b/apps/extension/src/Approvals/ApproveTx/ConfirmTx.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from "react-router-dom";
 
 import { SupportedTx, TxTypeLabel } from "@heliax/namada-sdk/web";
 import { ActionButton, Alert, Input, Stack } from "@namada/components";
-import { shortenAddress } from "@namada/utils";
 import { ApprovalDetails, Status } from "Approvals/Approvals";
 import { SubmitApprovedTxMsg } from "background/approvals";
 import { UnlockVaultMsg } from "background/vault";
@@ -18,7 +17,6 @@ type Props = {
 
 export const ConfirmTx: React.FC<Props> = ({ details }) => {
   const { msgId, txType } = details || {};
-  const { source } = details?.tx[0] || {};
 
   const navigate = useNavigate();
   const requester = useRequester();
@@ -99,12 +97,9 @@ export const ConfirmTx: React.FC<Props> = ({ details }) => {
           Try again
         </Alert>
       )}
-      {status !== (Status.Pending || Status.Completed) && source && (
+      {status !== (Status.Pending || Status.Completed) && (
         <>
-          <Alert type="warning">
-            Decrypt keys for{" "}
-            <strong className="text-xs">{shortenAddress(source)}</strong>
-          </Alert>
+          <Alert type="warning">Verify your password to continue</Alert>
           <Input
             variant="Password"
             label={"Password"}

--- a/apps/extension/src/background/approvals/handler.test.ts
+++ b/apps/extension/src/background/approvals/handler.test.ts
@@ -23,7 +23,7 @@ import { ApprovalsService } from "./service";
 jest.mock("webextension-polyfill", () => ({}));
 
 class UnknownMsg extends Message<unknown> {
-  validate(): void {}
+  validate(): void { }
   route(): string {
     return "unknown";
   }
@@ -45,13 +45,17 @@ describe("approvals handler", () => {
     const env = {
       isInternalMsg: true,
       senderTabId: 1,
-      requestInteraction: () => {},
+      requestInteraction: () => { },
     };
 
     const approveTxMsg = new ApproveTxMsg(
       TxType.Bond,
-      "txMsg",
-      "specificMsg",
+      [
+        {
+          txMsg: "txMsg",
+          specificMsg: "specificMsg",
+        },
+      ],
       AccountType.Mnemonic
     );
     handler(env, approveTxMsg);

--- a/apps/extension/src/background/approvals/handler.test.ts
+++ b/apps/extension/src/background/approvals/handler.test.ts
@@ -23,7 +23,7 @@ import { ApprovalsService } from "./service";
 jest.mock("webextension-polyfill", () => ({}));
 
 class UnknownMsg extends Message<unknown> {
-  validate(): void { }
+  validate(): void {}
   route(): string {
     return "unknown";
   }
@@ -45,7 +45,7 @@ describe("approvals handler", () => {
     const env = {
       isInternalMsg: true,
       senderTabId: 1,
-      requestInteraction: () => { },
+      requestInteraction: () => {},
     };
 
     const approveTxMsg = new ApproveTxMsg(

--- a/apps/extension/src/background/approvals/handler.ts
+++ b/apps/extension/src/background/approvals/handler.ts
@@ -7,6 +7,7 @@ import {
 import { Env, Handler, InternalHandler, Message } from "router";
 import {
   ConnectInterfaceResponseMsg,
+  QueryPendingTxMsg,
   RejectSignatureMsg,
   RejectTxMsg,
   RevokeConnectionMsg,
@@ -27,6 +28,8 @@ export const getHandler: (service: ApprovalsService) => Handler = (service) => {
           env,
           msg as SubmitApprovedTxMsg
         );
+      case QueryPendingTxMsg:
+        return handleQueryPendingTxMsg(service)(env, msg as QueryPendingTxMsg);
       case IsConnectionApprovedMsg:
         return handleIsConnectionApprovedMsg(service)(
           env,
@@ -90,6 +93,14 @@ const handleSubmitApprovedTxMsg: (
 ) => InternalHandler<SubmitApprovedTxMsg> = (service) => {
   return async (_, { msgId }) => {
     return await service.submitTx(msgId);
+  };
+};
+
+const handleQueryPendingTxMsg: (
+  service: ApprovalsService
+) => InternalHandler<QueryPendingTxMsg> = (service) => {
+  return async (_, { msgId }) => {
+    return await service.queryPendingTx(msgId);
   };
 };
 

--- a/apps/extension/src/background/approvals/handler.ts
+++ b/apps/extension/src/background/approvals/handler.ts
@@ -75,8 +75,8 @@ export const getHandler: (service: ApprovalsService) => Handler = (service) => {
 const handleApproveTxMsg: (
   service: ApprovalsService
 ) => InternalHandler<ApproveTxMsg> = (service) => {
-  return async (_, { txType, specificMsg, txMsg, accountType }) => {
-    return await service.approveTx(txType, specificMsg, txMsg, accountType);
+  return async (_, { txType, tx, accountType }) => {
+    return await service.approveTx(txType, tx, accountType);
   };
 };
 

--- a/apps/extension/src/background/approvals/init.ts
+++ b/apps/extension/src/background/approvals/init.ts
@@ -7,6 +7,7 @@ import {
 import { Router } from "router";
 import {
   ConnectInterfaceResponseMsg,
+  QueryPendingTxMsg,
   RejectSignatureMsg,
   RejectTxMsg,
   RevokeConnectionMsg,
@@ -21,6 +22,7 @@ import { ApprovalsService } from "./service";
 export function init(router: Router, service: ApprovalsService): void {
   router.registerMessage(ApproveTxMsg);
   router.registerMessage(RejectTxMsg);
+  router.registerMessage(QueryPendingTxMsg);
   router.registerMessage(SubmitApprovedTxMsg);
   router.registerMessage(ApproveSignArbitraryMsg);
   router.registerMessage(RejectSignatureMsg);

--- a/apps/extension/src/background/approvals/messages.ts
+++ b/apps/extension/src/background/approvals/messages.ts
@@ -3,10 +3,12 @@ import { Message } from "router";
 import { ROUTE } from "./constants";
 
 import { validateProps } from "utils";
+import { PendingTxDetails } from "./types";
 
 export enum MessageType {
-  SubmitApprovedTx = "submit-approved-tx",
   RejectTx = "reject-tx",
+  SubmitApprovedTx = "submit-approved-tx",
+  QueryPendingTx = "query-pending-tx",
   SubmitApprovedSignature = "submit-approved-signature",
   RejectSignature = "reject-signature",
   ConnectInterfaceResponse = "connect-interface-response",
@@ -23,10 +25,7 @@ export class RejectTxMsg extends Message<void> {
   }
 
   validate(): void {
-    if (!this.msgId) {
-      throw new Error("msgId must not be empty!");
-    }
-    return;
+    validateProps(this, ["msgId"]);
   }
 
   route(): string {
@@ -63,9 +62,9 @@ export class SubmitApprovedTxMsg extends Message<void> {
   }
 }
 
-export class RejectSignatureMsg extends Message<void> {
+export class QueryPendingTxMsg extends Message<PendingTxDetails[]> {
   public static type(): MessageType {
-    return MessageType.RejectSignature;
+    return MessageType.QueryPendingTx;
   }
 
   constructor(public readonly msgId: string) {
@@ -73,10 +72,7 @@ export class RejectSignatureMsg extends Message<void> {
   }
 
   validate(): void {
-    if (!this.msgId) {
-      throw new Error("msgId must not be empty!");
-    }
-    return;
+    validateProps(this, ["msgId"]);
   }
 
   route(): string {
@@ -84,7 +80,7 @@ export class RejectSignatureMsg extends Message<void> {
   }
 
   type(): string {
-    return RejectSignatureMsg.type();
+    return RejectTxMsg.type();
   }
 }
 
@@ -113,6 +109,29 @@ export class SubmitApprovedSignatureMsg extends Message<void> {
   }
 }
 
+export class RejectSignatureMsg extends Message<void> {
+  public static type(): MessageType {
+    return MessageType.RejectSignature;
+  }
+
+  constructor(public readonly msgId: string) {
+    super();
+  }
+
+  validate(): void {
+    validateProps(this, ["msgId"]);
+    return;
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return RejectSignatureMsg.type();
+  }
+}
+
 export class ConnectInterfaceResponseMsg extends Message<void> {
   public static type(): MessageType {
     return MessageType.ConnectInterfaceResponse;
@@ -127,17 +146,11 @@ export class ConnectInterfaceResponseMsg extends Message<void> {
   }
 
   validate(): void {
-    if (typeof this.interfaceTabId === "undefined") {
-      throw new Error("interfaceTabId not set");
-    }
-
-    if (!this.interfaceOrigin) {
-      throw new Error("interfaceOrigin not set");
-    }
-
-    if (typeof this.allowConnection === "undefined") {
-      throw new Error("allowConnection not set");
-    }
+    validateProps(this, [
+      "interfaceTabId",
+      "interfaceOrigin",
+      "allowConnection",
+    ]);
   }
 
   route(): string {
@@ -159,9 +172,7 @@ export class RevokeConnectionMsg extends Message<void> {
   }
 
   validate(): void {
-    if (typeof this.originToRevoke === "undefined") {
-      throw new Error("originToRevoke not set");
-    }
+    validateProps(this, ["originToRevoke"]);
   }
 
   route(): string {

--- a/apps/extension/src/background/approvals/messages.ts
+++ b/apps/extension/src/background/approvals/messages.ts
@@ -80,7 +80,7 @@ export class QueryPendingTxMsg extends Message<PendingTxDetails[]> {
   }
 
   type(): string {
-    return RejectTxMsg.type();
+    return QueryPendingTxMsg.type();
   }
 }
 

--- a/apps/extension/src/background/approvals/service.test.ts
+++ b/apps/extension/src/background/approvals/service.test.ts
@@ -431,6 +431,7 @@ describe("approvals service", () => {
         amount: bondMsgValue.amount.toString(),
         publicKey: txMsgValue.publicKey,
         nativeToken: bondMsgValue.nativeToken,
+        validator: bondMsgValue.validator,
       });
     });
   });
@@ -461,6 +462,7 @@ describe("approvals service", () => {
       expect(params).toEqual({
         source: unbondMsgValue.source,
         amount: unbondMsgValue.amount.toString(),
+        validator: unbondMsgValue.validator,
         publicKey: txMsgValue.publicKey,
         nativeToken: txMsgValue.token,
       });

--- a/apps/extension/src/background/approvals/service.test.ts
+++ b/apps/extension/src/background/approvals/service.test.ts
@@ -264,18 +264,13 @@ describe("approvals service", () => {
       jest.spyOn(service as any, "_launchApprovalWindow");
 
       try {
-        const res = await service.approveTx(type, "", "", AccountType.Mnemonic);
+        const res = await service.approveTx(
+          type,
+          [{ specificMsg: "", txMsg: "" }],
+          AccountType.Mnemonic
+        );
         expect(res).toBeUndefined();
-      } catch (e) {}
-    });
-
-    it("should throw an error if txType is not found", async () => {
-      const type: any = 999;
-      jest.spyOn(borsh, "deserialize").mockReturnValue({});
-
-      await expect(
-        service.approveTx(type, "", "", AccountType.Mnemonic)
-      ).rejects.toBeDefined();
+      } catch (e) { }
     });
   });
 
@@ -559,8 +554,12 @@ describe("approvals service", () => {
       jest.spyOn(service["txStore"], "get").mockImplementation(() => {
         return Promise.resolve({
           txType,
-          txMsg,
-          specificMsg,
+          tx: [
+            {
+              txMsg,
+              specificMsg,
+            },
+          ],
         });
       });
 
@@ -585,8 +584,12 @@ describe("approvals service", () => {
       jest.spyOn(service["txStore"], "get").mockImplementation(() => {
         return Promise.resolve({
           txType,
-          txMsg,
-          specificMsg,
+          tx: [
+            {
+              txMsg,
+              specificMsg,
+            },
+          ],
         });
       });
 

--- a/apps/extension/src/background/approvals/service.test.ts
+++ b/apps/extension/src/background/approvals/service.test.ts
@@ -270,7 +270,7 @@ describe("approvals service", () => {
           AccountType.Mnemonic
         );
         expect(res).toBeUndefined();
-      } catch (e) { }
+      } catch (e) {}
     });
   });
 

--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -35,14 +35,14 @@ type GetParams = (
 
 const getParamsMethod = (txType: SupportedTx): GetParams =>
   txType === TxType.Bond ? ApprovalsService.getParamsBond
-    : txType === TxType.Unbond ? ApprovalsService.getParamsUnbond
-      : txType === TxType.Withdraw ? ApprovalsService.getParamsWithdraw
-        : txType === TxType.Transfer ? ApprovalsService.getParamsTransfer
-          : txType === TxType.IBCTransfer ? ApprovalsService.getParamsIbcTransfer
-            : txType === TxType.EthBridgeTransfer ?
-              ApprovalsService.getParamsEthBridgeTransfer
-              : txType === TxType.VoteProposal ? ApprovalsService.getParamsVoteProposal
-                : assertNever(txType);
+  : txType === TxType.Unbond ? ApprovalsService.getParamsUnbond
+  : txType === TxType.Withdraw ? ApprovalsService.getParamsWithdraw
+  : txType === TxType.Transfer ? ApprovalsService.getParamsTransfer
+  : txType === TxType.IBCTransfer ? ApprovalsService.getParamsIbcTransfer
+  : txType === TxType.EthBridgeTransfer ?
+    ApprovalsService.getParamsEthBridgeTransfer
+  : txType === TxType.VoteProposal ? ApprovalsService.getParamsVoteProposal
+  : assertNever(txType);
 
 export class ApprovalsService {
   // holds promises which can be resolved with a message from a pop-up window
@@ -324,16 +324,16 @@ export class ApprovalsService {
         const { specificMsg, txMsg } = pendingTx;
         const submitFn =
           txType === TxType.Bond ? this.keyRingService.submitBond
-            : txType === TxType.Unbond ? this.keyRingService.submitUnbond
-              : txType === TxType.Transfer ? this.keyRingService.submitTransfer
-                : txType === TxType.IBCTransfer ?
-                  this.keyRingService.submitIbcTransfer
-                  : txType === TxType.EthBridgeTransfer ?
-                    this.keyRingService.submitEthBridgeTransfer
-                    : txType === TxType.Withdraw ? this.keyRingService.submitWithdraw
-                      : txType === TxType.VoteProposal ?
-                        this.keyRingService.submitVoteProposal
-                        : assertNever(txType);
+          : txType === TxType.Unbond ? this.keyRingService.submitUnbond
+          : txType === TxType.Transfer ? this.keyRingService.submitTransfer
+          : txType === TxType.IBCTransfer ?
+            this.keyRingService.submitIbcTransfer
+          : txType === TxType.EthBridgeTransfer ?
+            this.keyRingService.submitEthBridgeTransfer
+          : txType === TxType.Withdraw ? this.keyRingService.submitWithdraw
+          : txType === TxType.VoteProposal ?
+            this.keyRingService.submitVoteProposal
+          : assertNever(txType);
 
         await submitFn.call(this.keyRingService, specificMsg, txMsg, msgId);
       })

--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -61,7 +61,7 @@ export class ApprovalsService {
     protected readonly ledgerService: LedgerService,
     protected readonly vaultService: VaultService,
     protected readonly broadcaster: ExtensionBroadcaster
-  ) { }
+  ) {}
 
   async queryPendingTx(msgId: string): Promise<PendingTxDetails[]> {
     const storedTx = await this.txStore.get(msgId);

--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -35,14 +35,14 @@ type GetParams = (
 
 const getParamsMethod = (txType: SupportedTx): GetParams =>
   txType === TxType.Bond ? ApprovalsService.getParamsBond
-  : txType === TxType.Unbond ? ApprovalsService.getParamsUnbond
-  : txType === TxType.Withdraw ? ApprovalsService.getParamsWithdraw
-  : txType === TxType.Transfer ? ApprovalsService.getParamsTransfer
-  : txType === TxType.IBCTransfer ? ApprovalsService.getParamsIbcTransfer
-  : txType === TxType.EthBridgeTransfer ?
-    ApprovalsService.getParamsEthBridgeTransfer
-  : txType === TxType.VoteProposal ? ApprovalsService.getParamsVoteProposal
-  : assertNever(txType);
+    : txType === TxType.Unbond ? ApprovalsService.getParamsUnbond
+      : txType === TxType.Withdraw ? ApprovalsService.getParamsWithdraw
+        : txType === TxType.Transfer ? ApprovalsService.getParamsTransfer
+          : txType === TxType.IBCTransfer ? ApprovalsService.getParamsIbcTransfer
+            : txType === TxType.EthBridgeTransfer ?
+              ApprovalsService.getParamsEthBridgeTransfer
+              : txType === TxType.VoteProposal ? ApprovalsService.getParamsVoteProposal
+                : assertNever(txType);
 
 export class ApprovalsService {
   // holds promises which can be resolved with a message from a pop-up window
@@ -61,7 +61,7 @@ export class ApprovalsService {
     protected readonly ledgerService: LedgerService,
     protected readonly vaultService: VaultService,
     protected readonly broadcaster: ExtensionBroadcaster
-  ) {}
+  ) { }
 
   async queryPendingTx(msgId: string): Promise<PendingTxDetails[]> {
     // TODO: Update storage to support array of Tx
@@ -165,7 +165,7 @@ export class ApprovalsService {
 
     const baseUrl = `${browser.runtime.getURL(
       "approvals.html"
-    )}#/approve-tx/${txType}`;
+    )}#/approve-tx/${msgId}/${txType}/${type}`;
 
     const url = paramsToUrl(baseUrl, {
       ...getParamsMethod(txType)(specificMsgBuffer, txDetails),
@@ -251,6 +251,7 @@ export class ApprovalsService {
       source,
       nativeToken: tokenAddress,
       amount: amountBN,
+      validator,
     } = specificDetails;
     const amount = new BigNumber(amountBN.toString());
 
@@ -262,13 +263,14 @@ export class ApprovalsService {
       amount: amount.toString(),
       publicKey,
       nativeToken: tokenAddress,
+      validator,
     };
   };
 
   static getParamsUnbond: GetParams = (specificMsg, txDetails) => {
     const specificDetails = deserialize(specificMsg, UnbondMsgValue);
 
-    const { source, amount: amountBN } = specificDetails;
+    const { source, amount: amountBN, validator } = specificDetails;
     const amount = new BigNumber(amountBN.toString());
 
     const { publicKey, nativeToken } = ApprovalsService.getTxDetails(txDetails);
@@ -278,6 +280,7 @@ export class ApprovalsService {
       amount: amount.toString(),
       publicKey,
       nativeToken,
+      validator,
     };
   };
 
@@ -329,14 +332,14 @@ export class ApprovalsService {
 
     const submitFn =
       txType === TxType.Bond ? this.keyRingService.submitBond
-      : txType === TxType.Unbond ? this.keyRingService.submitUnbond
-      : txType === TxType.Transfer ? this.keyRingService.submitTransfer
-      : txType === TxType.IBCTransfer ? this.keyRingService.submitIbcTransfer
-      : txType === TxType.EthBridgeTransfer ?
-        this.keyRingService.submitEthBridgeTransfer
-      : txType === TxType.Withdraw ? this.keyRingService.submitWithdraw
-      : txType === TxType.VoteProposal ? this.keyRingService.submitVoteProposal
-      : assertNever(txType);
+        : txType === TxType.Unbond ? this.keyRingService.submitUnbond
+          : txType === TxType.Transfer ? this.keyRingService.submitTransfer
+            : txType === TxType.IBCTransfer ? this.keyRingService.submitIbcTransfer
+              : txType === TxType.EthBridgeTransfer ?
+                this.keyRingService.submitEthBridgeTransfer
+                : txType === TxType.Withdraw ? this.keyRingService.submitWithdraw
+                  : txType === TxType.VoteProposal ? this.keyRingService.submitVoteProposal
+                    : assertNever(txType);
 
     await submitFn.call(this.keyRingService, specificMsg, txMsg, msgId);
 

--- a/apps/extension/src/background/approvals/types.ts
+++ b/apps/extension/src/background/approvals/types.ts
@@ -2,10 +2,14 @@ import { SupportedTx } from "@heliax/namada-sdk/web";
 
 export type ApprovedOriginsStore = string[];
 
-export type TxStore = {
-  txType: SupportedTx;
+export type PendingTx = {
   txMsg: string;
   specificMsg: string;
+};
+
+export type TxStore = {
+  txType: SupportedTx;
+  tx: PendingTx[];
 };
 
 // TODO: Add specific types here!

--- a/apps/extension/src/background/approvals/types.ts
+++ b/apps/extension/src/background/approvals/types.ts
@@ -7,3 +7,6 @@ export type TxStore = {
   txMsg: string;
   specificMsg: string;
 };
+
+// TODO: Add specific types here!
+export type PendingTxDetails = Record<string, string>;

--- a/apps/extension/src/background/ledger/handler.ts
+++ b/apps/extension/src/background/ledger/handler.ts
@@ -1,13 +1,13 @@
-import { Handler, Env, Message, InternalHandler } from "router";
-import { LedgerService } from "./service";
+import { Env, Handler, InternalHandler, Message } from "router";
 import {
-  GetTxBytesMsg,
-  SubmitSignedRevealPKMsg,
   GetRevealPKBytesMsg,
-  SubmitSignedTxMsg,
+  GetTxBytesMsg,
   QueryStoredPK,
   StoreRevealedPK,
+  SubmitSignedRevealPKMsg,
+  SubmitSignedTxMsg,
 } from "./messages";
+import { LedgerService } from "./service";
 
 export const getHandler: (service: LedgerService) => Handler = (service) => {
   return (env: Env, msg: Message<unknown>) => {
@@ -15,7 +15,10 @@ export const getHandler: (service: LedgerService) => Handler = (service) => {
       case GetTxBytesMsg:
         return handleGetTxBytesMsg(service)(env, msg as GetTxBytesMsg);
       case GetRevealPKBytesMsg:
-        return handleGetRevealPKBytesMsg(service)(env, msg as GetTxBytesMsg);
+        return handleGetRevealPKBytesMsg(service)(
+          env,
+          msg as GetRevealPKBytesMsg
+        );
       case SubmitSignedRevealPKMsg:
         return handleSubmitSignedRevealPKMsg(service)(
           env,

--- a/apps/extension/src/background/ledger/messages.ts
+++ b/apps/extension/src/background/ledger/messages.ts
@@ -12,10 +12,12 @@ enum MessageType {
   StoreRevealedPK = "store-revealed-pk",
 }
 
-export class GetTxBytesMsg extends Message<{
-  bytes: Uint8Array;
-  path: string;
-}> {
+export class GetTxBytesMsg extends Message<
+  {
+    bytes: Uint8Array;
+    path: string;
+  }[]
+> {
   public static type(): MessageType {
     return MessageType.GetTxBytes;
   }

--- a/apps/extension/src/provider/Namada.ts
+++ b/apps/extension/src/provider/Namada.ts
@@ -30,7 +30,7 @@ export class Namada implements INamada {
   constructor(
     private readonly _version: string,
     protected readonly requester?: MessageRequester
-  ) {}
+  ) { }
 
   public async connect(): Promise<void> {
     return await this.requester?.sendMessage(
@@ -136,7 +136,7 @@ export class Namada implements INamada {
   public async submitTx(props: TxMsgProps): Promise<void> {
     return await this.requester?.sendMessage(
       Ports.Background,
-      new ApproveTxMsg(props.txType, props.specificMsg, props.txMsg, props.type)
+      new ApproveTxMsg(props.txType, props.tx, props.type)
     );
   }
 

--- a/apps/extension/src/provider/Namada.ts
+++ b/apps/extension/src/provider/Namada.ts
@@ -30,7 +30,7 @@ export class Namada implements INamada {
   constructor(
     private readonly _version: string,
     protected readonly requester?: MessageRequester
-  ) { }
+  ) {}
 
   public async connect(): Promise<void> {
     return await this.requester?.sendMessage(

--- a/apps/extension/src/provider/Signer.ts
+++ b/apps/extension/src/provider/Signer.ts
@@ -28,7 +28,7 @@ import {
 } from "@namada/types";
 
 export class Signer implements ISigner {
-  constructor(private readonly _namada: Namada) {}
+  constructor(private readonly _namada: Namada) { }
 
   public async accounts(): Promise<Account[] | undefined> {
     return (await this._namada.accounts())?.map(
@@ -80,22 +80,28 @@ export class Signer implements ISigner {
   private async submitTx<T extends Schema, Args>(
     txType: SupportedTx,
     constructor: new (args: Args) => T,
-    args: Args,
+    args: Args[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void> {
-    const msgValue = new constructor(args);
-    const msg = new Message<T>();
-    const encoded = msg.encode(msgValue);
+    const tx = args.map((arg) => {
+      const msgValue = new constructor(arg);
+      const msg = new Message<T>();
+      const encoded = msg.encode(msgValue);
 
-    const txMsgValue = new TxMsgValue(txArgs);
-    const txMsg = new Message<TxMsgValue>();
-    const txEncoded = txMsg.encode(txMsgValue);
+      const txMsgValue = new TxMsgValue(txArgs);
+      const txMsg = new Message<TxMsgValue>();
+      const txEncoded = txMsg.encode(txMsgValue);
+
+      return {
+        specificMsg: toBase64(encoded),
+        txMsg: toBase64(txEncoded),
+      };
+    });
 
     return await this._namada.submitTx({
       txType,
-      specificMsg: toBase64(encoded),
-      txMsg: toBase64(txEncoded),
+      tx,
       type,
     });
   }
@@ -104,7 +110,7 @@ export class Signer implements ISigner {
    * Submit bond transaction
    */
   public async submitBond(
-    args: BondProps,
+    args: BondProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void> {
@@ -115,7 +121,7 @@ export class Signer implements ISigner {
    * Submit unbond transaction
    */
   public async submitUnbond(
-    args: UnbondProps,
+    args: UnbondProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void> {
@@ -126,7 +132,7 @@ export class Signer implements ISigner {
    * Submit withdraw transaction
    */
   public async submitWithdraw(
-    args: WithdrawProps,
+    args: WithdrawProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void> {
@@ -137,7 +143,7 @@ export class Signer implements ISigner {
    * Submit vote proposal transaction
    */
   public async submitVoteProposal(
-    args: VoteProposalProps,
+    args: VoteProposalProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void> {
@@ -154,7 +160,7 @@ export class Signer implements ISigner {
    * Submit a transfer
    */
   public async submitTransfer(
-    args: TransferProps,
+    args: TransferProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void> {
@@ -165,7 +171,7 @@ export class Signer implements ISigner {
    * Submit an ibc transfer
    */
   public async submitIbcTransfer(
-    args: IbcTransferProps,
+    args: IbcTransferProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void> {
@@ -182,7 +188,7 @@ export class Signer implements ISigner {
    * Submit an eth bridge transfer
    */
   public async submitEthBridgeTransfer(
-    args: EthBridgeTransferProps,
+    args: EthBridgeTransferProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void> {

--- a/apps/extension/src/provider/Signer.ts
+++ b/apps/extension/src/provider/Signer.ts
@@ -28,7 +28,7 @@ import {
 } from "@namada/types";
 
 export class Signer implements ISigner {
-  constructor(private readonly _namada: Namada) { }
+  constructor(private readonly _namada: Namada) {}
 
   public async accounts(): Promise<Account[] | undefined> {
     return (await this._namada.accounts())?.map(
@@ -80,11 +80,11 @@ export class Signer implements ISigner {
   private async submitTx<T extends Schema, Args>(
     txType: SupportedTx,
     constructor: new (args: Args) => T,
-    args: Args[],
+    args: Args | Args[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void> {
-    const tx = args.map((arg) => {
+    const tx = (args instanceof Array ? args : [args]).map((arg) => {
       const msgValue = new constructor(arg);
       const msg = new Message<T>();
       const encoded = msg.encode(msgValue);
@@ -110,7 +110,7 @@ export class Signer implements ISigner {
    * Submit bond transaction
    */
   public async submitBond(
-    args: BondProps[],
+    args: BondProps | BondProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void> {
@@ -121,7 +121,7 @@ export class Signer implements ISigner {
    * Submit unbond transaction
    */
   public async submitUnbond(
-    args: UnbondProps[],
+    args: UnbondProps | UnbondProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void> {
@@ -132,7 +132,7 @@ export class Signer implements ISigner {
    * Submit withdraw transaction
    */
   public async submitWithdraw(
-    args: WithdrawProps[],
+    args: WithdrawProps | WithdrawProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void> {
@@ -143,7 +143,7 @@ export class Signer implements ISigner {
    * Submit vote proposal transaction
    */
   public async submitVoteProposal(
-    args: VoteProposalProps[],
+    args: VoteProposalProps | VoteProposalProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void> {
@@ -160,7 +160,7 @@ export class Signer implements ISigner {
    * Submit a transfer
    */
   public async submitTransfer(
-    args: TransferProps[],
+    args: TransferProps | TransferProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void> {
@@ -171,7 +171,7 @@ export class Signer implements ISigner {
    * Submit an ibc transfer
    */
   public async submitIbcTransfer(
-    args: IbcTransferProps[],
+    args: IbcTransferProps | IbcTransferProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void> {
@@ -188,7 +188,7 @@ export class Signer implements ISigner {
    * Submit an eth bridge transfer
    */
   public async submitEthBridgeTransfer(
-    args: EthBridgeTransferProps[],
+    args: EthBridgeTransferProps | EthBridgeTransferProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void> {

--- a/apps/extension/src/provider/messages.ts
+++ b/apps/extension/src/provider/messages.ts
@@ -98,7 +98,7 @@ export class GetChainMsg extends Message<Chain> {
     super();
   }
 
-  validate(): void { }
+  validate(): void {}
 
   route(): string {
     return Route.Chains;
@@ -178,7 +178,7 @@ export class ShieldedSyncMsg extends Message<void> {
     super();
   }
 
-  validate(): void { }
+  validate(): void {}
 
   route(): string {
     return Route.KeyRing;

--- a/apps/extension/src/provider/messages.ts
+++ b/apps/extension/src/provider/messages.ts
@@ -5,6 +5,7 @@ import {
   DerivedAccount,
   SignatureResponse,
 } from "@namada/types";
+import { PendingTx } from "background/approvals";
 import { Message } from "router";
 import { validateProps } from "utils";
 
@@ -97,7 +98,7 @@ export class GetChainMsg extends Message<Chain> {
     super();
   }
 
-  validate(): void {}
+  validate(): void { }
 
   route(): string {
     return Route.Chains;
@@ -177,7 +178,7 @@ export class ShieldedSyncMsg extends Message<void> {
     super();
   }
 
-  validate(): void {}
+  validate(): void { }
 
   route(): string {
     return Route.KeyRing;
@@ -219,15 +220,14 @@ export class ApproveTxMsg extends Message<void> {
 
   constructor(
     public readonly txType: SupportedTx,
-    public readonly txMsg: string,
-    public readonly specificMsg: string,
+    public readonly tx: PendingTx[],
     public readonly accountType: AccountType
   ) {
     super();
   }
 
   validate(): void {
-    validateProps(this, ["txType", "txMsg", "specificMsg", "accountType"]);
+    validateProps(this, ["txType", "tx", "accountType"]);
   }
 
   route(): string {

--- a/apps/extension/src/utils/index.ts
+++ b/apps/extension/src/utils/index.ts
@@ -1,9 +1,7 @@
 import { v5 as uuid } from "uuid";
 import browser from "webextension-polyfill";
 
-import { Message, SignatureMsgValue, TxMsgValue, TxProps } from "@namada/types";
 import { Result } from "@namada/utils";
-import { ISignature } from "@zondax/ledger-namada";
 
 /**
  * Query the current extension tab and close it
@@ -37,45 +35,9 @@ export const generateId = (
   return uuid(args.join(":"), namespace);
 };
 
-/**
- * Convert ISignature into serialized and encoded signature
- */
-export const encodeSignature = (sig: ISignature): Uint8Array => {
-  const {
-    pubkey,
-    raw_indices,
-    raw_signature,
-    wrapper_indices,
-    wrapper_signature,
-  } = sig;
-
-  /* eslint-disable */
-  const props = {
-    pubkey: new Uint8Array((pubkey as any).data),
-    rawIndices: new Uint8Array((raw_indices as any).data),
-    rawSignature: new Uint8Array((raw_signature as any).data),
-    wrapperIndices: new Uint8Array((wrapper_indices as any).data),
-    wrapperSignature: new Uint8Array((wrapper_signature as any).data),
-  };
-  /* eslint-enable */
-
-  const value = new SignatureMsgValue(props);
-  const msg = new Message<SignatureMsgValue>();
-  return msg.encode(value);
-};
-
-/**
- * Helper to encode Tx given TxProps
- */
-export const encodeTx = (tx: TxProps): Uint8Array => {
-  const txMsgValue = new TxMsgValue(tx);
-  const msg = new Message<TxMsgValue>();
-  return msg.encode(txMsgValue);
-};
-
 export const validateProps = <T>(object: T, props: (keyof T)[]): void => {
   props.forEach((prop) => {
-    if (!object[prop]) {
+    if (typeof object[prop] === "undefined") {
       throw new Error(`${String(prop)} was not provided!`);
     }
   });
@@ -91,14 +53,13 @@ export type PrivateKeyError =
 export const validatePrivateKey = (
   privateKey: string
 ): Result<null, PrivateKeyError> =>
-  privateKey.length > PRIVATE_KEY_MAX_LENGTH
-    ? Result.err({ t: "TooLong", maxLength: PRIVATE_KEY_MAX_LENGTH })
-    : !/^[0-9a-f]*$/.test(privateKey)
-      ? Result.err({ t: "BadCharacter" })
+  privateKey.length > PRIVATE_KEY_MAX_LENGTH ?
+    Result.err({ t: "TooLong", maxLength: PRIVATE_KEY_MAX_LENGTH })
+    : !/^[0-9a-f]*$/.test(privateKey) ? Result.err({ t: "BadCharacter" })
       : Result.ok(null);
 
 // Remove prefix from private key, which may be present when exporting keys from CLI
 export const filterPrivateKeyPrefix = (privateKey: string): string =>
-  privateKey.length === PRIVATE_KEY_MAX_LENGTH + 2
-    ? privateKey.replace(/^00/, "")
+  privateKey.length === PRIVATE_KEY_MAX_LENGTH + 2 ?
+    privateKey.replace(/^00/, "")
     : privateKey;

--- a/apps/namada-interface/src/App/Proposals/ProposalDetails.tsx
+++ b/apps/namada-interface/src/App/Proposals/ProposalDetails.tsx
@@ -86,11 +86,13 @@ export const ProposalDetails = (props: ProposalDetailsProps): JSX.Element => {
       const proposal = maybeProposal.value;
 
       await signer.submitVoteProposal(
-        {
-          signer: maybeActiveDelegator.value,
-          vote: voteStr,
-          proposalId: BigInt(proposal.id),
-        },
+        [
+          {
+            signer: maybeActiveDelegator.value,
+            vote: voteStr,
+            proposalId: BigInt(proposal.id),
+          },
+        ],
         {
           token: Tokens.NAM.address || "",
           feeAmount: new BigNumber(0),

--- a/apps/namada-interface/src/App/Proposals/ProposalDetails.tsx
+++ b/apps/namada-interface/src/App/Proposals/ProposalDetails.tsx
@@ -86,13 +86,11 @@ export const ProposalDetails = (props: ProposalDetailsProps): JSX.Element => {
       const proposal = maybeProposal.value;
 
       await signer.submitVoteProposal(
-        [
-          {
-            signer: maybeActiveDelegator.value,
-            vote: voteStr,
-            proposalId: BigInt(proposal.id),
-          },
-        ],
+        {
+          signer: maybeActiveDelegator.value,
+          vote: voteStr,
+          proposalId: BigInt(proposal.id),
+        },
         {
           token: Tokens.NAM.address || "",
           feeAmount: new BigNumber(0),

--- a/apps/namada-interface/src/App/Token/TokenSend/TokenSendForm.tsx
+++ b/apps/namada-interface/src/App/Token/TokenSend/TokenSendForm.tsx
@@ -22,7 +22,7 @@ import {
 
 const {
   NAMADA_INTERFACE_NAMADA_TOKEN:
-    tokenAddress = "tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e",
+  tokenAddress = "tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e",
 } = process.env;
 
 export const submitTransferTransaction = async (
@@ -68,7 +68,7 @@ export const submitTransferTransaction = async (
     memo,
   };
 
-  await signer.submitTransfer(transferArgs, txArgs, type);
+  await signer.submitTransfer([transferArgs], txArgs, type);
 };
 
 type Props = {

--- a/apps/namada-interface/src/App/Token/TokenSend/TokenSendForm.tsx
+++ b/apps/namada-interface/src/App/Token/TokenSend/TokenSendForm.tsx
@@ -22,7 +22,7 @@ import {
 
 const {
   NAMADA_INTERFACE_NAMADA_TOKEN:
-  tokenAddress = "tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e",
+    tokenAddress = "tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e",
 } = process.env;
 
 export const submitTransferTransaction = async (
@@ -68,7 +68,7 @@ export const submitTransferTransaction = async (
     memo,
   };
 
-  await signer.submitTransfer([transferArgs], txArgs, type);
+  await signer.submitTransfer(transferArgs, txArgs, type);
 };
 
 type Props = {

--- a/apps/namada-interface/src/slices/StakingAndGovernance/actions.ts
+++ b/apps/namada-interface/src/slices/StakingAndGovernance/actions.ts
@@ -260,6 +260,7 @@ export const postNewBonding = createAsyncThunk<
   const { type, publicKey } = account.details;
 
   await signer.submitBond(
+    // TODO: Interface should allow multiple Bond Tx
     [{
       source,
       validator,
@@ -310,6 +311,7 @@ export const postNewUnbonding = createAsyncThunk<
   } = derived[id][source];
 
   await signer.submitUnbond(
+    // TODO: Interface should allow multiple Unbond Tx
     [{
       source,
       validator,
@@ -353,6 +355,7 @@ export const postNewWithdraw = createAsyncThunk<
     } = derived[id][owner];
 
     await signer.submitWithdraw(
+      // TODO: Interface should allow multiple Withdraw Tx
       [{
         source: owner,
         validator: validatorId,

--- a/apps/namada-interface/src/slices/StakingAndGovernance/actions.ts
+++ b/apps/namada-interface/src/slices/StakingAndGovernance/actions.ts
@@ -26,7 +26,7 @@ import {
 
 const {
   NAMADA_INTERFACE_NAMADA_TOKEN:
-    tokenAddress = "tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e",
+  tokenAddress = "tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e",
 } = process.env;
 
 const toValidator = (address: string): Validator => ({
@@ -53,9 +53,9 @@ const toMyValidators = (
     index == -1
       ? (arr: MyValidators[]) => arr
       : (arr: MyValidators[], idx: number) => [
-          ...arr.slice(0, idx),
-          ...arr.slice(idx + 1),
-        ];
+        ...arr.slice(0, idx),
+        ...arr.slice(idx + 1),
+      ];
 
   const stakedAmount = new BigNumber(stake).plus(
     new BigNumber(v?.stakedAmount || 0)
@@ -260,12 +260,12 @@ export const postNewBonding = createAsyncThunk<
   const { type, publicKey } = account.details;
 
   await signer.submitBond(
-    {
+    [{
       source,
       validator,
       amount: new BigNumber(amount),
       nativeToken: nativeToken || tokenAddress,
-    },
+    }],
     {
       token: nativeToken || tokenAddress,
       feeAmount: gasPrice,
@@ -310,11 +310,11 @@ export const postNewUnbonding = createAsyncThunk<
   } = derived[id][source];
 
   await signer.submitUnbond(
-    {
+    [{
       source,
       validator,
       amount: new BigNumber(amount),
-    },
+    }],
     {
       token: nativeToken || tokenAddress,
       feeAmount: gasPrice,
@@ -353,10 +353,10 @@ export const postNewWithdraw = createAsyncThunk<
     } = derived[id][owner];
 
     await signer.submitWithdraw(
-      {
+      [{
         source: owner,
         validator: validatorId,
-      },
+      }],
       {
         token: nativeToken || tokenAddress,
         feeAmount: gasPrice,

--- a/packages/integrations/src/Namada.ts
+++ b/packages/integrations/src/Namada.ts
@@ -67,13 +67,13 @@ export default class Namada implements Integration<Account, Signer> {
     const signer = this._namada?.getSigner();
     if (props.ibcProps) {
       return await signer?.submitIbcTransfer(
-        [props.ibcProps],
+        props.ibcProps,
         props.txProps,
         type
       );
     } else if (props.bridgeProps) {
       return await signer?.submitEthBridgeTransfer(
-        [props.bridgeProps],
+        props.bridgeProps,
         props.txProps,
         type
       );

--- a/packages/integrations/src/Namada.ts
+++ b/packages/integrations/src/Namada.ts
@@ -15,7 +15,7 @@ import { BridgeProps, Integration } from "./types/Integration";
 export default class Namada implements Integration<Account, Signer> {
   private _namada: WindowWithNamada["namada"] | undefined;
 
-  constructor(public readonly chain: Chain) {}
+  constructor(public readonly chain: Chain) { }
 
   public get instance(): INamada | undefined {
     return this._namada;
@@ -67,13 +67,13 @@ export default class Namada implements Integration<Account, Signer> {
     const signer = this._namada?.getSigner();
     if (props.ibcProps) {
       return await signer?.submitIbcTransfer(
-        props.ibcProps,
+        [props.ibcProps],
         props.txProps,
         type
       );
     } else if (props.bridgeProps) {
       return await signer?.submitEthBridgeTransfer(
-        props.bridgeProps,
+        [props.bridgeProps],
         props.txProps,
         type
       );

--- a/packages/types/src/namada.ts
+++ b/packages/types/src/namada.ts
@@ -6,8 +6,10 @@ export type TxMsgProps = {
   //TODO: figure out if we can make it better
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   txType: any;
-  specificMsg: string;
-  txMsg: string;
+  tx: {
+    specificMsg: string;
+    txMsg: string;
+  }[];
   type: AccountType;
 };
 

--- a/packages/types/src/signer.ts
+++ b/packages/types/src/signer.ts
@@ -24,37 +24,37 @@ export interface Signer {
   ) => Promise<SignatureResponse | undefined>;
   verify: (publicKey: string, hash: string, signature: string) => Promise<void>;
   submitBond(
-    args: BondProps[],
+    args: BondProps | BondProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void>;
   submitUnbond(
-    args: UnbondProps[],
+    args: UnbondProps | UnbondProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void>;
   submitWithdraw(
-    args: WithdrawProps[],
+    args: WithdrawProps | WithdrawProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void>;
   submitTransfer(
-    args: TransferProps[],
+    args: TransferProps | TransferProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void>;
   submitIbcTransfer(
-    args: IbcTransferProps[],
+    args: IbcTransferProps | IbcTransferProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void>;
   submitVoteProposal(
-    args: VoteProposalProps[],
+    args: VoteProposalProps | VoteProposalProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void>;
   submitEthBridgeTransfer(
-    args: EthBridgeTransferProps[],
+    args: EthBridgeTransferProps | EthBridgeTransferProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void>;

--- a/packages/types/src/signer.ts
+++ b/packages/types/src/signer.ts
@@ -24,37 +24,37 @@ export interface Signer {
   ) => Promise<SignatureResponse | undefined>;
   verify: (publicKey: string, hash: string, signature: string) => Promise<void>;
   submitBond(
-    args: BondProps,
+    args: BondProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void>;
   submitUnbond(
-    args: UnbondProps,
+    args: UnbondProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void>;
   submitWithdraw(
-    args: WithdrawProps,
+    args: WithdrawProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void>;
   submitTransfer(
-    args: TransferProps,
+    args: TransferProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void>;
   submitIbcTransfer(
-    args: IbcTransferProps,
+    args: IbcTransferProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void>;
   submitVoteProposal(
-    args: VoteProposalProps,
+    args: VoteProposalProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void>;
   submitEthBridgeTransfer(
-    args: EthBridgeTransferProps,
+    args: EthBridgeTransferProps[],
     txArgs: TxProps,
     type: AccountType
   ): Promise<void>;


### PR DESCRIPTION
Relates to #677 

- [x] Add support to the Requester to obtain these details via a query
- [x] Implement for all current Tx and remove query params from Approvals popup
- [x] Update storage to support  multiple Tx per `msgId`
- [x] Signer provider should accept either single or multiple Tx

_NOTE_ A follow-up PR will provide the interface changes to submit multiple Staking Tx

_NOTE_ Approval styles are still a bit wonky, this will be addressed in the follow-up PR to match designs

### Testing

Testing this PR is simple: We need to ensure all Tx approvals/submission/events works as expected, as there isn't a way currently in the interface to invoke multiple Tx (will address in a separate PR). 