### PR TITLE
Namadillo release configuration

### DIFF
--- a/.github/workflows/release-namadillo.yml
+++ b/.github/workflows/release-namadillo.yml
@@ -1,0 +1,44 @@
+name: Create Namadillo draft release
+on:
+  workflow_dispatch:
+    inputs:
+      INCREMENT:
+        required: true
+        type: string
+        default: "patch"
+        description: "Version increment (major/minor/patch etc.)"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./apps/namadillo
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install yarn dependencies
+        uses: ./.github/actions/yarn-cache
+
+      - name: Restore Rust cache
+        uses: ./.github/actions/rust-cache
+        with:
+          cache-name: build
+
+      - name: Install protoc
+        run: sudo apt-get install -y protobuf-compiler
+
+      - name: Build Namadillo
+        run: yarn build
+
+      - name: Configure git identity
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+      - name: Create a draft release
+        run: npx release-it --increment $INCREMENT
+        env:
+          INCREMENT: ${{ inputs.INCREMENT }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/apps/namadillo/.release-it.cjs
+++ b/apps/namadillo/.release-it.cjs
@@ -1,7 +1,25 @@
-const baseConfig = require("../../.release-it.base.cjs");
-
-const config = {
-  ...baseConfig,
+module.exports = {
+  hooks: {
+    "after:git:release": "scripts/package.sh ${version}"
+  },
+  git: {
+    commitMessage: "chore: release namadillo v${version}",
+    tagName: "namadillo-${version}",
+    tagAnnotation: "Release namadillo ${version}",
+  },
+  github: {
+    release: true,
+    draft: true,
+    releaseName: "Namadillo ${version}",
+    assets: ["namadillo-*.zip"],
+  },
+  npm: {
+    publish: false
+  },
+  plugins: {
+    "@release-it/keep-a-changelog": {
+      strictLatest: false, // TODO: remove after initial release
+      addVersionUrl: true
+    }
+  }
 };
-
-module.exports = config;

--- a/apps/namadillo/CHANGELOG.md
+++ b/apps/namadillo/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [Unreleased]
+
+First release.

--- a/apps/namadillo/README-dist.md
+++ b/apps/namadillo/README-dist.md
@@ -1,0 +1,4 @@
+Namadillo
+=========
+
+TODO: Add hosting instructions

--- a/apps/namadillo/RELEASE.md
+++ b/apps/namadillo/RELEASE.md
@@ -1,0 +1,28 @@
+Namadillo release procedure
+===========================
+
+TODO: These docs won't be correct until we have defined a process for adding
+CHANGELOG entries. For now this is loosely based on the namada process.
+
+1. Build the changelog
+  - Run the command TODO to generate the CHANGELOG.md
+  - Check the Unreleased section of CHANGELOG.md to make sure there is nothing
+    missing. It is fine to manually edit CHANGELOG.md if there are errors
+  - Leave the "Unreleased" header as it will be automatically replaced with the
+    version number later
+  - Commit CHANGELOG.md and push
+
+2. Run the "Create Namadillo draft release" workflow on GitHub actions
+  - <https://github.com/anoma/namada-interface/actions/workflows/release-namadillo.yml>
+  - This will build and package Namadillo, create a new tag and release commit,
+    and create a draft release on GitHub
+
+3. Publish the release
+  - <https://github.com/anoma/namada-interface/releases>
+  - Check the draft release is correct, including:
+    - Namadillo is attached as a zipped asset
+    - The version and tag are correct
+    - The release text includes the changelog entry for this release
+  - Click edit and "Publish release"
+
+That's it! A new version of Namadillo has been released.

--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -80,6 +80,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.24.1",
+    "@release-it/keep-a-changelog": "^5.0.0",
     "@svgr/webpack": "^6.5.1",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",
@@ -108,6 +109,7 @@
     "local-cors-proxy": "^1.1.0",
     "postcss": "^8.4.32",
     "postcss-loader": "^7.3.3",
+    "release-it": "^17.0.1",
     "style-loader": "^3.3.1",
     "tailwindcss": "^3.4.0",
     "ts-jest": "^29.0.5",

--- a/apps/namadillo/scripts/package.sh
+++ b/apps/namadillo/scripts/package.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#  Creates a ZIP file of Namadillo for publishing.
+#  Usage:
+#      ./scripts/package.sh <version>
+
+set -e
+
+if [[ -z "$1" ]]
+then
+    echo "no version string specified"
+    exit 1
+fi
+
+VERSION="$1"
+DIR="namadillo-$VERSION"
+README="$DIR/README.md"
+
+echo "Copying files"
+mkdir $DIR
+cp -r dist $DIR
+cp README-dist.md $README
+cp CHANGELOG.md $DIR
+
+echo "Adding build information to README"
+BUILD_INFO="
+Build information
+-----------------
+
+Version: $VERSION"
+echo "$BUILD_INFO" >> $README
+
+echo "Zipping"
+zip -r "$DIR.zip" $DIR

--- a/apps/namadillo/src/index.tsx
+++ b/apps/namadillo/src/index.tsx
@@ -6,7 +6,6 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import { getRouter } from "./App/AppRoutes";
-import reportWebVitals from "./reportWebVitals";
 import { IntegrationsProvider } from "./services";
 
 import "@namada/components/src/base.css";
@@ -32,7 +31,3 @@ if (container) {
     );
   });
 }
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();

