### PR TITLE
WIP: feat/744: Refactoring provider to accept props

### DIFF
--- a/apps/extension/src/Approvals/Approvals.tsx
+++ b/apps/extension/src/Approvals/Approvals.tsx
@@ -4,9 +4,9 @@ import { Route, Routes } from "react-router-dom";
 import { TxType } from "@heliax/namada-sdk/web";
 import { Container } from "@namada/components";
 
+import { TxMsgProps } from "@namada/types";
 import { AppHeader } from "App/Common/AppHeader";
 import { TopLevelRoute } from "Approvals/types";
-import { PendingTxDetails } from "background/approvals";
 import { ApproveConnection } from "./ApproveConnection";
 import { ApproveSignature } from "./ApproveSignature";
 import { ApproveTx } from "./ApproveTx/ApproveTx";
@@ -23,7 +23,7 @@ export enum Status {
 export type ApprovalDetails = {
   msgId: string;
   txType: TxType;
-  tx: PendingTxDetails[];
+  tx: TxMsgProps;
 };
 
 export type SignatureDetails = {

--- a/apps/extension/src/Approvals/ApproveTx/ApproveTx.tsx
+++ b/apps/extension/src/Approvals/ApproveTx/ApproveTx.tsx
@@ -4,15 +4,18 @@ import { useNavigate } from "react-router-dom";
 import { TxType, TxTypeLabel } from "@heliax/namada-sdk/web";
 import { ActionButton, Alert, Stack } from "@namada/components";
 import { useSanitizedParams } from "@namada/hooks";
-import { AccountType, Tokens } from "@namada/types";
+import {
+  AccountType,
+  BondProps,
+  RedelegateProps,
+  Tokens,
+  TransferProps,
+  TxMsgProps,
+} from "@namada/types";
 import { shortenAddress } from "@namada/utils";
 import { ApprovalDetails } from "Approvals/Approvals";
 import { TopLevelRoute } from "Approvals/types";
-import {
-  PendingTxDetails,
-  QueryPendingTxMsg,
-  RejectTxMsg,
-} from "background/approvals";
+import { QueryPendingTxMsg, RejectTxMsg } from "background/approvals";
 import { ExtensionRequester } from "extension";
 import { useRequester } from "hooks/useRequester";
 import { Ports } from "router";
@@ -26,7 +29,7 @@ type Props = {
 const fetchPendingTxDetails = async (
   requester: ExtensionRequester,
   msgId: string
-): Promise<PendingTxDetails[] | void> => {
+): Promise<TxMsgProps> => {
   return await requester.sendMessage(
     Ports.Background,
     new QueryPendingTxMsg(msgId)
@@ -91,17 +94,19 @@ export const ApproveTx: React.FC<Props> = ({ details, setDetails }) => {
         <strong>{TxTypeLabel[txType as TxType]}</strong> transaction?
       </Alert>
       <Stack gap={2}>
-        {details?.tx.map((txDetails, i) => {
+        {details?.tx.txProps.map((txDetails, i) => {
+          // Destructure possible details to display
+          // TODO: This should be improved!
           const {
             amount,
             source,
             target,
-            publicKey,
-            tokenAddress,
-            validator,
-            sourceValidator,
-            destinationValidator,
-          } = txDetails || {};
+            token: tokenAddress,
+          } = (txDetails as TransferProps) || {};
+          const { publicKey } = details.tx.wrapperTxProps;
+          const { validator } = (txDetails as BondProps) || {};
+          const { sourceValidator, destinationValidator } =
+            (txDetails as RedelegateProps) || {};
 
           const tokenType =
             Object.values(Tokens).find(

--- a/apps/extension/src/Approvals/ApproveTx/ConfirmLedgerTx.tsx
+++ b/apps/extension/src/Approvals/ApproveTx/ConfirmLedgerTx.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import { TxType, TxTypeLabel } from "@heliax/namada-sdk/web";
 import { ActionButton, Alert, Stack } from "@namada/components";
-import { Message, TxMsgValue, TxProps } from "@namada/types";
+import { Message, TransferProps, TxMsgValue, TxProps } from "@namada/types";
 import { LedgerError } from "@zondax/ledger-namada";
 import { ApprovalDetails, Status } from "Approvals/Approvals";
 import { QueryPublicKeyMsg } from "background/keyring";
@@ -32,7 +32,9 @@ export const ConfirmLedgerTx: React.FC<Props> = ({ details }) => {
   const [status, setStatus] = useState<Status>();
   const [statusInfo, setStatusInfo] = useState("");
   const { msgId, txType } = details || {};
-  const { source, publicKey, nativeToken } = details?.tx[0] || {};
+  const props = (details?.tx.txProps[0] as TransferProps) || {};
+  const source = props.source || "";
+  const { token: nativeToken, publicKey } = details?.tx.wrapperTxProps || {};
 
   useEffect(() => {
     if (status === Status.Completed) {

--- a/apps/extension/src/background/approvals/handler.test.ts
+++ b/apps/extension/src/background/approvals/handler.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { TxType } from "@heliax/namada-sdk/web";
-import { AccountType } from "@namada/types";
+import { AccountType, TransferProps } from "@namada/types";
+import BigNumber from "bignumber.js";
 import createMockInstance from "jest-create-mock-instance";
 import {
   ApproveConnectInterfaceMsg,
@@ -48,16 +49,23 @@ describe("approvals handler", () => {
       requestInteraction: () => {},
     };
 
-    const approveTxMsg = new ApproveTxMsg(
-      TxType.Bond,
-      [
+    const approveTxMsg = new ApproveTxMsg({
+      txType: TxType.Transfer,
+      wrapperTxProps: {
+        chainId: "",
+        token: "",
+        feeAmount: BigNumber(0),
+        gasLimit: BigNumber(1000),
+      },
+      txProps: [
         {
-          txMsg: "txMsg",
-          specificMsg: "specificMsg",
-        },
+          source: "",
+          target: "",
+          amount: BigNumber(0),
+        } as TransferProps,
       ],
-      AccountType.Mnemonic
-    );
+      type: AccountType.Mnemonic,
+    });
     handler(env, approveTxMsg);
     expect(service.approveTx).toBeCalled();
 

--- a/apps/extension/src/background/approvals/handler.ts
+++ b/apps/extension/src/background/approvals/handler.ts
@@ -75,8 +75,8 @@ export const getHandler: (service: ApprovalsService) => Handler = (service) => {
 const handleApproveTxMsg: (
   service: ApprovalsService
 ) => InternalHandler<ApproveTxMsg> = (service) => {
-  return async (_, { txType, tx, accountType }) => {
-    return await service.approveTx(txType, tx, accountType);
+  return async (_, { props }) => {
+    return await service.approveTx(props);
   };
 };
 

--- a/apps/extension/src/background/approvals/messages.ts
+++ b/apps/extension/src/background/approvals/messages.ts
@@ -2,8 +2,8 @@ import { SupportedTx } from "@heliax/namada-sdk/web";
 import { Message } from "router";
 import { ROUTE } from "./constants";
 
+import { TxMsgProps } from "@namada/types";
 import { validateProps } from "utils";
-import { PendingTxDetails } from "./types";
 
 export enum MessageType {
   RejectTx = "reject-tx",
@@ -62,7 +62,7 @@ export class SubmitApprovedTxMsg extends Message<void> {
   }
 }
 
-export class QueryPendingTxMsg extends Message<PendingTxDetails[]> {
+export class QueryPendingTxMsg extends Message<TxMsgProps> {
   public static type(): MessageType {
     return MessageType.QueryPendingTx;
   }

--- a/apps/extension/src/background/approvals/service.test.ts
+++ b/apps/extension/src/background/approvals/service.test.ts
@@ -285,7 +285,7 @@ describe("approvals service", () => {
       try {
         const res = await service.approveTx(fakeTransfer);
         expect(res).toBeUndefined();
-      } catch (e) { }
+      } catch (e) {}
     });
   });
 

--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -32,7 +32,6 @@ type GetParams = (
   txDetails: TxMsgValue
 ) => Record<string, string>;
 
-
 // const getParamsMethod = (txType: SupportedTx): GetParams =>
 //   txType === TxType.Bond ? ApprovalsService.getParamsBond
 //   : txType === TxType.Unbond ? ApprovalsService.getParamsUnbond
@@ -343,11 +342,12 @@ export class ApprovalsService {
           : txType === TxType.VoteProposal ?
             this.keyRingService.submitVoteProposal
           : txType === TxType.Redelegate ? this.keyRingService.submitRedelegate
-          : assertNever(txType);
+            // TODO: Why is txType "any" here?
+          : assertNever(txType as never);
 
         // TODO: Encode message based on type!
-        const specificMsg = "";
-        const txMsg = "";
+        const specificMsg = "specificMsg";
+        const txMsg = "txMsg";
 
         await submitFn.call(this.keyRingService, specificMsg, txMsg, msgId);
       })

--- a/apps/extension/src/background/approvals/types.ts
+++ b/apps/extension/src/background/approvals/types.ts
@@ -17,4 +17,5 @@ export type PendingTxDetails = {
   target?: string;
   publicKey?: string;
   validator?: string;
+  nativeToken?: string;
 };

--- a/apps/extension/src/background/approvals/types.ts
+++ b/apps/extension/src/background/approvals/types.ts
@@ -1,16 +1,20 @@
 import { SupportedTx } from "@heliax/namada-sdk/web";
+import { SupportedTxProps, TxMsgProps } from "@namada/types";
 
 export type ApprovedOriginsStore = string[];
 
-export type PendingTx = {
-  txMsg: string;
-  specificMsg: string;
-};
-
-export type TxStore = {
+export type PendingTx = SupportedTxProps;
+export type TxStore = TxMsgProps & {
+  // Override "any" from @namada/types
   txType: SupportedTx;
-  tx: PendingTx[];
 };
 
-// TODO: Add specific types here!
-export type PendingTxDetails = Record<string, string>;
+// TODO: Remove this! We should return all details to approvals for the "data" inspection feature
+export type PendingTxDetails = {
+  amount: string;
+  tokenAddress: string;
+  source?: string;
+  target?: string;
+  publicKey?: string;
+  validator?: string;
+};

--- a/apps/extension/src/provider/Namada.ts
+++ b/apps/extension/src/provider/Namada.ts
@@ -136,7 +136,7 @@ export class Namada implements INamada {
   public async submitTx(props: TxMsgProps): Promise<void> {
     return await this.requester?.sendMessage(
       Ports.Background,
-      new ApproveTxMsg(props.txType, props.tx, props.type)
+      new ApproveTxMsg(props)
     );
   }
 

--- a/apps/extension/src/provider/Signer.ts
+++ b/apps/extension/src/provider/Signer.ts
@@ -1,31 +1,20 @@
-import { toBase64 } from "@cosmjs/encoding";
 import { SupportedTx, TxType } from "@heliax/namada-sdk/web";
 import { chains } from "@namada/chains";
 import {
   Account,
   AccountType,
-  BondMsgValue,
   BondProps,
-  EthBridgeTransferMsgValue,
   EthBridgeTransferProps,
   Signer as ISigner,
-  IbcTransferMsgValue,
   IbcTransferProps,
-  Message,
   Namada,
-  RedelegateMsgValue,
   RedelegateProps,
-  Schema,
   SignatureResponse,
-  TransferMsgValue,
+  SupportedTxProps,
   TransferProps,
-  TxMsgValue,
   TxProps,
-  UnbondMsgValue,
   UnbondProps,
-  VoteProposalMsgValue,
   VoteProposalProps,
-  WithdrawMsgValue,
   WithdrawProps,
 } from "@namada/types";
 
@@ -79,31 +68,17 @@ export class Signer implements ISigner {
     return await this._namada.verify({ publicKey, hash, signature });
   }
 
-  private async submitTx<T extends Schema, Args>(
+  private async submitTx(
     txType: SupportedTx,
-    constructor: new (args: Args) => T,
-    args: Args | Args[],
-    txArgs: TxProps,
+    txProps: SupportedTxProps | SupportedTxProps[],
+    wrapperTxProps: TxProps,
     type: AccountType
   ): Promise<void> {
-    const tx = (args instanceof Array ? args : [args]).map((arg) => {
-      const msgValue = new constructor(arg);
-      const msg = new Message<T>();
-      const encoded = msg.encode(msgValue);
-
-      const txMsgValue = new TxMsgValue(txArgs);
-      const txMsg = new Message<TxMsgValue>();
-      const txEncoded = txMsg.encode(txMsgValue);
-
-      return {
-        specificMsg: toBase64(encoded),
-        txMsg: toBase64(txEncoded),
-      };
-    });
-
+    const tx = txProps instanceof Array ? txProps : [txProps];
     return await this._namada.submitTx({
       txType,
-      tx,
+      wrapperTxProps,
+      txProps: tx,
       type,
     });
   }
@@ -112,48 +87,47 @@ export class Signer implements ISigner {
    * Submit bond transaction
    */
   public async submitBond(
-    args: BondProps | BondProps[],
-    txArgs: TxProps,
+    txProps: BondProps | BondProps[],
+    wrapperTxProps: TxProps,
     type: AccountType
   ): Promise<void> {
-    return this.submitTx(TxType.Bond, BondMsgValue, args, txArgs, type);
+    return this.submitTx(TxType.Bond, txProps, wrapperTxProps, type);
   }
 
   /**
    * Submit unbond transaction
    */
   public async submitUnbond(
-    args: UnbondProps | UnbondProps[],
-    txArgs: TxProps,
+    txProps: UnbondProps | UnbondProps[],
+    wrapperTxProps: TxProps,
     type: AccountType
   ): Promise<void> {
-    return this.submitTx(TxType.Unbond, UnbondMsgValue, args, txArgs, type);
+    return this.submitTx(TxType.Unbond, txProps, wrapperTxProps, type);
   }
 
   /**
    * Submit withdraw transaction
    */
   public async submitWithdraw(
-    args: WithdrawProps | WithdrawProps[],
-    txArgs: TxProps,
+    txProps: WithdrawProps | WithdrawProps[],
+    wrapperTxProps: TxProps,
     type: AccountType
   ): Promise<void> {
-    return this.submitTx(TxType.Withdraw, WithdrawMsgValue, args, txArgs, type);
+    return this.submitTx(TxType.Withdraw, txProps, wrapperTxProps, type);
   }
 
   /**
    * Submit redelegate transaction
    */
   public async submitRedelegate(
-    args: RedelegateProps | RedelegateProps[],
-    txArgs: TxProps,
+    txProps: RedelegateProps | RedelegateProps[],
+    wrapperTxProps: TxProps,
     type: AccountType
   ): Promise<void> {
     return this.submitTx(
       TxType.Redelegate,
-      RedelegateMsgValue,
-      args,
-      txArgs,
+      txProps,
+      wrapperTxProps,
       type
     );
   }
@@ -162,60 +136,47 @@ export class Signer implements ISigner {
    * Submit vote proposal transaction
    */
   public async submitVoteProposal(
-    args: VoteProposalProps | VoteProposalProps[],
-    txArgs: TxProps,
+    txProps: VoteProposalProps | VoteProposalProps[],
+    wrapperTxProps: TxProps,
     type: AccountType
   ): Promise<void> {
-    return this.submitTx(
-      TxType.VoteProposal,
-      VoteProposalMsgValue,
-      args,
-      txArgs,
-      type
-    );
+    return this.submitTx(TxType.VoteProposal, txProps, wrapperTxProps, type);
   }
 
   /**
    * Submit a transfer
    */
   public async submitTransfer(
-    args: TransferProps | TransferProps[],
-    txArgs: TxProps,
+    txProps: TransferProps | TransferProps[],
+    wrapperTxProps: TxProps,
     type: AccountType
   ): Promise<void> {
-    return this.submitTx(TxType.Transfer, TransferMsgValue, args, txArgs, type);
+    return this.submitTx(TxType.Transfer, txProps, wrapperTxProps, type);
   }
 
   /**
    * Submit an ibc transfer
    */
   public async submitIbcTransfer(
-    args: IbcTransferProps | IbcTransferProps[],
-    txArgs: TxProps,
+    txProps: IbcTransferProps | IbcTransferProps[],
+    wrapperTxProps: TxProps,
     type: AccountType
   ): Promise<void> {
-    return this.submitTx(
-      TxType.IBCTransfer,
-      IbcTransferMsgValue,
-      args,
-      txArgs,
-      type
-    );
+    return this.submitTx(TxType.IBCTransfer, txProps, wrapperTxProps, type);
   }
 
   /**
    * Submit an eth bridge transfer
    */
   public async submitEthBridgeTransfer(
-    args: EthBridgeTransferProps | EthBridgeTransferProps[],
-    txArgs: TxProps,
+    txProps: EthBridgeTransferProps | EthBridgeTransferProps[],
+    wrapperTxProps: TxProps,
     type: AccountType
   ): Promise<void> {
     return this.submitTx(
       TxType.EthBridgeTransfer,
-      EthBridgeTransferMsgValue,
-      args,
-      txArgs,
+      txProps,
+      wrapperTxProps,
       type
     );
   }

--- a/apps/extension/src/provider/messages.ts
+++ b/apps/extension/src/provider/messages.ts
@@ -1,11 +1,9 @@
-import type { SupportedTx } from "@heliax/namada-sdk/web";
 import {
-  AccountType,
   Chain,
   DerivedAccount,
   SignatureResponse,
+  TxMsgProps,
 } from "@namada/types";
-import { PendingTx } from "background/approvals";
 import { Message } from "router";
 import { validateProps } from "utils";
 
@@ -218,16 +216,12 @@ export class ApproveTxMsg extends Message<void> {
     return MessageType.ApproveTx;
   }
 
-  constructor(
-    public readonly txType: SupportedTx,
-    public readonly tx: PendingTx[],
-    public readonly accountType: AccountType
-  ) {
+  constructor(public readonly props: TxMsgProps) {
     super();
   }
 
   validate(): void {
-    validateProps(this, ["txType", "tx", "accountType"]);
+    validateProps(this, ["props"]);
   }
 
   route(): string {

--- a/packages/types/src/namada.ts
+++ b/packages/types/src/namada.ts
@@ -1,15 +1,32 @@
 import { AccountType, DerivedAccount } from "./account";
 import { Chain } from "./chain";
 import { SignatureResponse, Signer } from "./signer";
+import {
+  BondProps,
+  EthBridgeTransferProps,
+  IbcTransferProps,
+  TransferProps,
+  TxProps,
+  UnbondProps,
+  VoteProposalProps,
+  WithdrawProps,
+} from "./tx";
+
+export type SupportedTxProps =
+  | TransferProps
+  | BondProps
+  | UnbondProps
+  | WithdrawProps
+  | EthBridgeTransferProps
+  | IbcTransferProps
+  | VoteProposalProps;
 
 export type TxMsgProps = {
   //TODO: figure out if we can make it better
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   txType: any;
-  tx: {
-    specificMsg: string;
-    txMsg: string;
-  }[];
+  wrapperTxProps: TxProps;
+  txProps: SupportedTxProps[];
   type: AccountType;
 };
 

--- a/packages/types/src/namada.ts
+++ b/packages/types/src/namada.ts
@@ -5,6 +5,7 @@ import {
   BondProps,
   EthBridgeTransferProps,
   IbcTransferProps,
+  RedelegateProps,
   TransferProps,
   TxProps,
   UnbondProps,
@@ -19,7 +20,8 @@ export type SupportedTxProps =
   | WithdrawProps
   | EthBridgeTransferProps
   | IbcTransferProps
-  | VoteProposalProps;
+  | VoteProposalProps
+  | RedelegateProps;
 
 export type TxMsgProps = {
   //TODO: figure out if we can make it better

--- a/packages/types/src/signer.ts
+++ b/packages/types/src/signer.ts
@@ -24,38 +24,38 @@ export interface Signer {
   ) => Promise<SignatureResponse | undefined>;
   verify: (publicKey: string, hash: string, signature: string) => Promise<void>;
   submitBond(
-    args: BondProps | BondProps[],
-    txArgs: TxProps,
+    txProps: BondProps | BondProps[],
+    wrapperTxProps: TxProps,
     type: AccountType
   ): Promise<void>;
   submitUnbond(
-    args: UnbondProps | UnbondProps[],
-    txArgs: TxProps,
+    txProps: UnbondProps | UnbondProps[],
+    wrapperTxProps: TxProps,
     type: AccountType
   ): Promise<void>;
   submitWithdraw(
-    args: WithdrawProps | WithdrawProps[],
-    txArgs: TxProps,
+    txProps: WithdrawProps | WithdrawProps[],
+    wrapperTxProps: TxProps,
     type: AccountType
   ): Promise<void>;
   submitTransfer(
-    args: TransferProps | TransferProps[],
-    txArgs: TxProps,
+    txProps: TransferProps | TransferProps[],
+    wrapperTxProps: TxProps,
     type: AccountType
   ): Promise<void>;
   submitIbcTransfer(
-    args: IbcTransferProps | IbcTransferProps[],
-    txArgs: TxProps,
+    txProps: IbcTransferProps | IbcTransferProps[],
+    wrapperTxProps: TxProps,
     type: AccountType
   ): Promise<void>;
   submitVoteProposal(
-    args: VoteProposalProps | VoteProposalProps[],
-    txArgs: TxProps,
+    txProps: VoteProposalProps | VoteProposalProps[],
+    wrapperTxProps: TxProps,
     type: AccountType
   ): Promise<void>;
   submitEthBridgeTransfer(
-    args: EthBridgeTransferProps | EthBridgeTransferProps[],
-    txArgs: TxProps,
+    txProps: EthBridgeTransferProps | EthBridgeTransferProps[],
+    wrapperTxProps: TxProps,
     type: AccountType
   ): Promise<void>;
 }

--- a/packages/types/src/signer.ts
+++ b/packages/types/src/signer.ts
@@ -3,6 +3,7 @@ import {
   BondProps,
   EthBridgeTransferProps,
   IbcTransferProps,
+  RedelegateProps,
   TransferProps,
   TxProps,
   UnbondProps,
@@ -35,6 +36,11 @@ export interface Signer {
   ): Promise<void>;
   submitWithdraw(
     txProps: WithdrawProps | WithdrawProps[],
+    wrapperTxProps: TxProps,
+    type: AccountType
+  ): Promise<void>;
+  submitRedelegate(
+    txProps: RedelegateProps | RedelegateProps[],
     wrapperTxProps: TxProps,
     type: AccountType
   ): Promise<void>;


### PR DESCRIPTION
Partially resolves #744 

As the extension will take responsibility of memo and fees, I'm moving the serialization of the tx data provided by the interface to just before the tx is submitted. This will allows us to append any info the user specifies in the approval process, as well as enable us to display the `data` of the Tx, as this will also allow querying for all tx details within the extension.

- [x] Provider should pass props into the extension instead of serialized data
- [x] Stored tx should keep all unserialized data of the tx
- [ ] The `QueryPendingTx` message should return the entirety of the stored Tx so that we may display props for `View data </>` (later PR)
- [ ] Before submitting the Tx, serialize so that it may be parsed in Rust

Immediately following this PR, Memo & Fees UI will be added to the extension.