### PR TITLE
Small fixes 2024-07-08

### DIFF
--- a/apps/namadillo/src/App/AppSetup.tsx
+++ b/apps/namadillo/src/App/AppSetup.tsx
@@ -66,7 +66,7 @@ export const AppSetup = ({ children }: AppSetupProps): JSX.Element => {
               onClick={() => setChangeIndexerSettings(true)}
             >
               click here
-            </button>
+            </button>{" "}
             to verify your indexer settings.
           </>
         }

--- a/apps/namadillo/src/App/Common/Container.tsx
+++ b/apps/namadillo/src/App/Common/Container.tsx
@@ -46,7 +46,8 @@ export const Container = ({
           className={clsx(
             "transition-transform duration-500 ease-out-expo",
             "pt-10 bg-black rounded-sm fixed top-0 z-[9999] w-[240px]",
-            "h-[calc(100svh-90px)] left-0 xl:z-0 xl:transition-none xl:pt-0 xl:w-auto xl:relative",
+            "h-svh xl:h-[calc(100svh-90px)] left-0 xl:z-0 xl:transition-none",
+            "xl:pt-0 xl:w-auto xl:relative",
             { "-translate-x-full xl:translate-x-0": !displayNavigation }
           )}
         >

--- a/apps/namadillo/src/App/Common/Container.tsx
+++ b/apps/namadillo/src/App/Common/Container.tsx
@@ -46,7 +46,7 @@ export const Container = ({
           className={clsx(
             "transition-transform duration-500 ease-out-expo",
             "pt-10 bg-black rounded-sm fixed top-0 z-[9999] w-[240px]",
-            "h-[calc(100svh-85px)] left-0 xl:z-0 xl:transition-none xl:pt-0 xl:w-auto xl:relative",
+            "h-[calc(100svh-90px)] left-0 xl:z-0 xl:transition-none xl:pt-0 xl:w-auto xl:relative",
             { "-translate-x-full xl:translate-x-0": !displayNavigation }
           )}
         >

--- a/apps/namadillo/src/App/Common/Search.tsx
+++ b/apps/namadillo/src/App/Common/Search.tsx
@@ -15,12 +15,19 @@ type SearchProps = Omit<
 export const Search = ({
   onChange,
   className,
+  placeholder,
   ...rest
 }: SearchProps): JSX.Element => {
   const [displaySearchIcon, setDisplaySearchIcon] = useState(true);
   const debouncedSearch = useRef(
     debounce((value: string) => onChange?.(value), 300)
   );
+
+  // Hideous hack to add padding to placeholder in Firefox.
+  // Needed because setting padding or text-indent on ::placeholder in Firefox
+  // doesn't work.
+  const isFirefox = /firefox/i.test(navigator.userAgent);
+  const paddedPlaceholder = isFirefox ? `       ${placeholder}` : placeholder;
 
   return (
     <div className="w-full text-neutral-500/50 flex relative">
@@ -45,6 +52,7 @@ export const Search = ({
         onBlur={(e) =>
           e.target.value.length === 0 && setDisplaySearchIcon(true)
         }
+        placeholder={paddedPlaceholder}
         {...rest}
       />
     </div>


### PR DESCRIPTION
Several small bug fixes for Namadillo.

With the fix about reducing the menu height to stop the scroll, I was only able to reproduce this on Firefox and not Chrome, and I'm not entirely sure why the heights are different. I think we could have a better solution for this by calculating the panel heights based on the viewport height, but it will potentially be tricky to do this nicely, so for now I've just reduced the pixel height.

---

### Fixed
- Add missing space in indexer error message. Fixes #911.
- Fix padding in search input on Firefox. Fixes #802.
- Reduce menu height to stop small scroll. Fixes #912.
- ~Don't open menu when changing to small screen. Fixes #914.~ Dropped.
- Make side menu viewport height on mobile.