### PR TITLE
WIP: feat/817 - Ledger HW wallet updates

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -41,7 +41,7 @@
     "@ledgerhq/hw-transport": "^6.30.0",
     "@ledgerhq/hw-transport-webhid": "^6.28.0",
     "@ledgerhq/hw-transport-webusb": "^6.28.0",
-    "@zondax/ledger-namada": "^0.0.4",
+    "@zondax/ledger-namada": "^0.0.6",
     "bignumber.js": "^9.1.1",
     "buffer": "^6.0.3",
     "dompurify": "^3.0.2",

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -1,6 +1,4 @@
-import { fromHex } from "@cosmjs/encoding";
-
-import { PhraseSize, publicKeyToBech32 } from "@heliax/namada-sdk/web";
+import { PhraseSize } from "@heliax/namada-sdk/web";
 import { IndexedDBKVStore, KVStore } from "@namada/storage";
 import {
   AccountType,
@@ -78,9 +76,6 @@ export class KeyRingService {
     publicKey: string,
     bip44Path: Bip44Path
   ): Promise<AccountStore | false> {
-    const publicKeyBytes = fromHex(publicKey);
-    const bech32PublicKey = publicKeyToBech32(publicKeyBytes);
-
     const account = await this._keyRing.queryAccountByAddress(address);
     if (account) {
       throw new Error(
@@ -91,7 +86,7 @@ export class KeyRingService {
     const response = await this._keyRing.storeLedger(
       alias,
       address,
-      bech32PublicKey,
+      publicKey,
       bip44Path
     );
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -65,7 +65,7 @@
     "@ledgerhq/hw-transport": "^6.30.0",
     "@ledgerhq/hw-transport-webhid": "^6.28.0",
     "@ledgerhq/hw-transport-webusb": "^6.28.0",
-    "@zondax/ledger-namada": "^0.0.4",
+    "@zondax/ledger-namada": "^0.0.6",
     "bignumber.js": "^9.1.1",
     "buffer": "^6.0.3",
     "slip44": "^3.0.18",

--- a/packages/sdk/src/ledger.ts
+++ b/packages/sdk/src/ledger.ts
@@ -1,4 +1,3 @@
-import { toHex } from "@cosmjs/encoding";
 import Transport from "@ledgerhq/hw-transport";
 import TransportHID from "@ledgerhq/hw-transport-webhid";
 import TransportUSB from "@ledgerhq/hw-transport-webusb";
@@ -97,14 +96,13 @@ export class Ledger {
   public async getAddressAndPublicKey(
     path: string = DEFAULT_LEDGER_BIP44_PATH
   ): Promise<AddressAndPublicKey> {
-    const { address, publicKey } =
-      await this.namadaApp.getAddressAndPubKey(path);
+    const { address, pubkey } = await this.namadaApp.getAddressAndPubKey(path);
 
     return {
       // Return address as bech32-encoded string
       address: address.toString(),
-      // Return public key as hex-encoded string
-      publicKey: toHex(publicKey),
+      // Return public key as bech32-encoded string
+      publicKey: pubkey.toString(),
     };
   }
 
@@ -119,14 +117,14 @@ export class Ledger {
     path: string = DEFAULT_LEDGER_BIP44_PATH
   ): Promise<AddressAndPublicKey> {
     try {
-      const { address, publicKey } =
+      const { address, pubkey } =
         await this.namadaApp.showAddressAndPubKey(path);
 
       return {
         // Return address as bech32-encoded string
         address: address.toString(),
-        // Return public key as hex-encoded string
-        publicKey: toHex(publicKey),
+        // Return public key as bech32-encoded string
+        publicKey: pubkey.toString(),
       };
     } catch (e) {
       throw new Error(`Connect Ledger rejected by user: ${e}`);

--- a/packages/sdk/src/tests/ledger.test.ts
+++ b/packages/sdk/src/tests/ledger.test.ts
@@ -137,7 +137,7 @@ describe("ledger", () => {
       const namadaApp = {
         getAddressAndPubKey: jest.fn().mockReturnValue({
           address: adrBuffer,
-          publicKey: keyBuffer,
+          pubkey: keyBuffer,
         }),
       };
       const path = "path";
@@ -147,7 +147,7 @@ describe("ledger", () => {
 
       expect(namadaApp.getAddressAndPubKey).toHaveBeenCalledWith(path);
       expect(address).toEqual("addr");
-      expect(publicKey).toEqual("6b6579");
+      expect(publicKey).toEqual("key");
     });
 
     it("should return the address and public key of the ledger", async () => {
@@ -156,7 +156,7 @@ describe("ledger", () => {
       const namadaApp = {
         getAddressAndPubKey: jest.fn().mockReturnValue({
           address: adrBuffer,
-          publicKey: keyBuffer,
+          pubkey: keyBuffer,
         }),
       };
 
@@ -176,7 +176,7 @@ describe("ledger", () => {
       const namadaApp = {
         showAddressAndPubKey: jest.fn().mockReturnValue({
           address: adrBuffer,
-          publicKey: keyBuffer,
+          pubkey: keyBuffer,
         }),
       };
       const path = "path";
@@ -186,7 +186,7 @@ describe("ledger", () => {
 
       expect(namadaApp.showAddressAndPubKey).toHaveBeenCalledWith(path);
       expect(address).toEqual("addr");
-      expect(publicKey).toEqual("6b6579");
+      expect(publicKey).toEqual("key");
     });
 
     it("should throw an error when the ledger can't show the address and public key", async () => {

--- a/packages/sdk/src/tx/tx.ts
+++ b/packages/sdk/src/tx/tx.ts
@@ -398,7 +398,7 @@ export class Tx {
     }
 
     const {
-      pubkey,
+      rawPubkey,
       raw_indices,
       raw_signature,
       wrapper_indices,
@@ -408,7 +408,7 @@ export class Tx {
     // Construct props from ledgerSignature
     /* eslint-disable */
     const props = {
-      pubkey: new Uint8Array((pubkey as any).data),
+      pubkey: new Uint8Array((rawPubkey as any).data),
       rawIndices: new Uint8Array((raw_indices as any).data),
       rawSignature: new Uint8Array((raw_signature as any).data),
       wrapperIndices: new Uint8Array((wrapper_indices as any).data),

--- a/yarn.lock
+++ b/yarn.lock
@@ -6222,7 +6222,7 @@ __metadata:
     "@release-it/conventional-changelog": "npm:^8.0.1"
     "@types/jest": "npm:^29.0.3"
     "@types/node": "npm:^20.11.4"
-    "@zondax/ledger-namada": "npm:^0.0.4"
+    "@zondax/ledger-namada": "npm:^0.0.6"
     babel-jest: "npm:^29.0.3"
     bignumber.js: "npm:^9.1.1"
     buffer: "npm:^6.0.3"
@@ -8032,10 +8032,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ledgerhq/devices@npm:^8.3.0":
+  version: 8.3.0
+  resolution: "@ledgerhq/devices@npm:8.3.0"
+  dependencies:
+    "@ledgerhq/errors": "npm:^6.16.4"
+    "@ledgerhq/logs": "npm:^6.12.0"
+    rxjs: "npm:^7.8.1"
+    semver: "npm:^7.3.5"
+  checksum: 7a78383056a5cf55fc3e4411505cf6f789f1a68cf151fff01f386f81f3f5286f6752264d41a7dac2572efe489e4c299d95d0a9ea7233717f9d1e3c96d09e87c4
+  languageName: node
+  linkType: hard
+
 "@ledgerhq/errors@npm:^6.16.1":
   version: 6.16.1
   resolution: "@ledgerhq/errors@npm:6.16.1"
   checksum: cabd4c2768be3f2eec9e15d83519b8eae113efb2d9f3dcd241e2ad01101f3a073dbf2eceae72073151db3bd36ab231d69b66b9aa4106c23ff5444185c66de849
+  languageName: node
+  linkType: hard
+
+"@ledgerhq/errors@npm:^6.16.4":
+  version: 6.16.4
+  resolution: "@ledgerhq/errors@npm:6.16.4"
+  checksum: 6c0f31ac188486063f33ef3ae2e8b7cf5bdd73616ea4715caab3e3a7b722b3b230742c5dd6227b080f70f28598df6833b6c62f38a8a238035e4d48f2073c3636
   languageName: node
   linkType: hard
 
@@ -8075,15 +8094,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ledgerhq/hw-transport@npm:^6.30.3":
-  version: 6.30.3
-  resolution: "@ledgerhq/hw-transport@npm:6.30.3"
+"@ledgerhq/hw-transport@npm:^6.30.6":
+  version: 6.30.6
+  resolution: "@ledgerhq/hw-transport@npm:6.30.6"
   dependencies:
-    "@ledgerhq/devices": "npm:^8.2.0"
-    "@ledgerhq/errors": "npm:^6.16.1"
+    "@ledgerhq/devices": "npm:^8.3.0"
+    "@ledgerhq/errors": "npm:^6.16.4"
     "@ledgerhq/logs": "npm:^6.12.0"
     events: "npm:^3.3.0"
-  checksum: e50b9f99d6127b641d293d33b5141f55e59a8a14afb231e7d5c696e234a210ca94a6573a442548384ac4afa315b60b9c3ff7cff29f3df5e00f9cb59385801d70
+  checksum: 85dc3e4938f921996821fbb0ce65808b210823f53aeeb98fb3537348cebab0c852702dca72a3d763b58b9362257d0f16f76930bacd8cc594ee5cd3d367836fda
   languageName: node
   linkType: hard
 
@@ -8268,7 +8287,7 @@ __metadata:
     "@types/uuid": "npm:^8.3.4"
     "@types/webextension-polyfill": "npm:^0.10.6"
     "@types/zxcvbn": "npm:^4.4.1"
-    "@zondax/ledger-namada": "npm:^0.0.4"
+    "@zondax/ledger-namada": "npm:^0.0.6"
     bignumber.js: "npm:^9.1.1"
     buffer: "npm:^6.0.3"
     copy-webpack-plugin: "npm:^11.0.0"
@@ -11770,12 +11789,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@zondax/ledger-namada@npm:^0.0.4":
-  version: 0.0.4
-  resolution: "@zondax/ledger-namada@npm:0.0.4"
+"@zondax/ledger-namada@npm:^0.0.6":
+  version: 0.0.6
+  resolution: "@zondax/ledger-namada@npm:0.0.6"
   dependencies:
-    "@ledgerhq/hw-transport": "npm:^6.30.3"
-  checksum: c0302c84ac82309af4844c147d94fbe2b3c4b84f37d0f50fe3dc8b2b3068bd672fbe46a053633a77cac08ca94d109867de303c9a8bda357284b0e429ded512e3
+    "@ledgerhq/hw-transport": "npm:^6.30.6"
+  checksum: 39aabba4be347e5329413be53de82e6519ff9b8e44473d6753cd096b733d075891528d12353108bf653071cbcd6804a9b826703753061428a7f93861607bce80
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves #817 

- [ ] Update to latest `@zondax/ledger-namada` package (currently `v0.0.6`) and fix tests
- [ ] When importing account from Ledger, also import shielded address (is this possible?)