### PR TITLE
fix: mainnet phases link

### DIFF
--- a/apps/namadillo/src/App/Governance/ProposalHeader.tsx
+++ b/apps/namadillo/src/App/Governance/ProposalHeader.tsx
@@ -179,7 +179,6 @@ const WasmButton: React.FC<{
       outlined
       borderRadius="sm"
       disabled={disabled}
-      as="a"
       download={filename}
       href={href}
     >

--- a/apps/namadillo/src/App/Sidebars/ProposalDiscord.tsx
+++ b/apps/namadillo/src/App/Sidebars/ProposalDiscord.tsx
@@ -16,7 +16,6 @@ export const ProposalDiscord: React.FC = () => {
           color="black"
           className="text-white"
           hoverColor="secondary"
-          as="a"
           href={DISCORD_URL}
           target="_blank"
         >

--- a/packages/components/src/ActionButton.tsx
+++ b/packages/components/src/ActionButton.tsx
@@ -125,7 +125,7 @@ export const ActionButton = ({
   ...props
 }: ActionButtonProps<keyof React.ReactHTML>): JSX.Element => {
   return createElement(
-    props.as || "button",
+    props.as ?? ("href" in props ? "a" : "button"),
     {
       className: actionButton({
         class: className,


### PR DESCRIPTION
Fix the Mainnet Phases link using `<a>` instead of `<button>`

Also, update the default value for `as` prop on `<ActionButton>` to observe the presence of the `href` prop

![Screenshot 2024-07-08 at 17 19 32](https://github.com/anoma/namada-interface/assets/557598/9baac513-121e-41de-9074-8cebcb542db6)

