### PR TITLE
feat: add error messages in toasts

### DIFF
--- a/apps/extension/src/provider/InjectedProxy.ts
+++ b/apps/extension/src/provider/InjectedProxy.ts
@@ -60,7 +60,11 @@ export class InjectedProxy {
         }
 
         if (result.error) {
-          reject(new Error(`${result.error}`));
+          const error =
+            result.error instanceof Error ?
+              result.error
+            : new Error(`${result.error}`);
+          reject(error);
           return;
         }
 

--- a/apps/namadillo/src/App/Common/TextLink.tsx
+++ b/apps/namadillo/src/App/Common/TextLink.tsx
@@ -1,0 +1,11 @@
+import clsx from "clsx";
+
+export const TextLink: React.FC<React.ComponentProps<"div">> = ({
+  className,
+  children,
+  ...rest
+}) => (
+  <span className={clsx("underline cursor-pointer", className)} {...rest}>
+    {children}
+  </span>
+);

--- a/apps/namadillo/src/App/Common/ToastErrorDescription.tsx
+++ b/apps/namadillo/src/App/Common/ToastErrorDescription.tsx
@@ -1,0 +1,30 @@
+import { useState } from "react";
+import { TextLink } from "./TextLink";
+
+export const ToastErrorDescription: React.FC<{
+  basicMessage?: string;
+  errorMessage?: string;
+}> = ({ basicMessage, errorMessage }) => {
+  const [expanded, setExpanded] = useState<boolean>(false);
+
+  const errorPart = (() => {
+    if (typeof errorMessage === "undefined") {
+      return null;
+    }
+
+    return expanded ?
+        <div style={{ overflowWrap: "anywhere" }}>{errorMessage}</div>
+      : <TextLink onClick={() => setExpanded(!expanded)}>
+          Show error message
+        </TextLink>;
+  })();
+
+  return (
+    <>
+      {basicMessage}
+      {basicMessage && <br />}
+      {basicMessage && expanded && <br />}
+      {errorPart}
+    </>
+  );
+};

--- a/apps/namadillo/src/App/Common/TransactionFees.tsx
+++ b/apps/namadillo/src/App/Common/TransactionFees.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx";
 import { useGasEstimate } from "hooks/useGasEstimate";
 import { NamCurrency } from "./NamCurrency";
