### PR TITLE
Feat: staking rewards

### DIFF
--- a/apps/extension/src/background/approvals/service.test.ts
+++ b/apps/extension/src/background/approvals/service.test.ts
@@ -4,6 +4,7 @@ import { TxType } from "@namada/sdk/web";
 import {
   AccountType,
   BondMsgValue,
+  ClaimRewardsMsgValue,
   EthBridgeTransferMsgValue,
   IbcTransferMsgValue,
   TokenInfo,
@@ -496,6 +497,37 @@ describe("approvals service", () => {
     });
   });
 
+  describe("getParamsClaimRewards", () => {
+    it("should return claim rewards params", () => {
+      const claimRewardsMsgValue = new ClaimRewardsMsgValue({
+        source: "source",
+        validator: "validator",
+      });
+
+      const txMsgValue = {
+        token: "token",
+        feeAmount: BigNumber(0.5),
+        gasLimit: BigNumber(0.5),
+        chainId: "chainId",
+        publicKey: "publicKey",
+      };
+
+      jest.spyOn(borsh, "deserialize").mockReturnValue(claimRewardsMsgValue);
+
+      const params = ApprovalsService.getParamsClaimRewards(
+        new Uint8Array([]),
+        txMsgValue
+      );
+
+      expect(params).toEqual({
+        source: claimRewardsMsgValue.source,
+        validator: claimRewardsMsgValue.validator,
+        publicKey: txMsgValue.publicKey,
+        nativeToken: txMsgValue.token,
+      });
+    });
+  });
+
   describe("getParamsVoteProposal", () => {
     it("should return vote proposal params", () => {
       const voteProposalMsgValue = new VoteProposalMsgValue({
@@ -544,6 +576,7 @@ describe("approvals service", () => {
     [TxType.IBCTransfer, "submitIbcTransfer"],
     [TxType.EthBridgeTransfer, "submitEthBridgeTransfer"],
     [TxType.VoteProposal, "submitVoteProposal"],
+    [TxType.ClaimRewards, "submitClaimRewards"],
   ] as const;
 
   describe("submitTx", () => {

--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -9,6 +9,7 @@ import { KVStore } from "@namada/storage";
 import {
   AccountType,
   BondMsgValue,
+  ClaimRewardsMsgValue,
   EthBridgeTransferMsgValue,
   IbcTransferMsgValue,
   SignatureResponse,
@@ -136,21 +137,16 @@ export class ApprovalsService {
     const specificMsgBuffer = Buffer.from(fromBase64(specificMsg));
 
     const getParams =
-      txType === TxType.Bond
-        ? ApprovalsService.getParamsBond
-        : txType === TxType.Unbond
-          ? ApprovalsService.getParamsUnbond
-          : txType === TxType.Withdraw
-            ? ApprovalsService.getParamsWithdraw
-            : txType === TxType.Transfer
-              ? ApprovalsService.getParamsTransfer
-              : txType === TxType.IBCTransfer
-                ? ApprovalsService.getParamsIbcTransfer
-                : txType === TxType.EthBridgeTransfer
-                  ? ApprovalsService.getParamsEthBridgeTransfer
-                  : txType === TxType.VoteProposal
-                    ? ApprovalsService.getParamsVoteProposal
-                    : assertNever(txType);
+      txType === TxType.Bond ? ApprovalsService.getParamsBond
+      : txType === TxType.Unbond ? ApprovalsService.getParamsUnbond
+      : txType === TxType.Withdraw ? ApprovalsService.getParamsWithdraw
+      : txType === TxType.Transfer ? ApprovalsService.getParamsTransfer
+      : txType === TxType.IBCTransfer ? ApprovalsService.getParamsIbcTransfer
+      : txType === TxType.EthBridgeTransfer ?
+        ApprovalsService.getParamsEthBridgeTransfer
+      : txType === TxType.VoteProposal ? ApprovalsService.getParamsVoteProposal
+      : txType === TxType.ClaimRewards ? ApprovalsService.getParamsClaimRewards
+      : assertNever(txType);
 
     const baseUrl = `${browser.runtime.getURL(
       "approvals.html"
@@ -285,6 +281,21 @@ export class ApprovalsService {
     };
   };
 
+  static getParamsClaimRewards: GetParams = (specificMsg, txDetails) => {
+    const specificDetails = deserialize(specificMsg, ClaimRewardsMsgValue);
+
+    const { source, validator } = specificDetails;
+
+    const { publicKey, nativeToken } = ApprovalsService.getTxDetails(txDetails);
+
+    return {
+      source,
+      validator,
+      publicKey,
+      nativeToken,
+    };
+  };
+
   static getParamsVoteProposal: GetParams = (specificMsg, txDetails) => {
     const specificDetails = deserialize(specificMsg, VoteProposalMsgValue);
 
@@ -317,21 +328,16 @@ export class ApprovalsService {
     const { txType, specificMsg, txMsg } = tx;
 
     const submitFn =
-      txType === TxType.Bond
-        ? this.keyRingService.submitBond
-        : txType === TxType.Unbond
-          ? this.keyRingService.submitUnbond
-          : txType === TxType.Transfer
-            ? this.keyRingService.submitTransfer
-            : txType === TxType.IBCTransfer
-              ? this.keyRingService.submitIbcTransfer
-              : txType === TxType.EthBridgeTransfer
-                ? this.keyRingService.submitEthBridgeTransfer
-                : txType === TxType.Withdraw
-                  ? this.keyRingService.submitWithdraw
-                  : txType === TxType.VoteProposal
-                    ? this.keyRingService.submitVoteProposal
-                    : assertNever(txType);
+      txType === TxType.Bond ? this.keyRingService.submitBond
+      : txType === TxType.Unbond ? this.keyRingService.submitUnbond
+      : txType === TxType.Transfer ? this.keyRingService.submitTransfer
+      : txType === TxType.IBCTransfer ? this.keyRingService.submitIbcTransfer
+      : txType === TxType.EthBridgeTransfer ?
+        this.keyRingService.submitEthBridgeTransfer
+      : txType === TxType.Withdraw ? this.keyRingService.submitWithdraw
+      : txType === TxType.VoteProposal ? this.keyRingService.submitVoteProposal
+      : txType === TxType.ClaimRewards ? this.keyRingService.submitClaimRewards
+      : assertNever(txType);
 
     await submitFn.call(this.keyRingService, specificMsg, txMsg, msgId);
 

--- a/apps/extension/src/provider/Signer.ts
+++ b/apps/extension/src/provider/Signer.ts
@@ -6,6 +6,8 @@ import {
   AccountType,
   BondMsgValue,
   BondProps,
+  ClaimRewardsMsgValue,
+  ClaimRewardsProps,
   EthBridgeTransferMsgValue,
   EthBridgeTransferProps,
   Signer as ISigner,
@@ -131,6 +133,23 @@ export class Signer implements ISigner {
     type: AccountType
   ): Promise<void> {
     return this.submitTx(TxType.Withdraw, WithdrawMsgValue, args, txArgs, type);
+  }
+
+  /**
+   * Submit claim rewards transaction
+   */
+  public async submitClaimRewards(
+    args: ClaimRewardsProps,
+    txArgs: TxProps,
+    type: AccountType
+  ): Promise<void> {
+    return this.submitTx(
+      TxType.ClaimRewards,
+      ClaimRewardsMsgValue,
+      args,
+      txArgs,
+      type
+    );
   }
 
   /**

--- a/packages/sdk/src/tx/tx.ts
+++ b/packages/sdk/src/tx/tx.ts
@@ -2,6 +2,8 @@ import { Sdk as SdkWasm, TxType } from "@namada/shared";
 import {
   BondMsgValue,
   BondProps,
+  ClaimRewardsMsgValue,
+  ClaimRewardsProps,
   EthBridgeTransferMsgValue,
   EthBridgeTransferProps,
   IbcTransferMsgValue,
@@ -80,6 +82,12 @@ export class Tx {
         return await this.buildWithdraw(
           txProps,
           props as WithdrawProps,
+          gasPayer
+        );
+      case TxType.ClaimRewards:
+        return await this.buildClaimRewards(
+          txProps,
+          props as ClaimRewardsProps,
           gasPayer
         );
       case TxType.RevealPK:
@@ -235,6 +243,33 @@ export class Tx {
       encodedWithdraw,
       encodedTx,
       gasPayer || withdrawProps.source
+    );
+  }
+
+  /**
+   * Build Claim Rewards Tx
+   * @async
+   * @param txProps - properties of the transaction
+   * @param claimRewardsProps - properties of the claim rewards tx
+   * @param [gasPayer] - optional gas payer, if not provided, defaults to claimRewardsProps.source
+   * @returns promise that resolves to an EncodedTx
+   */
+  async buildClaimRewards(
+    txProps: TxProps,
+    claimRewardsProps: ClaimRewardsProps,
+    gasPayer?: string
+  ): Promise<EncodedTx> {
+    const bondMsg = new Message<ClaimRewardsProps>();
+    const encodedTx = this.encodeTxArgs(txProps);
+    const encodedClaimRewards = bondMsg.encode(
+      new ClaimRewardsMsgValue(claimRewardsProps)
+    );
+
+    return this.buildTxFromSerializedArgs(
+      TxType.ClaimRewards,
+      encodedClaimRewards,
+      encodedTx,
+      gasPayer || claimRewardsProps.source
     );
   }
 

--- a/packages/shared/lib/src/sdk/mod.rs
+++ b/packages/shared/lib/src/sdk/mod.rs
@@ -19,8 +19,9 @@ use namada::sdk::masp::{DefaultLogger, ShieldedContext};
 use namada::sdk::rpc::query_epoch;
 use namada::sdk::signing::{find_key_by_pk, SigningTxData};
 use namada::sdk::tx::{
-    build_bond, build_ibc_transfer, build_reveal_pk, build_transfer, build_unbond,
-    build_vote_proposal, build_withdraw, is_reveal_pk_needed, process_tx,
+    build_bond, build_ibc_transfer, build_reveal_pk, build_transfer,
+    build_unbond, build_vote_proposal, build_withdraw, build_claim_rewards,
+    is_reveal_pk_needed, process_tx,
 };
 use namada::sdk::wallet::{Store, Wallet};
 use namada::sdk::{Namada, NamadaImpl};
@@ -43,6 +44,7 @@ pub enum TxType {
     EthBridgeTransfer = 6,
     RevealPK = 7,
     VoteProposal = 8,
+    ClaimRewards = 9,
 }
 
 #[wasm_bindgen]
@@ -274,6 +276,8 @@ impl Sdk {
                 self.build_vote_proposal(specific_msg, tx_msg, Some(gas_payer))
                     .await?
             }
+            TxType::ClaimRewards =>
+                self.build_claim_rewards(specific_msg, tx_msg).await?,
         };
 
         Ok(tx)
@@ -421,6 +425,17 @@ impl Sdk {
     ) -> Result<BuiltTx, JsError> {
         let args = tx::withdraw_tx_args(withdraw_msg, tx_msg)?;
         let (tx, signing_data) = build_withdraw(&self.namada, &args).await?;
+
+        Ok(BuiltTx { tx, signing_data })
+    }
+
+    pub async fn build_claim_rewards(
+        &mut self,
+        claim_rewards_msg: &[u8],
+        tx_msg: &[u8],
+    ) -> Result<BuiltTx, JsError> {
+        let args = tx::claim_rewards_tx_args(claim_rewards_msg, tx_msg)?;
+        let (tx, signing_data) = build_claim_rewards(&self.namada, &args).await?;
 
         Ok(BuiltTx { tx, signing_data })
     }

--- a/packages/shared/lib/src/sdk/tx.rs
+++ b/packages/shared/lib/src/sdk/tx.rs
@@ -155,6 +155,42 @@ pub fn withdraw_tx_args(withdraw_msg: &[u8], tx_msg: &[u8]) -> Result<args::With
 
 #[derive(BorshSerialize, BorshDeserialize)]
 #[borsh(crate = "namada::core::borsh")]
+pub struct SubmitClaimRewardsMsg {
+    source: String,
+    validator: String,
+}
+
+/// Maps serialized tx_msg into ClaimRewardsTx args.
+///
+/// # Arguments
+///
+/// * `tx_msg` - Borsh serialized tx_msg.
+///
+/// # Errors
+///
+/// Returns JsError if the tx_msg can't be deserialized or
+/// Rust structs can't be created.
+pub fn claim_rewards_tx_args(claim_rewards_msg: &[u8], tx_msg: &[u8]) -> Result<args::ClaimRewards, JsError> {
+    let claim_rewards_msg = SubmitClaimRewardsMsg::try_from_slice(claim_rewards_msg)?;
+
+    let SubmitClaimRewardsMsg { source, validator } = claim_rewards_msg;
+
+    let source = Address::from_str(&source)?;
+    let validator = Address::from_str(&validator)?;
+    let tx = tx_msg_into_args(tx_msg)?;
+
+    let args = args::ClaimRewards {
+        tx,
+        validator,
+        source: Some(source),
+        tx_code_path: PathBuf::from("tx_claim_rewards.wasm"),
+    };
+
+    Ok(args)
+}
+
+#[derive(BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "namada::core::borsh")]
 pub struct SubmitVoteProposalMsg {
     signer: String,
     proposal_id: u64,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -9,6 +9,7 @@ export type SupportedTx = Extract<
   | TxType.EthBridgeTransfer
   | TxType.Withdraw
   | TxType.VoteProposal
+  | TxType.ClaimRewards
 >;
 
 export type TxLabel =
@@ -19,7 +20,8 @@ export type TxLabel =
   | "Add to Eth Bridge Pool"
   | "Withdraw"
   | "RevealPK"
-  | "Vote Proposal";
+  | "Vote Proposal"
+  | "Claim Rewards";
 
 export const TxTypeLabel: Record<TxType, TxLabel> = {
   [TxType.Bond]: "Bond",
@@ -30,6 +32,7 @@ export const TxTypeLabel: Record<TxType, TxLabel> = {
   [TxType.EthBridgeTransfer]: "Add to Eth Bridge Pool",
   [TxType.RevealPK]: "RevealPK",
   [TxType.VoteProposal]: "Vote Proposal",
+  [TxType.ClaimRewards]: "Claim Rewards",
 };
 
 type TransferToEthereumKind = "Erc20" | "Nut";

--- a/packages/types/src/tx/schema/claimRewards.ts
+++ b/packages/types/src/tx/schema/claimRewards.ts
@@ -1,0 +1,15 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { field } from "@dao-xyz/borsh";
+import { ClaimRewardsProps } from "../types";
+
+export class ClaimRewardsMsgValue {
+  @field({ type: "string" })
+  source!: string;
+
+  @field({ type: "string" })
+  validator!: string;
+
+  constructor(data: ClaimRewardsProps) {
+    Object.assign(this, data);
+  }
+}

--- a/packages/types/src/tx/schema/index.ts
+++ b/packages/types/src/tx/schema/index.ts
@@ -1,4 +1,5 @@
 export * from "./bond";
+export * from "./claimRewards";
 export * from "./ethBridgeTransfer";
 export * from "./ibcTransfer";
 export * from "./signature";
@@ -10,6 +11,7 @@ export * from "./voteProposal";
 export * from "./withdraw";
 
 import { BondMsgValue } from "./bond";
+import { ClaimRewardsMsgValue } from "./claimRewards";
 import { EthBridgeTransferMsgValue } from "./ethBridgeTransfer";
 import { IbcTransferMsgValue } from "./ibcTransfer";
 import { SignatureMsgValue } from "./signature";
@@ -27,5 +29,6 @@ export type Schema =
   | UnbondMsgValue
   | VoteProposalMsgValue
   | WithdrawMsgValue
+  | ClaimRewardsMsgValue
   | TransferMsgValue
   | TxMsgValue;

--- a/packages/types/src/tx/types.ts
+++ b/packages/types/src/tx/types.ts
@@ -1,5 +1,6 @@
 import {
   BondMsgValue,
+  ClaimRewardsMsgValue,
   EthBridgeTransferMsgValue,
   IbcTransferMsgValue,
   SignatureMsgValue,
@@ -14,6 +15,7 @@ export type TxProps = TxMsgValue;
 export type BondProps = BondMsgValue;
 export type UnbondProps = UnbondMsgValue;
 export type WithdrawProps = WithdrawMsgValue;
+export type ClaimRewardsProps = ClaimRewardsMsgValue;
 export type TransferProps = TransferMsgValue;
 export type EthBridgeTransferProps = EthBridgeTransferMsgValue;
 export type SignatureProps = SignatureMsgValue;


### PR DESCRIPTION
Adds support for querying and claiming rewards.

I used `BigNumber` as a return type in the SDK, but I'm not sure whether we would rather have that as `string` to stick to non-library TypeScript types.

Closes #679.

---

### Added
- Add ability to submit claim rewards TX
- Add SDK method to query available rewards
<!--

Make sure you have read CONTRIBUTING.md before submitting a pull request!

-->
