### PR TITLE
bug: Approve sign promise should resolve when rejected

### DIFF
--- a/apps/extension/src/background/approvals/handler.test.ts
+++ b/apps/extension/src/background/approvals/handler.test.ts
@@ -84,7 +84,7 @@ describe("approvals handler", () => {
 
     const rejectSignArbitraryMsg = new RejectSignArbitraryMsg("");
     handler(env, rejectSignArbitraryMsg);
-    expect(service.rejectSignature).toBeCalled();
+    expect(service.rejectSignArbitrary).toBeCalled();
 
     const submitApprovedSignArbitrartyMsg = new SubmitApprovedSignArbitraryMsg(
       "",

--- a/apps/extension/src/background/approvals/handler.ts
+++ b/apps/extension/src/background/approvals/handler.ts
@@ -120,8 +120,8 @@ const handleApproveSignTxMsg: (
 const handleRejectSignTxMsg: (
   service: ApprovalsService
 ) => InternalHandler<RejectSignTxMsg> = (service) => {
-  return async (_, { msgId }) => {
-    return await service.rejectSignTx(msgId);
+  return async ({ senderTabId: popupTabId }, { msgId }) => {
+    return await service.rejectSignTx(popupTabId, msgId);
   };
 };
 
@@ -145,7 +145,7 @@ const handleRejectSignArbitraryMsg: (
   service: ApprovalsService
 ) => InternalHandler<RejectSignArbitraryMsg> = (service) => {
   return async ({ senderTabId: popupTabId }, { msgId }) => {
-    return await service.rejectSignature(popupTabId, msgId);
+    return await service.rejectSignArbitrary(popupTabId, msgId);
   };
 };
 

--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -67,7 +67,6 @@ export class ApprovalsService {
       this.resolverMap[popupTabId] = { resolve, reject };
     });
   }
-
   async approveSignArbitrary(
     signer: string,
     data: string
@@ -104,7 +103,6 @@ export class ApprovalsService {
     signer: string
   ): Promise<void> {
     const pendingTx = await this.txStore.get(msgId);
-    console.log("encodedTx", pendingTx);
     const resolvers = this.resolverMap[popupTabId];
 
     if (!resolvers) {
@@ -156,7 +154,7 @@ export class ApprovalsService {
     await this._clearPendingSignature(msgId);
   }
 
-  async rejectSignature(popupTabId: number, msgId: string): Promise<void> {
+  async rejectSignArbitrary(popupTabId: number, msgId: string): Promise<void> {
     const resolvers = this.resolverMap[popupTabId];
 
     if (!resolvers) {
@@ -164,12 +162,18 @@ export class ApprovalsService {
     }
 
     await this._clearPendingSignature(msgId);
-    resolvers.reject();
+    resolvers.reject(new Error("Sign arbitrary rejected"));
   }
 
   // Remove pending transaction from storage
-  async rejectSignTx(msgId: string): Promise<void> {
+  async rejectSignTx(popupTabId: number, msgId: string): Promise<void> {
+    const resolvers = this.resolverMap[popupTabId];
+    if (!resolvers) {
+      throw new Error(`no resolvers found for tab ID ${popupTabId}`);
+    }
+
     await this._clearPendingTx(msgId);
+    resolvers.reject(new Error("Sign Tx rejected"));
   }
 
   async isConnectionApproved(interfaceOrigin: string): Promise<boolean> {


### PR DESCRIPTION
Fixes an issue where approval promise was not being resolved when the transaction was rejected.

- Updated to resolve promise on reject sign tx
- Moved `rejectSignature` -> `rejectSignArbitrary` to avoid confusion
- Updated tests

### Testing

- Create a transaction, and submit
- In the first view in the popup, click `Reject` -_NOTE_ the interface does not currently display a response, but (in the case of Bond) the `Stake` button will be available again. You can see the error message in the console