### PR TITLE
chore: switch to use namada_sdk instead of namada

### DIFF
--- a/packages/shared/lib/Cargo.lock
+++ b/packages/shared/lib/Cargo.lock
@@ -1927,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -1940,7 +1940,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -1950,7 +1950,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -1971,7 +1971,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -1981,7 +1981,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1999,7 +1999,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -2008,7 +2008,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -2025,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -2042,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
@@ -2056,7 +2056,7 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -2065,7 +2065,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2081,7 +2081,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -2096,7 +2096,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2119,7 +2119,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -2132,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2148,7 +2148,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2168,11 +2168,12 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "borsh",
  "derive_more",
  "displaydoc",
+ "ibc-core-host-types",
  "ibc-primitives",
  "ibc-proto",
  "ics23",
@@ -2186,7 +2187,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "ibc-client-wasm-types",
  "ibc-core-client",
@@ -2200,7 +2201,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2221,7 +2222,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2236,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2260,7 +2261,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2278,7 +2279,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2301,7 +2302,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2316,7 +2317,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2330,7 +2331,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2349,7 +2350,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.7.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2359,7 +2360,7 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.53.0"
-source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2841,57 +2842,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
-name = "namada"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
-dependencies = [
- "async-trait",
- "borsh",
- "borsh-ext",
- "clru",
- "either",
- "ethers",
- "eyre",
- "itertools 0.12.1",
- "masp_primitives",
- "masp_proofs",
- "namada_account",
- "namada_core",
- "namada_ethereum_bridge",
- "namada_events",
- "namada_gas",
- "namada_governance",
- "namada_ibc",
- "namada_parameters",
- "namada_proof_of_stake",
- "namada_replay_protection",
- "namada_sdk",
- "namada_state",
- "namada_token",
- "namada_tx",
- "namada_tx_env",
- "namada_vote_ext",
- "namada_vp_env",
- "prost",
- "rand 0.8.5",
- "ripemd",
- "serde_json",
- "sha2 0.9.9",
- "smooth-operator",
- "tendermint-rpc",
- "thiserror",
- "tiny-bip39 0.8.2 (git+https://github.com/anoma/tiny-bip39.git?rev=bf0f6d8713589b83af7a917366ec31f5275c0e57)",
- "tokio",
- "tracing",
- "uint",
- "wasmparser",
- "wasmtimer",
-]
-
-[[package]]
 name = "namada_account"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2902,8 +2855,8 @@ dependencies = [
 
 [[package]]
 name = "namada_controller"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
 dependencies = [
  "namada_core",
  "smooth-operator",
@@ -2912,8 +2865,8 @@ dependencies = [
 
 [[package]]
 name = "namada_core"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
 dependencies = [
  "bech32 0.8.1",
  "borsh",
@@ -2924,6 +2877,7 @@ dependencies = [
  "ethabi",
  "ethbridge-structs",
  "eyre",
+ "futures",
  "ibc",
  "ics23",
  "impl-num-traits",
@@ -2951,15 +2905,17 @@ dependencies = [
  "tendermint-proto 0.37.0",
  "thiserror",
  "tiny-keccak",
+ "tokio",
  "tracing",
  "uint",
+ "wasmtimer",
  "zeroize",
 ]
 
 [[package]]
 name = "namada_ethereum_bridge"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
 dependencies = [
  "borsh",
  "ethers",
@@ -2973,18 +2929,21 @@ dependencies = [
  "namada_proof_of_stake",
  "namada_state",
  "namada_storage",
+ "namada_systems",
  "namada_trans_token",
  "namada_tx",
  "namada_vote_ext",
+ "namada_vp",
  "serde",
+ "smooth-operator",
  "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "namada_events"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2997,8 +2956,8 @@ dependencies = [
 
 [[package]]
 name = "namada_gas"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3010,18 +2969,20 @@ dependencies = [
 
 [[package]]
 name = "namada_governance"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
  "konst",
+ "namada_account",
  "namada_core",
  "namada_events",
  "namada_macros",
- "namada_parameters",
- "namada_storage",
- "namada_trans_token",
+ "namada_state",
+ "namada_systems",
+ "namada_tx",
+ "namada_vp",
  "serde",
  "serde_json",
  "smooth-operator",
@@ -3031,8 +2992,8 @@ dependencies = [
 
 [[package]]
 name = "namada_ibc"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
 dependencies = [
  "borsh",
  "data-encoding",
@@ -3043,12 +3004,13 @@ dependencies = [
  "masp_primitives",
  "namada_core",
  "namada_events",
- "namada_governance",
+ "namada_gas",
  "namada_macros",
- "namada_parameters",
  "namada_state",
  "namada_storage",
- "namada_token",
+ "namada_systems",
+ "namada_tx",
+ "namada_vp",
  "primitive-types",
  "prost",
  "serde",
@@ -3061,8 +3023,8 @@ dependencies = [
 
 [[package]]
 name = "namada_macros"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
 dependencies = [
  "data-encoding",
  "proc-macro2",
@@ -3073,8 +3035,8 @@ dependencies = [
 
 [[package]]
 name = "namada_merkle_tree"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
 dependencies = [
  "borsh",
  "eyre",
@@ -3088,32 +3050,38 @@ dependencies = [
 
 [[package]]
 name = "namada_parameters"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
 dependencies = [
  "namada_core",
  "namada_macros",
+ "namada_state",
  "namada_storage",
+ "namada_systems",
+ "namada_tx",
+ "namada_vp",
  "smooth-operator",
  "thiserror",
 ]
 
 [[package]]
 name = "namada_proof_of_stake"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
 dependencies = [
  "borsh",
+ "itertools 0.12.1",
  "konst",
  "namada_account",
  "namada_controller",
  "namada_core",
  "namada_events",
- "namada_governance",
  "namada_macros",
- "namada_parameters",
+ "namada_state",
  "namada_storage",
- "namada_trans_token",
+ "namada_systems",
+ "namada_tx",
+ "namada_vp",
  "once_cell",
  "serde",
  "smooth-operator",
@@ -3123,16 +3091,16 @@ dependencies = [
 
 [[package]]
 name = "namada_replay_protection"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
 dependencies = [
  "namada_core",
 ]
 
 [[package]]
 name = "namada_sdk"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
 dependencies = [
  "async-trait",
  "bimap",
@@ -3167,7 +3135,9 @@ dependencies = [
  "namada_storage",
  "namada_token",
  "namada_tx",
+ "namada_vm",
  "namada_vote_ext",
+ "namada_vp",
  "num-traits 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "num256",
  "orion",
@@ -3191,36 +3161,41 @@ dependencies = [
  "tokio",
  "toml 0.5.11",
  "tracing",
- "wasmtimer",
  "zeroize",
 ]
 
 [[package]]
 name = "namada_shielded_token"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
 dependencies = [
  "borsh",
  "lazy_static",
  "masp_primitives",
  "masp_proofs",
+ "namada_account",
  "namada_controller",
  "namada_core",
  "namada_gas",
- "namada_parameters",
+ "namada_state",
  "namada_storage",
- "namada_trans_token",
+ "namada_systems",
+ "namada_tx",
+ "namada_vp",
  "rand_core 0.6.4",
  "rayon",
+ "ripemd",
  "serde",
+ "sha2 0.9.9",
  "smooth-operator",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "namada_state"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
 dependencies = [
  "borsh",
  "clru",
@@ -3230,9 +3205,9 @@ dependencies = [
  "namada_gas",
  "namada_macros",
  "namada_merkle_tree",
- "namada_parameters",
  "namada_replay_protection",
  "namada_storage",
+ "namada_systems",
  "namada_tx",
  "patricia_tree",
  "smooth-operator",
@@ -3242,8 +3217,8 @@ dependencies = [
 
 [[package]]
 name = "namada_storage"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3259,9 +3234,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "namada_systems"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+dependencies = [
+ "namada_core",
+ "namada_storage",
+]
+
+[[package]]
 name = "namada_token"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3269,25 +3253,32 @@ dependencies = [
  "namada_macros",
  "namada_shielded_token",
  "namada_storage",
+ "namada_systems",
  "namada_trans_token",
  "serde",
 ]
 
 [[package]]
 name = "namada_trans_token"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
 dependencies = [
  "konst",
  "namada_core",
  "namada_events",
+ "namada_state",
  "namada_storage",
+ "namada_systems",
+ "namada_tx",
+ "namada_vp",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
 name = "namada_tx"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
 dependencies = [
  "ark-bls12-381",
  "bitflags 2.5.0",
@@ -3313,19 +3304,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "namada_tx_env"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
+name = "namada_vm"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
 dependencies = [
+ "borsh",
+ "clru",
  "namada_core",
  "namada_events",
- "namada_storage",
+ "namada_gas",
+ "namada_parameters",
+ "namada_state",
+ "namada_token",
+ "namada_tx",
+ "namada_vp",
+ "smooth-operator",
+ "thiserror",
+ "tracing",
+ "wasmparser",
 ]
 
 [[package]]
 name = "namada_vote_ext"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3335,15 +3337,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "namada_vp"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+dependencies = [
+ "namada_core",
+ "namada_events",
+ "namada_gas",
+ "namada_state",
+ "namada_tx",
+ "namada_vp_env",
+ "smooth-operator",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "namada_vp_env"
-version = "0.41.0"
-source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
+version = "0.42.0"
+source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
 dependencies = [
  "derivative",
  "masp_primitives",
  "namada_core",
  "namada_events",
- "namada_ibc",
  "namada_storage",
  "namada_tx",
  "smooth-operator",
@@ -4761,7 +4778,7 @@ dependencies = [
  "gloo-utils",
  "hex",
  "js-sys",
- "namada",
+ "namada_sdk",
  "rand 0.8.5",
  "reqwest",
  "rexie",

--- a/packages/shared/lib/Cargo.lock
+++ b/packages/shared/lib/Cargo.lock
@@ -423,6 +423,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
 dependencies = [
  "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "bls12_381"
+version = "0.8.0"
+source = "git+https://github.com/heliaxdev/bls12_381.git?rev=d3ebe9dd6488fac1923db120a7498079e55dd838#d3ebe9dd6488fac1923db120a7498079e55dd838"
+dependencies = [
+ "ff",
  "group",
  "pairing",
  "rand_core 0.6.4",
@@ -1927,7 +1937,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -1940,7 +1950,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -1950,7 +1960,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer-types"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -1971,7 +1981,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -1981,7 +1991,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "borsh",
  "derive_more",
@@ -1999,7 +2009,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -2008,7 +2018,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -2025,7 +2035,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -2042,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
@@ -2056,7 +2066,7 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -2065,7 +2075,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2081,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -2096,7 +2106,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2119,7 +2129,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -2132,7 +2142,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2148,7 +2158,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-types"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2168,7 +2178,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2187,7 +2197,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "ibc-client-wasm-types",
  "ibc-core-client",
@@ -2201,7 +2211,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2222,7 +2232,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2237,7 +2247,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2261,7 +2271,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2279,7 +2289,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2302,7 +2312,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-types"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2317,7 +2327,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2331,7 +2341,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2350,7 +2360,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.7.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2360,7 +2370,7 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b#1dd9be8c1cdc773e6b5b0b3609f3390a9a69eb9b"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2540,6 +2550,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "init-once"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0863329819ed5ecf33446da6cb9104d2f8943ff8530d2b6c51adbc6be4f0632"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2626,7 +2645,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8499f7a74008aafbecb2a2e608a3e13e4dd3e84df198b604451efe93f2de6e61"
 dependencies = [
  "bitvec",
- "bls12_381",
+ "bls12_381 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ff",
+ "group",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "jubjub"
+version = "0.10.0"
+source = "git+https://github.com/heliaxdev/jubjub.git?rev=a373686962f4e9d0edb3b4716f86ff6bbd9aa86c#a373686962f4e9d0edb3b4716f86ff6bbd9aa86c"
+dependencies = [
+ "bitvec",
+ "bls12_381 0.8.0 (git+https://github.com/heliaxdev/bls12_381.git?rev=d3ebe9dd6488fac1923db120a7498079e55dd838)",
  "ff",
  "group",
  "rand_core 0.6.4",
@@ -2646,6 +2678,16 @@ dependencies = [
  "serdect",
  "sha2 0.10.8",
  "signature",
+]
+
+[[package]]
+name = "kdam"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "526586ea01a9a132b5f8d3a60f6d6b41b411550236f5ee057795f20b37316957"
+dependencies = [
+ "terminal_size",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2730,7 +2772,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 [[package]]
 name = "masp_note_encryption"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=8d83b172698098fba393006016072bc201ed9ab7#8d83b172698098fba393006016072bc201ed9ab7"
+source = "git+https://github.com/anoma/masp?rev=12ed8b060b295c06502a2ff8468e4a941cb7cca4#12ed8b060b295c06502a2ff8468e4a941cb7cca4"
 dependencies = [
  "borsh",
  "chacha20",
@@ -2743,14 +2785,14 @@ dependencies = [
 [[package]]
 name = "masp_primitives"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=8d83b172698098fba393006016072bc201ed9ab7#8d83b172698098fba393006016072bc201ed9ab7"
+source = "git+https://github.com/anoma/masp?rev=12ed8b060b295c06502a2ff8468e4a941cb7cca4#12ed8b060b295c06502a2ff8468e4a941cb7cca4"
 dependencies = [
  "aes",
  "bip0039",
  "bitvec",
  "blake2b_simd",
  "blake2s_simd",
- "bls12_381",
+ "bls12_381 0.8.0 (git+https://github.com/heliaxdev/bls12_381.git?rev=d3ebe9dd6488fac1923db120a7498079e55dd838)",
  "borsh",
  "byteorder",
  "ff",
@@ -2758,7 +2800,7 @@ dependencies = [
  "group",
  "hex",
  "incrementalmerkletree",
- "jubjub",
+ "jubjub 0.10.0 (git+https://github.com/heliaxdev/jubjub.git?rev=a373686962f4e9d0edb3b4716f86ff6bbd9aa86c)",
  "lazy_static",
  "masp_note_encryption",
  "memuse",
@@ -2774,16 +2816,16 @@ dependencies = [
 [[package]]
 name = "masp_proofs"
 version = "1.0.0"
-source = "git+https://github.com/anoma/masp?rev=8d83b172698098fba393006016072bc201ed9ab7#8d83b172698098fba393006016072bc201ed9ab7"
+source = "git+https://github.com/anoma/masp?rev=12ed8b060b295c06502a2ff8468e4a941cb7cca4#12ed8b060b295c06502a2ff8468e4a941cb7cca4"
 dependencies = [
  "bellman",
  "blake2b_simd",
- "bls12_381",
+ "bls12_381 0.8.0 (git+https://github.com/heliaxdev/bls12_381.git?rev=d3ebe9dd6488fac1923db120a7498079e55dd838)",
  "directories",
  "getrandom 0.2.15",
  "group",
  "itertools 0.11.0",
- "jubjub",
+ "jubjub 0.10.0 (git+https://github.com/heliaxdev/jubjub.git?rev=a373686962f4e9d0edb3b4716f86ff6bbd9aa86c)",
  "lazy_static",
  "masp_primitives",
  "rand_core 0.6.4",
@@ -2843,8 +2885,8 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "namada_account"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2855,8 +2897,8 @@ dependencies = [
 
 [[package]]
 name = "namada_controller"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "namada_core",
  "smooth-operator",
@@ -2865,8 +2907,8 @@ dependencies = [
 
 [[package]]
 name = "namada_core"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "bech32 0.8.1",
  "borsh",
@@ -2884,6 +2926,7 @@ dependencies = [
  "index-set",
  "indexmap 2.2.4",
  "k256",
+ "lazy_static",
  "masp_primitives",
  "namada_macros",
  "num-integer",
@@ -2914,8 +2957,8 @@ dependencies = [
 
 [[package]]
 name = "namada_ethereum_bridge"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "borsh",
  "ethers",
@@ -2942,8 +2985,8 @@ dependencies = [
 
 [[package]]
 name = "namada_events"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2956,8 +2999,8 @@ dependencies = [
 
 [[package]]
 name = "namada_gas"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2969,8 +3012,8 @@ dependencies = [
 
 [[package]]
 name = "namada_governance"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -2992,8 +3035,8 @@ dependencies = [
 
 [[package]]
 name = "namada_ibc"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "borsh",
  "data-encoding",
@@ -3023,8 +3066,8 @@ dependencies = [
 
 [[package]]
 name = "namada_macros"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "data-encoding",
  "proc-macro2",
@@ -3035,8 +3078,8 @@ dependencies = [
 
 [[package]]
 name = "namada_merkle_tree"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "borsh",
  "eyre",
@@ -3050,8 +3093,8 @@ dependencies = [
 
 [[package]]
 name = "namada_parameters"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "namada_core",
  "namada_macros",
@@ -3066,8 +3109,8 @@ dependencies = [
 
 [[package]]
 name = "namada_proof_of_stake"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3091,16 +3134,16 @@ dependencies = [
 
 [[package]]
 name = "namada_replay_protection"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "namada_core",
 ]
 
 [[package]]
 name = "namada_sdk"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "async-trait",
  "bimap",
@@ -3117,7 +3160,9 @@ dependencies = [
  "eyre",
  "flume",
  "futures",
+ "init-once",
  "itertools 0.12.1",
+ "kdam",
  "lazy_static",
  "masp_primitives",
  "masp_proofs",
@@ -3147,6 +3192,7 @@ dependencies = [
  "prost",
  "rand 0.8.5",
  "rand_core 0.6.4",
+ "rayon",
  "regex",
  "reqwest",
  "serde",
@@ -3154,6 +3200,7 @@ dependencies = [
  "sha2 0.9.9",
  "slip10_ed25519",
  "smooth-operator",
+ "tempfile",
  "tendermint-rpc",
  "thiserror",
  "tiny-bip39 0.8.2 (git+https://github.com/anoma/tiny-bip39.git?rev=bf0f6d8713589b83af7a917366ec31f5275c0e57)",
@@ -3161,13 +3208,15 @@ dependencies = [
  "tokio",
  "toml 0.5.11",
  "tracing",
+ "typed-builder",
+ "xorf",
  "zeroize",
 ]
 
 [[package]]
 name = "namada_shielded_token"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "borsh",
  "lazy_static",
@@ -3194,8 +3243,8 @@ dependencies = [
 
 [[package]]
 name = "namada_state"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "borsh",
  "clru",
@@ -3217,8 +3266,8 @@ dependencies = [
 
 [[package]]
 name = "namada_storage"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3235,8 +3284,8 @@ dependencies = [
 
 [[package]]
 name = "namada_systems"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "namada_core",
  "namada_storage",
@@ -3244,8 +3293,8 @@ dependencies = [
 
 [[package]]
 name = "namada_token"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3260,8 +3309,8 @@ dependencies = [
 
 [[package]]
 name = "namada_trans_token"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "konst",
  "namada_core",
@@ -3277,8 +3326,8 @@ dependencies = [
 
 [[package]]
 name = "namada_tx"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "ark-bls12-381",
  "bitflags 2.5.0",
@@ -3305,8 +3354,8 @@ dependencies = [
 
 [[package]]
 name = "namada_vm"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "borsh",
  "clru",
@@ -3326,8 +3375,8 @@ dependencies = [
 
 [[package]]
 name = "namada_vote_ext"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3338,8 +3387,8 @@ dependencies = [
 
 [[package]]
 name = "namada_vp"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -3354,8 +3403,8 @@ dependencies = [
 
 [[package]]
 name = "namada_vp_env"
-version = "0.42.0"
-source = "git+https://github.com/anoma/namada#80268fa9ade3e515a475b9194831d72451ed3bd7"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
 dependencies = [
  "derivative",
  "masp_primitives",
@@ -3921,6 +3970,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4194,7 +4249,7 @@ dependencies = [
  "byteorder",
  "group",
  "hex",
- "jubjub",
+ "jubjub 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pasta_curves",
  "rand_core 0.6.4",
  "serde",
@@ -5209,6 +5264,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5504,6 +5569,26 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typed-builder"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06fbd5b8de54c5f7c91f6fe4cebb949be2125d7758e630bb58b1d831dbce600"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9534daa9fd3ed0bd911d462a37f172228077e7abf18c18a5f67199d959205f8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.65",
+]
 
 [[package]]
 name = "typenum"
@@ -6044,6 +6129,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xorf"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf24c008fe464f5d8f58b8d16a1ab7e930bd73b2a6933ff8704c414b2bed7f92"
+dependencies = [
+ "libm",
+ "rand 0.8.5",
+ "serde",
 ]
 
 [[package]]

--- a/packages/shared/lib/Cargo.toml
+++ b/packages/shared/lib/Cargo.toml
@@ -24,7 +24,7 @@ chrono = "0.4.22"
 getrandom = { version = "0.2.7", features = ["js"] }
 gloo-utils = { version = "0.1.5", features = ["serde"] }
 js-sys = "0.3.60"
-namada_sdk = { git = "https://github.com/anoma/namada", version = "0.42.0", default-features = false }
+namada_sdk = { git = "https://github.com/anoma/namada", version = "0.43.0", default-features = false }
 rand = "0.8.5"
 rexie = "0.5"
 serde = "^1.0.181"

--- a/packages/shared/lib/Cargo.toml
+++ b/packages/shared/lib/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = []
 dev = []
-multicore = ["wasm-bindgen-rayon", "namada/multicore"]
+multicore = ["wasm-bindgen-rayon", "namada_sdk/multicore"]
 nodejs = []
 web = []
 
@@ -24,7 +24,7 @@ chrono = "0.4.22"
 getrandom = { version = "0.2.7", features = ["js"] }
 gloo-utils = { version = "0.1.5", features = ["serde"] }
 js-sys = "0.3.60"
-namada = { git = "https://github.com/anoma/namada", version = "0.41.0", default-features = false, features = ["namada-sdk"] }
+namada_sdk = { git = "https://github.com/anoma/namada", version = "0.42.0", default-features = false }
 rand = "0.8.5"
 rexie = "0.5"
 serde = "^1.0.181"

--- a/packages/shared/lib/src/query.rs
+++ b/packages/shared/lib/src/query.rs
@@ -1,37 +1,37 @@
 use gloo_utils::format::JsValueSerdeExt;
 use js_sys::Uint8Array;
-use namada::address::Address;
-use namada::core::borsh::BorshSerialize;
-use namada::core::collections::{HashMap, HashSet};
-use namada::eth_bridge_pool::TransferToEthereum;
-use namada::governance::storage::keys as governance_storage;
-use namada::governance::utils::{
+use namada_sdk::address::Address;
+use namada_sdk::borsh::BorshSerialize;
+use namada_sdk::collections::{HashMap, HashSet};
+use namada_sdk::eth_bridge::bridge_pool::query_signed_bridge_pool;
+use namada_sdk::eth_bridge_pool::TransferToEthereum;
+use namada_sdk::governance::storage::keys as governance_storage;
+use namada_sdk::governance::utils::{
     compute_proposal_result, ProposalVotes, TallyResult, TallyType, VotePower,
 };
-use namada::governance::{ProposalType, ProposalVote};
-use namada::ledger::eth_bridge::bridge_pool::query_signed_bridge_pool;
-use namada::ledger::parameters::storage;
-use namada::ledger::queries::RPC;
-use namada::masp::ExtendedViewingKey;
-use namada::proof_of_stake::Epoch;
-use namada::sdk::hash::Hash;
-use namada::sdk::masp::ShieldedContext;
-use namada::sdk::masp_primitives::asset_type::AssetType;
-use namada::sdk::masp_primitives::sapling::ViewingKey;
-use namada::sdk::masp_primitives::transaction::components::ValueSum;
-use namada::sdk::masp_primitives::zip32::ExtendedFullViewingKey;
-use namada::sdk::rpc::{
+use namada_sdk::governance::{ProposalType, ProposalVote};
+use namada_sdk::hash::Hash;
+use namada_sdk::masp::ExtendedViewingKey;
+use namada_sdk::masp::ShieldedContext;
+use namada_sdk::masp_primitives::asset_type::AssetType;
+use namada_sdk::masp_primitives::sapling::ViewingKey;
+use namada_sdk::masp_primitives::transaction::components::ValueSum;
+use namada_sdk::masp_primitives::zip32::ExtendedFullViewingKey;
+use namada_sdk::parameters::storage;
+use namada_sdk::proof_of_stake::Epoch;
+use namada_sdk::queries::RPC;
+use namada_sdk::rpc::{
     self, format_denominated_amount, get_public_key_at, get_token_balance, get_total_staked_tokens,
     is_steward, query_epoch, query_masp_epoch, query_native_token, query_proposal_by_id,
     query_proposal_votes, query_storage_value,
 };
-use namada::sdk::state::Key;
-use namada::sdk::tx::{
+use namada_sdk::state::Key;
+use namada_sdk::token;
+use namada_sdk::tx::{
     TX_BOND_WASM, TX_CLAIM_REWARDS_WASM, TX_REDELEGATE_WASM, TX_REVEAL_PK, TX_TRANSFER_WASM,
     TX_UNBOND_WASM, TX_VOTE_PROPOSAL, TX_WITHDRAW_WASM,
 };
-use namada::token;
-use namada::uint::I256;
+use namada_sdk::uint::I256;
 use std::collections::BTreeMap;
 use std::str::FromStr;
 use wasm_bindgen::prelude::*;

--- a/packages/shared/lib/src/rpc_client.rs
+++ b/packages/shared/lib/src/rpc_client.rs
@@ -1,5 +1,5 @@
 use js_sys::JSON::stringify;
-use namada::storage::BlockHeight;
+use namada_sdk::storage::BlockHeight;
 use std::fmt::Debug;
 use std::fmt::Display;
 use thiserror::Error;
@@ -8,9 +8,9 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::Response;
 
-use namada::ledger::queries::{Client, EncodedResponseQuery};
-use namada::tendermint::{self, abci::Code};
-use namada::tendermint_rpc::{
+use namada_sdk::queries::{Client, EncodedResponseQuery};
+use namada_sdk::tendermint::{self, abci::Code};
+use namada_sdk::tendermint_rpc::{
     error::Error as TendermintRpcError, Response as RpcResponse, SimpleRequest,
 };
 
@@ -41,14 +41,14 @@ impl From<std::io::Error> for RpcError {
     }
 }
 
-impl From<namada::tendermint::Error> for RpcError {
-    fn from(error: namada::tendermint::Error) -> Self {
+impl From<namada_sdk::tendermint::Error> for RpcError {
+    fn from(error: namada_sdk::tendermint::Error) -> Self {
         RpcError::new(&error.to_string())
     }
 }
 
-impl From<namada::tendermint_rpc::Error> for RpcError {
-    fn from(error: namada::tendermint_rpc::Error) -> Self {
+impl From<namada_sdk::tendermint_rpc::Error> for RpcError {
+    fn from(error: namada_sdk::tendermint_rpc::Error) -> Self {
         RpcError::new(&error.to_string())
     }
 }

--- a/packages/shared/lib/src/sdk/args.rs
+++ b/packages/shared/lib/src/sdk/args.rs
@@ -1,23 +1,23 @@
 use std::{path::PathBuf, str::FromStr};
 
-use namada::core::borsh::{BorshDeserialize, BorshSerialize};
-use namada::core::ibc::core::host::types::identifiers::{ChannelId, PortId};
-use namada::ibc::IbcShieldingData;
-use namada::tendermint_rpc;
-use namada::tx::data::GasLimit;
-use namada::{
+use namada_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use namada_sdk::ibc::core::host::types::identifiers::{ChannelId, PortId};
+use namada_sdk::ibc::IbcShieldingData;
+use namada_sdk::tendermint_rpc;
+use namada_sdk::tx::data::GasLimit;
+use namada_sdk::{
     address::Address,
+    args::{self, InputAmount, TxExpiration},
     chain::ChainId,
     ethereum_events::EthAddress,
     key::common::PublicKey,
     masp::TransferSource,
-    sdk::args::{self, InputAmount, TxExpiration},
     token::{Amount, DenominatedAmount, NATIVE_MAX_DECIMAL_PLACES},
 };
 use wasm_bindgen::JsError;
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct RevealPkMsg {
     public_key: String,
 }
@@ -29,7 +29,7 @@ impl RevealPkMsg {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct WrapperTxMsg {
     token: String,
     fee_amount: String,
@@ -60,7 +60,7 @@ impl WrapperTxMsg {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct BondMsg {
     source: String,
     validator: String,
@@ -114,7 +114,7 @@ pub fn bond_tx_args(bond_msg: &[u8], tx_msg: &[u8]) -> Result<args::Bond, JsErro
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct UnbondMsg {
     source: String,
     validator: String,
@@ -169,7 +169,7 @@ pub fn unbond_tx_args(unbond_msg: &[u8], tx_msg: &[u8]) -> Result<args::Unbond, 
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct WithdrawMsg {
     source: String,
     validator: String,
@@ -212,7 +212,7 @@ pub fn withdraw_tx_args(withdraw_msg: &[u8], tx_msg: &[u8]) -> Result<args::With
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct RedelegateMsg {
     owner: String,
     source_validator: String,
@@ -279,7 +279,7 @@ pub fn redelegate_tx_args(
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct VoteProposalMsg {
     signer: String,
     proposal_id: u64,
@@ -333,7 +333,7 @@ pub fn vote_proposal_tx_args(
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct ClaimRewardsMsg {
     validator: String,
     source: Option<String>,
@@ -379,7 +379,7 @@ pub fn claim_rewards_tx_args(
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct TransferDataMsg {
     owner: String,
     token: String,
@@ -397,7 +397,7 @@ impl TransferDataMsg {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct TransferMsg {
     sources: Vec<TransferDataMsg>,
     targets: Vec<TransferDataMsg>,
@@ -419,7 +419,7 @@ impl TransferMsg {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct TransparentTransferDataMsg {
     source: String,
     target: String,
@@ -428,7 +428,7 @@ pub struct TransparentTransferDataMsg {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct TransparentTransferMsg {
     data: Vec<TransparentTransferDataMsg>,
 }
@@ -481,7 +481,7 @@ pub fn transparent_transfer_tx_args(
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct IbcTransferMsg {
     source: String,
     receiver: String,
@@ -560,7 +560,7 @@ pub fn ibc_transfer_tx_args(
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct EthBridgeTransferMsg {
     nut: bool,
     asset: String,
@@ -693,6 +693,7 @@ fn tx_msg_into_args(tx_msg: &[u8]) -> Result<args::Tx, JsError> {
         use_device: false,
         password: None,
         memo,
+        device_transport: Default::default(),
     };
 
     Ok(args)

--- a/packages/shared/lib/src/sdk/io.rs
+++ b/packages/shared/lib/src/sdk/io.rs
@@ -1,4 +1,4 @@
-use namada::io::Io;
+use namada_sdk::io::Io;
 use wasm_bindgen::JsValue;
 
 fn read(question: Option<&str>) -> std::io::Result<String> {

--- a/packages/shared/lib/src/sdk/masp/masp_node.rs
+++ b/packages/shared/lib/src/sdk/masp/masp_node.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use namada::sdk::{
+use namada_sdk::{
     borsh::{BorshDeserialize, BorshSerialize},
     masp::{ContextSyncStatus, ShieldedContext, ShieldedUtils},
     masp_proofs::prover::LocalTxProver,
@@ -25,7 +25,7 @@ const SPECULATIVE_TMP_FILE_NAME: &str = "speculative_shielded.tmp";
 /// Mostly copied from the Namada CLI
 
 #[derive(Default, Debug, BorshSerialize, BorshDeserialize, Clone)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct NodeShieldedUtils {
     #[borsh(skip)]
     context_dir: PathBuf,

--- a/packages/shared/lib/src/sdk/masp/masp_node.rs
+++ b/packages/shared/lib/src/sdk/masp/masp_node.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use namada_sdk::{
     borsh::{BorshDeserialize, BorshSerialize},
-    masp::{ContextSyncStatus, ShieldedContext, ShieldedUtils},
+    masp::{ContextSyncStatus, DispatcherCache, ShieldedContext, ShieldedUtils},
     masp_proofs::prover::LocalTxProver,
 };
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
@@ -135,6 +135,20 @@ impl ShieldedUtils for NodeShieldedUtils {
         }
 
         Ok(())
+    }
+
+    /// Save a cache of data as part of shielded sync if that
+    /// process gets interrupted.
+    async fn cache_save(&self, _cache: &DispatcherCache) -> std::io::Result<()> {
+        // TODO:
+        todo!()
+    }
+
+    /// Load a cache of data as part of shielded sync if that
+    /// process gets interrupted.
+    async fn cache_load(&self) -> std::io::Result<DispatcherCache> {
+        // TODO:
+        todo!()
     }
 }
 

--- a/packages/shared/lib/src/sdk/masp/masp_web.rs
+++ b/packages/shared/lib/src/sdk/masp/masp_web.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use gloo_utils::format::JsValueSerdeExt;
 use namada_sdk::borsh::{BorshDeserialize, BorshSerialize};
-use namada_sdk::masp::{ContextSyncStatus, ShieldedContext, ShieldedUtils};
+use namada_sdk::masp::{ContextSyncStatus, DispatcherCache, ShieldedContext, ShieldedUtils};
 use namada_sdk::masp_proofs::prover::LocalTxProver;
 use rexie::{Error, ObjectStore, Rexie, TransactionMode};
 use wasm_bindgen::{JsError, JsValue};
@@ -179,5 +179,17 @@ impl ShieldedUtils for WebShieldedUtils {
         }
 
         Ok(())
+    }
+
+    /// Save a cache of data as part of shielded sync if that
+    /// process gets interrupted.
+    async fn cache_save(&self, _cache: &DispatcherCache) -> std::io::Result<()> {
+        todo!()
+    }
+
+    /// Load a cache of data as part of shielded sync if that
+    /// process gets interrupted.
+    async fn cache_load(&self) -> std::io::Result<DispatcherCache> {
+        todo!()
     }
 }

--- a/packages/shared/lib/src/sdk/masp/masp_web.rs
+++ b/packages/shared/lib/src/sdk/masp/masp_web.rs
@@ -1,20 +1,20 @@
 use async_trait::async_trait;
 use gloo_utils::format::JsValueSerdeExt;
-use namada::core::borsh::{BorshDeserialize, BorshSerialize};
-use namada::sdk::masp::{ContextSyncStatus, ShieldedContext, ShieldedUtils};
-use namada::sdk::masp_proofs::prover::LocalTxProver;
+use namada_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use namada_sdk::masp::{ContextSyncStatus, ShieldedContext, ShieldedUtils};
+use namada_sdk::masp_proofs::prover::LocalTxProver;
 use rexie::{Error, ObjectStore, Rexie, TransactionMode};
 use wasm_bindgen::{JsError, JsValue};
 
 use crate::utils::to_bytes;
 
-const DB_PREFIX: &str = "Namada::MASP";
+const DB_PREFIX: &str = "namada_sdk::MASP";
 const SHIELDED_CONTEXT_TABLE: &str = "ShieldedContext";
 const SHIELDED_CONTEXT_KEY_CONFIRMED: &str = "shielded-context-confirmed";
 const SHIELDED_CONTEXT_KEY_SPECULATIVE: &str = "shielded-context-speculative";
 
 #[derive(Default, Debug, BorshSerialize, BorshDeserialize, Clone)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct WebShieldedUtils {
     spend_param_bytes: Vec<u8>,
     output_param_bytes: Vec<u8>,

--- a/packages/shared/lib/src/sdk/mod.rs
+++ b/packages/shared/lib/src/sdk/mod.rs
@@ -14,29 +14,29 @@ use crate::utils::to_bytes;
 use crate::utils::to_js_result;
 use gloo_utils::format::JsValueSerdeExt;
 use js_sys::Uint8Array;
-use namada::address::Address;
-use namada::core::borsh::{self, BorshDeserialize, BorshSerialize};
-use namada::hash::Hash;
-use namada::key::{common, ed25519, SigScheme};
-use namada::ledger::eth_bridge::bridge_pool::build_bridge_pool_tx;
-use namada::sdk::masp::ShieldedContext;
-use namada::sdk::rpc::query_epoch;
-use namada::sdk::signing::SigningTxData;
-use namada::sdk::tx::{
+use namada_sdk::address::Address;
+use namada_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
+use namada_sdk::eth_bridge::bridge_pool::build_bridge_pool_tx;
+use namada_sdk::hash::Hash;
+use namada_sdk::key::{common, ed25519, SigScheme};
+use namada_sdk::masp::ShieldedContext;
+use namada_sdk::rpc::query_epoch;
+use namada_sdk::signing::SigningTxData;
+use namada_sdk::string_encoding::Format;
+use namada_sdk::tx::Tx;
+use namada_sdk::tx::{
     build_batch, build_bond, build_claim_rewards, build_ibc_transfer, build_redelegation,
     build_reveal_pk, build_transparent_transfer, build_unbond, build_vote_proposal, build_withdraw,
     is_reveal_pk_needed, process_tx, ProcessTxResponse,
 };
-use namada::sdk::wallet::{Store, Wallet};
-use namada::sdk::{Namada, NamadaImpl};
-use namada::string_encoding::Format;
-use namada::tx::Tx;
+use namada_sdk::wallet::{Store, Wallet};
+use namada_sdk::{Namada, NamadaImpl};
 use std::str::FromStr;
 use wasm_bindgen::{prelude::wasm_bindgen, JsError, JsValue};
 
 #[wasm_bindgen]
 #[derive(BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct BatchTxResult {
     hash: String,
     is_applied: bool,
@@ -44,7 +44,7 @@ pub struct BatchTxResult {
 
 #[wasm_bindgen]
 #[derive(BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct TxResponse {
     code: String,
     commitments: Vec<BatchTxResult>,

--- a/packages/shared/lib/src/sdk/signature.rs
+++ b/packages/shared/lib/src/sdk/signature.rs
@@ -1,5 +1,5 @@
-use namada::core::borsh::{BorshDeserialize, BorshSerialize};
-use namada::{
+use namada_sdk::borsh::{BorshDeserialize, BorshSerialize};
+use namada_sdk::{
     key::common::{PublicKey, Signature},
     tx::{CompressedAuthorization, Section, Signer, Tx},
 };
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 use wasm_bindgen::JsError;
 
 #[derive(BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct SignatureMsg {
     pub pubkey: Vec<u8>,
     pub raw_indices: Vec<u8>,

--- a/packages/shared/lib/src/sdk/transaction.rs
+++ b/packages/shared/lib/src/sdk/transaction.rs
@@ -1,10 +1,10 @@
-use namada::token::Transfer;
+use namada_sdk::token::Transfer;
 use serde::Serialize;
 
-use namada::governance::VoteProposalData;
-use namada::tx::data::pos::{Bond, ClaimRewards, Redelegation, Unbond, Withdraw};
-use namada::{
-    core::borsh::{self, BorshDeserialize},
+use namada_sdk::governance::VoteProposalData;
+use namada_sdk::tx::data::pos::{Bond, ClaimRewards, Redelegation, Unbond, Withdraw};
+use namada_sdk::{
+    borsh::{self, BorshDeserialize},
     key::common::PublicKey,
 };
 use wasm_bindgen::JsError;

--- a/packages/shared/lib/src/sdk/tx.rs
+++ b/packages/shared/lib/src/sdk/tx.rs
@@ -2,15 +2,15 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use gloo_utils::format::JsValueSerdeExt;
-use namada::core::borsh::{self, BorshDeserialize, BorshSerialize};
-use namada::sdk::signing::SigningTxData;
-use namada::sdk::tx::{
+use namada_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
+use namada_sdk::signing::SigningTxData;
+use namada_sdk::tx;
+use namada_sdk::tx::{
     TX_BOND_WASM, TX_CLAIM_REWARDS_WASM, TX_REDELEGATE_WASM, TX_REVEAL_PK, TX_TRANSFER_WASM,
     TX_UNBOND_WASM, TX_VOTE_PROPOSAL, TX_WITHDRAW_WASM,
 };
-use namada::sdk::uint::Uint;
-use namada::tx;
-use namada::{address::Address, key::common::PublicKey};
+use namada_sdk::uint::Uint;
+use namada_sdk::{address::Address, key::common::PublicKey};
 use wasm_bindgen::{prelude::wasm_bindgen, JsError, JsValue};
 
 use super::args::WrapperTxMsg;
@@ -19,7 +19,7 @@ use crate::types::query::WasmHash;
 
 #[wasm_bindgen]
 #[derive(BorshSerialize, BorshDeserialize, Copy, Clone, Debug)]
-#[borsh(crate = "namada::core::borsh", use_discriminant = true)]
+#[borsh(crate = "namada_sdk::borsh", use_discriminant = true)]
 pub enum TxType {
     Bond = 1,
     Unbond = 2,
@@ -35,7 +35,7 @@ pub enum TxType {
 }
 
 #[derive(BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct SigningData {
     owner: Option<String>,
     public_keys: Vec<u8>,
@@ -128,7 +128,7 @@ pub fn deserialize_tx(tx_bytes: Vec<u8>, wasm_hashes: JsValue) -> Result<Vec<u8>
 }
 
 #[derive(BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct Commitment {
     tx_type: TxType,
     hash: String,
@@ -138,7 +138,7 @@ pub struct Commitment {
 }
 
 #[derive(BorshSerialize, BorshDeserialize)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct TxDetails {
     wrapper_tx: WrapperTxMsg,
     commitments: Vec<Commitment>,

--- a/packages/shared/lib/src/sdk/wallet/mod.rs
+++ b/packages/shared/lib/src/sdk/wallet/mod.rs
@@ -1,10 +1,8 @@
-use namada::{
+use namada_sdk::{
     key::common::SecretKey,
     masp::{ExtendedSpendingKey, ExtendedViewingKey, PaymentAddress},
-    sdk::{
-        masp_primitives::zip32::ExtendedFullViewingKey,
-        wallet::{alias::Alias, Wallet, WalletIo},
-    },
+    masp_primitives::zip32::ExtendedFullViewingKey,
+    wallet::{alias::Alias, Wallet, WalletIo},
 };
 use std::str::FromStr;
 use zeroize::Zeroizing;

--- a/packages/shared/lib/src/sdk/wallet/mod.rs
+++ b/packages/shared/lib/src/sdk/wallet/mod.rs
@@ -35,7 +35,7 @@ pub fn add_spending_key<U: WalletIo>(wallet: &mut Wallet<U>, xsk: String, alias:
     // xsk is decrypted outside of this wallet instance, so we specify None below
     if wallet
         .store_mut()
-        .insert_spending_key::<U>(alias.clone(), xsk, None, None, true)
+        .insert_spending_key::<U>(alias.clone(), xsk, None, None, None, true)
         .is_none()
     {
         panic!("Action cancelled, no changes persisted.");
@@ -48,7 +48,7 @@ pub fn add_viewing_key<U: WalletIo>(wallet: &mut Wallet<U>, xvk: String, alias: 
 
     if wallet
         .store_mut()
-        .insert_viewing_key::<U>(alias.clone(), xvk, true)
+        .insert_viewing_key::<U>(alias.clone(), xvk, None, true)
         .is_none()
     {
         panic!("Action cancelled, no changes persisted.");

--- a/packages/shared/lib/src/sdk/wallet/wallet_node.rs
+++ b/packages/shared/lib/src/sdk/wallet/wallet_node.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use namada::sdk::{
+use namada_sdk::{
     borsh::{BorshDeserialize, BorshSerialize},
     wallet::{LoadStoreError, Store, Wallet, WalletIo, WalletStorage},
 };
@@ -10,7 +10,7 @@ use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 use crate::utils::to_bytes;
 
 #[derive(Debug, BorshSerialize, BorshDeserialize, Clone)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct NodeWalletUtils {
     #[borsh(skip)]
     store_dir: PathBuf,
@@ -40,7 +40,7 @@ impl NodeWalletStorage for NodeWalletUtils {
 const FILE_NAME: &str = "wallet.toml";
 
 impl WalletStorage for NodeWalletUtils {
-    fn save<U>(&self, wallet: &Wallet<U>) -> Result<(), namada::sdk::wallet::LoadStoreError> {
+    fn save<U>(&self, wallet: &Wallet<U>) -> Result<(), namada_sdk::wallet::LoadStoreError> {
         let data = wallet.store().encode();
 
         let wallet_path = self.store_dir().join(FILE_NAME);
@@ -57,7 +57,7 @@ impl WalletStorage for NodeWalletUtils {
         Ok(())
     }
 
-    fn load<U>(&self, wallet: &mut Wallet<U>) -> Result<(), namada::sdk::wallet::LoadStoreError> {
+    fn load<U>(&self, wallet: &mut Wallet<U>) -> Result<(), namada_sdk::wallet::LoadStoreError> {
         let wallet_file = self.store_dir().join(FILE_NAME);
 
         let stored_data: Vec<u8> =

--- a/packages/shared/lib/src/sdk/wallet/wallet_web.rs
+++ b/packages/shared/lib/src/sdk/wallet/wallet_web.rs
@@ -1,11 +1,11 @@
-use namada::sdk::{
+use namada_sdk::{
     borsh::{BorshDeserialize, BorshSerialize},
     wallet::{Wallet, WalletIo, WalletStorage},
 };
 use rand::rngs::OsRng;
 
 #[derive(Debug, BorshSerialize, BorshDeserialize, Clone)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct BrowserWalletUtils {
     #[borsh(skip)]
     _name: String,
@@ -25,11 +25,11 @@ impl WalletIo for BrowserWalletUtils {
 
 //TODO: We can't implement it until namada changes trait to be async
 impl WalletStorage for BrowserWalletUtils {
-    fn save<U>(&self, _wallet: &Wallet<U>) -> Result<(), namada::sdk::wallet::LoadStoreError> {
+    fn save<U>(&self, _wallet: &Wallet<U>) -> Result<(), namada_sdk::wallet::LoadStoreError> {
         todo!()
     }
 
-    fn load<U>(&self, _wallet: &mut Wallet<U>) -> Result<(), namada::sdk::wallet::LoadStoreError> {
+    fn load<U>(&self, _wallet: &mut Wallet<U>) -> Result<(), namada_sdk::wallet::LoadStoreError> {
         todo!()
     }
 }

--- a/packages/shared/lib/src/types/address.rs
+++ b/packages/shared/lib/src/types/address.rs
@@ -1,5 +1,5 @@
-use namada::core::borsh::BorshDeserialize;
-use namada::{
+use namada_sdk::borsh::BorshDeserialize;
+use namada_sdk::{
     address,
     key::{
         self,

--- a/packages/shared/lib/src/types/masp.rs
+++ b/packages/shared/lib/src/types/masp.rs
@@ -1,8 +1,8 @@
 //! PaymentAddress - Provide wasm_bindgen bindings for shielded addresses
 //! See @namada/crypto for zip32 HD wallet functionality.
-use namada::core::borsh::BorshDeserialize;
-use namada::masp;
-use namada::sdk::masp_primitives::{sapling, zip32};
+use namada_sdk::borsh::BorshDeserialize;
+use namada_sdk::masp;
+use namada_sdk::masp_primitives::{sapling, zip32};
 use thiserror::Error;
 use wasm_bindgen::prelude::*;
 

--- a/packages/shared/lib/src/types/query.rs
+++ b/packages/shared/lib/src/types/query.rs
@@ -1,8 +1,8 @@
-use namada::core::borsh::BorshSerialize;
+use namada_sdk::borsh::BorshSerialize;
 use serde::{Deserialize, Serialize};
 
 #[derive(BorshSerialize)]
-#[borsh(crate = "namada::core::borsh")]
+#[borsh(crate = "namada_sdk::borsh")]
 pub struct ProposalInfo {
     pub id: u64,
     pub content: String,


### PR DESCRIPTION
In https://github.com/anoma/namada/pull/3402 we're removing the `namada` crate that contained various unrelated stuff. This PR switches to use `namada_sdk` that will provide the same modules instead (note that this will not compile until https://github.com/anoma/namada/pull/3402 is released, hopefully in v0.40.0, but I did check it against a local path)