+import { TextLink } from "./TextLink";
 type TransactionFeesProps = {
   numberOfTransactions: number;
   className?: string;
@@ -16,7 +17,7 @@ export const TransactionFees = ({
   if (!minimumGas || minimumGas.eq(0)) return <></>;
   return (
     <div className={clsx("text-white text-sm", className)}>
-      <span className="underline cursor-pointer">Transaction fee:</span>{" "}
+      <TextLink>Transaction fee:</TextLink>{" "}
       <NamCurrency
         className="font-medium"
         amount={minimumGas}

--- a/apps/namadillo/src/App/Governance/SubmitVote.tsx
+++ b/apps/namadillo/src/App/Governance/SubmitVote.tsx
@@ -11,6 +11,7 @@ import {
   isVoteType,
   voteTypes,
 } from "@namada/types";
+import { ToastErrorDescription } from "App/Common/ToastErrorDescription";
 import { TransactionFees } from "App/Common/TransactionFees";
 import clsx from "clsx";
 import { useProposalIdParam } from "hooks";
@@ -53,6 +54,8 @@ export const WithProposalId: React.FC<{ proposalId: bigint }> = ({
     mutate: createVoteTx,
     isSuccess,
     data: voteTxData,
+    isError,
+    error: voteTxError,
   } = useAtomValue(createVoteTxAtom);
   const dispatchNotification = useSetAtom(dispatchToastNotificationAtom);
   const minimumGasPrice = useAtomValue(minimumGasPriceAtom);
@@ -84,6 +87,23 @@ export const WithProposalId: React.FC<{ proposalId: bigint }> = ({
           #${proposalId}. Your transaction is being processed.`,
     });
   };
+
+  useEffect(() => {
+    if (isError) {
+      dispatchNotification({
+        id: "vote-tx-error",
+        title: "Governance transaction failed",
+        description: (
+          <ToastErrorDescription
+            errorMessage={
+              voteTxError instanceof Error ? voteTxError.message : undefined
+            }
+          />
+        ),
+        type: "error",
+      });
+    }
+  }, [isError]);
 
   const onSubmit = (e: React.FormEvent): void => {
     e.preventDefault();

--- a/apps/namadillo/src/App/Staking/IncrementBonding.tsx
+++ b/apps/namadillo/src/App/Staking/IncrementBonding.tsx
@@ -5,6 +5,7 @@ import { Info } from "App/Common/Info";
 import { ModalContainer } from "App/Common/ModalContainer";
 import { NamCurrency } from "App/Common/NamCurrency";
 import { TableRowLoading } from "App/Common/TableRowLoading";
+import { ToastErrorDescription } from "App/Common/ToastErrorDescription";
 import { TransactionFees } from "App/Common/TransactionFees";
 import clsx from "clsx";
 import { useStakeModule } from "hooks/useStakeModule";
@@ -43,7 +44,9 @@ const IncrementBonding = (): JSX.Element => {
     mutate: createBondTransaction,
     isPending: isPerformingBond,
     isSuccess,
+    isError,
     data: bondTransactionData,
+    error: bondTransactionError,
   } = useAtomValue(createBondTxAtom);
 
   const {
@@ -129,6 +132,25 @@ const IncrementBonding = (): JSX.Element => {
       onCloseModal();
     }
   }, [isSuccess]);
+
+  useEffect(() => {
+    if (isError) {
+      dispatchNotification({
+        id: "staking-error",
+        title: "Staking transaction failed",
+        description: (
+          <ToastErrorDescription
+            errorMessage={
+              bondTransactionError instanceof Error ?
+                bondTransactionError.message
+              : undefined
+            }
+          />
+        ),
+        type: "error",
+      });
+    }
+  }, [isError]);
 
   const errorMessage = ((): string => {
     if (accountBalance.isPending) return "Loading...";

--- a/apps/namadillo/src/App/Staking/ReDelegate.tsx
+++ b/apps/namadillo/src/App/Staking/ReDelegate.tsx
@@ -2,6 +2,7 @@ import { ActionButton, Alert, Modal, Panel } from "@namada/components";
 import { RedelegateMsgValue } from "@namada/types";
 import { Info } from "App/Common/Info";
 import { ModalContainer } from "App/Common/ModalContainer";
+import { ToastErrorDescription } from "App/Common/ToastErrorDescription";
 import BigNumber from "bignumber.js";
 import clsx from "clsx";
 import { useGasEstimate } from "hooks/useGasEstimate";
@@ -49,6 +50,8 @@ export const ReDelegate = (): JSX.Element => {
     isPending: isCreatingTx,
     data: redelegateTxData,
     isSuccess,
+    isError,
+    error: redelegateTxError,
   } = useAtomValue(createReDelegateTxAtom);
 
   useEffect(() => {
@@ -86,6 +89,25 @@ export const ReDelegate = (): JSX.Element => {
       type: "pending",
     });
   };
+
+  useEffect(() => {
+    if (isError) {
+      dispatchNotification({
+        id: "staking-redelegate-error",
+        title: "Staking re-delegation failed",
+        description: (
+          <ToastErrorDescription
+            errorMessage={
+              redelegateTxError instanceof Error ?
+                redelegateTxError.message
+              : undefined
+            }
+          />
+        ),
+        type: "error",
+      });
+    }
+  }, [isError]);
 
   const dispatchReDelegateTransactions = (
     transactions: TransactionPair<RedelegateMsgValue>[]

--- a/apps/namadillo/src/App/Staking/Unstake.tsx
+++ b/apps/namadillo/src/App/Staking/Unstake.tsx
@@ -5,6 +5,7 @@ import { Info } from "App/Common/Info";
 import { ModalContainer } from "App/Common/ModalContainer";
 import { NamCurrency } from "App/Common/NamCurrency";
 import { TableRowLoading } from "App/Common/TableRowLoading";
+import { ToastErrorDescription } from "App/Common/ToastErrorDescription";
 import { TransactionFees } from "App/Common/TransactionFees";
 import BigNumber from "bignumber.js";
 import clsx from "clsx";
@@ -36,6 +37,8 @@ const Unstake = (): JSX.Element => {
     isPending: isPerformingUnbond,
     data: unbondTransactionData,
     isSuccess,
+    isError,
+    error: unstakeTxError,
   } = useAtomValue(createUnbondTxAtom);
 
   const {
@@ -91,6 +94,25 @@ const Unstake = (): JSX.Element => {
       type: "pending",
     });
   };
+
+  useEffect(() => {
+    if (isError) {
+      dispatchNotification({
+        id: "unstake-error",
+        title: "Unstake transaction failed",
+        description: (
+          <ToastErrorDescription
+            errorMessage={
+              unstakeTxError instanceof Error ?
+                unstakeTxError.message
+              : undefined
+            }
+          />
+        ),
+        type: "error",
+      });
+    }
+  }, [isError]);
 
   const dispatchUnbondingTransactions = (
     transactions: TransactionPair<UnbondProps>[]

--- a/apps/namadillo/src/App/Staking/WithdrawalButton.tsx
+++ b/apps/namadillo/src/App/Staking/WithdrawalButton.tsx
@@ -1,6 +1,7 @@
 import { ActionButton } from "@namada/components";
 import { WithdrawMsgValue } from "@namada/types";
 import { NamCurrency } from "App/Common/NamCurrency";
+import { ToastErrorDescription } from "App/Common/ToastErrorDescription";
 import BigNumber from "bignumber.js";
 import { useGasEstimate } from "hooks/useGasEstimate";
 import invariant from "invariant";
@@ -29,6 +30,8 @@ export const WithdrawalButton = ({
     data: withdrawalTxs,
     isPending,
     isSuccess,
+    isError,
+    error: withdrawalTransactionError,
   } = useAtomValue(createWithdrawTxAtom);
 
   const onWithdraw = useCallback(async (myValidator: MyValidator) => {
@@ -86,6 +89,25 @@ export const WithdrawalButton = ({
       type: "pending",
     });
   };
+
+  useEffect(() => {
+    if (isError) {
+      dispatchNotification({
+        id: "withdrawal-error",
+        title: "Withdrawal transaction failed",
+        description: (
+          <ToastErrorDescription
+            errorMessage={
+              withdrawalTransactionError instanceof Error ?
+                withdrawalTransactionError.message
+              : undefined
+            }
+          />
+        ),
+        type: "error",
+      });
+    }
+  }, [isError]);
 
   useEffect(() => {
     if (withdrawalTxs) {

--- a/apps/namadillo/src/hooks/useTransactionNotifications.tsx
+++ b/apps/namadillo/src/hooks/useTransactionNotifications.tsx
@@ -7,6 +7,7 @@ import {
   WithdrawProps,
 } from "@namada/types";
 import { shortenAddress } from "@namada/utils";
+import { ToastErrorDescription } from "App/Common/ToastErrorDescription";
 import { useSetAtom } from "jotai";
 import {
   dispatchToastNotificationAtom,
@@ -35,8 +36,12 @@ export const useTransactionNotifications = (): void => {
         id: e.detail.transactionId,
         type: "error",
         title: "Staking transaction failed",
-        description: `Your staking transaction to ${address} has failed.`,
-        timeout: 5000,
+        description: (
+          <ToastErrorDescription
+            basicMessage={`Your staking transaction to ${address} has failed.`}
+            errorMessage={e.detail.error?.message}
+          />
+        ),
       });
     });
 
@@ -70,9 +75,13 @@ export const useTransactionNotifications = (): void => {
       dispatchNotification({
         id: e.detail.transactionId,
         title: "Unstake transaction failed",
-        description: `Your request to unstake ${e.detail.data.amount} NAM from ${address} has failed`,
-        type: "success",
-        timeout: 5000,
+        type: "error",
+        description: (
+          <ToastErrorDescription
+            basicMessage={`Your request to unstake ${e.detail.data.amount} NAM from ${address} has failed`}
+            errorMessage={e.detail.error?.message}
+          />
+        ),
       });
     });
 
@@ -85,11 +94,16 @@ export const useTransactionNotifications = (): void => {
         dispatchNotification({
           id: e.detail.transactionId,
           title: "Re-delegate failed",
-          description:
-            `Your re-delegate transaction of ${e.detail.data.amount}` +
-            ` NAM from ${sourceAddress} to ${destAddress} has failed`,
-          type: "success",
-          timeout: 5000,
+          description: (
+            <ToastErrorDescription
+              basicMessage={
+                `Your re-delegate transaction of ${e.detail.data.amount}` +
+                ` NAM from ${sourceAddress} to ${destAddress} has failed`
+              }
+              errorMessage={e.detail.error?.message}
+            />
+          ),
+          type: "error",
         });
       }
     );
@@ -135,10 +149,15 @@ export const useTransactionNotifications = (): void => {
         dispatchNotification({
           id: e.detail.transactionId,
           title: "Withdrawal Error",
-          description:
-            `Your withdrawal transaction ` + ` from ${address} has failed`,
+          description: (
+            <ToastErrorDescription
+              basicMessage={
+                `Your withdrawal transaction ` + ` from ${address} has failed`
+              }
+              errorMessage={e.detail.error?.message}
+            />
+          ),
           type: "error",
-          timeout: 5000,
         });
       }
     );
@@ -151,8 +170,12 @@ export const useTransactionNotifications = (): void => {
           id: e.detail.transactionId,
           type: "error",
           title: "Staking transaction failed",
-          description: `Your vote transaction for proposal ${e.detail.data.proposalId} has failed.`,
-          timeout: 5000,
+          description: (
+            <ToastErrorDescription
+              basicMessage={`Your vote transaction for proposal ${e.detail.data.proposalId} has failed.`}
+              errorMessage={e.detail.error?.message}
+            />
+          ),
         });
       }
     );

--- a/apps/namadillo/src/lib/query.ts
+++ b/apps/namadillo/src/lib/query.ts
@@ -133,7 +133,8 @@ export const signTxArray = async <T>(
 
     return signedTxs;
   } catch (err) {
-    throw new Error("Signing failed: " + err);
+    const message = err instanceof Error ? err.message : err;
+    throw new Error("Signing failed: " + message);
   }
 };
 


### PR DESCRIPTION
I'm guessing with the styling/layout of these toasts with error messages, so UX comments especially welcome!

---

### Changed
- Stop error toasts from auto-closing on timeout

### Added
- Add error messages in toasts
- Show error toast when signing fails

### Fixed
- Remove "Error:" prefix from extension error messages
- Fix success toasts showing for stake/redelegate errors