### PR TITLE
Namadillo persist cache

### DIFF
--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -7,6 +7,8 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
+    "@tailwindcss/container-queries": "^0.1.1",
+    "@tanstack/query-core": "^5.32.0",
     "@types/invariant": "^2.2.37",
     "@types/react-paginate": "^7.1.2",
     "bignumber.js": "^9.1.1",
@@ -17,6 +19,7 @@
     "framer-motion": "^11.0.28",
     "invariant": "^2.2.4",
     "jotai": "^2.6.3",
+    "jotai-tanstack-query": "^0.8.5",
     "lodash.debounce": "^4.0.8",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
@@ -27,7 +30,8 @@
     "styled-components": "^5.3.3",
     "tailwind-merge": "^2.3.0",
     "typescript": "^5.1.3",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "wonka": "^6.3.4"
   },
   "scripts": {
     "bump": "yarn workspace namada run bump --target apps/namadillo",

--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -8,7 +8,8 @@
   "private": true,
   "dependencies": {
     "@tailwindcss/container-queries": "^0.1.1",
-    "@tanstack/query-core": "^5.32.0",
+    "@tanstack/react-query": "^5.40.0",
+    "@tanstack/react-query-persist-client": "^5.40.0",
     "@types/invariant": "^2.2.37",
     "@types/react-paginate": "^7.1.2",
     "bignumber.js": "^9.1.1",
@@ -17,6 +18,7 @@
     "ethers": "^6.7.1",
     "fp-ts": "^2.16.1",
     "framer-motion": "^11.0.28",
+    "idb-keyval": "^6.2.1",
     "invariant": "^2.2.4",
     "jotai": "^2.6.3",
     "jotai-tanstack-query": "^0.8.5",
@@ -29,6 +31,7 @@
     "react-scripts": "5.0.1",
     "styled-components": "^5.3.3",
     "tailwind-merge": "^2.3.0",
+    "traverse": "^0.6.9",
     "typescript": "^5.1.3",
     "web-vitals": "^2.1.4",
     "wonka": "^6.3.4"
@@ -84,6 +87,7 @@
     "@types/react": "^17.0.39",
     "@types/react-dom": "^17.0.11",
     "@types/styled-components": "^5.1.22",
+    "@types/traverse": "^0.6.36",
     "@vitejs/plugin-react": "^4.2.1",
     "autoprefixer": "^10.4.16",
     "css-loader": "^6.7.3",

--- a/apps/namadillo/src/App/Governance/ProposalAndVote.tsx
+++ b/apps/namadillo/src/App/Governance/ProposalAndVote.tsx
@@ -1,15 +1,11 @@
-import { Panel, SkeletonLoading } from "@namada/components";
+import { Panel } from "@namada/components";
 import { useAtomValue } from "jotai";
 
 import { ProposalDiscord } from "App/Sidebars/ProposalDiscord";
 import { useProposalIdParam } from "hooks";
 import { proposalFamily, proposalVotedFamily } from "slices/proposals";
 import { namadaExtensionConnectedAtom } from "slices/settings";
-import {
-  atomsAreFetching,
-  atomsAreLoaded,
-  useNotifyOnAtomError,
-} from "store/utils";
+import { useNotifyOnAtomError } from "store/utils";
 import { ProposalDescription } from "./ProposalDescription";
 import { ProposalHeader } from "./ProposalHeader";
 import { ProposalStatusSummary } from "./ProposalStatusSummary";
@@ -44,40 +40,15 @@ export const WithProposalId: React.FC<{ proposalId: bigint }> = ({
     <div className="flex flex-col md:grid md:grid-cols-[auto_270px] gap-2">
       <div className="flex flex-col gap-1.5">
         <Panel className="px-3">
-          {atomsAreFetching(proposal, ...extensionAtoms) && (
-            <SkeletonLoading height="150px" width="100%" />
-          )}
           <div className="px-12">
-            {isConnected && atomsAreLoaded(proposal, ...extensionAtoms) && (
-              <ProposalHeader
-                proposal={proposal.data!}
-                isExtensionConnected={true}
-                voted={voted.data!}
-              />
-            )}
-            {!isConnected && atomsAreLoaded(proposal) && (
-              <ProposalHeader
-                proposal={proposal.data!}
-                isExtensionConnected={false}
-              />
-            )}
+            <ProposalHeader proposalId={proposalId} />
           </div>
         </Panel>
         <Panel title="Description">
-          {atomsAreFetching(proposal) && (
-            <SkeletonLoading height="150px" width="100%" />
-          )}
-          {atomsAreLoaded(proposal) && (
-            <ProposalDescription proposal={proposal.data!} />
-          )}
+          <ProposalDescription proposalId={proposalId} />
         </Panel>
         <Panel className="py-6 px-7">
-          {atomsAreFetching(proposal) && (
-            <SkeletonLoading height="150px" width="100%" />
-          )}
-          {atomsAreLoaded(proposal) && (
-            <VoteInfoCards proposal={proposal.data!} />
-          )}
+          <VoteInfoCards proposalId={proposalId} />
         </Panel>
         <Panel className="py-6">
           <VoteHelpText />
@@ -85,12 +56,7 @@ export const WithProposalId: React.FC<{ proposalId: bigint }> = ({
       </div>
       <aside className="flex flex-col gap-2">
         <Panel className="@container" title="Proposal Status">
-          {atomsAreFetching(proposal) && (
-            <ProposalStatusSummary loading={true} />
-          )}
-          {atomsAreLoaded(proposal) && (
-            <ProposalStatusSummary loading={false} proposal={proposal.data!} />
-          )}
+          <ProposalStatusSummary proposalId={proposalId} />
         </Panel>
         <ProposalDiscord />
       </aside>

--- a/apps/namadillo/src/App/Governance/ProposalDescription.tsx
+++ b/apps/namadillo/src/App/Governance/ProposalDescription.tsx
@@ -1,10 +1,28 @@
-import { Stack } from "@namada/components";
+import { SkeletonLoading, Stack } from "@namada/components";
+import { useAtomValue } from "jotai";
 import { useState } from "react";
 
-import { Proposal } from "@namada/types";
+import { proposalFamilyPersist, StoredProposal } from "slices/proposals";
 
 export const ProposalDescription: React.FC<{
-  proposal: Proposal;
+  proposalId: bigint;
+}> = ({ proposalId }) => {
+  const proposal = useAtomValue(proposalFamilyPersist(proposalId));
+
+  return (
+    <Stack className="text-sm px-8 -mt-3" gap={4}>
+      {proposal.status === "error" || proposal.status === "pending" ?
+        <>
+          <SkeletonLoading height="1em" width="100%" />
+          <SkeletonLoading height="1em" width="100%" />
+        </>
+      : <Loaded proposal={proposal.data} />}
+    </Stack>
+  );
+};
+
+export const Loaded: React.FC<{
+  proposal: StoredProposal;
 }> = ({ proposal }) => {
   const [expanded, setExpanded] = useState(false);
 
@@ -19,7 +37,7 @@ export const ProposalDescription: React.FC<{
   });
 
   return (
-    <Stack className="text-sm px-8 -mt-3" gap={4}>
+    <>
       <section>{abstract}</section>
 
       {expanded &&
@@ -36,6 +54,6 @@ export const ProposalDescription: React.FC<{
       >
         Show {expanded ? "Less" : "More"}
       </a>
-    </Stack>
+    </>
   );
 };

--- a/apps/namadillo/src/App/Governance/ProposalHeader.tsx
+++ b/apps/namadillo/src/App/Governance/ProposalHeader.tsx
@@ -1,28 +1,125 @@
-import { ActionButton, ProgressBar, Stack } from "@namada/components";
-import { Proposal } from "@namada/types";
+import {
+  ActionButton,
+  ProgressBar as ProgressBarComponent,
+  Stack,
+} from "@namada/components";
+import { Proposal, ProposalStatus } from "@namada/types";
 import clsx from "clsx";
 import { useAtomValue } from "jotai";
+import { AtomWithQueryResult } from "jotai-tanstack-query";
 import { FaChevronLeft } from "react-icons/fa";
 import { SiWebassembly } from "react-icons/si";
 import { VscJson } from "react-icons/vsc";
 import { Link, useNavigate } from "react-router-dom";
-import { currentEpochAtom } from "slices/proposals";
-import { showEpoch } from "utils";
-import { StatusLabel, TypeLabel, VotedLabel } from "./ProposalLabels";
+import {
+  StoredProposal,
+  currentEpochAtom,
+  proposalFamily,
+  proposalFamilyPersist,
+  proposalVotedFamily,
+} from "slices/proposals";
+import { namadaExtensionConnectedAtom } from "slices/settings";
+import { showEpoch, showProposalId } from "utils";
+import {
+  StatusLabel as StatusLabelComponent,
+  TypeLabel as TypeLabelComponent,
+  VotedLabel as VotedLabelComponent,
+} from "./ProposalLabels";
 import GovernanceRoutes from "./routes";
 
-const WasmButton: React.FC<{
-  wasmCode?: Uint8Array;
+export const ProposalHeader: React.FC<{
   proposalId: bigint;
-}> = ({ wasmCode, proposalId }) => {
-  const href =
-    typeof wasmCode === "undefined" ? undefined : (
-      URL.createObjectURL(
-        new Blob([wasmCode], { type: "application/octet-stream" })
-      )
-    );
+}> = ({ proposalId }) => {
+  const proposal = useAtomValue(proposalFamily(proposalId));
+  const cachedProposal = useAtomValue(proposalFamilyPersist(proposalId));
+  const voted = useAtomValue(proposalVotedFamily(proposalId));
 
-  const filename = `proposal-${proposalId.toString()}.wasm`;
+  return (
+    <>
+      <div className="flex mb-5">
+        <div className="w-full">
+          <Breadcrumbs proposalId={proposalId} />
+          <BackButton />
+          <Stack gap={2.5}>
+            <TypeLabel proposal={cachedProposal} />
+            <Title proposal={cachedProposal} proposalId={proposalId} />
+          </Stack>
+        </div>
+        <Stack gap={2}>
+          <JsonButton proposalId={proposalId} />
+          <WasmButton proposal={cachedProposal} />
+        </Stack>
+      </div>
+      <hr className="border-neutral-900 w-full mb-4" />
+      <div className="flex gap-2 mb-4">
+        <StatusLabel proposal={proposal} cachedProposal={cachedProposal} />
+        <VotedLabel voted={voted} />
+      </div>
+      <div className="flex gap-10 bg-neutral-900 mb-9 px-5 py-3 -mx-3 rounded-md">
+        <Progress proposal={cachedProposal} />
+        <VoteButton proposal={proposal} voted={voted} proposalId={proposalId} />
+      </div>
+    </>
+  );
+};
+
+const Title: React.FC<{
+  proposal: AtomWithQueryResult<StoredProposal>;
+  proposalId: bigint;
+}> = ({ proposal, proposalId }) => (
+  <div className="text-xl">
+    {showProposalId(proposalId)}{" "}
+    {proposal.status === "pending" || proposal.status === "error" ? null : (
+      proposal.data.content.title
+    )}
+  </div>
+);
+
+const Breadcrumbs: React.FC<{ proposalId: bigint }> = ({ proposalId }) => (
+  <div className="text-xxs text-neutral-500">
+    <Link
+      className="transition-colors hover:text-white"
+      to={GovernanceRoutes.index()}
+    >
+      Governance
+    </Link>{" "}
+    /&nbsp;
+    <Link
+      className="transition-colors hover:text-white"
+      to={GovernanceRoutes.proposal(proposalId).url}
+    >
+      Proposal {showProposalId(proposalId)}
+    </Link>
+  </div>
+);
+
+const BackButton: React.FC = () => (
+  <Link
+    to={GovernanceRoutes.index()}
+    className={clsx(
+      "inline-flex items-center text-xxs gap-1",
+      "text-neutral-200 bg-neutral-900 my-2 px-2 py-0.5 rounded-sm",
+      "hover:text-yellow"
+    )}
+  >
+    <i className="text-[0.8em]">
+      <FaChevronLeft />
+    </i>{" "}
+    Back
+  </Link>
+);
+
+const TypeLabel: React.FC<{
+  proposal: AtomWithQueryResult<StoredProposal>;
+}> = ({ proposal }) =>
+  proposal.status === "pending" || proposal.status === "error" ?
+    null
+  : <TypeLabelComponent proposalType={proposal.data.proposalType} />;
+
+const JsonButton: React.FC<{
+  proposalId: bigint;
+}> = ({ proposalId }) => {
+  const navigate = useNavigate();
 
   return (
     <ActionButton
@@ -31,7 +128,54 @@ const WasmButton: React.FC<{
       size="xs"
       outlined
       borderRadius="sm"
-      disabled={typeof wasmCode === "undefined"}
+      onClick={() => navigate(GovernanceRoutes.viewJson(proposalId).url)}
+    >
+      <span className="flex text-xs justify-between gap-2">
+        <VscJson />
+        JSON
+      </span>
+    </ActionButton>
+  );
+};
+
+const WasmButton: React.FC<{
+  proposal: AtomWithQueryResult<StoredProposal>;
+}> = ({ proposal }) => {
+  const { disabled, href, filename } = (() => {
+    if (proposal.status !== "pending" && proposal.status !== "error") {
+      const { type, data } = proposal.data.proposalType;
+      const wasmCode = type === "default" ? data : undefined;
+
+      if (typeof wasmCode !== "undefined") {
+        const href = URL.createObjectURL(
+          new Blob([wasmCode], { type: "application/octet-stream" })
+        );
+
+        const filename = `proposal-${proposal.data.id.toString()}.wasm`;
+
+        return {
+          disabled: false,
+          href,
+          filename,
+        };
+      }
+    }
+
+    return {
+      disabled: true,
+      href: undefined,
+      filename: undefined,
+    };
+  })();
+
+  return (
+    <ActionButton
+      className="px-3 py-2"
+      color="white"
+      size="xs"
+      outlined
+      borderRadius="sm"
+      disabled={disabled}
       as="a"
       download={filename}
       href={href}
@@ -44,125 +188,167 @@ const WasmButton: React.FC<{
   );
 };
 
-type ProposalHeaderProps = (
-  | { isExtensionConnected: true; voted: boolean }
-  | { isExtensionConnected: false }
-) & {
-  proposal: Proposal;
+const StatusLabel: React.FC<{
+  proposal: AtomWithQueryResult<Proposal>;
+  cachedProposal: AtomWithQueryResult<StoredProposal>;
+}> = ({ proposal, cachedProposal }) => {
+  const status: ProposalStatus | undefined = (() => {
+    if (proposal.status !== "pending" && proposal.status !== "error") {
+      return proposal.data.status;
+    } else if (
+      cachedProposal.status !== "pending" &&
+      cachedProposal.status !== "error"
+    ) {
+      return cachedProposal.data.status;
+    } else {
+      return undefined;
+    }
+  })();
+
+  return typeof status === "undefined" ? null : (
+      <StatusLabelComponent status={status} className="text-xs min-w-42" />
+    );
 };
 
-export const ProposalHeader: React.FC<ProposalHeaderProps> = (props) => {
-  const { proposal, isExtensionConnected } = props;
-  const { status } = proposal;
+const Progress: React.FC<{
+  proposal: AtomWithQueryResult<StoredProposal>;
+}> = ({ proposal }) => {
+  return (
+    <div className="w-full grid grid-cols-2 text-xs">
+      <span>Progress</span>
+      <div className="col-span-2 mt-3 mb-2">
+        <ProgressBar cachedProposal={proposal} />
+      </div>
+      <ProgressStartEnd
+        proposal={proposal}
+        epochKey="startEpoch"
+        className="col-start-1"
+      />
+      <ProgressStartEnd
+        proposal={proposal}
+        epochKey="endEpoch"
+        className="text-right"
+      />
+    </div>
+  );
+};
 
-  const navigate = useNavigate();
-  const voteButtonDisabled =
-    !isExtensionConnected || props.voted || status !== "ongoing";
-  const { startEpoch, endEpoch } = proposal;
+const ProgressStartEnd: React.FC<{
+  proposal: AtomWithQueryResult<StoredProposal>;
+  epochKey: "startEpoch" | "endEpoch";
+  className: string;
+}> = ({ proposal, epochKey, className }) => (
+  <div className={className}>
+    {proposal.status === "pending" || proposal.status === "error" ?
+      "..."
+    : showEpoch(proposal.data[epochKey])}
+  </div>
+);
+
+const ProgressBar: React.FC<{
+  cachedProposal: AtomWithQueryResult<StoredProposal>;
+}> = ({ cachedProposal }) => {
   const currentEpoch = useAtomValue(currentEpochAtom);
 
-  if (!currentEpoch.isSuccess) {
+  const { value, total } = (() => {
+    const loadingData = {
+      value: 0,
+      total: 0,
+    };
+
+    if (
+      cachedProposal.status === "pending" ||
+      cachedProposal.status === "error"
+    ) {
+      return loadingData;
+    }
+
+    const { startEpoch, endEpoch, status } = cachedProposal.data;
+
+    // If proposal already passed or rejected, bypass waiting for currentEpochAtom
+    if (status === "passed" || status === "rejected") {
+      return {
+        value: 1,
+        total: 1,
+      };
+    }
+
+    if (currentEpoch.status === "pending" || currentEpoch.status === "error") {
+      return loadingData;
+    }
+
+    const totalEpochs = endEpoch - startEpoch;
+    const relativeCurrentEpoch = currentEpoch.data - startEpoch;
+
+    return {
+      value: relativeCurrentEpoch,
+      total: totalEpochs,
+    };
+  })();
+
+  return (
+    <ProgressBarComponent
+      value={{ value, color: "#11DFDF" }}
+      total={{ value: total, color: "#3A3A3A" }}
+    />
+  );
+};
+
+const VoteButton: React.FC<{
+  proposal: AtomWithQueryResult<Proposal>;
+  voted: AtomWithQueryResult<boolean>;
+  proposalId: bigint;
+}> = ({ proposal, voted, proposalId }) => {
+  const navigate = useNavigate();
+  const isExtensionConnected = useAtomValue(namadaExtensionConnectedAtom);
+
+  if (!isExtensionConnected) {
     return null;
   }
 
-  const totalEpochs = endEpoch - startEpoch;
-  const relativeCurrentEpoch = currentEpoch.data - startEpoch;
+  const { disabled, onClick } = (() => {
+    if (
+      proposal.status === "pending" ||
+      proposal.status === "error" ||
+      voted.status === "pending" ||
+      voted.status === "error"
+    ) {
+      return {
+        disabled: true,
+        onClick: undefined,
+      };
+    } else {
+      const { status } = proposal.data;
 
-  const { type, data } = proposal.proposalType;
-  const wasmCode = type === "default" ? data : undefined;
+      const disabled =
+        !isExtensionConnected || voted.data || status !== "ongoing";
+
+      return {
+        disabled,
+        onClick: () => navigate(GovernanceRoutes.submitVote(proposalId).url),
+      };
+    }
+  })();
 
   return (
-    <>
-      <div className="flex mb-5">
-        <div className="w-full">
-          <div className="text-xxs text-neutral-500">
-            <Link
-              className="transition-colors hover:text-white"
-              to={GovernanceRoutes.index()}
-            >
-              Governance
-            </Link>{" "}
-            /&nbsp;
-            <Link
-              className="transition-colors hover:text-white"
-              to={GovernanceRoutes.proposal(proposal.id).url}
-            >
-              Proposal #{proposal.id.toString()}
-            </Link>
-          </div>
-          <Link
-            to={GovernanceRoutes.index()}
-            className={clsx(
-              "inline-flex items-center text-xxs gap-1",
-              "text-neutral-200 bg-neutral-900 my-2 px-2 py-0.5 rounded-sm",
-              "hover:text-yellow"
-            )}
-          >
-            <i className="text-[0.8em]">
-              <FaChevronLeft />
-            </i>{" "}
-            Back
-          </Link>
-          <Stack gap={2.5}>
-            <TypeLabel proposalType={proposal.proposalType} />
-            <div className="text-xl">
-              #{proposal.id.toString()} {proposal.content.title}
-            </div>
-          </Stack>
-        </div>
-        <Stack gap={2}>
-          <ActionButton
-            className="px-3 py-2"
-            color="white"
-            size="xs"
-            outlined
-            borderRadius="sm"
-            onClick={() => navigate(GovernanceRoutes.viewJson(proposal.id).url)}
-          >
-            <span className="flex text-xs justify-between gap-2">
-              <VscJson />
-              JSON
-            </span>
-          </ActionButton>
-          <WasmButton wasmCode={wasmCode} proposalId={proposal.id} />
-        </Stack>
-      </div>
-      <hr className="border-neutral-900 w-full mb-4" />
-      <div className="flex gap-2 mb-4">
-        <StatusLabel status={status} className="text-xs min-w-42" />
-        {isExtensionConnected && props.voted && (
-          <VotedLabel className="text-xs min-w-22" />
-        )}
-      </div>
-      <div className="flex gap-10 bg-neutral-900 mb-9 px-5 py-3 -mx-3 rounded-md">
-        <div className="w-full grid grid-cols-2 text-xs">
-          <span>Progress</span>
-          <div className="col-span-2 mt-3 mb-2">
-            <ProgressBar
-              value={{ value: relativeCurrentEpoch, color: "#11DFDF" }}
-              total={{ value: totalEpochs, color: "#3A3A3A" }}
-            />
-          </div>
-          <div className="col-start-1">{showEpoch(startEpoch)}</div>
-          <div className="text-right">{showEpoch(endEpoch)}</div>
-        </div>
-        {isExtensionConnected && (
-          <div className="w-32 flex items-center justify-center">
-            <ActionButton
-              size="sm"
-              borderRadius="sm"
-              className="py-2"
-              color="white"
-              disabled={voteButtonDisabled}
-              onClick={() =>
-                navigate(GovernanceRoutes.submitVote(proposal.id).url)
-              }
-            >
-              Vote
-            </ActionButton>
-          </div>
-        )}
-      </div>
-    </>
+    <div className="w-32 flex items-center justify-center">
+      <ActionButton
+        size="sm"
+        borderRadius="sm"
+        className="py-2"
+        color="white"
+        disabled={disabled}
+        onClick={onClick}
+      >
+        Vote
+      </ActionButton>
+    </div>
   );
 };
+
+const VotedLabel: React.FC<{
+  voted: AtomWithQueryResult<boolean>;
+}> = ({ voted }) =>
+  voted.status === "pending" || voted.status === "error" || !voted.data ?
+    null
+  : <VotedLabelComponent className="text-xs min-w-22" />;

--- a/apps/namadillo/src/index.tsx
+++ b/apps/namadillo/src/index.tsx
@@ -3,6 +3,7 @@ import { SdkProvider } from "hooks/useSdk";
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
+import { StoreProvider } from "store";
 import { getRouter } from "./App/AppRoutes";
 import reportWebVitals from "./reportWebVitals";
 import { ExtensionEventsProvider, IntegrationsProvider } from "./services";
@@ -17,13 +18,15 @@ if (container) {
   initShared().then(() => {
     root.render(
       <React.StrictMode>
-        <IntegrationsProvider>
-          <SdkProvider>
-            <ExtensionEventsProvider>
-              <RouterProvider router={getRouter()} />
-            </ExtensionEventsProvider>
-          </SdkProvider>
-        </IntegrationsProvider>
+        <StoreProvider>
+          <IntegrationsProvider>
+            <SdkProvider>
+              <ExtensionEventsProvider>
+                <RouterProvider router={getRouter()} />
+              </ExtensionEventsProvider>
+            </SdkProvider>
+          </IntegrationsProvider>
+        </StoreProvider>
       </React.StrictMode>
     );
   });

--- a/apps/namadillo/src/store/index.tsx
+++ b/apps/namadillo/src/store/index.tsx
@@ -1,0 +1,86 @@
+import { QueryClient } from "@tanstack/react-query";
+import {
+  PersistQueryClientProvider,
+  PersistedClient,
+  Persister,
+} from "@tanstack/react-query-persist-client";
+import BigNumber from "bignumber.js";
+import { del, get, set } from "idb-keyval";
+import traverse, { TraverseContext } from "traverse";
+
+/**
+ * Objects lose their prototype when stored in Indexed DB, so in order to store
+ * and retrieve BigNumbers we traverse the object being stored and write/read the
+ * `_isBigNumber` property.
+ */
+const fixBigNumbers = (
+  client: PersistedClient,
+  traverseCallback: (this: TraverseContext, value: unknown) => void
+): void => {
+  const { queries, mutations } = client.clientState;
+  [...queries, ...mutations].forEach((query) =>
+    traverse(query.state.data).forEach(traverseCallback)
+  );
+};
+
+/**
+ * Creates an Indexed DB persister
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
+ *
+ * Taken from https://tanstack.com/query/latest/docs/framework/react/plugins/persistQueryClient#building-a-persister
+ */
+const createIDBPersister = (
+  idbValidKey: IDBValidKey = "reactQuery"
+): Persister => ({
+  persistClient: async (client: PersistedClient) => {
+    fixBigNumbers(client, function (value) {
+      if (BigNumber.isBigNumber(value)) {
+        this.update({ ...value, _isBigNumber: true }, true);
+      }
+    });
+
+    await set(idbValidKey, client);
+  },
+  restoreClient: async () => {
+    const client = await get<PersistedClient>(idbValidKey);
+
+    if (typeof client !== "undefined") {
+      fixBigNumbers(client, function (value) {
+        if (
+          typeof value === "object" &&
+          value !== null &&
+          "_isBigNumber" in value &&
+          value._isBigNumber
+        ) {
+          this.update(BigNumber(value as unknown as BigNumber.Value), true);
+        }
+      });
+    }
+
+    return client;
+  },
+  removeClient: async () => {
+    await del(idbValidKey);
+  },
+});
+
+export const queryClient = new QueryClient();
+
+const persister = createIDBPersister();
+
+export const StoreProvider: React.FC = ({ children }) => {
+  return (
+    <PersistQueryClientProvider
+      client={queryClient}
+      persistOptions={{
+        persister,
+        dehydrateOptions: {
+          // only persist queries that set the meta.persist flag
+          shouldDehydrateQuery: (query) => Boolean(query.meta?.persist),
+        },
+      }}
+    >
+      {children}
+    </PersistQueryClientProvider>
+  );
+};

--- a/apps/namadillo/src/store/utils.ts
+++ b/apps/namadillo/src/store/utils.ts
@@ -8,7 +8,7 @@ import {
 import { ToastNotification } from "types/notifications";
 
 export const atomsAreFetching = (...args: AtomWithQueryResult[]): boolean => {
-  return args.reduce((prev, current) => prev || current.isLoading, false);
+  return args.reduce((prev, current) => prev || current.isPending, false);
 };
 
 export const atomsAreLoaded = (...args: AtomWithQueryResult[]): boolean => {

--- a/apps/namadillo/src/utils/index.ts
+++ b/apps/namadillo/src/utils/index.ts
@@ -24,6 +24,9 @@ export const showProposalTypeString = (type: ProposalTypeString): string => {
 
 export const showEpoch = (epoch: bigint): string => `Epoch ${epoch.toString()}`;
 
+export const showProposalId = (proposalId: bigint): string =>
+  `#${proposalId.toString()}`;
+
 export const addTransactionEvent = <T>(
   handle: TransactionEvent,
   callback: (e: EventData<T>) => void

--- a/package.json
+++ b/package.json
@@ -40,12 +40,5 @@
     "vite-plugin-checker": "^0.6.4",
     "wsrun": "^5.2.4"
   },
-  "packageManager": "yarn@4.0.2",
-  "dependencies": {
-    "@tailwindcss/container-queries": "^0.1.1",
-    "@tanstack/query-core": "^5.32.0",
-    "invariant": "^2.2.4",
-    "jotai-tanstack-query": "^0.8.5",
-    "wonka": "^6.3.4"
-  }
+  "packageManager": "yarn@4.0.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8414,7 +8414,8 @@ __metadata:
     "@playwright/test": "npm:^1.24.1"
     "@svgr/webpack": "npm:^6.5.1"
     "@tailwindcss/container-queries": "npm:^0.1.1"
-    "@tanstack/query-core": "npm:^5.32.0"
+    "@tanstack/react-query": "npm:^5.40.0"
+    "@tanstack/react-query-persist-client": "npm:^5.40.0"
     "@testing-library/jest-dom": "npm:^5.16.2"
     "@testing-library/react": "npm:^12.1.3"
     "@testing-library/user-event": "npm:^13.5.0"
@@ -8426,6 +8427,7 @@ __metadata:
     "@types/react-dom": "npm:^17.0.11"
     "@types/react-paginate": "npm:^7.1.2"
     "@types/styled-components": "npm:^5.1.22"
+    "@types/traverse": "npm:^0.6.36"
     "@vitejs/plugin-react": "npm:^4.2.1"
     autoprefixer: "npm:^10.4.16"
     bignumber.js: "npm:^9.1.1"
@@ -8444,6 +8446,7 @@ __metadata:
     framer-motion: "npm:^11.0.28"
     history: "npm:^5.3.0"
     html-webpack-plugin: "npm:^5.5.0"
+    idb-keyval: "npm:^6.2.1"
     invariant: "npm:^2.2.4"
     jest: "npm:^29.4.1"
     jest-fetch-mock: "npm:^3.0.3"
@@ -8463,6 +8466,7 @@ __metadata:
     styled-components: "npm:^5.3.3"
     tailwind-merge: "npm:^2.3.0"
     tailwindcss: "npm:^3.4.0"
+    traverse: "npm:^0.6.9"
     ts-jest: "npm:^29.0.5"
     ts-loader: "npm:^9.4.2"
     ts-node: "npm:^10.9.1"
@@ -9833,10 +9837,42 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/query-core@npm:^5.32.0":
-  version: 5.32.0
-  resolution: "@tanstack/query-core@npm:5.32.0"
-  checksum: 58e7b053579a23dba36189a1fd87261819b31b344648f693fd613c722260066e11ad8c82dc07f5e5af2e276bde1b9f6a1dd6da3bf93cdd3583d128a2b373fce0
+"@tanstack/query-core@npm:5.40.0":
+  version: 5.40.0
+  resolution: "@tanstack/query-core@npm:5.40.0"
+  checksum: 8ed200657dcdc1c05a44571be07e7a9d9a6c19c4ac067560bfb9d065a9cfb3e0dbbd0c44c17814272fd0b8d559030e9f4b50fb917c4312bbe61c9848767fde38
+  languageName: node
+  linkType: hard
+
+"@tanstack/query-persist-client-core@npm:5.40.0":
+  version: 5.40.0
+  resolution: "@tanstack/query-persist-client-core@npm:5.40.0"
+  dependencies:
+    "@tanstack/query-core": "npm:5.40.0"
+  checksum: 3d9b3affabebc0cb264bf1eb78e0619d02371f6efa793e30babb77d97816fb8b061ace2504c94e414cb8e34dff14b34a07d643bacfa112c8be39a83b2949c573
+  languageName: node
+  linkType: hard
+
+"@tanstack/react-query-persist-client@npm:^5.40.0":
+  version: 5.40.0
+  resolution: "@tanstack/react-query-persist-client@npm:5.40.0"
+  dependencies:
+    "@tanstack/query-persist-client-core": "npm:5.40.0"
+  peerDependencies:
+    "@tanstack/react-query": ^5.40.0
+    react: ^18 || ^19
+  checksum: 736f4be1f184fb559b0ca49614395d8d567afd17dbc322b813a14d9875b11c659488ab9f7ae324368d2a4d55f4fc60ce7f02935303973f72873ac98d21f28990
+  languageName: node
+  linkType: hard
+
+"@tanstack/react-query@npm:^5.40.0":
+  version: 5.40.0
+  resolution: "@tanstack/react-query@npm:5.40.0"
+  dependencies:
+    "@tanstack/query-core": "npm:5.40.0"
+  peerDependencies:
+    react: ^18.0.0
+  checksum: 7298215fb1243c858006541267904023aa58a47e440c9b09425de7ed5547e88d56f9366a28cc01d0d165cf26d09b85c0cc6fcf884a1cf3936ead14b4afb3fa11
   languageName: node
   linkType: hard
 
@@ -10845,6 +10881,13 @@ __metadata:
   version: 4.0.2
   resolution: "@types/tough-cookie@npm:4.0.2"
   checksum: 38d01fc79a9a87166253b8c548bb401599424c57a818bea1b47a68be6dcd37fc3bff381f978354e00221f284937d5066bb92d58bf79952f9d21deb934e8ec9a7
+  languageName: node
+  linkType: hard
+
+"@types/traverse@npm:^0.6.36":
+  version: 0.6.36
+  resolution: "@types/traverse@npm:0.6.36"
+  checksum: 29947be184fe53ee33fa7f53999fadf884780bd759380e4549784af8051adca7fa8e73b7e825d4fb49bd76e0bec571ccd2275ab7ede6528b99f5f7beb259abbe
   languageName: node
   linkType: hard
 
@@ -12420,6 +12463,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"array-buffer-byte-length@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "array-buffer-byte-length@npm:1.0.1"
+  dependencies:
+    call-bind: "npm:^1.0.5"
+    is-array-buffer: "npm:^3.0.4"
+  checksum: f5cdf54527cd18a3d2852ddf73df79efec03829e7373a8322ef5df2b4ef546fb365c19c71d6b42d641cb6bfe0f1a2f19bc0ece5b533295f86d7c3d522f228917
+  languageName: node
+  linkType: hard
+
 "array-differ@npm:^4.0.0":
   version: 4.0.0
   resolution: "array-differ@npm:4.0.0"
@@ -12588,6 +12641,22 @@ __metadata:
     is-array-buffer: "npm:^3.0.2"
     is-shared-array-buffer: "npm:^1.0.2"
   checksum: 96b6e40e439678ffb7fa266398510074d33c3980fbb475490b69980cca60adec3b0777047ef377068a29862157f83edef42efc64ce48ce38977d04d68de5b7fb
+  languageName: node
+  linkType: hard
+
+"arraybuffer.prototype.slice@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "arraybuffer.prototype.slice@npm:1.0.3"
+  dependencies:
+    array-buffer-byte-length: "npm:^1.0.1"
+    call-bind: "npm:^1.0.5"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.22.3"
+    es-errors: "npm:^1.2.1"
+    get-intrinsic: "npm:^1.2.3"
+    is-array-buffer: "npm:^3.0.4"
+    is-shared-array-buffer: "npm:^1.0.2"
+  checksum: d32754045bcb2294ade881d45140a5e52bda2321b9e98fa514797b7f0d252c4c5ab0d1edb34112652c62fa6a9398def568da63a4d7544672229afea283358c36
   languageName: node
   linkType: hard
 
@@ -14072,7 +14141,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"call-bind@npm:^1.0.7":
+"call-bind@npm:^1.0.6, call-bind@npm:^1.0.7":
   version: 1.0.7
   resolution: "call-bind@npm:1.0.7"
   dependencies:
@@ -16069,6 +16138,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"data-view-buffer@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "data-view-buffer@npm:1.0.1"
+  dependencies:
+    call-bind: "npm:^1.0.6"
+    es-errors: "npm:^1.3.0"
+    is-data-view: "npm:^1.0.1"
+  checksum: 8984119e59dbed906a11fcfb417d7d861936f16697a0e7216fe2c6c810f6b5e8f4a5281e73f2c28e8e9259027190ac4a33e2a65fdd7fa86ac06b76e838918583
+  languageName: node
+  linkType: hard
+
+"data-view-byte-length@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "data-view-byte-length@npm:1.0.1"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    es-errors: "npm:^1.3.0"
+    is-data-view: "npm:^1.0.1"
+  checksum: b7d9e48a0cf5aefed9ab7d123559917b2d7e0d65531f43b2fd95b9d3a6b46042dd3fca597c42bba384e66b70d7ad66ff23932f8367b241f53d93af42cfe04ec2
+  languageName: node
+  linkType: hard
+
+"data-view-byte-offset@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "data-view-byte-offset@npm:1.0.0"
+  dependencies:
+    call-bind: "npm:^1.0.6"
+    es-errors: "npm:^1.3.0"
+    is-data-view: "npm:^1.0.1"
+  checksum: 21b0d2e53fd6e20cc4257c873bf6d36d77bd6185624b84076c0a1ddaa757b49aaf076254006341d35568e89f52eecd1ccb1a502cfb620f2beca04f48a6a62a8f
+  languageName: node
+  linkType: hard
+
 "debounce@npm:1.2.1, debounce@npm:^1.2.1":
   version: 1.2.1
   resolution: "debounce@npm:1.2.1"
@@ -17301,6 +17403,60 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-abstract@npm:^1.22.3, es-abstract@npm:^1.23.0":
+  version: 1.23.3
+  resolution: "es-abstract@npm:1.23.3"
+  dependencies:
+    array-buffer-byte-length: "npm:^1.0.1"
+    arraybuffer.prototype.slice: "npm:^1.0.3"
+    available-typed-arrays: "npm:^1.0.7"
+    call-bind: "npm:^1.0.7"
+    data-view-buffer: "npm:^1.0.1"
+    data-view-byte-length: "npm:^1.0.1"
+    data-view-byte-offset: "npm:^1.0.0"
+    es-define-property: "npm:^1.0.0"
+    es-errors: "npm:^1.3.0"
+    es-object-atoms: "npm:^1.0.0"
+    es-set-tostringtag: "npm:^2.0.3"
+    es-to-primitive: "npm:^1.2.1"
+    function.prototype.name: "npm:^1.1.6"
+    get-intrinsic: "npm:^1.2.4"
+    get-symbol-description: "npm:^1.0.2"
+    globalthis: "npm:^1.0.3"
+    gopd: "npm:^1.0.1"
+    has-property-descriptors: "npm:^1.0.2"
+    has-proto: "npm:^1.0.3"
+    has-symbols: "npm:^1.0.3"
+    hasown: "npm:^2.0.2"
+    internal-slot: "npm:^1.0.7"
+    is-array-buffer: "npm:^3.0.4"
+    is-callable: "npm:^1.2.7"
+    is-data-view: "npm:^1.0.1"
+    is-negative-zero: "npm:^2.0.3"
+    is-regex: "npm:^1.1.4"
+    is-shared-array-buffer: "npm:^1.0.3"
+    is-string: "npm:^1.0.7"
+    is-typed-array: "npm:^1.1.13"
+    is-weakref: "npm:^1.0.2"
+    object-inspect: "npm:^1.13.1"
+    object-keys: "npm:^1.1.1"
+    object.assign: "npm:^4.1.5"
+    regexp.prototype.flags: "npm:^1.5.2"
+    safe-array-concat: "npm:^1.1.2"
+    safe-regex-test: "npm:^1.0.3"
+    string.prototype.trim: "npm:^1.2.9"
+    string.prototype.trimend: "npm:^1.0.8"
+    string.prototype.trimstart: "npm:^1.0.8"
+    typed-array-buffer: "npm:^1.0.2"
+    typed-array-byte-length: "npm:^1.0.1"
+    typed-array-byte-offset: "npm:^1.0.2"
+    typed-array-length: "npm:^1.0.6"
+    unbox-primitive: "npm:^1.0.2"
+    which-typed-array: "npm:^1.1.15"
+  checksum: d27e9afafb225c6924bee9971a7f25f20c314f2d6cb93a63cada4ac11dcf42040896a6c22e5fb8f2a10767055ed4ddf400be3b1eb12297d281726de470b75666
+  languageName: node
+  linkType: hard
+
 "es-array-method-boxes-properly@npm:^1.0.0":
   version: 1.0.0
   resolution: "es-array-method-boxes-properly@npm:1.0.0"
@@ -17317,7 +17473,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-errors@npm:^1.3.0":
+"es-errors@npm:^1.2.1, es-errors@npm:^1.3.0":
   version: 1.3.0
   resolution: "es-errors@npm:1.3.0"
   checksum: 0a61325670072f98d8ae3b914edab3559b6caa980f08054a3b872052640d91da01d38df55df797fcc916389d77fc92b8d5906cf028f4db46d7e3003abecbca85
@@ -17355,6 +17511,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-object-atoms@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "es-object-atoms@npm:1.0.0"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+  checksum: 1fed3d102eb27ab8d983337bb7c8b159dd2a1e63ff833ec54eea1311c96d5b08223b433060ba240541ca8adba9eee6b0a60cdbf2f80634b784febc9cc8b687b4
+  languageName: node
+  linkType: hard
+
 "es-set-tostringtag@npm:^2.0.1":
   version: 2.0.1
   resolution: "es-set-tostringtag@npm:2.0.1"
@@ -17363,6 +17528,17 @@ __metadata:
     has: "npm:^1.0.3"
     has-tostringtag: "npm:^1.0.0"
   checksum: 9af096365e3861bb29755cc5f76f15f66a7eab0e83befca396129090c1d9737e54090278b8e5357e97b5f0a5b0459fca07c40c6740884c2659cbf90ef8e508cc
+  languageName: node
+  linkType: hard
+
+"es-set-tostringtag@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "es-set-tostringtag@npm:2.0.3"
+  dependencies:
+    get-intrinsic: "npm:^1.2.4"
+    has-tostringtag: "npm:^1.0.2"
+    hasown: "npm:^2.0.1"
+  checksum: f22aff1585eb33569c326323f0b0d175844a1f11618b86e193b386f8be0ea9474cfbe46df39c45d959f7aa8f6c06985dc51dd6bce5401645ec5a74c4ceaa836a
   languageName: node
   linkType: hard
 
@@ -19607,7 +19783,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.2.4":
+"get-intrinsic@npm:^1.2.3, get-intrinsic@npm:^1.2.4":
   version: 1.2.4
   resolution: "get-intrinsic@npm:1.2.4"
   dependencies:
@@ -19673,6 +19849,17 @@ __metadata:
     call-bind: "npm:^1.0.2"
     get-intrinsic: "npm:^1.1.1"
   checksum: 23bc3b44c221cdf7669a88230c62f4b9e30393b61eb21ba4400cb3e346801bd8f95fe4330ee78dbae37aecd874646d53e3e76a17a654d0c84c77f6690526d6bb
+  languageName: node
+  linkType: hard
+
+"get-symbol-description@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "get-symbol-description@npm:1.0.2"
+  dependencies:
+    call-bind: "npm:^1.0.5"
+    es-errors: "npm:^1.3.0"
+    get-intrinsic: "npm:^1.2.4"
+  checksum: 867be6d63f5e0eb026cb3b0ef695ec9ecf9310febb041072d2e142f260bd91ced9eeb426b3af98791d1064e324e653424afa6fd1af17dee373bea48ae03162bc
   languageName: node
   linkType: hard
 
@@ -20242,6 +20429,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"has-proto@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "has-proto@npm:1.0.3"
+  checksum: 35a6989f81e9f8022c2f4027f8b48a552de714938765d019dbea6bb547bd49ce5010a3c7c32ec6ddac6e48fc546166a3583b128f5a7add8b058a6d8b4afec205
+  languageName: node
+  linkType: hard
+
 "has-symbols@npm:^1.0.1, has-symbols@npm:^1.0.2, has-symbols@npm:^1.0.3":
   version: 1.0.3
   resolution: "has-symbols@npm:1.0.3"
@@ -20310,6 +20504,15 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 5d415b114f410661208c95e7ab4879f1cc2765b8daceff4dc8718317d1cb7b9ffa7c5d1eafd9a4389c9aab7445d6ea88e05f3096cb1e529618b55304956b87fc
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.1, hasown@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "hasown@npm:2.0.2"
+  dependencies:
+    function-bind: "npm:^1.1.2"
+  checksum: 3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
   languageName: node
   linkType: hard
 
@@ -20795,6 +20998,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"idb-keyval@npm:^6.2.1":
+  version: 6.2.1
+  resolution: "idb-keyval@npm:6.2.1"
+  checksum: 9f0c83703a365e00bd0b4ed6380ce509a06dedfc6ec39b2ba5740085069fd2f2ff5c14ba19356488e3612a2f9c49985971982d836460a982a5d0b4019eeba48a
+  languageName: node
+  linkType: hard
+
 "idb@npm:^6.1.4":
   version: 6.1.5
   resolution: "idb@npm:6.1.5"
@@ -21008,6 +21218,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"internal-slot@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "internal-slot@npm:1.0.7"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    hasown: "npm:^2.0.0"
+    side-channel: "npm:^1.0.4"
+  checksum: f8b294a4e6ea3855fc59551bbf35f2b832cf01fd5e6e2a97f5c201a071cc09b49048f856e484b67a6c721da5e55736c5b6ddafaf19e2dbeb4a3ff1821680de6c
+  languageName: node
+  linkType: hard
+
 "interpret@npm:^1.0.0":
   version: 1.4.0
   resolution: "interpret@npm:1.4.0"
@@ -21116,6 +21337,16 @@ __metadata:
     get-intrinsic: "npm:^1.2.0"
     is-typed-array: "npm:^1.1.10"
   checksum: 40ed13a5f5746ac3ae2f2e463687d9b5a3f5fd0086f970fb4898f0253c2a5ec2e3caea2d664dd8f54761b1c1948609702416921a22faebe160c7640a9217c80e
+  languageName: node
+  linkType: hard
+
+"is-array-buffer@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "is-array-buffer@npm:3.0.4"
+  dependencies:
+    call-bind: "npm:^1.0.2"
+    get-intrinsic: "npm:^1.2.1"
+  checksum: 42a49d006cc6130bc5424eae113e948c146f31f9d24460fc0958f855d9d810e6fd2e4519bf19aab75179af9c298ea6092459d8cafdec523cd19e529b26eab860
   languageName: node
   linkType: hard
 
@@ -21228,6 +21459,15 @@ __metadata:
   dependencies:
     has: "npm:^1.0.3"
   checksum: f1139970deb2ec159c54be154d35cd17d71b9b56c60221ff7c8c328ca7efe20b6d676cef43d08c21966e162bfd5068dcd0ce23e64c77b76a19824563ecd82e0e
+  languageName: node
+  linkType: hard
+
+"is-data-view@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "is-data-view@npm:1.0.1"
+  dependencies:
+    is-typed-array: "npm:^1.1.13"
+  checksum: a3e6ec84efe303da859107aed9b970e018e2bee7ffcb48e2f8096921a493608134240e672a2072577e5f23a729846241d9634806e8a0e51d9129c56d5f65442d
   languageName: node
   linkType: hard
 
@@ -21409,6 +21649,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-negative-zero@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "is-negative-zero@npm:2.0.3"
+  checksum: bcdcf6b8b9714063ffcfa9929c575ac69bfdabb8f4574ff557dfc086df2836cf07e3906f5bbc4f2a5c12f8f3ba56af640c843cdfc74da8caed86c7c7d66fd08e
+  languageName: node
+  linkType: hard
+
 "is-npm@npm:^6.0.0":
   version: 6.0.0
   resolution: "is-npm@npm:6.0.0"
@@ -21544,6 +21791,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-shared-array-buffer@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "is-shared-array-buffer@npm:1.0.3"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+  checksum: adc11ab0acbc934a7b9e5e9d6c588d4ec6682f6fea8cda5180721704fa32927582ede5b123349e32517fdadd07958973d24716c80e7ab198970c47acc09e59c7
+  languageName: node
+  linkType: hard
+
 "is-ssh@npm:^1.4.0":
   version: 1.4.0
   resolution: "is-ssh@npm:1.4.0"
@@ -21623,7 +21879,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-typed-array@npm:^1.1.3":
+"is-typed-array@npm:^1.1.13, is-typed-array@npm:^1.1.3":
   version: 1.1.13
   resolution: "is-typed-array@npm:1.1.13"
   dependencies:
@@ -27312,6 +27568,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object.assign@npm:^4.1.5":
+  version: 4.1.5
+  resolution: "object.assign@npm:4.1.5"
+  dependencies:
+    call-bind: "npm:^1.0.5"
+    define-properties: "npm:^1.2.1"
+    has-symbols: "npm:^1.0.3"
+    object-keys: "npm:^1.1.1"
+  checksum: 60108e1fa2706f22554a4648299b0955236c62b3685c52abf4988d14fffb0e7731e00aa8c6448397e3eb63d087dcc124a9f21e1980f36d0b2667f3c18bacd469
+  languageName: node
+  linkType: hard
+
 "object.entries@npm:^1.1.5":
   version: 1.1.5
   resolution: "object.entries@npm:1.1.5"
@@ -30921,6 +31189,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regexp.prototype.flags@npm:^1.5.2":
+  version: 1.5.2
+  resolution: "regexp.prototype.flags@npm:1.5.2"
+  dependencies:
+    call-bind: "npm:^1.0.6"
+    define-properties: "npm:^1.2.1"
+    es-errors: "npm:^1.3.0"
+    set-function-name: "npm:^2.0.1"
+  checksum: 0f3fc4f580d9c349f8b560b012725eb9c002f36daa0041b3fbf6f4238cb05932191a4d7d5db3b5e2caa336d5150ad0402ed2be81f711f9308fe7e1a9bf9bd552
+  languageName: node
+  linkType: hard
+
 "regexpp@npm:^3.2.0":
   version: 3.2.0
   resolution: "regexpp@npm:3.2.0"
@@ -31639,6 +31919,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"safe-array-concat@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "safe-array-concat@npm:1.1.2"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    get-intrinsic: "npm:^1.2.4"
+    has-symbols: "npm:^1.0.3"
+    isarray: "npm:^2.0.5"
+  checksum: 12f9fdb01c8585e199a347eacc3bae7b5164ae805cdc8c6707199dbad5b9e30001a50a43c4ee24dc9ea32dbb7279397850e9208a7e217f4d8b1cf5d90129dec9
+  languageName: node
+  linkType: hard
+
 "safe-buffer@npm:5.1.2, safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
   version: 5.1.2
   resolution: "safe-buffer@npm:5.1.2"
@@ -31668,6 +31960,17 @@ __metadata:
     get-intrinsic: "npm:^1.1.3"
     is-regex: "npm:^1.1.4"
   checksum: 14a81a7e683f97b2d6e9c8be61fddcf8ed7a02f4e64a825515f96bb1738eb007145359313741d2704d28b55b703a0f6300c749dde7c1dbc13952a2b85048ede2
+  languageName: node
+  linkType: hard
+
+"safe-regex-test@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "safe-regex-test@npm:1.0.3"
+  dependencies:
+    call-bind: "npm:^1.0.6"
+    es-errors: "npm:^1.3.0"
+    is-regex: "npm:^1.1.4"
+  checksum: 900bf7c98dc58f08d8523b7012b468e4eb757afa624f198902c0643d7008ba777b0bdc35810ba0b758671ce887617295fb742b3f3968991b178ceca54cb07603
   languageName: node
   linkType: hard
 
@@ -32148,6 +32451,18 @@ __metadata:
     functions-have-names: "npm:^1.2.3"
     has-property-descriptors: "npm:^1.0.0"
   checksum: 6be7d3e15be47f4db8a5a563a35c60b5e7c4af91cc900e8972ffad33d3aaa227900faa55f60121cdb04b85866a734bb7fe4cd91f654c632861cc86121a48312a
+  languageName: node
+  linkType: hard
+
+"set-function-name@npm:^2.0.1":
+  version: 2.0.2
+  resolution: "set-function-name@npm:2.0.2"
+  dependencies:
+    define-data-property: "npm:^1.1.4"
+    es-errors: "npm:^1.3.0"
+    functions-have-names: "npm:^1.2.3"
+    has-property-descriptors: "npm:^1.0.2"
+  checksum: fce59f90696c450a8523e754abb305e2b8c73586452619c2bad5f7bf38c7b6b4651895c9db895679c5bef9554339cf3ef1c329b66ece3eda7255785fbe299316
   languageName: node
   linkType: hard
 
@@ -33040,6 +33355,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string.prototype.trim@npm:^1.2.9":
+  version: 1.2.9
+  resolution: "string.prototype.trim@npm:1.2.9"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.23.0"
+    es-object-atoms: "npm:^1.0.0"
+  checksum: dcef1a0fb61d255778155006b372dff8cc6c4394bc39869117e4241f41a2c52899c0d263ffc7738a1f9e61488c490b05c0427faa15151efad721e1a9fb2663c2
+  languageName: node
+  linkType: hard
+
 "string.prototype.trimend@npm:^1.0.4":
   version: 1.0.4
   resolution: "string.prototype.trimend@npm:1.0.4"
@@ -33072,6 +33399,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string.prototype.trimend@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "string.prototype.trimend@npm:1.0.8"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+    es-object-atoms: "npm:^1.0.0"
+  checksum: 0a0b54c17c070551b38e756ae271865ac6cc5f60dabf2e7e343cceae7d9b02e1a1120a824e090e79da1b041a74464e8477e2da43e2775c85392be30a6f60963c
+  languageName: node
+  linkType: hard
+
 "string.prototype.trimstart@npm:^1.0.4":
   version: 1.0.4
   resolution: "string.prototype.trimstart@npm:1.0.4"
@@ -33101,6 +33439,17 @@ __metadata:
     define-properties: "npm:^1.2.0"
     es-abstract: "npm:^1.22.1"
   checksum: 0bcf391b41ea16d4fda9c9953d0a7075171fe090d33b4cf64849af94944c50862995672ac03e0c5dba2940a213ad7f53515a668dac859ce22a0276289ae5cf4f
+  languageName: node
+  linkType: hard
+
+"string.prototype.trimstart@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "string.prototype.trimstart@npm:1.0.8"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+    es-object-atoms: "npm:^1.0.0"
+  checksum: d53af1899959e53c83b64a5fd120be93e067da740e7e75acb433849aa640782fb6c7d4cd5b84c954c84413745a3764df135a8afeb22908b86a835290788d8366
   languageName: node
   linkType: hard
 
@@ -34196,6 +34545,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"traverse@npm:^0.6.9":
+  version: 0.6.9
+  resolution: "traverse@npm:0.6.9"
+  dependencies:
+    gopd: "npm:^1.0.1"
+    typedarray.prototype.slice: "npm:^1.0.3"
+    which-typed-array: "npm:^1.1.15"
+  checksum: 6809ef684b04cd6985a4470f93bf794ad417f04bb1c43a6b1166fe1c94506118c7a7a87c34545fe15918f4e1fe29ced7a5813d8455932042f4ccc5981634139d
+  languageName: node
+  linkType: hard
+
 "tree-kill@npm:^1.2.2":
   version: 1.2.2
   resolution: "tree-kill@npm:1.2.2"
@@ -34685,6 +35045,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typed-array-buffer@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "typed-array-buffer@npm:1.0.2"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    es-errors: "npm:^1.3.0"
+    is-typed-array: "npm:^1.1.13"
+  checksum: 9e043eb38e1b4df4ddf9dde1aa64919ae8bb909571c1cc4490ba777d55d23a0c74c7d73afcdd29ec98616d91bb3ae0f705fad4421ea147e1daf9528200b562da
+  languageName: node
+  linkType: hard
+
 "typed-array-byte-length@npm:^1.0.0":
   version: 1.0.0
   resolution: "typed-array-byte-length@npm:1.0.0"
@@ -34694,6 +35065,19 @@ __metadata:
     has-proto: "npm:^1.0.1"
     is-typed-array: "npm:^1.1.10"
   checksum: 6696435d53ce0e704ff6760c57ccc35138aec5f87859e03eb2a3246336d546feae367952dbc918116f3f0dffbe669734e3cbd8960283c2fa79aac925db50d888
+  languageName: node
+  linkType: hard
+
+"typed-array-byte-length@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "typed-array-byte-length@npm:1.0.1"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    for-each: "npm:^0.3.3"
+    gopd: "npm:^1.0.1"
+    has-proto: "npm:^1.0.3"
+    is-typed-array: "npm:^1.1.13"
+  checksum: fcebeffb2436c9f355e91bd19e2368273b88c11d1acc0948a2a306792f1ab672bce4cfe524ab9f51a0505c9d7cd1c98eff4235c4f6bfef6a198f6cfc4ff3d4f3
   languageName: node
   linkType: hard
 
@@ -34710,6 +35094,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typed-array-byte-offset@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "typed-array-byte-offset@npm:1.0.2"
+  dependencies:
+    available-typed-arrays: "npm:^1.0.7"
+    call-bind: "npm:^1.0.7"
+    for-each: "npm:^0.3.3"
+    gopd: "npm:^1.0.1"
+    has-proto: "npm:^1.0.3"
+    is-typed-array: "npm:^1.1.13"
+  checksum: d2628bc739732072e39269389a758025f75339de2ed40c4f91357023c5512d237f255b633e3106c461ced41907c1bf9a533c7e8578066b0163690ca8bc61b22f
+  languageName: node
+  linkType: hard
+
 "typed-array-length@npm:^1.0.4":
   version: 1.0.4
   resolution: "typed-array-length@npm:1.0.4"
@@ -34721,12 +35119,40 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typed-array-length@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "typed-array-length@npm:1.0.6"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    for-each: "npm:^0.3.3"
+    gopd: "npm:^1.0.1"
+    has-proto: "npm:^1.0.3"
+    is-typed-array: "npm:^1.1.13"
+    possible-typed-array-names: "npm:^1.0.0"
+  checksum: 74253d7dc488eb28b6b2711cf31f5a9dcefc9c41b0681fd1c178ed0a1681b4468581a3626d39cd4df7aee3d3927ab62be06aa9ca74e5baf81827f61641445b77
+  languageName: node
+  linkType: hard
+
 "typedarray-to-buffer@npm:^3.1.5":
   version: 3.1.5
   resolution: "typedarray-to-buffer@npm:3.1.5"
   dependencies:
     is-typedarray: "npm:^1.0.0"
   checksum: 4ac5b7a93d604edabf3ac58d3a2f7e07487e9f6e98195a080e81dbffdc4127817f470f219d794a843b87052cedef102b53ac9b539855380b8c2172054b7d5027
+  languageName: node
+  linkType: hard
+
+"typedarray.prototype.slice@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "typedarray.prototype.slice@npm:1.0.3"
+  dependencies:
+    call-bind: "npm:^1.0.7"
+    define-properties: "npm:^1.2.1"
+    es-abstract: "npm:^1.23.0"
+    es-errors: "npm:^1.3.0"
+    typed-array-buffer: "npm:^1.0.2"
+    typed-array-byte-offset: "npm:^1.0.2"
+  checksum: 6ac110a8b58a1ccb086242f09d1ce9c7ba2885924e816364a7879083b983d4096f19aab6f9aa8c0ce5ddd3d8ae3f3ba5581e10fa6838880f296a0c54c26f424b
   languageName: node
   linkType: hard
 
@@ -36375,7 +36801,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which-typed-array@npm:^1.1.14, which-typed-array@npm:^1.1.2":
+"which-typed-array@npm:^1.1.14, which-typed-array@npm:^1.1.15, which-typed-array@npm:^1.1.2":
   version: 1.1.15
   resolution: "which-typed-array@npm:1.1.15"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -8413,6 +8413,8 @@ __metadata:
   dependencies:
     "@playwright/test": "npm:^1.24.1"
     "@svgr/webpack": "npm:^6.5.1"
+    "@tailwindcss/container-queries": "npm:^0.1.1"
+    "@tanstack/query-core": "npm:^5.32.0"
     "@testing-library/jest-dom": "npm:^5.16.2"
     "@testing-library/react": "npm:^12.1.3"
     "@testing-library/user-event": "npm:^13.5.0"
@@ -8446,6 +8448,7 @@ __metadata:
     jest: "npm:^29.4.1"
     jest-fetch-mock: "npm:^3.0.3"
     jotai: "npm:^2.6.3"
+    jotai-tanstack-query: "npm:^0.8.5"
     local-cors-proxy: "npm:^1.1.0"
     lodash.debounce: "npm:^4.0.8"
     postcss: "npm:^8.4.32"
@@ -8473,6 +8476,7 @@ __metadata:
     webpack-bundle-analyzer: "npm:^4.10.1"
     webpack-cli: "npm:^5.0.1"
     webpack-dev-server: "npm:^4.11.1"
+    wonka: "npm:^6.3.4"
   languageName: unknown
   linkType: soft
 
@@ -26784,15 +26788,11 @@ __metadata:
   resolution: "namada@workspace:."
   dependencies:
     "@release-it/conventional-changelog": "npm:^8.0.1"
-    "@tailwindcss/container-queries": "npm:^0.1.1"
-    "@tanstack/query-core": "npm:^5.32.0"
     "@typescript-eslint/eslint-plugin": "npm:^6.13.0"
     "@typescript-eslint/parser": "npm:^6.13.0"
     eslint: "npm:^8.49.0"
     git-commit-msg-linter: "npm:^5.0.4"
     husky: "npm:^8.0.3"
-    invariant: "npm:^2.2.4"
-    jotai-tanstack-query: "npm:^0.8.5"
     jsdoc-to-markdown: "npm:^8.0.1"
     lint-staged: "npm:^15.2.0"
     prettier: "npm:^3.1.0"
@@ -26801,7 +26801,6 @@ __metadata:
     rimraf: "npm:^5.0.5"
     stream-browserify: "npm:^3.0.0"
     vite-plugin-checker: "npm:^0.6.4"
-    wonka: "npm:^6.3.4"
     wsrun: "npm:^5.2.4"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Adds persistent cache for react query.

- Persist proposal data and show in proposal info components
- Refactor proposal info page components
- Move dependencies from root to namadillo

To test this, open a proposal page such as `http://localhost:5173/governance/proposal/0`. The first time the page loads, the data will be fetched from the RPC. Refresh the page and you should see that the data loads faster since it has been persisted in the browser. You can also see there is an entry in Indexed DB.

I still need to figure out how to use the persisted data to speed up the proposals table, so for the moment the proposals table does not use the cached data. This will be done in a later PR.