--- a/yarn.lock
+++ b/yarn.lock
@@ -8434,6 +8434,7 @@ __metadata:
     "@anomaorg/namada-indexer-client": "npm:0.0.15"
     "@cosmjs/encoding": "npm:^0.32.3"
     "@playwright/test": "npm:^1.24.1"
+    "@release-it/keep-a-changelog": "npm:^5.0.0"
     "@svgr/webpack": "npm:^6.5.1"
     "@tailwindcss/container-queries": "npm:^0.1.1"
     "@tanstack/react-query": "npm:^5.40.0"
@@ -8484,6 +8485,7 @@ __metadata:
     react-paginate: "npm:^8.2.0"
     react-router-dom: "npm:^6.0.0"
     react-scripts: "npm:5.0.1"
+    release-it: "npm:^17.0.1"
     style-loader: "npm:^3.3.1"
     styled-components: "npm:^5.3.3"
     tailwind-merge: "npm:^2.3.0"
@@ -9045,6 +9047,18 @@ __metadata:
   peerDependencies:
     release-it: ^17.0.0
   checksum: b6057038b91c665129e37af1d297dad68abbe2095cc10e9d507be6dcc1432bc6b7545c1bbdf6eab4c35eeafca223c5a43a567ba1cdfdd774aa62bb6220c5ebe6
+  languageName: node
+  linkType: hard
+
+"@release-it/keep-a-changelog@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@release-it/keep-a-changelog@npm:5.0.0"
+  dependencies:
+    detect-newline: "npm:^4.0.1"
+    string-template: "npm:^1.0.0"
+  peerDependencies:
+    release-it: ^17.0.0
+  checksum: 352fae20b0814952cf0b15a98cbc00ff24e50f6042b48da6757f7e723579e39f0fbbcc0dc7f6dad706db9d9f3d179adc9a4d7f0065f3c3af642c1e637774c6c7
   languageName: node
   linkType: hard
 
@@ -16596,6 +16610,13 @@ __metadata:
   version: 3.1.0
   resolution: "detect-newline@npm:3.1.0"
   checksum: c38cfc8eeb9fda09febb44bcd85e467c970d4e3bf526095394e5a4f18bc26dd0cf6b22c69c1fa9969261521c593836db335c2795218f6d781a512aea2fb8209d
+  languageName: node
+  linkType: hard
+
+"detect-newline@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "detect-newline@npm:4.0.1"
+  checksum: 1cc1082e88ad477f30703ae9f23bd3e33816ea2db6a35333057e087d72d466f5a777809b71f560118ecff935d2c712f5b59e1008a8b56a900909d8fd4621c603
   languageName: node
   linkType: hard
 
@@ -33274,6 +33295,13 @@ __metadata:
   version: 3.0.1
   resolution: "string-natural-compare@npm:3.0.1"
   checksum: 85a6a9195736be500af5d817c7ea36b7e1ac278af079a807f70f79a56602359ee6743ca409af6291b94557de550ff60d1ec31b3c4fc8e7a08d0e12cdab57c149
+  languageName: node
+  linkType: hard
+
+"string-template@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "string-template@npm:1.0.0"
+  checksum: 7c07ab5b4274a50b1f077a47769044b9a8f0a5a4a47811cf3f9ba5acc9d2ff1231d593a93983ea554c3211fb09949e805912f9ce9d7688990eeb41d5008b95d2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds scripts and documentation for releasing Namadillo.

I have created a temporary release on my fork to show what a real release will look like:
https://github.com/emccorson/namada-interface/actions/runs/9656944071
https://github.com/emccorson/namada-interface/releases/tag/namadillo-1.0.0

There needs to be some follow-up work to define a process for adding changelog entries. For now, I have loosely based this PR on how the main namada team does changelog entries and created #893 for changelog discussion.

---

### Added
- Add scripts to release namadillo
- Add release process documentation
- Add changelog
- Add README for distribution

### Removed
- Remove web vitals from namadillo