### PR TITLE
Namadillo: disconnecting only if the respective origin access was revoked

### DIFF
--- a/apps/namadillo/src/hooks/useExtensionEvents.tsx
+++ b/apps/namadillo/src/hooks/useExtensionEvents.tsx
@@ -1,4 +1,5 @@
 import { useEventListenerOnce } from "@namada/hooks";
+import { useIntegration } from "@namada/integrations";
 import { Events } from "@namada/types";
 import { accountBalanceAtom, defaultAccountAtom } from "atoms/accounts";
 import { namadaExtensionConnectionStatus } from "atoms/settings";
@@ -7,6 +8,8 @@ import { useAtomValue, useSetAtom } from "jotai";
 export const useExtensionEvents = (): void => {
   const defaultAccount = useAtomValue(defaultAccountAtom);
   const balances = useAtomValue(accountBalanceAtom);
+  const integration = useIntegration("namada");
+
   const setNamadaExtensionConnected = useSetAtom(
     namadaExtensionConnectionStatus
   );
@@ -17,7 +20,9 @@ export const useExtensionEvents = (): void => {
     balances.refetch();
   });
 
-  useEventListenerOnce(Events.ConnectionRevoked, () =>
-    setNamadaExtensionConnected("idle")
-  );
+  useEventListenerOnce(Events.ConnectionRevoked, async () => {
+    setNamadaExtensionConnected(
+      (await integration.isConnected()) ? "connected" : "idle"
+    );
+  });
 };


### PR DESCRIPTION
Before this PR, Namadillo was disconnected after removing any origin in the extension. Now we verify if it is still connected.

Fixes #898 