### PR TITLE
Namadillo: disconnecting only from the specified origin

### DIFF
--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -253,7 +253,7 @@ export class ApprovalsService {
 
   async revokeConnection(originToRevoke: string): Promise<void> {
     await this.localStorage.removeApprovedOrigin(originToRevoke);
-    await this.broadcaster.revokeConnection();
+    await this.broadcaster.revokeConnection(originToRevoke);
   }
 
   private async _clearPendingTx(msgId: string): Promise<void> {

--- a/apps/extension/src/content/events.ts
+++ b/apps/extension/src/content/events.ts
@@ -75,7 +75,7 @@ export class ConnectionRevokedEventMsg extends Message<void> {
     return Events.ConnectionRevoked;
   }
 
-  constructor() {
+  constructor(public readonly originToRevoke: string) {
     super();
   }
 
@@ -122,7 +122,13 @@ export function initEvents(router: Router, localStorage: LocalStorage): void {
         window.dispatchEvent(new CustomEvent(Events.ExtensionLocked));
         break;
       case ConnectionRevokedEventMsg:
-        window.dispatchEvent(new CustomEvent(Events.ConnectionRevoked));
+        window.dispatchEvent(
+          new CustomEvent(Events.ConnectionRevoked, {
+            detail: {
+              originToRevoke: (msg as ConnectionRevokedEventMsg).originToRevoke,
+            },
+          })
+        );
         break;
       default:
         throw new Error("Unknown msg type");

--- a/apps/extension/src/extension/ExtensionBroadcaster.ts
+++ b/apps/extension/src/extension/ExtensionBroadcaster.ts
@@ -26,8 +26,8 @@ export class ExtensionBroadcaster {
     await this.sendMsgToTabs(new VaultLockedEventMsg());
   }
 
-  async revokeConnection(): Promise<void> {
-    await this.sendMsgToTabs(new ConnectionRevokedEventMsg());
+  async revokeConnection(origin: string): Promise<void> {
+    await this.sendMsgToTabs(new ConnectionRevokedEventMsg(origin));
   }
 
   /**

--- a/apps/namadillo/src/hooks/useExtensionEvents.tsx
+++ b/apps/namadillo/src/hooks/useExtensionEvents.tsx
@@ -17,7 +17,19 @@ export const useExtensionEvents = (): void => {
     balances.refetch();
   });
 
-  useEventListenerOnce(Events.ConnectionRevoked, () =>
-    setNamadaExtensionConnected("idle")
+  useEventListenerOnce(
+    Events.ConnectionRevoked,
+    (e: CustomEventInit<{ originToRevoke: string }>) => {
+      try {
+        const url = new URL(e.detail?.originToRevoke || "");
+        if (url.origin === window.location.origin) {
+          setNamadaExtensionConnected("idle");
+        }
+      } catch {
+        console.error(
+          "Unable to disconnect from origin. originToRevoke is not a valid URL."
+        );
+      }
+    }
   );
 };


### PR DESCRIPTION
Before this PR, Namadillo was disconnected after removing any origin in the extension. Now we pass the removed origin in the revoke event. 

Fixes #898 