### PR TITLE
feat: bump to Namada 0.39.0, update transparent transfer

### DIFF
--- a/packages/sdk/docs/classes/Crypto.md
+++ b/packages/sdk/docs/classes/Crypto.md
@@ -40,7 +40,7 @@ Class Crypto handles AES encryption tasks
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/crypto/crypto.ts#L20)
+[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/crypto.ts#L20)
 
 ## Properties
 
@@ -52,7 +52,7 @@ WebAssembly Memory for crypto
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/crypto/crypto.ts#L20)
+[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/crypto.ts#L20)
 
 ## Methods
 
@@ -75,7 +75,7 @@ decrypted text
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:115](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/crypto/crypto.ts#L115)
+[sdk/src/crypto/crypto.ts:115](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/crypto.ts#L115)
 
 ___
 
@@ -100,7 +100,7 @@ crypto record
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:61](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/crypto/crypto.ts#L61)
+[sdk/src/crypto/crypto.ts:61](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/crypto.ts#L61)
 
 ___
 
@@ -126,7 +126,7 @@ array of encrypted bytes
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:98](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/crypto/crypto.ts#L98)
+[sdk/src/crypto/crypto.ts:98](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/crypto.ts#L98)
 
 ___
 
@@ -153,7 +153,7 @@ crypto record used for storage
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:30](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/crypto/crypto.ts#L30)
+[sdk/src/crypto/crypto.ts:30](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/crypto.ts#L30)
 
 ___
 
@@ -178,4 +178,4 @@ encryption parameters
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:73](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/crypto/crypto.ts#L73)
+[sdk/src/crypto/crypto.ts:73](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/crypto.ts#L73)

--- a/packages/sdk/docs/classes/EncodedTx.md
+++ b/packages/sdk/docs/classes/EncodedTx.md
@@ -42,7 +42,7 @@ Create an EncodedTx class
 
 #### Defined in
 
-[sdk/src/tx/types.ts:12](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/types.ts#L12)
+[sdk/src/tx/types.ts:12](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/types.ts#L12)
 
 ## Properties
 
@@ -54,7 +54,7 @@ Specific tx struct instance
 
 #### Defined in
 
-[sdk/src/tx/types.ts:14](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/types.ts#L14)
+[sdk/src/tx/types.ts:14](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/types.ts#L14)
 
 ___
 
@@ -66,7 +66,7 @@ Borsh-serialized transaction
 
 #### Defined in
 
-[sdk/src/tx/types.ts:13](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/types.ts#L13)
+[sdk/src/tx/types.ts:13](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/types.ts#L13)
 
 ## Methods
 
@@ -82,7 +82,7 @@ Clear tx bytes resource
 
 #### Defined in
 
-[sdk/src/tx/types.ts:39](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/types.ts#L39)
+[sdk/src/tx/types.ts:39](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/types.ts#L39)
 
 ___
 
@@ -100,7 +100,7 @@ string of tx hash
 
 #### Defined in
 
-[sdk/src/tx/types.ts:32](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/types.ts#L32)
+[sdk/src/tx/types.ts:32](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/types.ts#L32)
 
 ___
 
@@ -119,4 +119,4 @@ Serialized tx bytes
 
 #### Defined in
 
-[sdk/src/tx/types.ts:22](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/types.ts#L22)
+[sdk/src/tx/types.ts:22](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/types.ts#L22)

--- a/packages/sdk/docs/classes/Ledger.md
+++ b/packages/sdk/docs/classes/Ledger.md
@@ -42,7 +42,7 @@ Functionality for interacting with NamadaApp for Ledger Hardware Wallets
 
 #### Defined in
 
-[sdk/src/ledger.ts:54](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/ledger.ts#L54)
+[sdk/src/ledger.ts:54](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L54)
 
 ## Properties
 
@@ -54,7 +54,7 @@ Inititalized NamadaApp class from Zondax package
 
 #### Defined in
 
-[sdk/src/ledger.ts:54](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/ledger.ts#L54)
+[sdk/src/ledger.ts:54](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L54)
 
 ## Methods
 
@@ -75,7 +75,7 @@ void
 
 #### Defined in
 
-[sdk/src/ledger.ts:176](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/ledger.ts#L176)
+[sdk/src/ledger.ts:176](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L176)
 
 ___
 
@@ -102,7 +102,7 @@ Address and public key
 
 #### Defined in
 
-[sdk/src/ledger.ts:97](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/ledger.ts#L97)
+[sdk/src/ledger.ts:97](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L97)
 
 ___
 
@@ -123,7 +123,7 @@ Error message if error is found
 
 #### Defined in
 
-[sdk/src/ledger.ts:159](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/ledger.ts#L159)
+[sdk/src/ledger.ts:159](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L159)
 
 ___
 
@@ -150,7 +150,7 @@ Address and public key
 
 #### Defined in
 
-[sdk/src/ledger.ts:118](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/ledger.ts#L118)
+[sdk/src/ledger.ts:118](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L118)
 
 ___
 
@@ -178,7 +178,7 @@ Response signature
 
 #### Defined in
 
-[sdk/src/ledger.ts:144](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/ledger.ts#L144)
+[sdk/src/ledger.ts:144](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L144)
 
 ___
 
@@ -199,7 +199,7 @@ Version and info of NamadaApp
 
 #### Defined in
 
-[sdk/src/ledger.ts:80](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/ledger.ts#L80)
+[sdk/src/ledger.ts:80](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L80)
 
 ___
 
@@ -225,4 +225,4 @@ Ledger class instance
 
 #### Defined in
 
-[sdk/src/ledger.ts:62](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/ledger.ts#L62)
+[sdk/src/ledger.ts:62](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L62)

--- a/packages/sdk/docs/classes/Masp.md
+++ b/packages/sdk/docs/classes/Masp.md
@@ -41,7 +41,7 @@ Class representing utilities related to MASP
 
 #### Defined in
 
-[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/masp.ts#L10)
+[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/masp.ts#L10)
 
 ## Properties
 
@@ -53,7 +53,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/masp.ts#L10)
+[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/masp.ts#L10)
 
 ## Methods
 
@@ -80,7 +80,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:69](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/masp.ts#L69)
+[sdk/src/masp.ts:69](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/masp.ts#L69)
 
 ___
 
@@ -107,7 +107,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:47](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/masp.ts#L47)
+[sdk/src/masp.ts:47](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/masp.ts#L47)
 
 ___
 
@@ -134,7 +134,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:58](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/masp.ts#L58)
+[sdk/src/masp.ts:58](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/masp.ts#L58)
 
 ___
 
@@ -154,7 +154,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:26](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/masp.ts#L26)
+[sdk/src/masp.ts:26](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/masp.ts#L26)
 
 ___
 
@@ -174,7 +174,7 @@ True if MASP parameters are loaded
 
 #### Defined in
 
-[sdk/src/masp.ts:17](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/masp.ts#L17)
+[sdk/src/masp.ts:17](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/masp.ts#L17)
 
 ___
 
@@ -200,4 +200,4 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:36](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/masp.ts#L36)
+[sdk/src/masp.ts:36](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/masp.ts#L36)

--- a/packages/sdk/docs/classes/Mnemonic.md
+++ b/packages/sdk/docs/classes/Mnemonic.md
@@ -38,7 +38,7 @@ Class for accessing mnemonic functionality from wasm
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/mnemonic.ts#L18)
+[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/mnemonic.ts#L18)
 
 ## Properties
 
@@ -50,7 +50,7 @@ Memory accessor for crypto lib
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/mnemonic.ts#L18)
+[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/mnemonic.ts#L18)
 
 ## Methods
 
@@ -76,7 +76,7 @@ Promise that resolves to array of words
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:26](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/mnemonic.ts#L26)
+[sdk/src/mnemonic.ts:26](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/mnemonic.ts#L26)
 
 ___
 
@@ -101,7 +101,7 @@ Seed bytes
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:44](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/mnemonic.ts#L44)
+[sdk/src/mnemonic.ts:44](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/mnemonic.ts#L44)
 
 ___
 
@@ -131,4 +131,4 @@ Object with validation result and error message if invalid
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:62](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/mnemonic.ts#L62)
+[sdk/src/mnemonic.ts:62](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/mnemonic.ts#L62)

--- a/packages/sdk/docs/classes/Rpc.md
+++ b/packages/sdk/docs/classes/Rpc.md
@@ -23,7 +23,6 @@ API for executing RPC requests with Namada
 - [queryDelegatorsVotes](Rpc.md#querydelegatorsvotes)
 - [queryGasCosts](Rpc.md#querygascosts)
 - [queryNativeToken](Rpc.md#querynativetoken)
-- [queryProposals](Rpc.md#queryproposals)
 - [queryPublicKey](Rpc.md#querypublickey)
 - [querySignedBridgePool](Rpc.md#querysignedbridgepool)
 - [queryStakingPositions](Rpc.md#querystakingpositions)
@@ -51,7 +50,7 @@ API for executing RPC requests with Namada
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:31](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/rpc.ts#L31)
+[sdk/src/rpc/rpc.ts:28](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L28)
 
 ## Properties
 
@@ -63,7 +62,7 @@ Instance of Query struct from wasm lib
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:33](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/rpc.ts#L33)
+[sdk/src/rpc/rpc.ts:30](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L30)
 
 ___
 
@@ -75,7 +74,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:32](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/rpc.ts#L32)
+[sdk/src/rpc/rpc.ts:29](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L29)
 
 ## Methods
 
@@ -101,7 +100,7 @@ void
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:210](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/rpc.ts#L210)
+[sdk/src/rpc/rpc.ts:196](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L196)
 
 ___
 
@@ -121,7 +120,7 @@ Array of all validator addresses
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:73](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/rpc.ts#L73)
+[sdk/src/rpc/rpc.ts:70](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L70)
 
 ___
 
@@ -148,7 +147,7 @@ Query balances from chain
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:43](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/rpc.ts#L43)
+[sdk/src/rpc/rpc.ts:40](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L40)
 
 ___
 
@@ -174,7 +173,7 @@ Promise resolving to delegators votes
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:108](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/rpc.ts#L108)
+[sdk/src/rpc/rpc.ts:94](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L94)
 
 ___
 
@@ -194,7 +193,7 @@ Query gas costs
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:200](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/rpc.ts#L200)
+[sdk/src/rpc/rpc.ts:186](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L186)
 
 ___
 
@@ -214,27 +213,7 @@ Address of native token
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:52](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/rpc.ts#L52)
-
-___
-
-### queryProposals
-
-▸ **queryProposals**(): `Promise`\<`Proposal`[]\>
-
-Query Proposals
-
-#### Returns
-
-`Promise`\<`Proposal`[]\>
-
-List of the proposals
-
-**`Async`**
-
-#### Defined in
-
-[sdk/src/rpc/rpc.ts:82](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/rpc.ts#L82)
+[sdk/src/rpc/rpc.ts:49](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L49)
 
 ___
 
@@ -261,7 +240,7 @@ String of public key if found
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:63](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/rpc.ts#L63)
+[sdk/src/rpc/rpc.ts:60](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L60)
 
 ___
 
@@ -287,7 +266,7 @@ Promise resolving to pending ethereum transfers
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:191](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/rpc.ts#L191)
+[sdk/src/rpc/rpc.ts:177](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L177)
 
 ___
 
@@ -313,7 +292,7 @@ Promise resolving to staking positions
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:145](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/rpc.ts#L145)
+[sdk/src/rpc/rpc.ts:131](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L131)
 
 ___
 
@@ -339,7 +318,7 @@ Promise resolving to staking totals
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:118](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/rpc.ts#L118)
+[sdk/src/rpc/rpc.ts:104](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L104)
 
 ___
 
@@ -363,7 +342,7 @@ Total bonds amount
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:181](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/rpc.ts#L181)
+[sdk/src/rpc/rpc.ts:167](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L167)
 
 ___
 
@@ -390,7 +369,7 @@ Promise resolving to total delegations
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:95](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/rpc.ts#L95)
+[sdk/src/rpc/rpc.ts:81](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L81)
 
 ___
 
@@ -414,4 +393,4 @@ Sync the shielded context
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:221](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/rpc.ts#L221)
+[sdk/src/rpc/rpc.ts:207](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L207)

--- a/packages/sdk/docs/classes/Sdk.md
+++ b/packages/sdk/docs/classes/Sdk.md
@@ -61,7 +61,7 @@ API for interacting with Namada SDK
 
 #### Defined in
 
-[sdk/src/sdk.ts:23](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/sdk.ts#L23)
+[sdk/src/sdk.ts:23](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L23)
 
 ## Properties
 
@@ -73,7 +73,7 @@ Memory accessor for crypto lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:26](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/sdk.ts#L26)
+[sdk/src/sdk.ts:26](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L26)
 
 ___
 
@@ -85,7 +85,7 @@ Address of chain's native token
 
 #### Defined in
 
-[sdk/src/sdk.ts:28](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/sdk.ts#L28)
+[sdk/src/sdk.ts:28](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L28)
 
 ___
 
@@ -97,7 +97,7 @@ Instance of Query struct from wasm lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:25](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/sdk.ts#L25)
+[sdk/src/sdk.ts:25](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L25)
 
 ___
 
@@ -109,7 +109,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:24](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/sdk.ts#L24)
+[sdk/src/sdk.ts:24](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L24)
 
 ___
 
@@ -121,7 +121,7 @@ RPC url
 
 #### Defined in
 
-[sdk/src/sdk.ts:27](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/sdk.ts#L27)
+[sdk/src/sdk.ts:27](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L27)
 
 ## Accessors
 
@@ -139,7 +139,7 @@ Utilities for encrypting and decrypting data
 
 #### Defined in
 
-[sdk/src/sdk.ts:148](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/sdk.ts#L148)
+[sdk/src/sdk.ts:148](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L148)
 
 ___
 
@@ -157,7 +157,7 @@ key-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:124](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/sdk.ts#L124)
+[sdk/src/sdk.ts:124](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L124)
 
 ___
 
@@ -175,7 +175,7 @@ Masp utilities for handling params
 
 #### Defined in
 
-[sdk/src/sdk.ts:140](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/sdk.ts#L140)
+[sdk/src/sdk.ts:140](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L140)
 
 ___
 
@@ -193,7 +193,7 @@ mnemonic-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:116](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/sdk.ts#L116)
+[sdk/src/sdk.ts:116](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L116)
 
 ___
 
@@ -211,7 +211,7 @@ rpc client
 
 #### Defined in
 
-[sdk/src/sdk.ts:100](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/sdk.ts#L100)
+[sdk/src/sdk.ts:100](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L100)
 
 ___
 
@@ -229,7 +229,7 @@ Non-Tx signing functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:132](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/sdk.ts#L132)
+[sdk/src/sdk.ts:132](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L132)
 
 ___
 
@@ -247,7 +247,7 @@ tx-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:108](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/sdk.ts#L108)
+[sdk/src/sdk.ts:108](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L108)
 
 ## Methods
 
@@ -265,7 +265,7 @@ Utilities for encrypting and decrypting data
 
 #### Defined in
 
-[sdk/src/sdk.ts:82](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/sdk.ts#L82)
+[sdk/src/sdk.ts:82](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L82)
 
 ___
 
@@ -283,7 +283,7 @@ key-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:58](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/sdk.ts#L58)
+[sdk/src/sdk.ts:58](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L58)
 
 ___
 
@@ -301,7 +301,7 @@ Masp utilities for handling params
 
 #### Defined in
 
-[sdk/src/sdk.ts:74](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/sdk.ts#L74)
+[sdk/src/sdk.ts:74](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L74)
 
 ___
 
@@ -319,7 +319,7 @@ mnemonic-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:50](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/sdk.ts#L50)
+[sdk/src/sdk.ts:50](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L50)
 
 ___
 
@@ -337,7 +337,7 @@ Namada RPC client
 
 #### Defined in
 
-[sdk/src/sdk.ts:34](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/sdk.ts#L34)
+[sdk/src/sdk.ts:34](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L34)
 
 ___
 
@@ -355,7 +355,7 @@ Non-Tx signing functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:66](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/sdk.ts#L66)
+[sdk/src/sdk.ts:66](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L66)
 
 ___
 
@@ -373,7 +373,7 @@ Tx-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:42](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/sdk.ts#L42)
+[sdk/src/sdk.ts:42](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L42)
 
 ___
 
@@ -399,4 +399,4 @@ Class for interacting with NamadaApp for Ledger Hardware Wallets
 
 #### Defined in
 
-[sdk/src/sdk.ts:92](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/sdk.ts#L92)
+[sdk/src/sdk.ts:92](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L92)

--- a/packages/sdk/docs/classes/SignedTx.md
+++ b/packages/sdk/docs/classes/SignedTx.md
@@ -34,7 +34,7 @@ Wrap results of tx signing to simplify passing between Sdk functions
 
 #### Defined in
 
-[sdk/src/tx/types.ts:52](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/types.ts#L52)
+[sdk/src/tx/types.ts:52](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/types.ts#L52)
 
 ## Properties
 
@@ -46,7 +46,7 @@ Serialized tx bytes
 
 #### Defined in
 
-[sdk/src/tx/types.ts:56](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/types.ts#L56)
+[sdk/src/tx/types.ts:56](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/types.ts#L56)
 
 ___
 
@@ -58,4 +58,4 @@ Serialized wrapper tx msg bytes
 
 #### Defined in
 
-[sdk/src/tx/types.ts:54](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/types.ts#L54)
+[sdk/src/tx/types.ts:54](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/types.ts#L54)

--- a/packages/sdk/docs/classes/Signing.md
+++ b/packages/sdk/docs/classes/Signing.md
@@ -40,7 +40,7 @@ Signing constructor
 
 #### Defined in
 
-[sdk/src/signing.ts:13](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/signing.ts#L13)
+[sdk/src/signing.ts:13](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/signing.ts#L13)
 
 ## Properties
 
@@ -52,7 +52,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/signing.ts:13](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/signing.ts#L13)
+[sdk/src/signing.ts:13](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/signing.ts#L13)
 
 ## Methods
 
@@ -78,7 +78,7 @@ signed tx bytes - Promise resolving to Uint8Array
 
 #### Defined in
 
-[sdk/src/signing.ts:22](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/signing.ts#L22)
+[sdk/src/signing.ts:22](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/signing.ts#L22)
 
 ___
 
@@ -103,7 +103,7 @@ hash and signature
 
 #### Defined in
 
-[sdk/src/signing.ts:36](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/signing.ts#L36)
+[sdk/src/signing.ts:36](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/signing.ts#L36)
 
 ___
 
@@ -129,4 +129,4 @@ void
 
 #### Defined in
 
-[sdk/src/signing.ts:47](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/signing.ts#L47)
+[sdk/src/signing.ts:47](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/signing.ts#L47)

--- a/packages/sdk/docs/classes/Tx.md
+++ b/packages/sdk/docs/classes/Tx.md
@@ -22,7 +22,7 @@ SDK functionality related to transactions
 - [buildIbcTransfer](Tx.md#buildibctransfer)
 - [buildRedelegate](Tx.md#buildredelegate)
 - [buildRevealPk](Tx.md#buildrevealpk)
-- [buildTransfer](Tx.md#buildtransfer)
+- [buildTransparentTransfer](Tx.md#buildtransparenttransfer)
 - [buildTx](Tx.md#buildtx)
 - [buildTxFromSerializedArgs](Tx.md#buildtxfromserializedargs)
 - [buildUnbond](Tx.md#buildunbond)
@@ -49,7 +49,7 @@ SDK functionality related to transactions
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:34](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/tx.ts#L34)
+[sdk/src/tx/tx.ts:34](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L34)
 
 ## Properties
 
@@ -61,7 +61,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:34](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/tx.ts#L34)
+[sdk/src/tx/tx.ts:34](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L34)
 
 ## Methods
 
@@ -86,7 +86,7 @@ Append signature for transactions signed by Ledger Hardware Wallet
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:391](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/tx.ts#L391)
+[sdk/src/tx/tx.ts:391](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L391)
 
 ___
 
@@ -114,7 +114,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:193](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/tx.ts#L193)
+[sdk/src/tx/tx.ts:193](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L193)
 
 ___
 
@@ -142,7 +142,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:322](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/tx.ts#L322)
+[sdk/src/tx/tx.ts:322](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L322)
 
 ___
 
@@ -170,7 +170,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:295](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/tx.ts#L295)
+[sdk/src/tx/tx.ts:295](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L295)
 
 ___
 
@@ -198,7 +198,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:268](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/tx.ts#L268)
+[sdk/src/tx/tx.ts:268](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L268)
 
 ___
 
@@ -225,13 +225,13 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:171](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/tx.ts#L171)
+[sdk/src/tx/tx.ts:171](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L171)
 
 ___
 
-### buildTransfer
+### buildTransparentTransfer
 
-▸ **buildTransfer**(`wrapperTxProps`, `transferProps`, `gasPayer?`): `Promise`\<[`EncodedTx`](EncodedTx.md)\>
+▸ **buildTransparentTransfer**(`wrapperTxProps`, `transferProps`, `gasPayer?`): `Promise`\<[`EncodedTx`](EncodedTx.md)\>
 
 Build Transfer Tx
 
@@ -240,7 +240,7 @@ Build Transfer Tx
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `wrapperTxProps` | `WrapperTxMsgValue` | properties of the transaction |
-| `transferProps` | `TransferMsgValue` | properties of the transfer |
+| `transferProps` | `TransparentTransferMsgValue` | properties of the transfer |
 | `gasPayer?` | `string` | optional gas payer, if not provided, defaults to transferProps.source |
 
 #### Returns
@@ -253,7 +253,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:144](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/tx.ts#L144)
+[sdk/src/tx/tx.ts:144](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L144)
 
 ___
 
@@ -282,7 +282,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:70](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/tx.ts#L70)
+[sdk/src/tx/tx.ts:70](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L70)
 
 ___
 
@@ -311,7 +311,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:45](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/tx.ts#L45)
+[sdk/src/tx/tx.ts:45](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L45)
 
 ___
 
@@ -339,7 +339,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:218](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/tx.ts#L218)
+[sdk/src/tx/tx.ts:218](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L218)
 
 ___
 
@@ -367,7 +367,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:349](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/tx.ts#L349)
+[sdk/src/tx/tx.ts:349](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L349)
 
 ___
 
@@ -395,7 +395,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:243](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/tx.ts#L243)
+[sdk/src/tx/tx.ts:243](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L243)
 
 ___
 
@@ -419,7 +419,7 @@ Serialized WrapperTxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:432](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/tx.ts#L432)
+[sdk/src/tx/tx.ts:432](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L432)
 
 ___
 
@@ -447,4 +447,4 @@ void
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:376](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/tx/tx.ts#L376)
+[sdk/src/tx/tx.ts:376](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L376)

--- a/packages/sdk/docs/enums/KdfType.md
+++ b/packages/sdk/docs/enums/KdfType.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:38](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/crypto/types.ts#L38)
+[sdk/src/crypto/types.ts:38](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/types.ts#L38)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:39](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/crypto/types.ts#L39)
+[sdk/src/crypto/types.ts:39](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/types.ts#L39)

--- a/packages/sdk/docs/enums/TxType.md
+++ b/packages/sdk/docs/enums/TxType.md
@@ -11,7 +11,7 @@
 - [IBCTransfer](TxType.md#ibctransfer)
 - [Redelegate](TxType.md#redelegate)
 - [RevealPK](TxType.md#revealpk)
-- [Transfer](TxType.md#transfer)
+- [TransparentTransfer](TxType.md#transparenttransfer)
 - [Unbond](TxType.md#unbond)
 - [VoteProposal](TxType.md#voteproposal)
 - [Withdraw](TxType.md#withdraw)
@@ -68,9 +68,9 @@ shared/src/shared/shared.d.ts:23
 
 ___
 
-### Transfer
+### TransparentTransfer
 
-• **Transfer** = ``4``
+• **TransparentTransfer** = ``4``
 
 #### Defined in
 

--- a/packages/sdk/docs/modules.md
+++ b/packages/sdk/docs/modules.md
@@ -71,7 +71,7 @@ Address and public key type
 
 #### Defined in
 
-[sdk/src/keys/types.ts:4](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/keys/types.ts#L4)
+[sdk/src/keys/types.ts:4](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/keys/types.ts#L4)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:17](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/ledger.ts#L17)
+[sdk/src/ledger.ts:17](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L17)
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:23](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/crypto/types.ts#L23)
+[sdk/src/crypto/types.ts:23](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/types.ts#L23)
 
 ___
 
@@ -111,7 +111,7 @@ Balance
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:69](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/types.ts#L69)
+[sdk/src/rpc/types.ts:69](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/types.ts#L69)
 
 ___
 
@@ -130,7 +130,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:27](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/types.ts#L27)
+[sdk/src/rpc/types.ts:27](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/types.ts#L27)
 
 ___
 
@@ -158,7 +158,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:42](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/crypto/types.ts#L42)
+[sdk/src/crypto/types.ts:42](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/types.ts#L42)
 
 ___
 
@@ -171,7 +171,7 @@ Record<address, totalDelegations>
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:51](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/types.ts#L51)
+[sdk/src/rpc/types.ts:51](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/types.ts#L51)
 
 ___
 
@@ -184,7 +184,7 @@ Record<address, boolean>
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:57](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/types.ts#L57)
+[sdk/src/rpc/types.ts:57](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/types.ts#L57)
 
 ___
 
@@ -203,7 +203,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:30](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/crypto/types.ts#L30)
+[sdk/src/crypto/types.ts:30](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/types.ts#L30)
 
 ___
 
@@ -220,7 +220,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:18](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/ledger.ts#L18)
+[sdk/src/ledger.ts:18](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L18)
 
 ___
 
@@ -240,7 +240,7 @@ Shielded keys and address
 
 #### Defined in
 
-[sdk/src/keys/types.ts:19](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/keys/types.ts#L19)
+[sdk/src/keys/types.ts:19](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/keys/types.ts#L19)
 
 ___
 
@@ -257,7 +257,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:42](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/types.ts#L42)
+[sdk/src/rpc/types.ts:42](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/types.ts#L42)
 
 ___
 
@@ -277,17 +277,17 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:19](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/types.ts#L19)
+[sdk/src/rpc/types.ts:19](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/types.ts#L19)
 
 ___
 
 ### SupportedTx
 
-Ƭ **SupportedTx**: `Extract`\<[`TxType`](enums/TxType.md), [`Bond`](enums/TxType.md#bond) \| [`Unbond`](enums/TxType.md#unbond) \| [`Transfer`](enums/TxType.md#transfer) \| [`IBCTransfer`](enums/TxType.md#ibctransfer) \| [`EthBridgeTransfer`](enums/TxType.md#ethbridgetransfer) \| [`Withdraw`](enums/TxType.md#withdraw) \| [`VoteProposal`](enums/TxType.md#voteproposal) \| [`Redelegate`](enums/TxType.md#redelegate)\>
+Ƭ **SupportedTx**: `Extract`\<[`TxType`](enums/TxType.md), [`Bond`](enums/TxType.md#bond) \| [`Unbond`](enums/TxType.md#unbond) \| [`TransparentTransfer`](enums/TxType.md#transparenttransfer) \| [`IBCTransfer`](enums/TxType.md#ibctransfer) \| [`EthBridgeTransfer`](enums/TxType.md#ethbridgetransfer) \| [`Withdraw`](enums/TxType.md#withdraw) \| [`VoteProposal`](enums/TxType.md#voteproposal) \| [`Redelegate`](enums/TxType.md#redelegate)\>
 
 #### Defined in
 
-[shared/src/types.ts:3](https://github.com/anoma/namada-interface/blob/2543347c/packages/shared/src/types.ts#L3)
+[shared/src/types.ts:3](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/shared/src/types.ts#L3)
 
 ___
 
@@ -299,7 +299,7 @@ Public and private keypair with address
 
 #### Defined in
 
-[sdk/src/keys/types.ts:12](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/keys/types.ts#L12)
+[sdk/src/keys/types.ts:12](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/keys/types.ts#L12)
 
 ___
 
@@ -319,7 +319,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:34](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/rpc/types.ts#L34)
+[sdk/src/rpc/types.ts:34](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/types.ts#L34)
 
 ## Variables
 
@@ -337,7 +337,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:3](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/crypto/types.ts#L3)
+[sdk/src/crypto/types.ts:3](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/types.ts#L3)
 
 ___
 
@@ -347,7 +347,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:41](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/ledger.ts#L41)
+[sdk/src/ledger.ts:41](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L41)
 
 ___
 
@@ -357,7 +357,7 @@ ___
 
 #### Defined in
 
-[shared/src/types.ts:26](https://github.com/anoma/namada-interface/blob/2543347c/packages/shared/src/types.ts#L26)
+[shared/src/types.ts:26](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/shared/src/types.ts#L26)
 
 ## Functions
 
@@ -377,7 +377,7 @@ Transport object
 
 #### Defined in
 
-[sdk/src/ledger.ts:37](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/ledger.ts#L37)
+[sdk/src/ledger.ts:37](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L37)
 
 ___
 
@@ -397,7 +397,7 @@ Transport object
 
 #### Defined in
 
-[sdk/src/ledger.ts:28](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/ledger.ts#L28)
+[sdk/src/ledger.ts:28](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L28)
 
 ___
 
@@ -417,4 +417,4 @@ ___
 
 #### Defined in
 
-[sdk/src/keys/keys.ts:173](https://github.com/anoma/namada-interface/blob/2543347c/packages/sdk/src/keys/keys.ts#L173)
+[sdk/src/keys/keys.ts:173](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/keys/keys.ts#L173)

--- a/packages/sdk/examples/submitTransfer.ts
+++ b/packages/sdk/examples/submitTransfer.ts
@@ -27,7 +27,7 @@ export const submitTransfer = async (
     chainId,
     publicKey,
   };
-  const transferMsgValue = {
+  const transparentTransferMsgValue = {
     source,
     target,
     token: nativeToken,
@@ -43,9 +43,9 @@ export const submitTransfer = async (
     await sdk.tx.revealPk(signingKey, wrapperTxMsgValue);
 
     console.log("Building transfer transaction...");
-    const encodedTx = await sdk.tx.buildTransfer(
+    const encodedTx = await sdk.tx.buildTransparentTransfer(
       wrapperTxMsgValue,
-      transferMsgValue
+      transparentTransferMsgValue
     );
 
     console.log("Signing transaction...");

--- a/packages/sdk/src/tests/tx.test.ts
+++ b/packages/sdk/src/tests/tx.test.ts
@@ -36,7 +36,7 @@ describe("Tx", () => {
       publicKey: account1.publicKey,
     };
 
-    const transferProps = {
+    const transparentTransferProps = {
       source: account1.address,
       token: nativeToken,
       target: account2.address,
@@ -44,7 +44,10 @@ describe("Tx", () => {
       amount: BigNumber(123),
     };
 
-    const encodedTx = await tx.buildTransfer(txProps, transferProps);
+    const encodedTx = await tx.buildTransparentTransfer(
+      txProps,
+      transparentTransferProps
+    );
     expect(encodedTx).toBeDefined();
 
     const txBytes = encodedTx.toBytes();

--- a/packages/sdk/src/tx/tx.ts
+++ b/packages/sdk/src/tx/tx.ts
@@ -10,8 +10,8 @@ import {
   RedelegateMsgValue,
   RedelegateProps,
   SignatureMsgValue,
-  TransferMsgValue,
-  TransferProps,
+  TransparentTransferMsgValue,
+  TransparentTransferProps,
   UnbondMsgValue,
   UnbondProps,
   VoteProposalMsgValue,
@@ -31,7 +31,7 @@ export class Tx {
   /**
    * @param sdk - Instance of Sdk struct from wasm lib
    */
-  constructor(protected readonly sdk: SdkWasm) {}
+  constructor(protected readonly sdk: SdkWasm) { }
 
   /**
    * Build a transaction
@@ -104,10 +104,10 @@ export class Tx {
           throw new Error("For RevealPK you must provide a public key!");
         }
         return await this.buildRevealPk(wrapperTxProps, publicKey);
-      case TxType.Transfer:
-        return await this.buildTransfer(
+      case TxType.TransparentTransfer:
+        return await this.buildTransparentTransfer(
           wrapperTxProps,
-          props as TransferProps,
+          props as TransparentTransferProps,
           gasPayer
         );
       case TxType.IBCTransfer:
@@ -141,20 +141,20 @@ export class Tx {
    * @param [gasPayer] - optional gas payer, if not provided, defaults to transferProps.source
    * @returns promise that resolves to an EncodedTx
    */
-  async buildTransfer(
+  async buildTransparentTransfer(
     wrapperTxProps: WrapperTxProps,
-    transferProps: TransferProps,
+    transferProps: TransparentTransferMsgValue,
     gasPayer?: string
   ): Promise<EncodedTx> {
-    const transferMsg = new Message<TransferMsgValue>();
+    const transferMsg = new Message<TransparentTransferMsgValue>();
 
     const encodedTx = this.encodeTxArgs(wrapperTxProps);
     const encodedTransfer = transferMsg.encode(
-      new TransferMsgValue(transferProps)
+      new TransparentTransferMsgValue(transferProps)
     );
 
     return await this.buildTxFromSerializedArgs(
-      TxType.Transfer,
+      TxType.TransparentTransfer,
       encodedTransfer,
       encodedTx,
       gasPayer || transferProps.source

--- a/packages/shared/lib/Cargo.lock
+++ b/packages/shared/lib/Cargo.lock
@@ -2732,12 +2732,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "leb128"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
-
-[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2784,7 +2778,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 [[package]]
 name = "masp_note_encryption"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=6fc4692841a2241633792c429cc66b42023e5bf3#6fc4692841a2241633792c429cc66b42023e5bf3"
+source = "git+https://github.com/anoma/masp?rev=4ede1c42d76d6348af8224bc8bfac4404321fe82#4ede1c42d76d6348af8224bc8bfac4404321fe82"
 dependencies = [
  "borsh 1.5.0",
  "chacha20",
@@ -2797,7 +2791,7 @@ dependencies = [
 [[package]]
 name = "masp_primitives"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=6fc4692841a2241633792c429cc66b42023e5bf3#6fc4692841a2241633792c429cc66b42023e5bf3"
+source = "git+https://github.com/anoma/masp?rev=4ede1c42d76d6348af8224bc8bfac4404321fe82#4ede1c42d76d6348af8224bc8bfac4404321fe82"
 dependencies = [
  "aes",
  "bip0039",
@@ -2817,7 +2811,7 @@ dependencies = [
  "masp_note_encryption",
  "memuse",
  "nonempty",
- "num-traits 0.2.19 (git+https://github.com/heliaxdev/num-traits?rev=db259754d33f193f02cbb65520d9ac00614be2c4)",
+ "num-traits 0.2.19 (git+https://github.com/heliaxdev/num-traits?rev=3f3657caa34b8e116fdf3f8a3519c4ac29f012fe)",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "sha2 0.10.8",
@@ -2828,7 +2822,7 @@ dependencies = [
 [[package]]
 name = "masp_proofs"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=6fc4692841a2241633792c429cc66b42023e5bf3#6fc4692841a2241633792c429cc66b42023e5bf3"
+source = "git+https://github.com/anoma/masp?rev=4ede1c42d76d6348af8224bc8bfac4404321fe82#4ede1c42d76d6348af8224bc8bfac4404321fe82"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -2897,24 +2891,16 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "namada"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
  "async-trait",
- "bimap",
  "borsh 1.5.0",
  "borsh-ext",
- "circular-queue",
  "clru",
- "data-encoding",
- "derivation-path",
- "derivative",
- "ethbridge-bridge-contract",
  "ethers",
  "eyre",
- "futures",
  "itertools 0.12.1",
- "konst",
  "masp_primitives",
  "masp_proofs",
  "namada_account",
@@ -2924,7 +2910,6 @@ dependencies = [
  "namada_gas",
  "namada_governance",
  "namada_ibc",
- "namada_macros",
  "namada_parameters",
  "namada_proof_of_stake",
  "namada_replay_protection",
@@ -2935,39 +2920,26 @@ dependencies = [
  "namada_tx_env",
  "namada_vote_ext",
  "namada_vp_env",
- "num-traits 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "num256",
- "orion",
- "owo-colors",
- "paste",
  "prost",
  "rand 0.8.5",
- "rand_core 0.6.4",
- "regex",
  "ripemd",
- "serde",
  "serde_json",
  "sha2 0.9.9",
- "slip10_ed25519",
  "smooth-operator",
  "tendermint-rpc",
  "thiserror",
  "tiny-bip39 0.8.2 (git+https://github.com/anoma/tiny-bip39.git?rev=bf0f6d8713589b83af7a917366ec31f5275c0e57)",
- "tiny-hderive",
  "tokio",
- "toml 0.5.11",
  "tracing",
  "uint",
  "wasmparser",
  "wasmtimer",
- "wat",
- "zeroize",
 ]
 
 [[package]]
 name = "namada_account"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
  "borsh 1.5.0",
  "namada_core",
@@ -2978,8 +2950,8 @@ dependencies = [
 
 [[package]]
 name = "namada_controller"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
  "namada_core",
  "smooth-operator",
@@ -2988,8 +2960,8 @@ dependencies = [
 
 [[package]]
 name = "namada_core"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
  "bech32 0.8.1",
  "borsh 1.5.0",
@@ -3033,11 +3005,10 @@ dependencies = [
 
 [[package]]
 name = "namada_ethereum_bridge"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
  "borsh 1.5.0",
- "ethabi",
  "ethers",
  "eyre",
  "itertools 0.12.1",
@@ -3052,19 +3023,15 @@ dependencies = [
  "namada_trans_token",
  "namada_tx",
  "namada_vote_ext",
- "rand 0.8.5",
  "serde",
- "serde_json",
- "tendermint 0.36.0",
- "tendermint-proto 0.36.0",
  "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "namada_events"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
  "borsh 1.5.0",
  "namada_core",
@@ -3077,8 +3044,8 @@ dependencies = [
 
 [[package]]
 name = "namada_gas"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
  "borsh 1.5.0",
  "namada_core",
@@ -3090,8 +3057,8 @@ dependencies = [
 
 [[package]]
 name = "namada_governance"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
  "borsh 1.5.0",
  "itertools 0.12.1",
@@ -3111,8 +3078,8 @@ dependencies = [
 
 [[package]]
 name = "namada_ibc"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
  "borsh 1.5.0",
  "ibc",
@@ -3122,14 +3089,12 @@ dependencies = [
  "masp_primitives",
  "namada_core",
  "namada_events",
- "namada_gas",
  "namada_governance",
  "namada_macros",
  "namada_parameters",
  "namada_state",
  "namada_storage",
  "namada_token",
- "namada_tx",
  "primitive-types",
  "prost",
  "serde",
@@ -3141,8 +3106,8 @@ dependencies = [
 
 [[package]]
 name = "namada_macros"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
  "data-encoding",
  "proc-macro2",
@@ -3153,8 +3118,8 @@ dependencies = [
 
 [[package]]
 name = "namada_merkle_tree"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
  "borsh 1.5.0",
  "eyre",
@@ -3168,10 +3133,9 @@ dependencies = [
 
 [[package]]
 name = "namada_parameters"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
- "borsh 1.5.0",
  "namada_core",
  "namada_macros",
  "namada_storage",
@@ -3180,11 +3144,10 @@ dependencies = [
 
 [[package]]
 name = "namada_proof_of_stake"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
  "borsh 1.5.0",
- "data-encoding",
  "konst",
  "namada_account",
  "namada_controller",
@@ -3195,7 +3158,6 @@ dependencies = [
  "namada_parameters",
  "namada_storage",
  "namada_trans_token",
- "num-traits 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell",
  "serde",
  "smooth-operator",
@@ -3205,16 +3167,16 @@ dependencies = [
 
 [[package]]
 name = "namada_replay_protection"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
  "namada_core",
 ]
 
 [[package]]
 name = "namada_sdk"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
  "async-trait",
  "bimap",
@@ -3263,7 +3225,6 @@ dependencies = [
  "sha2 0.9.9",
  "slip10_ed25519",
  "smooth-operator",
- "tendermint-config 0.36.0",
  "tendermint-rpc",
  "thiserror",
  "tiny-bip39 0.8.2 (git+https://github.com/anoma/tiny-bip39.git?rev=bf0f6d8713589b83af7a917366ec31f5275c0e57)",
@@ -3277,8 +3238,8 @@ dependencies = [
 
 [[package]]
 name = "namada_shielded_token"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
  "borsh 1.5.0",
  "masp_primitives",
@@ -3287,7 +3248,6 @@ dependencies = [
  "namada_parameters",
  "namada_storage",
  "namada_trans_token",
- "namada_tx",
  "rayon",
  "serde",
  "smooth-operator",
@@ -3296,11 +3256,10 @@ dependencies = [
 
 [[package]]
 name = "namada_state"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
  "borsh 1.5.0",
- "ics23",
  "itertools 0.12.1",
  "namada_core",
  "namada_events",
@@ -3312,18 +3271,15 @@ dependencies = [
  "namada_storage",
  "namada_tx",
  "patricia_tree",
- "sha2 0.9.9",
  "smooth-operator",
- "sparse-merkle-tree",
  "thiserror",
- "tiny-keccak",
  "tracing",
 ]
 
 [[package]]
 name = "namada_storage"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
  "borsh 1.5.0",
  "itertools 0.12.1",
@@ -3340,20 +3296,23 @@ dependencies = [
 
 [[package]]
 name = "namada_token"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
+ "borsh 1.5.0",
  "namada_core",
  "namada_events",
+ "namada_macros",
  "namada_shielded_token",
  "namada_storage",
  "namada_trans_token",
+ "serde",
 ]
 
 [[package]]
 name = "namada_trans_token"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
  "konst",
  "namada_core",
@@ -3363,8 +3322,8 @@ dependencies = [
 
 [[package]]
 name = "namada_tx"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
  "ark-bls12-381",
  "bitflags 2.5.0",
@@ -3376,7 +3335,7 @@ dependencies = [
  "namada_events",
  "namada_gas",
  "namada_macros",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost",
  "prost-types",
@@ -3389,8 +3348,8 @@ dependencies = [
 
 [[package]]
 name = "namada_tx_env"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -3399,8 +3358,8 @@ dependencies = [
 
 [[package]]
 name = "namada_vote_ext"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
  "borsh 1.5.0",
  "namada_core",
@@ -3411,8 +3370,8 @@ dependencies = [
 
 [[package]]
 name = "namada_vp_env"
-version = "0.36.0"
-source = "git+https://github.com/anoma/namada#1ecca97bda74f75859ef1aed30a404c75ded75cb"
+version = "0.39.0"
+source = "git+https://github.com/anoma/namada#879a3268f2edfbdd0da1c98cf0e4bbdac48f5b0d"
 dependencies = [
  "derivative",
  "masp_primitives",
@@ -3422,7 +3381,6 @@ dependencies = [
  "namada_storage",
  "namada_tx",
  "smooth-operator",
- "thiserror",
 ]
 
 [[package]]
@@ -3500,6 +3458,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.65",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3543,7 +3512,7 @@ dependencies = [
 [[package]]
 name = "num-traits"
 version = "0.2.19"
-source = "git+https://github.com/heliaxdev/num-traits?rev=db259754d33f193f02cbb65520d9ac00614be2c4#db259754d33f193f02cbb65520d9ac00614be2c4"
+source = "git+https://github.com/heliaxdev/num-traits?rev=3f3657caa34b8e116fdf3f8a3519c4ac29f012fe#3f3657caa34b8e116fdf3f8a3519c4ac29f012fe"
 dependencies = [
  "autocfg",
 ]
@@ -3556,7 +3525,7 @@ checksum = "aa9b5179e82f0867b23e0b9b822493821f9345561f271364f409c8e4a058367d"
 dependencies = [
  "lazy_static",
  "num",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_derive",
@@ -4900,16 +4869,16 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smooth-operator"
-version = "0.6.0"
-source = "git+https://github.com/heliaxdev/smooth-operator?tag=v0.6.0#1e9e2382dd6c053f54418db836f7f03143fcd2f3"
+version = "0.7.0"
+source = "git+https://github.com/heliaxdev/smooth-operator?tag=v0.7.0#0e182707f5e5bb9c6e0efa2d235dc9efd715d0a1"
 dependencies = [
  "smooth-operator-impl",
 ]
 
 [[package]]
 name = "smooth-operator-impl"
-version = "0.6.0"
-source = "git+https://github.com/heliaxdev/smooth-operator?tag=v0.6.0#1e9e2382dd6c053f54418db836f7f03143fcd2f3"
+version = "0.7.0"
+source = "git+https://github.com/heliaxdev/smooth-operator?tag=v0.7.0#0e182707f5e5bb9c6e0efa2d235dc9efd715d0a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5191,7 +5160,7 @@ checksum = "b797dd3d2beaaee91d2f065e7bdf239dc8d80bba4a183a288bc1279dd5a69a1e"
 dependencies = [
  "bytes",
  "flex-error",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost",
  "prost-types",
@@ -5610,12 +5579,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5811,15 +5774,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba64e81215916eaeb48fee292f29401d69235d62d8b8fd92a7b2844ec5ae5f7"
-dependencies = [
- "leb128",
-]
-
-[[package]]
 name = "wasm_sync"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5852,27 +5806,6 @@ dependencies = [
  "pin-utils",
  "slab",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "wast"
-version = "64.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a259b226fd6910225aa7baeba82f9d9933b6d00f2ce1b49b80fa4214328237cc"
-dependencies = [
- "leb128",
- "memchr",
- "unicode-width",
- "wasm-encoder",
-]
-
-[[package]]
-name = "wat"
-version = "1.0.71"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53253d920ab413fca1c7dc2161d601c79b4fdf631d0ba51dd4343bf9b556c3f6"
-dependencies = [
- "wast",
 ]
 
 [[package]]

--- a/packages/shared/lib/Cargo.toml
+++ b/packages/shared/lib/Cargo.toml
@@ -24,7 +24,7 @@ chrono = "0.4.22"
 getrandom = { version = "0.2.7", features = ["js"] }
 gloo-utils = { version = "0.1.5", features = ["serde"] }
 js-sys = "0.3.60"
-namada = { git = "https://github.com/anoma/namada", version = "0.36.0", default-features = false, features = ["namada-sdk"] }
+namada = { git = "https://github.com/anoma/namada", version = "0.39.0", default-features = false, features = ["namada-sdk"] }
 rand = "0.8.5"
 rexie = "0.5"
 serde = "^1.0.181"

--- a/packages/shared/lib/src/sdk/tx.rs
+++ b/packages/shared/lib/src/sdk/tx.rs
@@ -10,7 +10,7 @@ use namada::{
     chain::ChainId,
     ethereum_events::EthAddress,
     key::common::PublicKey,
-    masp::{ExtendedSpendingKey, PaymentAddress, TransferSource, TransferTarget},
+    masp::TransferSource,
     sdk::args::{self, InputAmount, TxExpiration},
     token::{Amount, DenominatedAmount, NATIVE_MAX_DECIMAL_PLACES},
 };
@@ -86,13 +86,12 @@ pub struct WrapperTxMsg {
     chain_id: String,
     public_key: Option<String>,
     disposable_signing_key: Option<bool>,
-    fee_unshield: Option<String>,
     memo: Option<String>,
 }
 
 #[derive(BorshSerialize, BorshDeserialize)]
 #[borsh(crate = "namada::core::borsh")]
-pub struct SubmitBondMsg {
+pub struct BondMsg {
     source: String,
     validator: String,
     amount: String,
@@ -111,9 +110,9 @@ pub struct SubmitBondMsg {
 /// Returns JsError if the tx_msg can't be deserialized or
 /// Rust structs can't be created.
 pub fn bond_tx_args(bond_msg: &[u8], tx_msg: &[u8]) -> Result<args::Bond, JsError> {
-    let bond_msg = SubmitBondMsg::try_from_slice(bond_msg)?;
+    let bond_msg = BondMsg::try_from_slice(bond_msg)?;
 
-    let SubmitBondMsg {
+    let BondMsg {
         source,
         validator,
         native_token: _native_token,
@@ -138,7 +137,7 @@ pub fn bond_tx_args(bond_msg: &[u8], tx_msg: &[u8]) -> Result<args::Bond, JsErro
 
 #[derive(BorshSerialize, BorshDeserialize)]
 #[borsh(crate = "namada::core::borsh")]
-pub struct SubmitUnbondMsg {
+pub struct UnbondMsg {
     source: String,
     validator: String,
     amount: String,
@@ -156,9 +155,9 @@ pub struct SubmitUnbondMsg {
 /// Returns JsError if the tx_msg can't be deserialized or
 /// Rust structs can't be created.
 pub fn unbond_tx_args(unbond_msg: &[u8], tx_msg: &[u8]) -> Result<args::Unbond, JsError> {
-    let unbond_msg = SubmitUnbondMsg::try_from_slice(unbond_msg)?;
+    let unbond_msg = UnbondMsg::try_from_slice(unbond_msg)?;
 
-    let SubmitUnbondMsg {
+    let UnbondMsg {
         source,
         validator,
         amount,
@@ -183,7 +182,7 @@ pub fn unbond_tx_args(unbond_msg: &[u8], tx_msg: &[u8]) -> Result<args::Unbond, 
 
 #[derive(BorshSerialize, BorshDeserialize)]
 #[borsh(crate = "namada::core::borsh")]
-pub struct SubmitWithdrawMsg {
+pub struct WithdrawMsg {
     source: String,
     validator: String,
 }
@@ -200,9 +199,9 @@ pub struct SubmitWithdrawMsg {
 /// Returns JsError if the tx_msg can't be deserialized or
 /// Rust structs can't be created.
 pub fn withdraw_tx_args(withdraw_msg: &[u8], tx_msg: &[u8]) -> Result<args::Withdraw, JsError> {
-    let withdraw_msg = SubmitWithdrawMsg::try_from_slice(withdraw_msg)?;
+    let withdraw_msg = WithdrawMsg::try_from_slice(withdraw_msg)?;
 
-    let SubmitWithdrawMsg { source, validator } = withdraw_msg;
+    let WithdrawMsg { source, validator } = withdraw_msg;
 
     let source = Address::from_str(&source)?;
     let validator = Address::from_str(&validator)?;
@@ -220,7 +219,7 @@ pub fn withdraw_tx_args(withdraw_msg: &[u8], tx_msg: &[u8]) -> Result<args::With
 
 #[derive(BorshSerialize, BorshDeserialize)]
 #[borsh(crate = "namada::core::borsh")]
-pub struct SubmitRedelegateMsg {
+pub struct RedelegateMsg {
     owner: String,
     source_validator: String,
     destination_validator: String,
@@ -242,9 +241,9 @@ pub fn redelegate_tx_args(
     redelegate_msg: &[u8],
     tx_msg: &[u8],
 ) -> Result<args::Redelegate, JsError> {
-    let redelegate_msg = SubmitRedelegateMsg::try_from_slice(redelegate_msg)?;
+    let redelegate_msg = RedelegateMsg::try_from_slice(redelegate_msg)?;
 
-    let SubmitRedelegateMsg {
+    let RedelegateMsg {
         owner,
         source_validator,
         destination_validator,
@@ -271,7 +270,7 @@ pub fn redelegate_tx_args(
 
 #[derive(BorshSerialize, BorshDeserialize)]
 #[borsh(crate = "namada::core::borsh")]
-pub struct SubmitVoteProposalMsg {
+pub struct VoteProposalMsg {
     signer: String,
     proposal_id: u64,
     vote: String,
@@ -292,9 +291,9 @@ pub fn vote_proposal_tx_args(
     vote_proposal_msg: &[u8],
     tx_msg: &[u8],
 ) -> Result<args::VoteProposal, JsError> {
-    let vote_proposal_msg = SubmitVoteProposalMsg::try_from_slice(vote_proposal_msg)?;
+    let vote_proposal_msg = VoteProposalMsg::try_from_slice(vote_proposal_msg)?;
 
-    let SubmitVoteProposalMsg {
+    let VoteProposalMsg {
         signer,
         proposal_id,
         vote,
@@ -315,7 +314,7 @@ pub fn vote_proposal_tx_args(
 
 #[derive(BorshSerialize, BorshDeserialize)]
 #[borsh(crate = "namada::core::borsh")]
-pub struct SubmitTransferMsg {
+pub struct TransparentTransferMsg {
     source: String,
     target: String,
     token: String,
@@ -334,9 +333,12 @@ pub struct SubmitTransferMsg {
 ///
 /// Returns JsError if the tx_msg can't be deserialized or
 /// Rust structs can't be created.
-pub fn transfer_tx_args(transfer_msg: &[u8], tx_msg: &[u8]) -> Result<args::TxTransfer, JsError> {
-    let transfer_msg = SubmitTransferMsg::try_from_slice(transfer_msg)?;
-    let SubmitTransferMsg {
+pub fn transparent_transfer_tx_args(
+    transfer_msg: &[u8],
+    tx_msg: &[u8],
+) -> Result<args::TxTransparentTransfer, JsError> {
+    let transfer_msg = TransparentTransferMsg::try_from_slice(transfer_msg)?;
+    let TransparentTransferMsg {
         source,
         target,
         token,
@@ -344,34 +346,16 @@ pub fn transfer_tx_args(transfer_msg: &[u8], tx_msg: &[u8]) -> Result<args::TxTr
         native_token: _native_token,
     } = transfer_msg;
 
-    let source = match Address::from_str(&source) {
-        Ok(v) => Ok(TransferSource::Address(v)),
-        Err(e1) => match ExtendedSpendingKey::from_str(&source) {
-            Ok(v) => Ok(TransferSource::ExtendedSpendingKey(v)),
-            Err(e2) => Err(JsError::new(&format!(
-                "Can't compute the transfer source. {}, {}",
-                e1, e2
-            ))),
-        },
-    }?;
+    let source = Address::from_str(&source)?;
 
-    let target = match Address::from_str(&target) {
-        Ok(v) => Ok(TransferTarget::Address(v)),
-        Err(e1) => match PaymentAddress::from_str(&target) {
-            Ok(v) => Ok(TransferTarget::PaymentAddress(v)),
-            Err(e2) => Err(JsError::new(&format!(
-                "Can't compute the transfer target. {}, {}",
-                e1, e2
-            ))),
-        },
-    }?;
+    let target = Address::from_str(&target)?;
 
     let token = Address::from_str(&token)?;
     let denom_amount = DenominatedAmount::from_str(&amount).expect("Amount to be valid.");
     let amount = InputAmount::Unvalidated(denom_amount);
     let tx = tx_msg_into_args(tx_msg)?;
 
-    let args = args::TxTransfer {
+    let args = args::TxTransparentTransfer {
         tx,
         source,
         target,
@@ -385,7 +369,7 @@ pub fn transfer_tx_args(transfer_msg: &[u8], tx_msg: &[u8]) -> Result<args::TxTr
 
 #[derive(BorshSerialize, BorshDeserialize)]
 #[borsh(crate = "namada::core::borsh")]
-pub struct SubmitIbcTransferMsg {
+pub struct IbcTransferMsg {
     source: String,
     receiver: String,
     token: String,
@@ -412,8 +396,8 @@ pub fn ibc_transfer_tx_args(
     ibc_transfer_msg: &[u8],
     tx_msg: &[u8],
 ) -> Result<args::TxIbcTransfer, JsError> {
-    let ibc_transfer_msg = SubmitIbcTransferMsg::try_from_slice(ibc_transfer_msg)?;
-    let SubmitIbcTransferMsg {
+    let ibc_transfer_msg = IbcTransferMsg::try_from_slice(ibc_transfer_msg)?;
+    let IbcTransferMsg {
         source,
         receiver,
         token,
@@ -454,7 +438,7 @@ pub fn ibc_transfer_tx_args(
 
 #[derive(BorshSerialize, BorshDeserialize)]
 #[borsh(crate = "namada::core::borsh")]
-pub struct SubmitEthBridgeTransferMsg {
+pub struct EthBridgeTransferMsg {
     nut: bool,
     asset: String,
     recipient: String,
@@ -469,9 +453,8 @@ pub fn eth_bridge_transfer_tx_args(
     eth_bridge_transfer_msg: &[u8],
     tx_msg: &[u8],
 ) -> Result<args::EthereumBridgePool, JsError> {
-    let eth_bridge_transfer_msg =
-        SubmitEthBridgeTransferMsg::try_from_slice(eth_bridge_transfer_msg)?;
-    let SubmitEthBridgeTransferMsg {
+    let eth_bridge_transfer_msg = EthBridgeTransferMsg::try_from_slice(eth_bridge_transfer_msg)?;
+    let EthBridgeTransferMsg {
         nut,
         asset,
         recipient,
@@ -536,7 +519,6 @@ fn tx_msg_into_args(tx_msg: &[u8]) -> Result<args::Tx, JsError> {
         chain_id,
         public_key,
         disposable_signing_key,
-        fee_unshield: _fee_unshield,
         memo,
     } = tx_msg;
 
@@ -559,15 +541,6 @@ fn tx_msg_into_args(tx_msg: &[u8]) -> Result<args::Tx, JsError> {
         Some(v) => vec![v.clone()],
         _ => vec![],
     };
-
-    // Support for fee_unshield was removed in 0.36.0 of namada
-    // Keeping this as a reminder
-    // let fee_unshield = match fee_unshield {
-    //     Some(v) => Some(TransferSource::ExtendedSpendingKey(
-    //         ExtendedSpendingKey::from_str(&v)?
-    //     )),
-    //     _ => None,
-    // };
 
     // Ledger address is not used in the SDK.
     // We can leave it as whatever as long as it's valid url.

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -4,7 +4,7 @@ export type SupportedTx = Extract<
   TxType,
   | TxType.Bond
   | TxType.Unbond
-  | TxType.Transfer
+  | TxType.TransparentTransfer
   | TxType.IBCTransfer
   | TxType.EthBridgeTransfer
   | TxType.Withdraw
@@ -15,7 +15,7 @@ export type SupportedTx = Extract<
 export type TxLabel =
   | "Bond"
   | "Unbond"
-  | "Transfer"
+  | "Transparent Transfer"
   | "IBC Transfer"
   | "Add to Eth Bridge Pool"
   | "Withdraw"
@@ -27,7 +27,7 @@ export const TxTypeLabel: Record<TxType, TxLabel> = {
   [TxType.Bond]: "Bond",
   [TxType.Unbond]: "Unbond",
   [TxType.Withdraw]: "Withdraw",
-  [TxType.Transfer]: "Transfer",
+  [TxType.TransparentTransfer]: "Transparent Transfer",
   [TxType.IBCTransfer]: "IBC Transfer",
   [TxType.EthBridgeTransfer]: "Add to Eth Bridge Pool",
   [TxType.RevealPK]: "RevealPK",

--- a/packages/types/src/tx/schema/index.ts
+++ b/packages/types/src/tx/schema/index.ts
@@ -3,7 +3,7 @@ export * from "./ethBridgeTransfer";
 export * from "./ibcTransfer";
 export * from "./redelegate";
 export * from "./signature";
-export * from "./transfer";
+export * from "./transparentTransfer";
 export * from "./unbond";
 export * from "./utils";
 export * from "./voteProposal";
@@ -15,7 +15,7 @@ import { EthBridgeTransferMsgValue } from "./ethBridgeTransfer";
 import { IbcTransferMsgValue } from "./ibcTransfer";
 import { RedelegateMsgValue } from "./redelegate";
 import { SignatureMsgValue } from "./signature";
-import { TransferMsgValue } from "./transfer";
+import { TransparentTransferMsgValue } from "./transparentTransfer";
 import { UnbondMsgValue } from "./unbond";
 import { VoteProposalMsgValue } from "./voteProposal";
 import { WithdrawMsgValue } from "./withdraw";
@@ -29,6 +29,6 @@ export type Schema =
   | UnbondMsgValue
   | VoteProposalMsgValue
   | WithdrawMsgValue
-  | TransferMsgValue
+  | TransparentTransferMsgValue
   | WrapperTxMsgValue
   | RedelegateMsgValue;

--- a/packages/types/src/tx/schema/transparentTransfer.ts
+++ b/packages/types/src/tx/schema/transparentTransfer.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import BigNumber from "bignumber.js";
 import { field } from "@dao-xyz/borsh";
+import BigNumber from "bignumber.js";
+import { TransparentTransferProps } from "../types";
 import { BigNumberSerializer } from "./utils";
-import { TransferProps } from "../types";
 
-export class TransferMsgValue {
+export class TransparentTransferMsgValue {
   @field({ type: "string" })
   source!: string;
 
@@ -20,7 +20,7 @@ export class TransferMsgValue {
   @field({ type: "string" })
   nativeToken!: string;
 
-  constructor(data: TransferProps) {
+  constructor(data: TransparentTransferProps) {
     Object.assign(this, data);
   }
 }

--- a/packages/types/src/tx/schema/wrapperTx.ts
+++ b/packages/types/src/tx/schema/wrapperTx.ts
@@ -24,9 +24,6 @@ export class WrapperTxMsgValue {
   disposableSigningKey?: boolean;
 
   @field({ type: option("string") })
-  feeUnshield?: string;
-
-  @field({ type: option("string") })
   memo?: string;
 
   constructor(data: WrapperTxProps) {

--- a/packages/types/src/tx/types.ts
+++ b/packages/types/src/tx/types.ts
@@ -4,7 +4,7 @@ import {
   IbcTransferMsgValue,
   RedelegateMsgValue,
   SignatureMsgValue,
-  TransferMsgValue,
+  TransparentTransferMsgValue,
   UnbondMsgValue,
   VoteProposalMsgValue,
   WithdrawMsgValue,
@@ -16,7 +16,7 @@ export type BondProps = BondMsgValue;
 export type UnbondProps = UnbondMsgValue;
 export type WithdrawProps = WithdrawMsgValue;
 export type RedelegateProps = RedelegateMsgValue;
-export type TransferProps = TransferMsgValue;
+export type TransparentTransferProps = TransparentTransferMsgValue;
 export type EthBridgeTransferProps = EthBridgeTransferMsgValue;
 export type SignatureProps = SignatureMsgValue;
 export type VoteProposalProps = VoteProposalMsgValue;


### PR DESCRIPTION
This PR includes the changes to support Namada `v0.39.0`, and makes some changes to our SDK package and types to indicate `Transparent Transfer` instead of simply `Transfer`

- [x] Namada -> `v0.39.0`
- [x] Update SDK package according to changes in `shared`, regen docs
- [x] Update types, moving `Transfer` -> `TransparentTransfer`, and set labels accordingly
- [x] Test existing functionality for `0.39.0`

### TODO

- Future PRs will implement the other transfer types: `ShieldingTransfer`, `UnshieldingTransfer`, and `ShieldedTransfer`

### TESTING

- Confirm that Namadillo and the extension behave properly with this update