### PR TITLE
Namadillo: Querying all validators

### DIFF
--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "@anomaorg/namada-indexer-client": "0.0.15",
+    "@anomaorg/namada-indexer-client": "0.0.16",
     "@cosmjs/encoding": "^0.32.3",
     "@tailwindcss/container-queries": "^0.1.1",
     "@tanstack/react-query": "^5.40.0",

--- a/apps/namadillo/src/atoms/validators/services.ts
+++ b/apps/namadillo/src/atoms/validators/services.ts
@@ -31,12 +31,10 @@ export const fetchAllValidators = async (
 ): Promise<Validator[]> => {
   const epochInfo = chainParameters.epochInfo;
   const nominalApr = chainParameters.apr;
-  const validatorsResponse = await api.apiV1PosValidatorGet(1, [
+  const validatorsResponse = await api.apiV1PosValidatorAllGet([
     IndexerValidatorStatus.Consensus,
   ]);
-
-  // TODO: rename one data to items?
-  const validators = validatorsResponse.data.data;
+  const validators = validatorsResponse.data;
   return validators.map((v) =>
     toValidator(v, votingPower, epochInfo, nominalApr)
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,12 +45,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@anomaorg/namada-indexer-client@npm:0.0.15":
-  version: 0.0.15
-  resolution: "@anomaorg/namada-indexer-client@npm:0.0.15"
+"@anomaorg/namada-indexer-client@npm:0.0.16":
+  version: 0.0.16
+  resolution: "@anomaorg/namada-indexer-client@npm:0.0.16"
   dependencies:
     axios: "npm:^0.21.1"
-  checksum: af42db9c2ad99e378327b1f569c150c53757c569a3ad046c212227d1fb11b3ced7c4be62f707806dedea4804137eebe2fdb5ab232a10990447502b2469c99b91
+  checksum: f9fb6fe95edc4049ca3d0b6af56e889ca99dfb8cb8b2262428103d74f12cca46ded70e26e1bcc240633414657e3853ca106fca848e246707acf83a9def4cf752
   languageName: node
   linkType: hard
 
@@ -8431,7 +8431,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@namada/namadillo@workspace:apps/namadillo"
   dependencies:
-    "@anomaorg/namada-indexer-client": "npm:0.0.15"
+    "@anomaorg/namada-indexer-client": "npm:0.0.16"
     "@cosmjs/encoding": "npm:^0.32.3"
     "@playwright/test": "npm:^1.24.1"
     "@svgr/webpack": "npm:^6.5.1"


### PR DESCRIPTION
We've moved to query all validators in order to simplify randomization, filters, etc. This PR only changes the endpoint used for it.