### PR TITLE
feat/860 - Update Sdk instance with new settings

### DIFF
--- a/packages/sdk/docs/classes/Crypto.md
+++ b/packages/sdk/docs/classes/Crypto.md
@@ -40,7 +40,7 @@ Class Crypto handles AES encryption tasks
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/crypto.ts#L20)
+[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/crypto/crypto.ts#L20)
 
 ## Properties
 
@@ -52,7 +52,7 @@ WebAssembly Memory for crypto
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/crypto.ts#L20)
+[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/crypto/crypto.ts#L20)
 
 ## Methods
 
@@ -75,7 +75,7 @@ decrypted text
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:115](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/crypto.ts#L115)
+[sdk/src/crypto/crypto.ts:115](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/crypto/crypto.ts#L115)
 
 ___
 
@@ -100,7 +100,7 @@ crypto record
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:61](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/crypto.ts#L61)
+[sdk/src/crypto/crypto.ts:61](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/crypto/crypto.ts#L61)
 
 ___
 
@@ -126,7 +126,7 @@ array of encrypted bytes
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:98](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/crypto.ts#L98)
+[sdk/src/crypto/crypto.ts:98](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/crypto/crypto.ts#L98)
 
 ___
 
@@ -153,7 +153,7 @@ crypto record used for storage
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:30](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/crypto.ts#L30)
+[sdk/src/crypto/crypto.ts:30](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/crypto/crypto.ts#L30)
 
 ___
 
@@ -178,4 +178,4 @@ encryption parameters
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:73](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/crypto.ts#L73)
+[sdk/src/crypto/crypto.ts:73](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/crypto/crypto.ts#L73)

--- a/packages/sdk/docs/classes/EncodedTx.md
+++ b/packages/sdk/docs/classes/EncodedTx.md
@@ -42,7 +42,7 @@ Create an EncodedTx class
 
 #### Defined in
 
-[sdk/src/tx/types.ts:12](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/types.ts#L12)
+[sdk/src/tx/types.ts:12](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/types.ts#L12)
 
 ## Properties
 
@@ -54,7 +54,7 @@ Specific tx struct instance
 
 #### Defined in
 
-[sdk/src/tx/types.ts:14](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/types.ts#L14)
+[sdk/src/tx/types.ts:14](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/types.ts#L14)
 
 ___
 
@@ -66,7 +66,7 @@ Borsh-serialized transaction
 
 #### Defined in
 
-[sdk/src/tx/types.ts:13](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/types.ts#L13)
+[sdk/src/tx/types.ts:13](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/types.ts#L13)
 
 ## Methods
 
@@ -82,7 +82,7 @@ Clear tx bytes resource
 
 #### Defined in
 
-[sdk/src/tx/types.ts:39](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/types.ts#L39)
+[sdk/src/tx/types.ts:39](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/types.ts#L39)
 
 ___
 
@@ -100,7 +100,7 @@ string of tx hash
 
 #### Defined in
 
-[sdk/src/tx/types.ts:32](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/types.ts#L32)
+[sdk/src/tx/types.ts:32](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/types.ts#L32)
 
 ___
 
@@ -119,4 +119,4 @@ Serialized tx bytes
 
 #### Defined in
 
-[sdk/src/tx/types.ts:22](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/types.ts#L22)
+[sdk/src/tx/types.ts:22](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/types.ts#L22)

--- a/packages/sdk/docs/classes/Ledger.md
+++ b/packages/sdk/docs/classes/Ledger.md
@@ -42,7 +42,7 @@ Functionality for interacting with NamadaApp for Ledger Hardware Wallets
 
 #### Defined in
 
-[sdk/src/ledger.ts:54](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L54)
+[sdk/src/ledger.ts:54](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/ledger.ts#L54)
 
 ## Properties
 
@@ -54,7 +54,7 @@ Inititalized NamadaApp class from Zondax package
 
 #### Defined in
 
-[sdk/src/ledger.ts:54](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L54)
+[sdk/src/ledger.ts:54](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/ledger.ts#L54)
 
 ## Methods
 
@@ -75,7 +75,7 @@ void
 
 #### Defined in
 
-[sdk/src/ledger.ts:176](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L176)
+[sdk/src/ledger.ts:176](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/ledger.ts#L176)
 
 ___
 
@@ -102,7 +102,7 @@ Address and public key
 
 #### Defined in
 
-[sdk/src/ledger.ts:97](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L97)
+[sdk/src/ledger.ts:97](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/ledger.ts#L97)
 
 ___
 
@@ -123,7 +123,7 @@ Error message if error is found
 
 #### Defined in
 
-[sdk/src/ledger.ts:159](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L159)
+[sdk/src/ledger.ts:159](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/ledger.ts#L159)
 
 ___
 
@@ -150,7 +150,7 @@ Address and public key
 
 #### Defined in
 
-[sdk/src/ledger.ts:118](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L118)
+[sdk/src/ledger.ts:118](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/ledger.ts#L118)
 
 ___
 
@@ -178,7 +178,7 @@ Response signature
 
 #### Defined in
 
-[sdk/src/ledger.ts:144](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L144)
+[sdk/src/ledger.ts:144](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/ledger.ts#L144)
 
 ___
 
@@ -199,7 +199,7 @@ Version and info of NamadaApp
 
 #### Defined in
 
-[sdk/src/ledger.ts:80](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L80)
+[sdk/src/ledger.ts:80](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/ledger.ts#L80)
 
 ___
 
@@ -225,4 +225,4 @@ Ledger class instance
 
 #### Defined in
 
-[sdk/src/ledger.ts:62](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L62)
+[sdk/src/ledger.ts:62](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/ledger.ts#L62)

--- a/packages/sdk/docs/classes/Masp.md
+++ b/packages/sdk/docs/classes/Masp.md
@@ -41,7 +41,7 @@ Class representing utilities related to MASP
 
 #### Defined in
 
-[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/masp.ts#L10)
+[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/masp.ts#L10)
 
 ## Properties
 
@@ -53,7 +53,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/masp.ts#L10)
+[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/masp.ts#L10)
 
 ## Methods
 
@@ -80,7 +80,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:69](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/masp.ts#L69)
+[sdk/src/masp.ts:69](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/masp.ts#L69)
 
 ___
 
@@ -107,7 +107,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:47](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/masp.ts#L47)
+[sdk/src/masp.ts:47](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/masp.ts#L47)
 
 ___
 
@@ -134,7 +134,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:58](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/masp.ts#L58)
+[sdk/src/masp.ts:58](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/masp.ts#L58)
 
 ___
 
@@ -154,7 +154,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:26](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/masp.ts#L26)
+[sdk/src/masp.ts:26](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/masp.ts#L26)
 
 ___
 
@@ -174,7 +174,7 @@ True if MASP parameters are loaded
 
 #### Defined in
 
-[sdk/src/masp.ts:17](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/masp.ts#L17)
+[sdk/src/masp.ts:17](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/masp.ts#L17)
 
 ___
 
@@ -200,4 +200,4 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:36](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/masp.ts#L36)
+[sdk/src/masp.ts:36](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/masp.ts#L36)

--- a/packages/sdk/docs/classes/Mnemonic.md
+++ b/packages/sdk/docs/classes/Mnemonic.md
@@ -38,7 +38,7 @@ Class for accessing mnemonic functionality from wasm
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/mnemonic.ts#L18)
+[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/mnemonic.ts#L18)
 
 ## Properties
 
@@ -50,7 +50,7 @@ Memory accessor for crypto lib
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/mnemonic.ts#L18)
+[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/mnemonic.ts#L18)
 
 ## Methods
 
@@ -76,7 +76,7 @@ Promise that resolves to array of words
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:26](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/mnemonic.ts#L26)
+[sdk/src/mnemonic.ts:26](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/mnemonic.ts#L26)
 
 ___
 
@@ -101,7 +101,7 @@ Seed bytes
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:44](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/mnemonic.ts#L44)
+[sdk/src/mnemonic.ts:44](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/mnemonic.ts#L44)
 
 ___
 
@@ -131,4 +131,4 @@ Object with validation result and error message if invalid
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:62](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/mnemonic.ts#L62)
+[sdk/src/mnemonic.ts:62](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/mnemonic.ts#L62)

--- a/packages/sdk/docs/classes/Rpc.md
+++ b/packages/sdk/docs/classes/Rpc.md
@@ -50,7 +50,7 @@ API for executing RPC requests with Namada
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:28](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L28)
+[sdk/src/rpc/rpc.ts:28](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/rpc/rpc.ts#L28)
 
 ## Properties
 
@@ -62,7 +62,7 @@ Instance of Query struct from wasm lib
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:30](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L30)
+[sdk/src/rpc/rpc.ts:30](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/rpc/rpc.ts#L30)
 
 ___
 
@@ -74,7 +74,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:29](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L29)
+[sdk/src/rpc/rpc.ts:29](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/rpc/rpc.ts#L29)
 
 ## Methods
 
@@ -100,7 +100,7 @@ void
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:196](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L196)
+[sdk/src/rpc/rpc.ts:196](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/rpc/rpc.ts#L196)
 
 ___
 
@@ -120,7 +120,7 @@ Array of all validator addresses
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:70](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L70)
+[sdk/src/rpc/rpc.ts:70](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/rpc/rpc.ts#L70)
 
 ___
 
@@ -147,7 +147,7 @@ Query balances from chain
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:40](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L40)
+[sdk/src/rpc/rpc.ts:40](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/rpc/rpc.ts#L40)
 
 ___
 
@@ -173,7 +173,7 @@ Promise resolving to delegators votes
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:94](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L94)
+[sdk/src/rpc/rpc.ts:94](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/rpc/rpc.ts#L94)
 
 ___
 
@@ -193,7 +193,7 @@ Query gas costs
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:186](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L186)
+[sdk/src/rpc/rpc.ts:186](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/rpc/rpc.ts#L186)
 
 ___
 
@@ -213,7 +213,7 @@ Address of native token
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:49](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L49)
+[sdk/src/rpc/rpc.ts:49](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/rpc/rpc.ts#L49)
 
 ___
 
@@ -240,7 +240,7 @@ String of public key if found
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:60](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L60)
+[sdk/src/rpc/rpc.ts:60](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/rpc/rpc.ts#L60)
 
 ___
 
@@ -266,7 +266,7 @@ Promise resolving to pending ethereum transfers
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:177](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L177)
+[sdk/src/rpc/rpc.ts:177](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/rpc/rpc.ts#L177)
 
 ___
 
@@ -292,7 +292,7 @@ Promise resolving to staking positions
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:131](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L131)
+[sdk/src/rpc/rpc.ts:131](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/rpc/rpc.ts#L131)
 
 ___
 
@@ -318,7 +318,7 @@ Promise resolving to staking totals
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:104](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L104)
+[sdk/src/rpc/rpc.ts:104](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/rpc/rpc.ts#L104)
 
 ___
 
@@ -342,7 +342,7 @@ Total bonds amount
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:167](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L167)
+[sdk/src/rpc/rpc.ts:167](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/rpc/rpc.ts#L167)
 
 ___
 
@@ -369,7 +369,7 @@ Promise resolving to total delegations
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:81](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L81)
+[sdk/src/rpc/rpc.ts:81](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/rpc/rpc.ts#L81)
 
 ___
 
@@ -393,4 +393,4 @@ Sync the shielded context
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:207](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/rpc.ts#L207)
+[sdk/src/rpc/rpc.ts:207](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/rpc/rpc.ts#L207)

--- a/packages/sdk/docs/classes/Sdk.md
+++ b/packages/sdk/docs/classes/Sdk.md
@@ -38,6 +38,7 @@ API for interacting with Namada SDK
 - [getSigning](Sdk.md#getsigning)
 - [getTx](Sdk.md#gettx)
 - [initLedger](Sdk.md#initledger)
+- [updateNetwork](Sdk.md#updatenetwork)
 
 ## Constructors
 
@@ -61,7 +62,7 @@ API for interacting with Namada SDK
 
 #### Defined in
 
-[sdk/src/sdk.ts:23](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L23)
+[sdk/src/sdk.ts:23](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/sdk.ts#L23)
 
 ## Properties
 
@@ -73,7 +74,7 @@ Memory accessor for crypto lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:26](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L26)
+[sdk/src/sdk.ts:26](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/sdk.ts#L26)
 
 ___
 
@@ -85,31 +86,31 @@ Address of chain's native token
 
 #### Defined in
 
-[sdk/src/sdk.ts:28](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L28)
+[sdk/src/sdk.ts:28](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/sdk.ts#L28)
 
 ___
 
 ### query
 
-• `Protected` `Readonly` **query**: `Query`
+• `Protected` **query**: `Query`
 
 Instance of Query struct from wasm lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:25](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L25)
+[sdk/src/sdk.ts:25](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/sdk.ts#L25)
 
 ___
 
 ### sdk
 
-• `Protected` `Readonly` **sdk**: `Sdk`
+• `Protected` **sdk**: `Sdk`
 
 Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:24](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L24)
+[sdk/src/sdk.ts:24](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/sdk.ts#L24)
 
 ___
 
@@ -121,7 +122,7 @@ RPC url
 
 #### Defined in
 
-[sdk/src/sdk.ts:27](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L27)
+[sdk/src/sdk.ts:27](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/sdk.ts#L27)
 
 ## Accessors
 
@@ -139,7 +140,7 @@ Utilities for encrypting and decrypting data
 
 #### Defined in
 
-[sdk/src/sdk.ts:148](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L148)
+[sdk/src/sdk.ts:166](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/sdk.ts#L166)
 
 ___
 
@@ -157,7 +158,7 @@ key-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:124](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L124)
+[sdk/src/sdk.ts:142](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/sdk.ts#L142)
 
 ___
 
@@ -175,7 +176,7 @@ Masp utilities for handling params
 
 #### Defined in
 
-[sdk/src/sdk.ts:140](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L140)
+[sdk/src/sdk.ts:158](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/sdk.ts#L158)
 
 ___
 
@@ -193,7 +194,7 @@ mnemonic-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:116](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L116)
+[sdk/src/sdk.ts:134](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/sdk.ts#L134)
 
 ___
 
@@ -211,7 +212,7 @@ rpc client
 
 #### Defined in
 
-[sdk/src/sdk.ts:100](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L100)
+[sdk/src/sdk.ts:118](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/sdk.ts#L118)
 
 ___
 
@@ -229,7 +230,7 @@ Non-Tx signing functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:132](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L132)
+[sdk/src/sdk.ts:150](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/sdk.ts#L150)
 
 ___
 
@@ -247,7 +248,7 @@ tx-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:108](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L108)
+[sdk/src/sdk.ts:126](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/sdk.ts#L126)
 
 ## Methods
 
@@ -265,7 +266,7 @@ Utilities for encrypting and decrypting data
 
 #### Defined in
 
-[sdk/src/sdk.ts:82](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L82)
+[sdk/src/sdk.ts:100](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/sdk.ts#L100)
 
 ___
 
@@ -283,7 +284,7 @@ key-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:58](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L58)
+[sdk/src/sdk.ts:76](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/sdk.ts#L76)
 
 ___
 
@@ -301,7 +302,7 @@ Masp utilities for handling params
 
 #### Defined in
 
-[sdk/src/sdk.ts:74](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L74)
+[sdk/src/sdk.ts:92](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/sdk.ts#L92)
 
 ___
 
@@ -319,7 +320,7 @@ mnemonic-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:50](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L50)
+[sdk/src/sdk.ts:68](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/sdk.ts#L68)
 
 ___
 
@@ -337,7 +338,7 @@ Namada RPC client
 
 #### Defined in
 
-[sdk/src/sdk.ts:34](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L34)
+[sdk/src/sdk.ts:52](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/sdk.ts#L52)
 
 ___
 
@@ -355,7 +356,7 @@ Non-Tx signing functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:66](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L66)
+[sdk/src/sdk.ts:84](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/sdk.ts#L84)
 
 ___
 
@@ -373,7 +374,7 @@ Tx-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:42](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L42)
+[sdk/src/sdk.ts:60](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/sdk.ts#L60)
 
 ___
 
@@ -399,4 +400,29 @@ Class for interacting with NamadaApp for Ledger Hardware Wallets
 
 #### Defined in
 
-[sdk/src/sdk.ts:92](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/sdk.ts#L92)
+[sdk/src/sdk.ts:110](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/sdk.ts#L110)
+
+___
+
+### updateNetwork
+
+▸ **updateNetwork**(`url`, `nativeToken?`): [`Sdk`](Sdk.md)
+
+Re-initialize wasm instances and return this instance
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `url` | `string` | RPC url |
+| `nativeToken?` | `string` | Address of chain's native token |
+
+#### Returns
+
+[`Sdk`](Sdk.md)
+
+this instance of Sdk
+
+#### Defined in
+
+[sdk/src/sdk.ts:37](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/sdk.ts#L37)

--- a/packages/sdk/docs/classes/SignedTx.md
+++ b/packages/sdk/docs/classes/SignedTx.md
@@ -34,7 +34,7 @@ Wrap results of tx signing to simplify passing between Sdk functions
 
 #### Defined in
 
-[sdk/src/tx/types.ts:52](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/types.ts#L52)
+[sdk/src/tx/types.ts:52](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/types.ts#L52)
 
 ## Properties
 
@@ -46,7 +46,7 @@ Serialized tx bytes
 
 #### Defined in
 
-[sdk/src/tx/types.ts:56](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/types.ts#L56)
+[sdk/src/tx/types.ts:56](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/types.ts#L56)
 
 ___
 
@@ -58,4 +58,4 @@ Serialized wrapper tx msg bytes
 
 #### Defined in
 
-[sdk/src/tx/types.ts:54](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/types.ts#L54)
+[sdk/src/tx/types.ts:54](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/types.ts#L54)

--- a/packages/sdk/docs/classes/Signing.md
+++ b/packages/sdk/docs/classes/Signing.md
@@ -40,7 +40,7 @@ Signing constructor
 
 #### Defined in
 
-[sdk/src/signing.ts:13](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/signing.ts#L13)
+[sdk/src/signing.ts:13](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/signing.ts#L13)
 
 ## Properties
 
@@ -52,7 +52,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/signing.ts:13](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/signing.ts#L13)
+[sdk/src/signing.ts:13](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/signing.ts#L13)
 
 ## Methods
 
@@ -78,7 +78,7 @@ signed tx bytes - Promise resolving to Uint8Array
 
 #### Defined in
 
-[sdk/src/signing.ts:22](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/signing.ts#L22)
+[sdk/src/signing.ts:22](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/signing.ts#L22)
 
 ___
 
@@ -103,7 +103,7 @@ hash and signature
 
 #### Defined in
 
-[sdk/src/signing.ts:36](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/signing.ts#L36)
+[sdk/src/signing.ts:36](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/signing.ts#L36)
 
 ___
 
@@ -129,4 +129,4 @@ void
 
 #### Defined in
 
-[sdk/src/signing.ts:47](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/signing.ts#L47)
+[sdk/src/signing.ts:47](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/signing.ts#L47)

--- a/packages/sdk/docs/classes/Tx.md
+++ b/packages/sdk/docs/classes/Tx.md
@@ -49,7 +49,7 @@ SDK functionality related to transactions
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:34](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L34)
+[sdk/src/tx/tx.ts:34](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/tx.ts#L34)
 
 ## Properties
 
@@ -61,7 +61,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:34](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L34)
+[sdk/src/tx/tx.ts:34](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/tx.ts#L34)
 
 ## Methods
 
@@ -86,7 +86,7 @@ Append signature for transactions signed by Ledger Hardware Wallet
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:391](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L391)
+[sdk/src/tx/tx.ts:391](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/tx.ts#L391)
 
 ___
 
@@ -114,7 +114,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:193](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L193)
+[sdk/src/tx/tx.ts:193](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/tx.ts#L193)
 
 ___
 
@@ -142,7 +142,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:322](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L322)
+[sdk/src/tx/tx.ts:322](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/tx.ts#L322)
 
 ___
 
@@ -170,7 +170,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:295](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L295)
+[sdk/src/tx/tx.ts:295](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/tx.ts#L295)
 
 ___
 
@@ -198,7 +198,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:268](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L268)
+[sdk/src/tx/tx.ts:268](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/tx.ts#L268)
 
 ___
 
@@ -225,7 +225,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:171](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L171)
+[sdk/src/tx/tx.ts:171](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/tx.ts#L171)
 
 ___
 
@@ -253,7 +253,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:144](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L144)
+[sdk/src/tx/tx.ts:144](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/tx.ts#L144)
 
 ___
 
@@ -282,7 +282,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:70](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L70)
+[sdk/src/tx/tx.ts:70](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/tx.ts#L70)
 
 ___
 
@@ -311,7 +311,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:45](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L45)
+[sdk/src/tx/tx.ts:45](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/tx.ts#L45)
 
 ___
 
@@ -339,7 +339,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:218](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L218)
+[sdk/src/tx/tx.ts:218](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/tx.ts#L218)
 
 ___
 
@@ -367,7 +367,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:349](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L349)
+[sdk/src/tx/tx.ts:349](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/tx.ts#L349)
 
 ___
 
@@ -395,7 +395,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:243](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L243)
+[sdk/src/tx/tx.ts:243](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/tx.ts#L243)
 
 ___
 
@@ -419,7 +419,7 @@ Serialized WrapperTxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:432](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L432)
+[sdk/src/tx/tx.ts:432](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/tx.ts#L432)
 
 ___
 
@@ -447,4 +447,4 @@ void
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:376](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/tx/tx.ts#L376)
+[sdk/src/tx/tx.ts:376](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/tx/tx.ts#L376)

--- a/packages/sdk/docs/enums/KdfType.md
+++ b/packages/sdk/docs/enums/KdfType.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:38](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/types.ts#L38)
+[sdk/src/crypto/types.ts:38](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/crypto/types.ts#L38)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:39](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/types.ts#L39)
+[sdk/src/crypto/types.ts:39](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/crypto/types.ts#L39)

--- a/packages/sdk/docs/modules.md
+++ b/packages/sdk/docs/modules.md
@@ -71,7 +71,7 @@ Address and public key type
 
 #### Defined in
 
-[sdk/src/keys/types.ts:4](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/keys/types.ts#L4)
+[sdk/src/keys/types.ts:4](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/keys/types.ts#L4)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:17](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L17)
+[sdk/src/ledger.ts:17](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/ledger.ts#L17)
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:23](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/types.ts#L23)
+[sdk/src/crypto/types.ts:23](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/crypto/types.ts#L23)
 
 ___
 
@@ -111,7 +111,7 @@ Balance
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:69](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/types.ts#L69)
+[sdk/src/rpc/types.ts:69](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/rpc/types.ts#L69)
 
 ___
 
@@ -130,7 +130,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:27](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/types.ts#L27)
+[sdk/src/rpc/types.ts:27](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/rpc/types.ts#L27)
 
 ___
 
@@ -158,7 +158,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:42](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/types.ts#L42)
+[sdk/src/crypto/types.ts:42](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/crypto/types.ts#L42)
 
 ___
 
@@ -171,7 +171,7 @@ Record<address, totalDelegations>
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:51](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/types.ts#L51)
+[sdk/src/rpc/types.ts:51](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/rpc/types.ts#L51)
 
 ___
 
@@ -184,7 +184,7 @@ Record<address, boolean>
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:57](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/types.ts#L57)
+[sdk/src/rpc/types.ts:57](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/rpc/types.ts#L57)
 
 ___
 
@@ -203,7 +203,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:30](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/types.ts#L30)
+[sdk/src/crypto/types.ts:30](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/crypto/types.ts#L30)
 
 ___
 
@@ -220,7 +220,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:18](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L18)
+[sdk/src/ledger.ts:18](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/ledger.ts#L18)
 
 ___
 
@@ -240,7 +240,7 @@ Shielded keys and address
 
 #### Defined in
 
-[sdk/src/keys/types.ts:19](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/keys/types.ts#L19)
+[sdk/src/keys/types.ts:19](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/keys/types.ts#L19)
 
 ___
 
@@ -257,7 +257,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:42](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/types.ts#L42)
+[sdk/src/rpc/types.ts:42](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/rpc/types.ts#L42)
 
 ___
 
@@ -277,7 +277,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:19](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/types.ts#L19)
+[sdk/src/rpc/types.ts:19](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/rpc/types.ts#L19)
 
 ___
 
@@ -287,7 +287,7 @@ ___
 
 #### Defined in
 
-[shared/src/types.ts:3](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/shared/src/types.ts#L3)
+[shared/src/types.ts:3](https://github.com/anoma/namada-interface/blob/3ad62004/packages/shared/src/types.ts#L3)
 
 ___
 
@@ -299,7 +299,7 @@ Public and private keypair with address
 
 #### Defined in
 
-[sdk/src/keys/types.ts:12](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/keys/types.ts#L12)
+[sdk/src/keys/types.ts:12](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/keys/types.ts#L12)
 
 ___
 
@@ -319,7 +319,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:34](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/rpc/types.ts#L34)
+[sdk/src/rpc/types.ts:34](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/rpc/types.ts#L34)
 
 ## Variables
 
@@ -337,7 +337,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:3](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/crypto/types.ts#L3)
+[sdk/src/crypto/types.ts:3](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/crypto/types.ts#L3)
 
 ___
 
@@ -347,7 +347,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:41](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L41)
+[sdk/src/ledger.ts:41](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/ledger.ts#L41)
 
 ___
 
@@ -357,7 +357,7 @@ ___
 
 #### Defined in
 
-[shared/src/types.ts:26](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/shared/src/types.ts#L26)
+[shared/src/types.ts:26](https://github.com/anoma/namada-interface/blob/3ad62004/packages/shared/src/types.ts#L26)
 
 ## Functions
 
@@ -377,7 +377,7 @@ Transport object
 
 #### Defined in
 
-[sdk/src/ledger.ts:37](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L37)
+[sdk/src/ledger.ts:37](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/ledger.ts#L37)
 
 ___
 
@@ -397,7 +397,7 @@ Transport object
 
 #### Defined in
 
-[sdk/src/ledger.ts:28](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/ledger.ts#L28)
+[sdk/src/ledger.ts:28](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/ledger.ts#L28)
 
 ___
 
@@ -417,4 +417,4 @@ ___
 
 #### Defined in
 
-[sdk/src/keys/keys.ts:173](https://github.com/anoma/namada-interface/blob/4a9f889e/packages/sdk/src/keys/keys.ts#L173)
+[sdk/src/keys/keys.ts:173](https://github.com/anoma/namada-interface/blob/3ad62004/packages/sdk/src/keys/keys.ts#L173)

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -21,12 +21,30 @@ export class Sdk {
    * @param nativeToken - Address of chain's native token
    */
   constructor(
-    protected readonly sdk: SdkWasm,
-    protected readonly query: QueryWasm,
+    protected sdk: SdkWasm,
+    protected query: QueryWasm,
     public readonly cryptoMemory: WebAssembly.Memory,
     public readonly url: string,
     public readonly nativeToken: string
   ) {}
+
+  /**
+   * Re-initialize wasm instances and return this instance
+   * @param url - RPC url
+   * @param [nativeToken] - Address of chain's native token
+   * @returns this instance of Sdk
+   */
+  updateNetwork(url: string, nativeToken?: string): Sdk {
+    const query = new QueryWasm(url);
+    this.query = query;
+
+    // Update nativeToken as well if provided
+    const sdk = new SdkWasm(url, nativeToken || this.nativeToken, "");
+    this.sdk = sdk;
+
+    return this;
+  }
+
   /**
    * Return initialized Rpc class
    * @returns Namada RPC client


### PR DESCRIPTION
Resolves #860 

- [x] Sdk instance can be updated with new `url` and `nativeToken` (`Sdk.updateNetwork()`)which will reload the wasms
- [x] Regen docs