### PR TITLE
feat/750: Add Redelegate Tx to SDK shared & js packages

### DIFF
--- a/apps/extension/src/Approvals/ApproveTx/ApproveTx.tsx
+++ b/apps/extension/src/Approvals/ApproveTx/ApproveTx.tsx
@@ -92,8 +92,17 @@ export const ApproveTx: React.FC<Props> = ({ details, setDetails }) => {
       </Alert>
       <Stack gap={2}>
         {details?.tx.map((txDetails, i) => {
-          const { amount, source, target, publicKey, tokenAddress, validator } =
-            txDetails || {};
+          const {
+            amount,
+            source,
+            target,
+            publicKey,
+            tokenAddress,
+            validator,
+            sourceValidator,
+            destinationValidator,
+          } = txDetails || {};
+
           const tokenType =
             Object.values(Tokens).find(
               (token) => token.address === tokenAddress
@@ -125,6 +134,16 @@ export const ApproveTx: React.FC<Props> = ({ details, setDetails }) => {
               {validator && (
                 <p className="text-xs">
                   Validator: {shortenAddress(validator)}
+                </p>
+              )}
+              {sourceValidator && (
+                <p className="text-xs">
+                  Source Validator: {shortenAddress(sourceValidator)}
+                </p>
+              )}
+              {destinationValidator && (
+                <p className="text-xs">
+                  Destination Validator: {shortenAddress(destinationValidator)}
                 </p>
               )}
             </div>

--- a/apps/extension/src/provider/Signer.ts
+++ b/apps/extension/src/provider/Signer.ts
@@ -13,6 +13,8 @@ import {
   IbcTransferProps,
   Message,
   Namada,
+  RedelegateMsgValue,
+  RedelegateProps,
   Schema,
   SignatureResponse,
   TransferMsgValue,
@@ -137,6 +139,23 @@ export class Signer implements ISigner {
     type: AccountType
   ): Promise<void> {
     return this.submitTx(TxType.Withdraw, WithdrawMsgValue, args, txArgs, type);
+  }
+
+  /**
+   * Submit redelegate transaction
+   */
+  public async submitRedelegate(
+    args: RedelegateProps | RedelegateProps[],
+    txArgs: TxProps,
+    type: AccountType
+  ): Promise<void> {
+    return this.submitTx(
+      TxType.Redelegate,
+      RedelegateMsgValue,
+      args,
+      txArgs,
+      type
+    );
   }
 
   /**

--- a/packages/sdk/docs/classes/Crypto.md
+++ b/packages/sdk/docs/classes/Crypto.md
@@ -40,7 +40,7 @@ Class Crypto handles AES encryption tasks
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/crypto/crypto.ts#L20)
+[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/crypto/crypto.ts#L20)
 
 ## Properties
 
@@ -52,7 +52,7 @@ WebAssembly Memory for crypto
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/crypto/crypto.ts#L20)
+[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/crypto/crypto.ts#L20)
 
 ## Methods
 
@@ -75,7 +75,7 @@ decrypted text
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:115](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/crypto/crypto.ts#L115)
+[sdk/src/crypto/crypto.ts:115](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/crypto/crypto.ts#L115)
 
 ___
 
@@ -100,7 +100,7 @@ crypto record
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:61](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/crypto/crypto.ts#L61)
+[sdk/src/crypto/crypto.ts:61](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/crypto/crypto.ts#L61)
 
 ___
 
@@ -126,7 +126,7 @@ array of encrypted bytes
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:98](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/crypto/crypto.ts#L98)
+[sdk/src/crypto/crypto.ts:98](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/crypto/crypto.ts#L98)
 
 ___
 
@@ -153,7 +153,7 @@ crypto record used for storage
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:30](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/crypto/crypto.ts#L30)
+[sdk/src/crypto/crypto.ts:30](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/crypto/crypto.ts#L30)
 
 ___
 
@@ -178,4 +178,4 @@ encryption parameters
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:73](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/crypto/crypto.ts#L73)
+[sdk/src/crypto/crypto.ts:73](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/crypto/crypto.ts#L73)

--- a/packages/sdk/docs/classes/EncodedTx.md
+++ b/packages/sdk/docs/classes/EncodedTx.md
@@ -41,7 +41,7 @@ Create an EncodedTx class
 
 #### Defined in
 
-[sdk/src/tx/types.ts:12](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/types.ts#L12)
+[sdk/src/tx/types.ts:12](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/types.ts#L12)
 
 ## Properties
 
@@ -53,7 +53,7 @@ Specific tx struct instance
 
 #### Defined in
 
-[sdk/src/tx/types.ts:14](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/types.ts#L14)
+[sdk/src/tx/types.ts:14](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/types.ts#L14)
 
 ___
 
@@ -65,7 +65,7 @@ Borsh-serialized transaction
 
 #### Defined in
 
-[sdk/src/tx/types.ts:13](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/types.ts#L13)
+[sdk/src/tx/types.ts:13](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/types.ts#L13)
 
 ## Methods
 
@@ -81,7 +81,7 @@ Clear tx bytes resource
 
 #### Defined in
 
-[sdk/src/tx/types.ts:31](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/types.ts#L31)
+[sdk/src/tx/types.ts:31](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/types.ts#L31)
 
 ___
 
@@ -100,4 +100,4 @@ Serialized tx bytes
 
 #### Defined in
 
-[sdk/src/tx/types.ts:22](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/types.ts#L22)
+[sdk/src/tx/types.ts:22](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/types.ts#L22)

--- a/packages/sdk/docs/classes/Ledger.md
+++ b/packages/sdk/docs/classes/Ledger.md
@@ -42,7 +42,7 @@ Functionality for interacting with NamadaApp for Ledger Hardware Wallets
 
 #### Defined in
 
-[sdk/src/ledger.ts:54](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/ledger.ts#L54)
+[sdk/src/ledger.ts:54](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/ledger.ts#L54)
 
 ## Properties
 
@@ -54,7 +54,7 @@ Inititalized NamadaApp class from Zondax package
 
 #### Defined in
 
-[sdk/src/ledger.ts:54](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/ledger.ts#L54)
+[sdk/src/ledger.ts:54](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/ledger.ts#L54)
 
 ## Methods
 
@@ -75,7 +75,7 @@ void
 
 #### Defined in
 
-[sdk/src/ledger.ts:176](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/ledger.ts#L176)
+[sdk/src/ledger.ts:176](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/ledger.ts#L176)
 
 ___
 
@@ -102,7 +102,7 @@ Address and public key
 
 #### Defined in
 
-[sdk/src/ledger.ts:97](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/ledger.ts#L97)
+[sdk/src/ledger.ts:97](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/ledger.ts#L97)
 
 ___
 
@@ -123,7 +123,7 @@ Error message if error is found
 
 #### Defined in
 
-[sdk/src/ledger.ts:159](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/ledger.ts#L159)
+[sdk/src/ledger.ts:159](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/ledger.ts#L159)
 
 ___
 
@@ -150,7 +150,7 @@ Address and public key
 
 #### Defined in
 
-[sdk/src/ledger.ts:118](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/ledger.ts#L118)
+[sdk/src/ledger.ts:118](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/ledger.ts#L118)
 
 ___
 
@@ -178,7 +178,7 @@ Response signature
 
 #### Defined in
 
-[sdk/src/ledger.ts:144](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/ledger.ts#L144)
+[sdk/src/ledger.ts:144](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/ledger.ts#L144)
 
 ___
 
@@ -199,7 +199,7 @@ Version and info of NamadaApp
 
 #### Defined in
 
-[sdk/src/ledger.ts:80](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/ledger.ts#L80)
+[sdk/src/ledger.ts:80](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/ledger.ts#L80)
 
 ___
 
@@ -225,4 +225,4 @@ Ledger class instance
 
 #### Defined in
 
-[sdk/src/ledger.ts:62](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/ledger.ts#L62)
+[sdk/src/ledger.ts:62](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/ledger.ts#L62)

--- a/packages/sdk/docs/classes/Masp.md
+++ b/packages/sdk/docs/classes/Masp.md
@@ -16,7 +16,9 @@ Class representing utilities related to MASP
 
 ### Methods
 
+- [addDefaultPaymentAddress](Masp.md#adddefaultpaymentaddress)
 - [addSpendingKey](Masp.md#addspendingkey)
+- [addViewingKey](Masp.md#addviewingkey)
 - [fetchAndStoreMaspParams](Masp.md#fetchandstoremaspparams)
 - [hasMaspParams](Masp.md#hasmaspparams)
 - [loadMaspParams](Masp.md#loadmaspparams)
@@ -39,7 +41,7 @@ Class representing utilities related to MASP
 
 #### Defined in
 
-[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/masp.ts#L10)
+[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/masp.ts#L10)
 
 ## Properties
 
@@ -51,9 +53,36 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/masp.ts#L10)
+[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/masp.ts#L10)
 
 ## Methods
+
+### addDefaultPaymentAddress
+
+▸ **addDefaultPaymentAddress**(`xvk`, `alias`): `Promise`\<`void`\>
+
+Add payment address to SDK wallet
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `xvk` | `string` | Extended viewing key |
+| `alias` | `string` | Alias for the key |
+
+#### Returns
+
+`Promise`\<`void`\>
+
+void
+
+**`Async`**
+
+#### Defined in
+
+[sdk/src/masp.ts:69](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/masp.ts#L69)
+
+___
 
 ### addSpendingKey
 
@@ -78,7 +107,34 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:47](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/masp.ts#L47)
+[sdk/src/masp.ts:47](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/masp.ts#L47)
+
+___
+
+### addViewingKey
+
+▸ **addViewingKey**(`xvk`, `alias`): `Promise`\<`void`\>
+
+Add viewing key to SDK wallet
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `xvk` | `string` | extended viewing key |
+| `alias` | `string` | alias for the key |
+
+#### Returns
+
+`Promise`\<`void`\>
+
+void
+
+**`Async`**
+
+#### Defined in
+
+[sdk/src/masp.ts:58](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/masp.ts#L58)
 
 ___
 
@@ -98,7 +154,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:26](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/masp.ts#L26)
+[sdk/src/masp.ts:26](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/masp.ts#L26)
 
 ___
 
@@ -118,7 +174,7 @@ True if MASP parameters are loaded
 
 #### Defined in
 
-[sdk/src/masp.ts:17](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/masp.ts#L17)
+[sdk/src/masp.ts:17](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/masp.ts#L17)
 
 ___
 
@@ -144,4 +200,4 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:36](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/masp.ts#L36)
+[sdk/src/masp.ts:36](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/masp.ts#L36)

--- a/packages/sdk/docs/classes/Mnemonic.md
+++ b/packages/sdk/docs/classes/Mnemonic.md
@@ -38,7 +38,7 @@ Class for accessing mnemonic functionality from wasm
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/mnemonic.ts#L18)
+[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/mnemonic.ts#L18)
 
 ## Properties
 
@@ -50,7 +50,7 @@ Memory accessor for crypto lib
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/mnemonic.ts#L18)
+[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/mnemonic.ts#L18)
 
 ## Methods
 
@@ -76,7 +76,7 @@ Promise that resolves to array of words
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:26](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/mnemonic.ts#L26)
+[sdk/src/mnemonic.ts:26](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/mnemonic.ts#L26)
 
 ___
 
@@ -101,7 +101,7 @@ Seed bytes
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:44](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/mnemonic.ts#L44)
+[sdk/src/mnemonic.ts:44](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/mnemonic.ts#L44)
 
 ___
 
@@ -131,4 +131,4 @@ Object with validation result and error message if invalid
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:62](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/mnemonic.ts#L62)
+[sdk/src/mnemonic.ts:62](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/mnemonic.ts#L62)

--- a/packages/sdk/docs/classes/Rpc.md
+++ b/packages/sdk/docs/classes/Rpc.md
@@ -51,7 +51,7 @@ API for executing RPC requests with Namada
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:31](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/rpc.ts#L31)
+[sdk/src/rpc/rpc.ts:31](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/rpc.ts#L31)
 
 ## Properties
 
@@ -63,7 +63,7 @@ Instance of Query struct from wasm lib
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:33](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/rpc.ts#L33)
+[sdk/src/rpc/rpc.ts:33](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/rpc.ts#L33)
 
 ___
 
@@ -75,7 +75,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:32](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/rpc.ts#L32)
+[sdk/src/rpc/rpc.ts:32](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/rpc.ts#L32)
 
 ## Methods
 
@@ -101,7 +101,7 @@ void
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:210](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/rpc.ts#L210)
+[sdk/src/rpc/rpc.ts:210](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/rpc.ts#L210)
 
 ___
 
@@ -121,7 +121,7 @@ Array of all validator addresses
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:73](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/rpc.ts#L73)
+[sdk/src/rpc/rpc.ts:73](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/rpc.ts#L73)
 
 ___
 
@@ -148,7 +148,7 @@ Query balances from chain
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:43](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/rpc.ts#L43)
+[sdk/src/rpc/rpc.ts:43](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/rpc.ts#L43)
 
 ___
 
@@ -174,7 +174,7 @@ Promise resolving to delegators votes
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:108](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/rpc.ts#L108)
+[sdk/src/rpc/rpc.ts:108](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/rpc.ts#L108)
 
 ___
 
@@ -194,7 +194,7 @@ Query gas costs
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:200](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/rpc.ts#L200)
+[sdk/src/rpc/rpc.ts:200](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/rpc.ts#L200)
 
 ___
 
@@ -214,7 +214,7 @@ Address of native token
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:52](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/rpc.ts#L52)
+[sdk/src/rpc/rpc.ts:52](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/rpc.ts#L52)
 
 ___
 
@@ -234,7 +234,7 @@ List of the proposals
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:82](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/rpc.ts#L82)
+[sdk/src/rpc/rpc.ts:82](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/rpc.ts#L82)
 
 ___
 
@@ -261,7 +261,7 @@ String of public key if found
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:63](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/rpc.ts#L63)
+[sdk/src/rpc/rpc.ts:63](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/rpc.ts#L63)
 
 ___
 
@@ -287,7 +287,7 @@ Promise resolving to pending ethereum transfers
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:191](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/rpc.ts#L191)
+[sdk/src/rpc/rpc.ts:191](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/rpc.ts#L191)
 
 ___
 
@@ -313,7 +313,7 @@ Promise resolving to staking positions
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:145](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/rpc.ts#L145)
+[sdk/src/rpc/rpc.ts:145](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/rpc.ts#L145)
 
 ___
 
@@ -339,7 +339,7 @@ Promise resolving to staking totals
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:118](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/rpc.ts#L118)
+[sdk/src/rpc/rpc.ts:118](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/rpc.ts#L118)
 
 ___
 
@@ -363,7 +363,7 @@ Total bonds amount
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:181](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/rpc.ts#L181)
+[sdk/src/rpc/rpc.ts:181](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/rpc.ts#L181)
 
 ___
 
@@ -390,7 +390,7 @@ Promise resolving to total delegations
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:95](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/rpc.ts#L95)
+[sdk/src/rpc/rpc.ts:95](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/rpc.ts#L95)
 
 ___
 
@@ -414,4 +414,4 @@ Sync the shielded context
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:221](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/rpc.ts#L221)
+[sdk/src/rpc/rpc.ts:221](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/rpc.ts#L221)

--- a/packages/sdk/docs/classes/Sdk.md
+++ b/packages/sdk/docs/classes/Sdk.md
@@ -61,7 +61,7 @@ API for interacting with Namada SDK
 
 #### Defined in
 
-[sdk/src/sdk.ts:23](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/sdk.ts#L23)
+[sdk/src/sdk.ts:23](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/sdk.ts#L23)
 
 ## Properties
 
@@ -73,7 +73,7 @@ Memory accessor for crypto lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:26](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/sdk.ts#L26)
+[sdk/src/sdk.ts:26](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/sdk.ts#L26)
 
 ___
 
@@ -85,7 +85,7 @@ Address of chain's native token
 
 #### Defined in
 
-[sdk/src/sdk.ts:28](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/sdk.ts#L28)
+[sdk/src/sdk.ts:28](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/sdk.ts#L28)
 
 ___
 
@@ -97,7 +97,7 @@ Instance of Query struct from wasm lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:25](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/sdk.ts#L25)
+[sdk/src/sdk.ts:25](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/sdk.ts#L25)
 
 ___
 
@@ -109,7 +109,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:24](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/sdk.ts#L24)
+[sdk/src/sdk.ts:24](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/sdk.ts#L24)
 
 ___
 
@@ -121,7 +121,7 @@ RPC url
 
 #### Defined in
 
-[sdk/src/sdk.ts:27](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/sdk.ts#L27)
+[sdk/src/sdk.ts:27](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/sdk.ts#L27)
 
 ## Accessors
 
@@ -139,7 +139,7 @@ Utilities for encrypting and decrypting data
 
 #### Defined in
 
-[sdk/src/sdk.ts:148](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/sdk.ts#L148)
+[sdk/src/sdk.ts:148](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/sdk.ts#L148)
 
 ___
 
@@ -157,7 +157,7 @@ key-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:124](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/sdk.ts#L124)
+[sdk/src/sdk.ts:124](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/sdk.ts#L124)
 
 ___
 
@@ -175,7 +175,7 @@ Masp utilities for handling params
 
 #### Defined in
 
-[sdk/src/sdk.ts:140](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/sdk.ts#L140)
+[sdk/src/sdk.ts:140](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/sdk.ts#L140)
 
 ___
 
@@ -193,7 +193,7 @@ mnemonic-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:116](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/sdk.ts#L116)
+[sdk/src/sdk.ts:116](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/sdk.ts#L116)
 
 ___
 
@@ -211,7 +211,7 @@ rpc client
 
 #### Defined in
 
-[sdk/src/sdk.ts:100](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/sdk.ts#L100)
+[sdk/src/sdk.ts:100](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/sdk.ts#L100)
 
 ___
 
@@ -229,7 +229,7 @@ Non-Tx signing functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:132](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/sdk.ts#L132)
+[sdk/src/sdk.ts:132](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/sdk.ts#L132)
 
 ___
 
@@ -247,7 +247,7 @@ tx-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:108](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/sdk.ts#L108)
+[sdk/src/sdk.ts:108](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/sdk.ts#L108)
 
 ## Methods
 
@@ -265,7 +265,7 @@ Utilities for encrypting and decrypting data
 
 #### Defined in
 
-[sdk/src/sdk.ts:82](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/sdk.ts#L82)
+[sdk/src/sdk.ts:82](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/sdk.ts#L82)
 
 ___
 
@@ -283,7 +283,7 @@ key-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:58](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/sdk.ts#L58)
+[sdk/src/sdk.ts:58](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/sdk.ts#L58)
 
 ___
 
@@ -301,7 +301,7 @@ Masp utilities for handling params
 
 #### Defined in
 
-[sdk/src/sdk.ts:74](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/sdk.ts#L74)
+[sdk/src/sdk.ts:74](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/sdk.ts#L74)
 
 ___
 
@@ -319,7 +319,7 @@ mnemonic-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:50](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/sdk.ts#L50)
+[sdk/src/sdk.ts:50](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/sdk.ts#L50)
 
 ___
 
@@ -337,7 +337,7 @@ Namada RPC client
 
 #### Defined in
 
-[sdk/src/sdk.ts:34](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/sdk.ts#L34)
+[sdk/src/sdk.ts:34](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/sdk.ts#L34)
 
 ___
 
@@ -355,7 +355,7 @@ Non-Tx signing functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:66](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/sdk.ts#L66)
+[sdk/src/sdk.ts:66](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/sdk.ts#L66)
 
 ___
 
@@ -373,7 +373,7 @@ Tx-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:42](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/sdk.ts#L42)
+[sdk/src/sdk.ts:42](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/sdk.ts#L42)
 
 ___
 
@@ -399,4 +399,4 @@ Class for interacting with NamadaApp for Ledger Hardware Wallets
 
 #### Defined in
 
-[sdk/src/sdk.ts:92](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/sdk.ts#L92)
+[sdk/src/sdk.ts:92](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/sdk.ts#L92)

--- a/packages/sdk/docs/classes/SignedTx.md
+++ b/packages/sdk/docs/classes/SignedTx.md
@@ -34,7 +34,7 @@ Wrap results of tx signing to simplify passing between Sdk functions
 
 #### Defined in
 
-[sdk/src/tx/types.ts:44](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/types.ts#L44)
+[sdk/src/tx/types.ts:44](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/types.ts#L44)
 
 ## Properties
 
@@ -46,7 +46,7 @@ Serialized tx bytes
 
 #### Defined in
 
-[sdk/src/tx/types.ts:48](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/types.ts#L48)
+[sdk/src/tx/types.ts:48](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/types.ts#L48)
 
 ___
 
@@ -58,4 +58,4 @@ Serialized tx msg bytes
 
 #### Defined in
 
-[sdk/src/tx/types.ts:46](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/types.ts#L46)
+[sdk/src/tx/types.ts:46](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/types.ts#L46)

--- a/packages/sdk/docs/classes/Signing.md
+++ b/packages/sdk/docs/classes/Signing.md
@@ -39,7 +39,7 @@ Signing constructor
 
 #### Defined in
 
-[sdk/src/signing.ts:13](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/signing.ts#L13)
+[sdk/src/signing.ts:13](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/signing.ts#L13)
 
 ## Properties
 
@@ -51,7 +51,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/signing.ts:13](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/signing.ts#L13)
+[sdk/src/signing.ts:13](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/signing.ts#L13)
 
 ## Methods
 
@@ -76,7 +76,7 @@ hash and signature
 
 #### Defined in
 
-[sdk/src/signing.ts:21](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/signing.ts#L21)
+[sdk/src/signing.ts:21](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/signing.ts#L21)
 
 ___
 
@@ -102,4 +102,4 @@ void
 
 #### Defined in
 
-[sdk/src/signing.ts:32](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/signing.ts#L32)
+[sdk/src/signing.ts:32](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/signing.ts#L32)

--- a/packages/sdk/docs/classes/Tx.md
+++ b/packages/sdk/docs/classes/Tx.md
@@ -20,6 +20,7 @@ SDK functionality related to transactions
 - [buildBond](Tx.md#buildbond)
 - [buildEthBridgeTransfer](Tx.md#buildethbridgetransfer)
 - [buildIbcTransfer](Tx.md#buildibctransfer)
+- [buildRedelegate](Tx.md#buildredelegate)
 - [buildRevealPk](Tx.md#buildrevealpk)
 - [buildTransfer](Tx.md#buildtransfer)
 - [buildTx](Tx.md#buildtx)
@@ -49,7 +50,7 @@ SDK functionality related to transactions
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:32](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/tx.ts#L32)
+[sdk/src/tx/tx.ts:34](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/tx.ts#L34)
 
 ## Properties
 
@@ -61,7 +62,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:32](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/tx.ts#L32)
+[sdk/src/tx/tx.ts:34](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/tx.ts#L34)
 
 ## Methods
 
@@ -86,7 +87,7 @@ Append signature for transactions signed by Ledger Hardware Wallet
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:354](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/tx.ts#L354)
+[sdk/src/tx/tx.ts:389](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/tx.ts#L389)
 
 ___
 
@@ -114,7 +115,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:174](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/tx.ts#L174)
+[sdk/src/tx/tx.ts:182](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/tx.ts#L182)
 
 ___
 
@@ -142,7 +143,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:276](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/tx.ts#L276)
+[sdk/src/tx/tx.ts:311](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/tx.ts#L311)
 
 ___
 
@@ -170,7 +171,35 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:249](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/tx.ts#L249)
+[sdk/src/tx/tx.ts:284](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/tx.ts#L284)
+
+___
+
+### buildRedelegate
+
+▸ **buildRedelegate**(`txProps`, `redelegateProps`, `gasPayer?`): `Promise`\<[`EncodedTx`](EncodedTx.md)\>
+
+Build Redelegate Tx
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `txProps` | `TxMsgValue` | properties of the transaction |
+| `redelegateProps` | `RedelegateMsgValue` | properties of the redelegate tx |
+| `gasPayer?` | `string` | optional gas payer, if not provided, defaults to redelegateProps.owner |
+
+#### Returns
+
+`Promise`\<[`EncodedTx`](EncodedTx.md)\>
+
+promise that resolves to an EncodedTx
+
+**`Async`**
+
+#### Defined in
+
+[sdk/src/tx/tx.ts:257](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/tx.ts#L257)
 
 ___
 
@@ -197,7 +226,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:155](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/tx.ts#L155)
+[sdk/src/tx/tx.ts:163](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/tx.ts#L163)
 
 ___
 
@@ -225,7 +254,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:128](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/tx.ts#L128)
+[sdk/src/tx/tx.ts:136](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/tx.ts#L136)
 
 ___
 
@@ -254,7 +283,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:68](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/tx.ts#L68)
+[sdk/src/tx/tx.ts:70](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/tx.ts#L70)
 
 ___
 
@@ -283,7 +312,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:43](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/tx.ts#L43)
+[sdk/src/tx/tx.ts:45](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/tx.ts#L45)
 
 ___
 
@@ -311,7 +340,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:199](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/tx.ts#L199)
+[sdk/src/tx/tx.ts:207](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/tx.ts#L207)
 
 ___
 
@@ -339,7 +368,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:303](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/tx.ts#L303)
+[sdk/src/tx/tx.ts:338](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/tx.ts#L338)
 
 ___
 
@@ -367,7 +396,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:224](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/tx.ts#L224)
+[sdk/src/tx/tx.ts:232](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/tx.ts#L232)
 
 ___
 
@@ -391,7 +420,7 @@ Serialized TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:395](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/tx.ts#L395)
+[sdk/src/tx/tx.ts:430](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/tx.ts#L430)
 
 ___
 
@@ -418,7 +447,7 @@ void
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:343](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/tx.ts#L343)
+[sdk/src/tx/tx.ts:378](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/tx.ts#L378)
 
 ___
 
@@ -445,4 +474,4 @@ promise that resolves to a SignedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:329](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/tx/tx.ts#L329)
+[sdk/src/tx/tx.ts:364](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/tx/tx.ts#L364)

--- a/packages/sdk/docs/enums/KdfType.md
+++ b/packages/sdk/docs/enums/KdfType.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:38](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/crypto/types.ts#L38)
+[sdk/src/crypto/types.ts:38](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/crypto/types.ts#L38)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:39](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/crypto/types.ts#L39)
+[sdk/src/crypto/types.ts:39](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/crypto/types.ts#L39)

--- a/packages/sdk/docs/enums/TxType.md
+++ b/packages/sdk/docs/enums/TxType.md
@@ -9,6 +9,7 @@
 - [Bond](TxType.md#bond)
 - [EthBridgeTransfer](TxType.md#ethbridgetransfer)
 - [IBCTransfer](TxType.md#ibctransfer)
+- [Redelegate](TxType.md#redelegate)
 - [RevealPK](TxType.md#revealpk)
 - [Transfer](TxType.md#transfer)
 - [Unbond](TxType.md#unbond)
@@ -44,6 +45,16 @@ ___
 #### Defined in
 
 shared/src/shared/shared.d.ts:21
+
+___
+
+### Redelegate
+
+• **Redelegate** = ``9``
+
+#### Defined in
+
+shared/src/shared/shared.d.ts:25
 
 ___
 

--- a/packages/sdk/docs/modules.md
+++ b/packages/sdk/docs/modules.md
@@ -71,7 +71,7 @@ Address and public key type
 
 #### Defined in
 
-[sdk/src/keys/types.ts:4](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/keys/types.ts#L4)
+[sdk/src/keys/types.ts:4](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/keys/types.ts#L4)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:17](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/ledger.ts#L17)
+[sdk/src/ledger.ts:17](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/ledger.ts#L17)
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:23](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/crypto/types.ts#L23)
+[sdk/src/crypto/types.ts:23](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/crypto/types.ts#L23)
 
 ___
 
@@ -111,7 +111,7 @@ Balance
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:69](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/types.ts#L69)
+[sdk/src/rpc/types.ts:69](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/types.ts#L69)
 
 ___
 
@@ -130,7 +130,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:27](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/types.ts#L27)
+[sdk/src/rpc/types.ts:27](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/types.ts#L27)
 
 ___
 
@@ -158,7 +158,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:42](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/crypto/types.ts#L42)
+[sdk/src/crypto/types.ts:42](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/crypto/types.ts#L42)
 
 ___
 
@@ -171,7 +171,7 @@ Record<address, totalDelegations>
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:51](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/types.ts#L51)
+[sdk/src/rpc/types.ts:51](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/types.ts#L51)
 
 ___
 
@@ -184,7 +184,7 @@ Record<address, boolean>
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:57](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/types.ts#L57)
+[sdk/src/rpc/types.ts:57](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/types.ts#L57)
 
 ___
 
@@ -203,7 +203,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:30](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/crypto/types.ts#L30)
+[sdk/src/crypto/types.ts:30](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/crypto/types.ts#L30)
 
 ___
 
@@ -220,7 +220,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:18](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/ledger.ts#L18)
+[sdk/src/ledger.ts:18](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/ledger.ts#L18)
 
 ___
 
@@ -240,7 +240,7 @@ Shielded keys and address
 
 #### Defined in
 
-[sdk/src/keys/types.ts:19](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/keys/types.ts#L19)
+[sdk/src/keys/types.ts:19](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/keys/types.ts#L19)
 
 ___
 
@@ -257,7 +257,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:42](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/types.ts#L42)
+[sdk/src/rpc/types.ts:42](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/types.ts#L42)
 
 ___
 
@@ -277,7 +277,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:19](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/types.ts#L19)
+[sdk/src/rpc/types.ts:19](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/types.ts#L19)
 
 ___
 
@@ -287,7 +287,7 @@ ___
 
 #### Defined in
 
-[shared/src/types.ts:3](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/shared/src/types.ts#L3)
+[shared/src/types.ts:3](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/shared/src/types.ts#L3)
 
 ___
 
@@ -299,7 +299,7 @@ Public and private keypair with address
 
 #### Defined in
 
-[sdk/src/keys/types.ts:12](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/keys/types.ts#L12)
+[sdk/src/keys/types.ts:12](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/keys/types.ts#L12)
 
 ___
 
@@ -319,7 +319,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:34](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/rpc/types.ts#L34)
+[sdk/src/rpc/types.ts:34](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/rpc/types.ts#L34)
 
 ## Variables
 
@@ -337,7 +337,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:3](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/crypto/types.ts#L3)
+[sdk/src/crypto/types.ts:3](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/crypto/types.ts#L3)
 
 ___
 
@@ -347,7 +347,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:41](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/ledger.ts#L41)
+[sdk/src/ledger.ts:41](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/ledger.ts#L41)
 
 ___
 
@@ -357,7 +357,7 @@ ___
 
 #### Defined in
 
-[shared/src/types.ts:24](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/shared/src/types.ts#L24)
+[shared/src/types.ts:25](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/shared/src/types.ts#L25)
 
 ## Functions
 
@@ -377,7 +377,7 @@ Transport object
 
 #### Defined in
 
-[sdk/src/ledger.ts:37](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/ledger.ts#L37)
+[sdk/src/ledger.ts:37](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/ledger.ts#L37)
 
 ___
 
@@ -397,7 +397,7 @@ Transport object
 
 #### Defined in
 
-[sdk/src/ledger.ts:28](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/ledger.ts#L28)
+[sdk/src/ledger.ts:28](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/ledger.ts#L28)
 
 ___
 
@@ -417,4 +417,4 @@ ___
 
 #### Defined in
 
-[sdk/src/keys/keys.ts:173](https://github.com/anoma/namada-interface/blob/9ed51c8a/packages/sdk/src/keys/keys.ts#L173)
+[sdk/src/keys/keys.ts:173](https://github.com/anoma/namada-interface/blob/b9bf6889/packages/sdk/src/keys/keys.ts#L173)

--- a/packages/sdk/src/tx/tx.ts
+++ b/packages/sdk/src/tx/tx.ts
@@ -7,6 +7,8 @@ import {
   IbcTransferMsgValue,
   IbcTransferProps,
   Message,
+  RedelegateMsgValue,
+  RedelegateProps,
   SignatureMsgValue,
   TransferMsgValue,
   TransferProps,
@@ -80,6 +82,12 @@ export class Tx {
         return await this.buildWithdraw(
           txProps,
           props as WithdrawProps,
+          gasPayer
+        );
+      case TxType.Redelegate:
+        return await this.buildRedelegate(
+          txProps,
+          props as RedelegateProps,
           gasPayer
         );
       case TxType.RevealPK:
@@ -235,6 +243,33 @@ export class Tx {
       encodedWithdraw,
       encodedTx,
       gasPayer || withdrawProps.source
+    );
+  }
+
+  /**
+   * Build Redelegate Tx
+   * @async
+   * @param txProps - properties of the transaction
+   * @param redelegateProps -  properties of the redelegate tx
+   * @param [gasPayer] - optional gas payer, if not provided, defaults to redelegateProps.owner
+   * @returns promise that resolves to an EncodedTx
+   */
+  async buildRedelegate(
+    txProps: TxProps,
+    redelegateProps: RedelegateProps,
+    gasPayer?: string
+  ): Promise<EncodedTx> {
+    const redelegateMsg = new Message<RedelegateMsgValue>();
+    const encodedTx = this.encodeTxArgs(txProps);
+    const encodedRedelegate = redelegateMsg.encode(
+      new RedelegateMsgValue(redelegateProps)
+    );
+
+    return await this.buildTxFromSerializedArgs(
+      TxType.Redelegate,
+      encodedRedelegate,
+      encodedTx,
+      gasPayer || redelegateProps.owner
     );
   }
 

--- a/packages/shared/lib/src/sdk/tx.rs
+++ b/packages/shared/lib/src/sdk/tx.rs
@@ -41,6 +41,7 @@ pub struct SubmitBondMsg {
 ///
 /// # Arguments
 ///
+/// * `bond_msg` - Borsh serialized bond_msg.
 /// * `tx_msg` - Borsh serialized tx_msg.
 ///
 /// # Errors
@@ -85,6 +86,7 @@ pub struct SubmitUnbondMsg {
 ///
 /// # Arguments
 ///
+/// * `unbond_msg` - Borsh serialized unbond_msg.
 /// * `tx_msg` - Borsh serialized tx_msg.
 ///
 /// # Errors
@@ -128,6 +130,7 @@ pub struct SubmitWithdrawMsg {
 ///
 /// # Arguments
 ///
+/// * `withdraw_msg` - Borsh serialized withdraw_msg.
 /// * `tx_msg` - Borsh serialized tx_msg.
 ///
 /// # Errors
@@ -155,6 +158,57 @@ pub fn withdraw_tx_args(withdraw_msg: &[u8], tx_msg: &[u8]) -> Result<args::With
 
 #[derive(BorshSerialize, BorshDeserialize)]
 #[borsh(crate = "namada::core::borsh")]
+pub struct SubmitRedelegateMsg {
+    owner: String,
+    source_validator: String,
+    destination_validator: String,
+    amount: String,
+}
+
+/// Maps serialized tx_msg into RedelgationTx args.
+///
+/// # Arguments
+///
+/// * `redelegate_msg` - Borsh serialized redelegation_msg.
+/// * `tx_msg` - Borsh serialized tx_msg.
+///
+/// # Errors
+///
+/// Returns JsError if the tx_msg can't be deserialized or
+/// Rust structs can't be created.
+pub fn redelegate_tx_args(
+    redelegate_msg: &[u8],
+    tx_msg: &[u8],
+) -> Result<args::Redelegate, JsError> {
+    let redelegate_msg = SubmitRedelegateMsg::try_from_slice(redelegate_msg)?;
+
+    let SubmitRedelegateMsg {
+        owner,
+        source_validator,
+        destination_validator,
+        amount,
+    } = redelegate_msg;
+
+    let owner = Address::from_str(&owner)?;
+    let src_validator = Address::from_str(&source_validator)?;
+    let dest_validator = Address::from_str(&destination_validator)?;
+    let amount = Amount::from_str(&amount, NATIVE_MAX_DECIMAL_PLACES)?;
+    let tx = tx_msg_into_args(tx_msg)?;
+
+    let args = args::Redelegate {
+        tx,
+        src_validator,
+        dest_validator,
+        amount,
+        owner,
+        tx_code_path: PathBuf::from("tx_redelegate.wasm"),
+    };
+
+    Ok(args)
+}
+
+#[derive(BorshSerialize, BorshDeserialize)]
+#[borsh(crate = "namada::core::borsh")]
 pub struct SubmitVoteProposalMsg {
     signer: String,
     proposal_id: u64,
@@ -165,6 +219,7 @@ pub struct SubmitVoteProposalMsg {
 ///
 /// # Arguments
 ///
+/// * `vote_proposal_msg` - Borsh serialized vote_proposal_msg.
 /// * `tx_msg` - Borsh serialized tx_msg.
 ///
 /// # Errors
@@ -212,6 +267,7 @@ pub struct SubmitTransferMsg {
 ///
 /// # Arguments
 ///
+/// * `transfer_msg` - Borsh serialized transfer_msg.
 /// * `tx_msg` - Borsh serialized tx_msg.
 ///
 /// # Errors
@@ -285,6 +341,7 @@ pub struct SubmitIbcTransferMsg {
 ///
 /// # Arguments
 ///
+/// * `ibc_transfer_msg` - Borsh serialized ibc_transfer_msg.
 /// * `tx_msg` - Borsh serialized tx_msg.
 ///
 /// # Errors

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -9,6 +9,7 @@ export type SupportedTx = Extract<
   | TxType.EthBridgeTransfer
   | TxType.Withdraw
   | TxType.VoteProposal
+  | TxType.Redelegate
 >;
 
 export type TxLabel =

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -19,7 +19,8 @@ export type TxLabel =
   | "Add to Eth Bridge Pool"
   | "Withdraw"
   | "RevealPK"
-  | "Vote Proposal";
+  | "Vote Proposal"
+  | "Redelegate";
 
 export const TxTypeLabel: Record<TxType, TxLabel> = {
   [TxType.Bond]: "Bond",
@@ -30,6 +31,7 @@ export const TxTypeLabel: Record<TxType, TxLabel> = {
   [TxType.EthBridgeTransfer]: "Add to Eth Bridge Pool",
   [TxType.RevealPK]: "RevealPK",
   [TxType.VoteProposal]: "Vote Proposal",
+  [TxType.Redelegate]: "Redelegate",
 };
 
 type TransferToEthereumKind = "Erc20" | "Nut";

--- a/packages/types/src/tx/schema/index.ts
+++ b/packages/types/src/tx/schema/index.ts
@@ -1,6 +1,7 @@
 export * from "./bond";
 export * from "./ethBridgeTransfer";
 export * from "./ibcTransfer";
+export * from "./redelegate";
 export * from "./signature";
 export * from "./transfer";
 export * from "./tx";
@@ -12,6 +13,7 @@ export * from "./withdraw";
 import { BondMsgValue } from "./bond";
 import { EthBridgeTransferMsgValue } from "./ethBridgeTransfer";
 import { IbcTransferMsgValue } from "./ibcTransfer";
+import { RedelegateMsgValue } from "./redelegate";
 import { SignatureMsgValue } from "./signature";
 import { TransferMsgValue } from "./transfer";
 import { TxMsgValue } from "./tx";
@@ -28,4 +30,5 @@ export type Schema =
   | VoteProposalMsgValue
   | WithdrawMsgValue
   | TransferMsgValue
-  | TxMsgValue;
+  | TxMsgValue
+  | RedelegateMsgValue;

--- a/packages/types/src/tx/schema/redelegate.ts
+++ b/packages/types/src/tx/schema/redelegate.ts
@@ -1,0 +1,22 @@
+import { field } from "@dao-xyz/borsh";
+import BigNumber from "bignumber.js";
+import { RedelegateProps } from "../types";
+import { BigNumberSerializer } from "./utils";
+
+export class RedelegateMsgValue {
+  @field({ type: "string" })
+  owner!: string;
+
+  @field({ type: "string" })
+  sourceValidator!: string;
+
+  @field({ type: "string" })
+  destinationValidator!: string;
+
+  @field(BigNumberSerializer)
+  amount!: BigNumber;
+
+  constructor(data: RedelegateProps) {
+    Object.assign(this, data);
+  }
+}

--- a/packages/types/src/tx/types.ts
+++ b/packages/types/src/tx/types.ts
@@ -2,6 +2,7 @@ import {
   BondMsgValue,
   EthBridgeTransferMsgValue,
   IbcTransferMsgValue,
+  RedelegateMsgValue,
   SignatureMsgValue,
   TransferMsgValue,
   TxMsgValue,
@@ -14,6 +15,7 @@ export type TxProps = TxMsgValue;
 export type BondProps = BondMsgValue;
 export type UnbondProps = UnbondMsgValue;
 export type WithdrawProps = WithdrawMsgValue;
+export type RedelegateProps = RedelegateMsgValue;
 export type TransferProps = TransferMsgValue;
 export type EthBridgeTransferProps = EthBridgeTransferMsgValue;
 export type SignatureProps = SignatureMsgValue;


### PR DESCRIPTION
Partially addresses #750 (_TODO_: Add any additional Tx needed by interface!)

- [x] Add `Redelegate` support to `packages/shared/lib`
- [x] Add schema for `RedelegateMsg` and export props
- [x] Add to `packages/sdk` & regenerate docs
- [x] Add to extension provider (`Signer`) and hook up to Keyring
