### PR TITLE
feat/917: Add docs build to types package

### DIFF
--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,87 +1,10 @@
-# types
+# @namada/types
 
 This package is to provide types shared between applications in the Namada ecosystem, primarily that of
-the `namada-interface` and `extension` apps.
+the `namadillo` and `extension` apps.
 
-Some types from `@keplr-wallet/types` have been aliased and re-exported, as we may want to support a
-more custom configuration for chain and currency configurations. These have been added to reduce the
-work necessary to refactor against a custom type definition.
-
-The exported `Namada` and `WindowWithNamada` types serve as a public interface allowing other applications to
-integrate with the APIs provided by the extension using TypeScript.
-
-## Borsh schemas
-
-In `src/tx`, we have several schemas for handling Borsh serialization and deserialization when submitting transaction data. As
-transaction data from the user needs to move between an external application and the extension, this allow greater
-privacy using with the `postMessage` API. These directly correlate to Rust `struct`s defined in the `@namada/shared` package,
-but exist here as to decouple them from the wasm dependency in the build pipeline. Including `@namada/shared` would imply
-that you're willing to deliver compiled wasm in your final bundle, but that shouldn't be the case when you're merely
-interacting with the extension.
-
-These types are primarily to be used by the `Signer`, a class which will do the work of serializing transaction data
-from the user and passing into the extension where the associated private keys can be used to sign data within the transaction.
-
-### Example usage of schemas
-
-An application can serialize transaction data using these schemas as follows:
-
-```ts
-import { Message, TransferMsgSchema, TransferMsgValue } from "@namada/types";
-
-// The user's data for transfer:
-const source =
-  "atest1v4ehgw368ycryv2z8qcnxv3cxgmrgvjpxs6yg333gym5vv2zxepnj334g4rryvj9xucrgve4x3xvr4";
-const target =
-  "atest1v4ehgw36xvcyyvejgvenxs34g3zygv3jxqunjd6rxyeyys3sxy6rwvfkx4qnj33hg9qnvse4lsfctw";
-const token =
-  "atest1v4ehgw36x3prswzxggunzv6pxqmnvdj9xvcyzvpsggeyvs3cg9qnywf589qnwvfsg5erg3fkl09rg5";
-const amount = 123.45;
-
-// Instantiate the appropriate class with the user's data:
-const transferMsgValue = new TransferMsgValue({
-  source,
-  target,
-  token,
-  amount,
-});
-
-// We construct a new "transfer" Message, specifying the _type_ as a type parameter:
-const transferMessage = new Message<TransferMsgValue>();
-const encoded = transferMessage.encode(TransferMsgSchema, transferMsgValue);
-
-// We have now created the encoded Namada `Transfer`, and can also serialize a "Transaction" data message
-// to specify the transaction parameters:
-const epoch = 5;
-const feeAmount = 1000;
-const gasLimit = 1_000_000;
-const txCode = new Uint8Array([]); // This is the byte array of the tx-transfer.wasm
-
-// Transaction Message
-const txMessage = new Message<TransactionMsgValue>();
-
-// Transaction Message Value
-const txMessageValue = new TransactionMsgValue({
-  token,
-  epoch,
-  fee_amount: feeAmount,
-  gas_limit: gasLimit,
-  tx_code: txCode,
-});
-```
-
-The `encoded` transfer may then be handed off to a `Signer` which will invoke the related wasm functions to wrap and sign
-the transaction. _Note_ that it is also the responsibility of the extension to look up the associated private key for the
-provided `source` address, hence why `secret` does not appear in the schema. The private key will be decrypted from storage
-in the extension at the point it is required to sign a transaction, with the results returned in a message back to the signer,
-at which point the resulting data can be broadcast to the ledger.
-
-**NOTE** While these types provide provisions for _deserialization_, when wrapping and signing transactions, it's not a
-necessary step. Within the wasm, a transaction will be wrapped, signed, and return in the form of the transaction hash and
-the encrypted bytes of that transaction. Encoding these two values with Borsh would be superfluous, as the Tx hash is already
-public, and the bytes of the tx are encrypted.
+See [docs](./docs) for more details on the types in this package.
 
 ### References
 
-- `near/borsh`: <https://github.com/near/borsh>
-- `near/borsh-js`: <https://github.com/near/borsh-js>
+- `borsh-ts`: <https://github.com/dao-xyz/borsh-ts>

--- a/packages/types/docs/.nojekyll
+++ b/packages/types/docs/.nojekyll
@@ -1,0 +1,1 @@
+TypeDoc added this file to prevent GitHub Pages from using Jekyll. You can turn off this behavior by setting the `githubPages` option to false.

--- a/packages/types/docs/classes/BatchTxResultMsgValue.md
+++ b/packages/types/docs/classes/BatchTxResultMsgValue.md
@@ -1,0 +1,65 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / BatchTxResultMsgValue
+
+# Class: BatchTxResultMsgValue
+
+## Table of contents
+
+### Constructors
+
+- [constructor](BatchTxResultMsgValue.md#constructor)
+
+### Properties
+
+- [gasUsed](BatchTxResultMsgValue.md#gasused)
+- [hash](BatchTxResultMsgValue.md#hash)
+- [isApplied](BatchTxResultMsgValue.md#isapplied)
+
+## Constructors
+
+### constructor
+
+• **new BatchTxResultMsgValue**(`data`): [`BatchTxResultMsgValue`](BatchTxResultMsgValue.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | [`BatchTxResultMsgValue`](BatchTxResultMsgValue.md) |
+
+#### Returns
+
+[`BatchTxResultMsgValue`](BatchTxResultMsgValue.md)
+
+#### Defined in
+
+[tx/schema/batchTxResult.ts:15](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/batchTxResult.ts#L15)
+
+## Properties
+
+### gasUsed
+
+• **gasUsed**: `string`
+
+#### Defined in
+
+[tx/schema/batchTxResult.ts:10](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/batchTxResult.ts#L10)
+
+___
+
+### hash
+
+• **hash**: `string`
+
+#### Defined in
+
+[tx/schema/batchTxResult.ts:7](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/batchTxResult.ts#L7)
+
+___
+
+### isApplied
+
+• **isApplied**: `string`
+
+#### Defined in
+
+[tx/schema/batchTxResult.ts:13](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/batchTxResult.ts#L13)

--- a/packages/types/docs/classes/BondMsgValue.md
+++ b/packages/types/docs/classes/BondMsgValue.md
@@ -1,0 +1,76 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / BondMsgValue
+
+# Class: BondMsgValue
+
+## Table of contents
+
+### Constructors
+
+- [constructor](BondMsgValue.md#constructor)
+
+### Properties
+
+- [amount](BondMsgValue.md#amount)
+- [nativeToken](BondMsgValue.md#nativetoken)
+- [source](BondMsgValue.md#source)
+- [validator](BondMsgValue.md#validator)
+
+## Constructors
+
+### constructor
+
+• **new BondMsgValue**(`data`): [`BondMsgValue`](BondMsgValue.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | [`BondMsgValue`](BondMsgValue.md) |
+
+#### Returns
+
+[`BondMsgValue`](BondMsgValue.md)
+
+#### Defined in
+
+[tx/schema/bond.ts:20](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/bond.ts#L20)
+
+## Properties
+
+### amount
+
+• **amount**: `BigNumber`
+
+#### Defined in
+
+[tx/schema/bond.ts:15](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/bond.ts#L15)
+
+___
+
+### nativeToken
+
+• **nativeToken**: `string`
+
+#### Defined in
+
+[tx/schema/bond.ts:18](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/bond.ts#L18)
+
+___
+
+### source
+
+• **source**: `string`
+
+#### Defined in
+
+[tx/schema/bond.ts:9](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/bond.ts#L9)
+
+___
+
+### validator
+
+• **validator**: `string`
+
+#### Defined in
+
+[tx/schema/bond.ts:12](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/bond.ts#L12)

--- a/packages/types/docs/classes/EthBridgeTransferMsgValue.md
+++ b/packages/types/docs/classes/EthBridgeTransferMsgValue.md
@@ -1,0 +1,120 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / EthBridgeTransferMsgValue
+
+# Class: EthBridgeTransferMsgValue
+
+## Table of contents
+
+### Constructors
+
+- [constructor](EthBridgeTransferMsgValue.md#constructor)
+
+### Properties
+
+- [amount](EthBridgeTransferMsgValue.md#amount)
+- [asset](EthBridgeTransferMsgValue.md#asset)
+- [feeAmount](EthBridgeTransferMsgValue.md#feeamount)
+- [feePayer](EthBridgeTransferMsgValue.md#feepayer)
+- [feeToken](EthBridgeTransferMsgValue.md#feetoken)
+- [nut](EthBridgeTransferMsgValue.md#nut)
+- [recipient](EthBridgeTransferMsgValue.md#recipient)
+- [sender](EthBridgeTransferMsgValue.md#sender)
+
+## Constructors
+
+### constructor
+
+• **new EthBridgeTransferMsgValue**(`data`): [`EthBridgeTransferMsgValue`](EthBridgeTransferMsgValue.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | [`EthBridgeTransferMsgValue`](EthBridgeTransferMsgValue.md) |
+
+#### Returns
+
+[`EthBridgeTransferMsgValue`](EthBridgeTransferMsgValue.md)
+
+#### Defined in
+
+[tx/schema/ethBridgeTransfer.ts:32](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/ethBridgeTransfer.ts#L32)
+
+## Properties
+
+### amount
+
+• **amount**: `BigNumber`
+
+#### Defined in
+
+[tx/schema/ethBridgeTransfer.ts:21](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/ethBridgeTransfer.ts#L21)
+
+___
+
+### asset
+
+• **asset**: `string`
+
+#### Defined in
+
+[tx/schema/ethBridgeTransfer.ts:12](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/ethBridgeTransfer.ts#L12)
+
+___
+
+### feeAmount
+
+• **feeAmount**: `BigNumber`
+
+#### Defined in
+
+[tx/schema/ethBridgeTransfer.ts:24](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/ethBridgeTransfer.ts#L24)
+
+___
+
+### feePayer
+
+• `Optional` **feePayer**: `string`
+
+#### Defined in
+
+[tx/schema/ethBridgeTransfer.ts:27](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/ethBridgeTransfer.ts#L27)
+
+___
+
+### feeToken
+
+• **feeToken**: `string`
+
+#### Defined in
+
+[tx/schema/ethBridgeTransfer.ts:30](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/ethBridgeTransfer.ts#L30)
+
+___
+
+### nut
+
+• **nut**: `boolean`
+
+#### Defined in
+
+[tx/schema/ethBridgeTransfer.ts:9](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/ethBridgeTransfer.ts#L9)
+
+___
+
+### recipient
+
+• **recipient**: `string`
+
+#### Defined in
+
+[tx/schema/ethBridgeTransfer.ts:15](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/ethBridgeTransfer.ts#L15)
+
+___
+
+### sender
+
+• **sender**: `string`
+
+#### Defined in
+
+[tx/schema/ethBridgeTransfer.ts:18](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/ethBridgeTransfer.ts#L18)

--- a/packages/types/docs/classes/IbcTransferMsgValue.md
+++ b/packages/types/docs/classes/IbcTransferMsgValue.md
@@ -1,0 +1,131 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / IbcTransferMsgValue
+
+# Class: IbcTransferMsgValue
+
+## Table of contents
+
+### Constructors
+
+- [constructor](IbcTransferMsgValue.md#constructor)
+
+### Properties
+
+- [amount](IbcTransferMsgValue.md#amount)
+- [channelId](IbcTransferMsgValue.md#channelid)
+- [memo](IbcTransferMsgValue.md#memo)
+- [portId](IbcTransferMsgValue.md#portid)
+- [receiver](IbcTransferMsgValue.md#receiver)
+- [source](IbcTransferMsgValue.md#source)
+- [timeoutHeight](IbcTransferMsgValue.md#timeoutheight)
+- [timeoutSecOffset](IbcTransferMsgValue.md#timeoutsecoffset)
+- [token](IbcTransferMsgValue.md#token)
+
+## Constructors
+
+### constructor
+
+• **new IbcTransferMsgValue**(`data`): [`IbcTransferMsgValue`](IbcTransferMsgValue.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | [`IbcTransferMsgValue`](IbcTransferMsgValue.md) |
+
+#### Returns
+
+[`IbcTransferMsgValue`](IbcTransferMsgValue.md)
+
+#### Defined in
+
+[tx/schema/ibcTransfer.ts:35](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/ibcTransfer.ts#L35)
+
+## Properties
+
+### amount
+
+• **amount**: `BigNumber`
+
+#### Defined in
+
+[tx/schema/ibcTransfer.ts:18](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/ibcTransfer.ts#L18)
+
+___
+
+### channelId
+
+• **channelId**: `string`
+
+#### Defined in
+
+[tx/schema/ibcTransfer.ts:24](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/ibcTransfer.ts#L24)
+
+___
+
+### memo
+
+• `Optional` **memo**: `string`
+
+#### Defined in
+
+[tx/schema/ibcTransfer.ts:33](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/ibcTransfer.ts#L33)
+
+___
+
+### portId
+
+• **portId**: `string`
+
+#### Defined in
+
+[tx/schema/ibcTransfer.ts:21](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/ibcTransfer.ts#L21)
+
+___
+
+### receiver
+
+• **receiver**: `string`
+
+#### Defined in
+
+[tx/schema/ibcTransfer.ts:12](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/ibcTransfer.ts#L12)
+
+___
+
+### source
+
+• **source**: `string`
+
+#### Defined in
+
+[tx/schema/ibcTransfer.ts:9](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/ibcTransfer.ts#L9)
+
+___
+
+### timeoutHeight
+
+• `Optional` **timeoutHeight**: `bigint`
+
+#### Defined in
+
+[tx/schema/ibcTransfer.ts:27](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/ibcTransfer.ts#L27)
+
+___
+
+### timeoutSecOffset
+
+• `Optional` **timeoutSecOffset**: `bigint`
+
+#### Defined in
+
+[tx/schema/ibcTransfer.ts:30](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/ibcTransfer.ts#L30)
+
+___
+
+### token
+
+• **token**: `string`
+
+#### Defined in
+
+[tx/schema/ibcTransfer.ts:15](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/ibcTransfer.ts#L15)

--- a/packages/types/docs/classes/Message.md
+++ b/packages/types/docs/classes/Message.md
@@ -1,0 +1,91 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / Message
+
+# Class: Message\<T\>
+
+## Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends [`Schema`](../modules.md#schema) |
+
+## Implements
+
+- [`IMessage`](../interfaces/IMessage.md)\<`T`\>
+
+## Table of contents
+
+### Constructors
+
+- [constructor](Message.md#constructor)
+
+### Methods
+
+- [encode](Message.md#encode)
+- [decode](Message.md#decode)
+
+## Constructors
+
+### constructor
+
+• **new Message**\<`T`\>(): [`Message`](Message.md)\<`T`\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends [`Schema`](../modules.md#schema) |
+
+#### Returns
+
+[`Message`](Message.md)\<`T`\>
+
+## Methods
+
+### encode
+
+▸ **encode**(`value`): `Uint8Array`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `T` |
+
+#### Returns
+
+`Uint8Array`
+
+#### Implementation of
+
+[IMessage](../interfaces/IMessage.md).[encode](../interfaces/IMessage.md#encode)
+
+#### Defined in
+
+[tx/messages/index.ts:9](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/messages/index.ts#L9)
+
+___
+
+### decode
+
+▸ **decode**\<`T`\>(`buffer`, `parser`): `T`
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends [`Schema`](../modules.md#schema) |
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `buffer` | `Uint8Array` |
+| `parser` | `Constructor`\<`T`\> |
+
+#### Returns
+
+`T`
+
+#### Defined in
+
+[tx/messages/index.ts:17](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/messages/index.ts#L17)

--- a/packages/types/docs/classes/RedelegateMsgValue.md
+++ b/packages/types/docs/classes/RedelegateMsgValue.md
@@ -1,0 +1,76 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / RedelegateMsgValue
+
+# Class: RedelegateMsgValue
+
+## Table of contents
+
+### Constructors
+
+- [constructor](RedelegateMsgValue.md#constructor)
+
+### Properties
+
+- [amount](RedelegateMsgValue.md#amount)
+- [destinationValidator](RedelegateMsgValue.md#destinationvalidator)
+- [owner](RedelegateMsgValue.md#owner)
+- [sourceValidator](RedelegateMsgValue.md#sourcevalidator)
+
+## Constructors
+
+### constructor
+
+• **new RedelegateMsgValue**(`data`): [`RedelegateMsgValue`](RedelegateMsgValue.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | [`RedelegateMsgValue`](RedelegateMsgValue.md) |
+
+#### Returns
+
+[`RedelegateMsgValue`](RedelegateMsgValue.md)
+
+#### Defined in
+
+[tx/schema/redelegate.ts:19](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/redelegate.ts#L19)
+
+## Properties
+
+### amount
+
+• **amount**: `BigNumber`
+
+#### Defined in
+
+[tx/schema/redelegate.ts:17](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/redelegate.ts#L17)
+
+___
+
+### destinationValidator
+
+• **destinationValidator**: `string`
+
+#### Defined in
+
+[tx/schema/redelegate.ts:14](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/redelegate.ts#L14)
+
+___
+
+### owner
+
+• **owner**: `string`
+
+#### Defined in
+
+[tx/schema/redelegate.ts:8](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/redelegate.ts#L8)
+
+___
+
+### sourceValidator
+
+• **sourceValidator**: `string`
+
+#### Defined in
+
+[tx/schema/redelegate.ts:11](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/redelegate.ts#L11)

--- a/packages/types/docs/classes/SignatureMsgValue.md
+++ b/packages/types/docs/classes/SignatureMsgValue.md
@@ -1,0 +1,87 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / SignatureMsgValue
+
+# Class: SignatureMsgValue
+
+## Table of contents
+
+### Constructors
+
+- [constructor](SignatureMsgValue.md#constructor)
+
+### Properties
+
+- [pubkey](SignatureMsgValue.md#pubkey)
+- [rawIndices](SignatureMsgValue.md#rawindices)
+- [rawSignature](SignatureMsgValue.md#rawsignature)
+- [wrapperIndices](SignatureMsgValue.md#wrapperindices)
+- [wrapperSignature](SignatureMsgValue.md#wrappersignature)
+
+## Constructors
+
+### constructor
+
+• **new SignatureMsgValue**(`data`): [`SignatureMsgValue`](SignatureMsgValue.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | [`SignatureMsgValue`](SignatureMsgValue.md) |
+
+#### Returns
+
+[`SignatureMsgValue`](SignatureMsgValue.md)
+
+#### Defined in
+
+[tx/schema/signature.ts:21](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/signature.ts#L21)
+
+## Properties
+
+### pubkey
+
+• **pubkey**: `Uint8Array`
+
+#### Defined in
+
+[tx/schema/signature.ts:7](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/signature.ts#L7)
+
+___
+
+### rawIndices
+
+• **rawIndices**: `Uint8Array`
+
+#### Defined in
+
+[tx/schema/signature.ts:10](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/signature.ts#L10)
+
+___
+
+### rawSignature
+
+• **rawSignature**: `Uint8Array`
+
+#### Defined in
+
+[tx/schema/signature.ts:13](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/signature.ts#L13)
+
+___
+
+### wrapperIndices
+
+• **wrapperIndices**: `Uint8Array`
+
+#### Defined in
+
+[tx/schema/signature.ts:16](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/signature.ts#L16)
+
+___
+
+### wrapperSignature
+
+• **wrapperSignature**: `Uint8Array`
+
+#### Defined in
+
+[tx/schema/signature.ts:19](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/signature.ts#L19)

--- a/packages/types/docs/classes/TransparentTransferMsgValue.md
+++ b/packages/types/docs/classes/TransparentTransferMsgValue.md
@@ -1,0 +1,87 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / TransparentTransferMsgValue
+
+# Class: TransparentTransferMsgValue
+
+## Table of contents
+
+### Constructors
+
+- [constructor](TransparentTransferMsgValue.md#constructor)
+
+### Properties
+
+- [amount](TransparentTransferMsgValue.md#amount)
+- [nativeToken](TransparentTransferMsgValue.md#nativetoken)
+- [source](TransparentTransferMsgValue.md#source)
+- [target](TransparentTransferMsgValue.md#target)
+- [token](TransparentTransferMsgValue.md#token)
+
+## Constructors
+
+### constructor
+
+• **new TransparentTransferMsgValue**(`data`): [`TransparentTransferMsgValue`](TransparentTransferMsgValue.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | [`TransparentTransferMsgValue`](TransparentTransferMsgValue.md) |
+
+#### Returns
+
+[`TransparentTransferMsgValue`](TransparentTransferMsgValue.md)
+
+#### Defined in
+
+[tx/schema/transparentTransfer.ts:23](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/transparentTransfer.ts#L23)
+
+## Properties
+
+### amount
+
+• **amount**: `BigNumber`
+
+#### Defined in
+
+[tx/schema/transparentTransfer.ts:18](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/transparentTransfer.ts#L18)
+
+___
+
+### nativeToken
+
+• **nativeToken**: `string`
+
+#### Defined in
+
+[tx/schema/transparentTransfer.ts:21](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/transparentTransfer.ts#L21)
+
+___
+
+### source
+
+• **source**: `string`
+
+#### Defined in
+
+[tx/schema/transparentTransfer.ts:9](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/transparentTransfer.ts#L9)
+
+___
+
+### target
+
+• **target**: `string`
+
+#### Defined in
+
+[tx/schema/transparentTransfer.ts:12](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/transparentTransfer.ts#L12)
+
+___
+
+### token
+
+• **token**: `string`
+
+#### Defined in
+
+[tx/schema/transparentTransfer.ts:15](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/transparentTransfer.ts#L15)

--- a/packages/types/docs/classes/TxResponseMsgValue.md
+++ b/packages/types/docs/classes/TxResponseMsgValue.md
@@ -1,0 +1,65 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / TxResponseMsgValue
+
+# Class: TxResponseMsgValue
+
+## Table of contents
+
+### Constructors
+
+- [constructor](TxResponseMsgValue.md#constructor)
+
+### Properties
+
+- [commitments](TxResponseMsgValue.md#commitments)
+- [gasUsed](TxResponseMsgValue.md#gasused)
+- [hash](TxResponseMsgValue.md#hash)
+
+## Constructors
+
+### constructor
+
+• **new TxResponseMsgValue**(`data`): [`TxResponseMsgValue`](TxResponseMsgValue.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | [`TxResponseMsgValue`](TxResponseMsgValue.md) |
+
+#### Returns
+
+[`TxResponseMsgValue`](TxResponseMsgValue.md)
+
+#### Defined in
+
+[tx/schema/txResponse.ts:16](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/txResponse.ts#L16)
+
+## Properties
+
+### commitments
+
+• **commitments**: [`BatchTxResultMsgValue`](BatchTxResultMsgValue.md)[]
+
+#### Defined in
+
+[tx/schema/txResponse.ts:14](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/txResponse.ts#L14)
+
+___
+
+### gasUsed
+
+• **gasUsed**: `string`
+
+#### Defined in
+
+[tx/schema/txResponse.ts:11](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/txResponse.ts#L11)
+
+___
+
+### hash
+
+• **hash**: `string`
+
+#### Defined in
+
+[tx/schema/txResponse.ts:8](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/txResponse.ts#L8)

--- a/packages/types/docs/classes/UnbondMsgValue.md
+++ b/packages/types/docs/classes/UnbondMsgValue.md
@@ -1,0 +1,65 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / UnbondMsgValue
+
+# Class: UnbondMsgValue
+
+## Table of contents
+
+### Constructors
+
+- [constructor](UnbondMsgValue.md#constructor)
+
+### Properties
+
+- [amount](UnbondMsgValue.md#amount)
+- [source](UnbondMsgValue.md#source)
+- [validator](UnbondMsgValue.md#validator)
+
+## Constructors
+
+### constructor
+
+• **new UnbondMsgValue**(`data`): [`UnbondMsgValue`](UnbondMsgValue.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | [`UnbondMsgValue`](UnbondMsgValue.md) |
+
+#### Returns
+
+[`UnbondMsgValue`](UnbondMsgValue.md)
+
+#### Defined in
+
+[tx/schema/unbond.ts:17](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/unbond.ts#L17)
+
+## Properties
+
+### amount
+
+• **amount**: `BigNumber`
+
+#### Defined in
+
+[tx/schema/unbond.ts:15](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/unbond.ts#L15)
+
+___
+
+### source
+
+• **source**: `string`
+
+#### Defined in
+
+[tx/schema/unbond.ts:9](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/unbond.ts#L9)
+
+___
+
+### validator
+
+• **validator**: `string`
+
+#### Defined in
+
+[tx/schema/unbond.ts:12](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/unbond.ts#L12)

--- a/packages/types/docs/classes/VoteProposalMsgValue.md
+++ b/packages/types/docs/classes/VoteProposalMsgValue.md
@@ -1,0 +1,65 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / VoteProposalMsgValue
+
+# Class: VoteProposalMsgValue
+
+## Table of contents
+
+### Constructors
+
+- [constructor](VoteProposalMsgValue.md#constructor)
+
+### Properties
+
+- [proposalId](VoteProposalMsgValue.md#proposalid)
+- [signer](VoteProposalMsgValue.md#signer)
+- [vote](VoteProposalMsgValue.md#vote)
+
+## Constructors
+
+### constructor
+
+• **new VoteProposalMsgValue**(`data`): [`VoteProposalMsgValue`](VoteProposalMsgValue.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | [`VoteProposalMsgValue`](VoteProposalMsgValue.md) |
+
+#### Returns
+
+[`VoteProposalMsgValue`](VoteProposalMsgValue.md)
+
+#### Defined in
+
+[tx/schema/voteProposal.ts:15](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/voteProposal.ts#L15)
+
+## Properties
+
+### proposalId
+
+• **proposalId**: `bigint`
+
+#### Defined in
+
+[tx/schema/voteProposal.ts:10](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/voteProposal.ts#L10)
+
+___
+
+### signer
+
+• **signer**: `string`
+
+#### Defined in
+
+[tx/schema/voteProposal.ts:7](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/voteProposal.ts#L7)
+
+___
+
+### vote
+
+• **vote**: `string`
+
+#### Defined in
+
+[tx/schema/voteProposal.ts:13](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/voteProposal.ts#L13)

--- a/packages/types/docs/classes/WithdrawMsgValue.md
+++ b/packages/types/docs/classes/WithdrawMsgValue.md
@@ -1,0 +1,54 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / WithdrawMsgValue
+
+# Class: WithdrawMsgValue
+
+## Table of contents
+
+### Constructors
+
+- [constructor](WithdrawMsgValue.md#constructor)
+
+### Properties
+
+- [source](WithdrawMsgValue.md#source)
+- [validator](WithdrawMsgValue.md#validator)
+
+## Constructors
+
+### constructor
+
+• **new WithdrawMsgValue**(`data`): [`WithdrawMsgValue`](WithdrawMsgValue.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | [`WithdrawMsgValue`](WithdrawMsgValue.md) |
+
+#### Returns
+
+[`WithdrawMsgValue`](WithdrawMsgValue.md)
+
+#### Defined in
+
+[tx/schema/withdraw.ts:12](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/withdraw.ts#L12)
+
+## Properties
+
+### source
+
+• **source**: `string`
+
+#### Defined in
+
+[tx/schema/withdraw.ts:7](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/withdraw.ts#L7)
+
+___
+
+### validator
+
+• **validator**: `string`
+
+#### Defined in
+
+[tx/schema/withdraw.ts:10](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/withdraw.ts#L10)

--- a/packages/types/docs/classes/WrapperTxMsgValue.md
+++ b/packages/types/docs/classes/WrapperTxMsgValue.md
@@ -1,0 +1,109 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / WrapperTxMsgValue
+
+# Class: WrapperTxMsgValue
+
+## Table of contents
+
+### Constructors
+
+- [constructor](WrapperTxMsgValue.md#constructor)
+
+### Properties
+
+- [chainId](WrapperTxMsgValue.md#chainid)
+- [disposableSigningKey](WrapperTxMsgValue.md#disposablesigningkey)
+- [feeAmount](WrapperTxMsgValue.md#feeamount)
+- [gasLimit](WrapperTxMsgValue.md#gaslimit)
+- [memo](WrapperTxMsgValue.md#memo)
+- [publicKey](WrapperTxMsgValue.md#publickey)
+- [token](WrapperTxMsgValue.md#token)
+
+## Constructors
+
+### constructor
+
+• **new WrapperTxMsgValue**(`data`): [`WrapperTxMsgValue`](WrapperTxMsgValue.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | [`WrapperTxMsgValue`](WrapperTxMsgValue.md) |
+
+#### Returns
+
+[`WrapperTxMsgValue`](WrapperTxMsgValue.md)
+
+#### Defined in
+
+[tx/schema/wrapperTx.ts:29](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/wrapperTx.ts#L29)
+
+## Properties
+
+### chainId
+
+• **chainId**: `string`
+
+#### Defined in
+
+[tx/schema/wrapperTx.ts:18](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/wrapperTx.ts#L18)
+
+___
+
+### disposableSigningKey
+
+• `Optional` **disposableSigningKey**: `boolean`
+
+#### Defined in
+
+[tx/schema/wrapperTx.ts:24](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/wrapperTx.ts#L24)
+
+___
+
+### feeAmount
+
+• **feeAmount**: `BigNumber`
+
+#### Defined in
+
+[tx/schema/wrapperTx.ts:12](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/wrapperTx.ts#L12)
+
+___
+
+### gasLimit
+
+• **gasLimit**: `BigNumber`
+
+#### Defined in
+
+[tx/schema/wrapperTx.ts:15](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/wrapperTx.ts#L15)
+
+___
+
+### memo
+
+• `Optional` **memo**: `string`
+
+#### Defined in
+
+[tx/schema/wrapperTx.ts:27](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/wrapperTx.ts#L27)
+
+___
+
+### publicKey
+
+• `Optional` **publicKey**: `string`
+
+#### Defined in
+
+[tx/schema/wrapperTx.ts:21](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/wrapperTx.ts#L21)
+
+___
+
+### token
+
+• **token**: `string`
+
+#### Defined in
+
+[tx/schema/wrapperTx.ts:9](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/wrapperTx.ts#L9)

--- a/packages/types/docs/enums/AccountType.md
+++ b/packages/types/docs/enums/AccountType.md
@@ -1,0 +1,52 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / AccountType
+
+# Enumeration: AccountType
+
+## Table of contents
+
+### Enumeration Members
+
+- [Ledger](AccountType.md#ledger)
+- [Mnemonic](AccountType.md#mnemonic)
+- [PrivateKey](AccountType.md#privatekey)
+- [ShieldedKeys](AccountType.md#shieldedkeys)
+
+## Enumeration Members
+
+### Ledger
+
+• **Ledger** = ``"ledger"``
+
+#### Defined in
+
+[account.ts:18](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/account.ts#L18)
+
+___
+
+### Mnemonic
+
+• **Mnemonic** = ``"mnemonic"``
+
+#### Defined in
+
+[account.ts:12](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/account.ts#L12)
+
+___
+
+### PrivateKey
+
+• **PrivateKey** = ``"private-key"``
+
+#### Defined in
+
+[account.ts:14](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/account.ts#L14)
+
+___
+
+### ShieldedKeys
+
+• **ShieldedKeys** = ``"shielded-keys"``
+
+#### Defined in
+
+[account.ts:16](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/account.ts#L16)

--- a/packages/types/docs/enums/BridgeType.md
+++ b/packages/types/docs/enums/BridgeType.md
@@ -1,0 +1,30 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / BridgeType
+
+# Enumeration: BridgeType
+
+## Table of contents
+
+### Enumeration Members
+
+- [Ethereum](BridgeType.md#ethereum)
+- [IBC](BridgeType.md#ibc)
+
+## Enumeration Members
+
+### Ethereum
+
+• **Ethereum** = ``"ethereum-bridge"``
+
+#### Defined in
+
+[chain.ts:14](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/chain.ts#L14)
+
+___
+
+### IBC
+
+• **IBC** = ``"ibc"``
+
+#### Defined in
+
+[chain.ts:13](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/chain.ts#L13)

--- a/packages/types/docs/enums/Events.md
+++ b/packages/types/docs/enums/Events.md
@@ -1,0 +1,52 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / Events
+
+# Enumeration: Events
+
+## Table of contents
+
+### Enumeration Members
+
+- [AccountChanged](Events.md#accountchanged)
+- [ConnectionRevoked](Events.md#connectionrevoked)
+- [ExtensionLocked](Events.md#extensionlocked)
+- [NetworkChanged](Events.md#networkchanged)
+
+## Enumeration Members
+
+### AccountChanged
+
+• **AccountChanged** = ``"namada-account-changed"``
+
+#### Defined in
+
+[events.ts:5](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/events.ts#L5)
+
+___
+
+### ConnectionRevoked
+
+• **ConnectionRevoked** = ``"namada-connection-revoked"``
+
+#### Defined in
+
+[events.ts:8](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/events.ts#L8)
+
+___
+
+### ExtensionLocked
+
+• **ExtensionLocked** = ``"namada-extension-locked"``
+
+#### Defined in
+
+[events.ts:7](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/events.ts#L7)
+
+___
+
+### NetworkChanged
+
+• **NetworkChanged** = ``"namada-network-changed"``
+
+#### Defined in
+
+[events.ts:6](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/events.ts#L6)

--- a/packages/types/docs/enums/KeplrEvents.md
+++ b/packages/types/docs/enums/KeplrEvents.md
@@ -1,0 +1,19 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / KeplrEvents
+
+# Enumeration: KeplrEvents
+
+## Table of contents
+
+### Enumeration Members
+
+- [AccountChanged](KeplrEvents.md#accountchanged)
+
+## Enumeration Members
+
+### AccountChanged
+
+• **AccountChanged** = ``"keplr_keystorechange"``
+
+#### Defined in
+
+[events.ts:13](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/events.ts#L13)

--- a/packages/types/docs/enums/MetamaskEvents.md
+++ b/packages/types/docs/enums/MetamaskEvents.md
@@ -1,0 +1,30 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / MetamaskEvents
+
+# Enumeration: MetamaskEvents
+
+## Table of contents
+
+### Enumeration Members
+
+- [AccountChanged](MetamaskEvents.md#accountchanged)
+- [BridgeTransferCompleted](MetamaskEvents.md#bridgetransfercompleted)
+
+## Enumeration Members
+
+### AccountChanged
+
+• **AccountChanged** = ``"accountsChanged"``
+
+#### Defined in
+
+[events.ts:18](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/events.ts#L18)
+
+___
+
+### BridgeTransferCompleted
+
+• **BridgeTransferCompleted** = ``"bridge-transfer-completed"``
+
+#### Defined in
+
+[events.ts:19](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/events.ts#L19)

--- a/packages/types/docs/interfaces/IMessage.md
+++ b/packages/types/docs/interfaces/IMessage.md
@@ -1,0 +1,39 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / IMessage
+
+# Interface: IMessage\<T\>
+
+## Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends [`Schema`](../modules.md#schema) |
+
+## Implemented by
+
+- [`Message`](../classes/Message.md)
+
+## Table of contents
+
+### Methods
+
+- [encode](IMessage.md#encode)
+
+## Methods
+
+### encode
+
+▸ **encode**(`value`): `Uint8Array`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `T` |
+
+#### Returns
+
+`Uint8Array`
+
+#### Defined in
+
+[tx/messages/index.ts:5](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/messages/index.ts#L5)

--- a/packages/types/docs/interfaces/Namada.md
+++ b/packages/types/docs/interfaces/Namada.md
@@ -1,0 +1,190 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / Namada
+
+# Interface: Namada
+
+## Table of contents
+
+### Properties
+
+- [getChain](Namada.md#getchain)
+- [version](Namada.md#version)
+
+### Methods
+
+- [accounts](Namada.md#accounts)
+- [connect](Namada.md#connect)
+- [defaultAccount](Namada.md#defaultaccount)
+- [isConnected](Namada.md#isconnected)
+- [sign](Namada.md#sign)
+- [signArbitrary](Namada.md#signarbitrary)
+- [verify](Namada.md#verify)
+
+## Properties
+
+### getChain
+
+• **getChain**: () => `Promise`\<`undefined` \| [`Chain`](../modules.md#chain)\>
+
+#### Type declaration
+
+▸ (): `Promise`\<`undefined` \| [`Chain`](../modules.md#chain)\>
+
+##### Returns
+
+`Promise`\<`undefined` \| [`Chain`](../modules.md#chain)\>
+
+#### Defined in
+
+[namada.ts:38](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/namada.ts#L38)
+
+___
+
+### version
+
+• **version**: () => `string`
+
+#### Type declaration
+
+▸ (): `string`
+
+##### Returns
+
+`string`
+
+#### Defined in
+
+[namada.ts:39](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/namada.ts#L39)
+
+## Methods
+
+### accounts
+
+▸ **accounts**(`chainId?`): `Promise`\<`undefined` \| [`DerivedAccount`](../modules.md#derivedaccount)[]\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `chainId?` | `string` |
+
+#### Returns
+
+`Promise`\<`undefined` \| [`DerivedAccount`](../modules.md#derivedaccount)[]\>
+
+#### Defined in
+
+[namada.ts:29](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/namada.ts#L29)
+
+___
+
+### connect
+
+▸ **connect**(`chainId?`): `Promise`\<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `chainId?` | `string` |
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Defined in
+
+[namada.ts:30](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/namada.ts#L30)
+
+___
+
+### defaultAccount
+
+▸ **defaultAccount**(`chainId?`): `Promise`\<`undefined` \| [`DerivedAccount`](../modules.md#derivedaccount)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `chainId?` | `string` |
+
+#### Returns
+
+`Promise`\<`undefined` \| [`DerivedAccount`](../modules.md#derivedaccount)\>
+
+#### Defined in
+
+[namada.ts:32](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/namada.ts#L32)
+
+___
+
+### isConnected
+
+▸ **isConnected**(): `Promise`\<`undefined` \| `boolean`\>
+
+#### Returns
+
+`Promise`\<`undefined` \| `boolean`\>
+
+#### Defined in
+
+[namada.ts:31](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/namada.ts#L31)
+
+___
+
+### sign
+
+▸ **sign**(`props`): `Promise`\<`undefined` \| `Uint8Array`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`SignProps`](../modules.md#signprops) |
+
+#### Returns
+
+`Promise`\<`undefined` \| `Uint8Array`\>
+
+#### Defined in
+
+[namada.ts:33](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/namada.ts#L33)
+
+___
+
+### signArbitrary
+
+▸ **signArbitrary**(`props`): `Promise`\<`undefined` \| [`SignArbitraryResponse`](../modules.md#signarbitraryresponse)\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`SignArbitraryProps`](../modules.md#signarbitraryprops) |
+
+#### Returns
+
+`Promise`\<`undefined` \| [`SignArbitraryResponse`](../modules.md#signarbitraryresponse)\>
+
+#### Defined in
+
+[namada.ts:34](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/namada.ts#L34)
+
+___
+
+### verify
+
+▸ **verify**(`props`): `Promise`\<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `props` | [`VerifyArbitraryProps`](../modules.md#verifyarbitraryprops) |
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Defined in
+
+[namada.ts:37](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/namada.ts#L37)

--- a/packages/types/docs/interfaces/Signer.md
+++ b/packages/types/docs/interfaces/Signer.md
@@ -1,0 +1,139 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / Signer
+
+# Interface: Signer
+
+## Table of contents
+
+### Properties
+
+- [accounts](Signer.md#accounts)
+- [defaultAccount](Signer.md#defaultaccount)
+- [sign](Signer.md#sign)
+- [signArbitrary](Signer.md#signarbitrary)
+- [verify](Signer.md#verify)
+
+## Properties
+
+### accounts
+
+• **accounts**: (`chainId?`: `string`) => `Promise`\<`undefined` \| [`Account`](../modules.md#account)[]\>
+
+#### Type declaration
+
+▸ (`chainId?`): `Promise`\<`undefined` \| [`Account`](../modules.md#account)[]\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `chainId?` | `string` |
+
+##### Returns
+
+`Promise`\<`undefined` \| [`Account`](../modules.md#account)[]\>
+
+#### Defined in
+
+[signer.ts:14](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/signer.ts#L14)
+
+___
+
+### defaultAccount
+
+• **defaultAccount**: (`chainId?`: `string`) => `Promise`\<`undefined` \| [`Account`](../modules.md#account)\>
+
+#### Type declaration
+
+▸ (`chainId?`): `Promise`\<`undefined` \| [`Account`](../modules.md#account)\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `chainId?` | `string` |
+
+##### Returns
+
+`Promise`\<`undefined` \| [`Account`](../modules.md#account)\>
+
+#### Defined in
+
+[signer.ts:15](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/signer.ts#L15)
+
+___
+
+### sign
+
+• **sign**: (`txType`: `unknown`, `tx`: [`TxData`](../modules.md#txdata), `signer`: `string`, `wrapperTxMsg`: `Uint8Array`) => `Promise`\<`undefined` \| `Uint8Array`\>
+
+#### Type declaration
+
+▸ (`txType`, `tx`, `signer`, `wrapperTxMsg`): `Promise`\<`undefined` \| `Uint8Array`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `txType` | `unknown` |
+| `tx` | [`TxData`](../modules.md#txdata) |
+| `signer` | `string` |
+| `wrapperTxMsg` | `Uint8Array` |
+
+##### Returns
+
+`Promise`\<`undefined` \| `Uint8Array`\>
+
+#### Defined in
+
+[signer.ts:16](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/signer.ts#L16)
+
+___
+
+### signArbitrary
+
+• **signArbitrary**: (`signer`: `string`, `data`: `string`) => `Promise`\<`undefined` \| [`SignArbitraryResponse`](../modules.md#signarbitraryresponse)\>
+
+#### Type declaration
+
+▸ (`signer`, `data`): `Promise`\<`undefined` \| [`SignArbitraryResponse`](../modules.md#signarbitraryresponse)\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `signer` | `string` |
+| `data` | `string` |
+
+##### Returns
+
+`Promise`\<`undefined` \| [`SignArbitraryResponse`](../modules.md#signarbitraryresponse)\>
+
+#### Defined in
+
+[signer.ts:22](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/signer.ts#L22)
+
+___
+
+### verify
+
+• **verify**: (`publicKey`: `string`, `hash`: `string`, `signature`: `string`) => `Promise`\<`void`\>
+
+#### Type declaration
+
+▸ (`publicKey`, `hash`, `signature`): `Promise`\<`void`\>
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `publicKey` | `string` |
+| `hash` | `string` |
+| `signature` | `string` |
+
+##### Returns
+
+`Promise`\<`void`\>
+
+#### Defined in
+
+[signer.ts:26](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/signer.ts#L26)

--- a/packages/types/docs/modules.md
+++ b/packages/types/docs/modules.md
@@ -1,0 +1,1072 @@
+[@namada/types](README.md) / Exports
+
+# @namada/types
+
+## Table of contents
+
+### Enumerations
+
+- [AccountType](enums/AccountType.md)
+- [BridgeType](enums/BridgeType.md)
+- [Events](enums/Events.md)
+- [KeplrEvents](enums/KeplrEvents.md)
+- [MetamaskEvents](enums/MetamaskEvents.md)
+
+### Classes
+
+- [BatchTxResultMsgValue](classes/BatchTxResultMsgValue.md)
+- [BondMsgValue](classes/BondMsgValue.md)
+- [EthBridgeTransferMsgValue](classes/EthBridgeTransferMsgValue.md)
+- [IbcTransferMsgValue](classes/IbcTransferMsgValue.md)
+- [Message](classes/Message.md)
+- [RedelegateMsgValue](classes/RedelegateMsgValue.md)
+- [SignatureMsgValue](classes/SignatureMsgValue.md)
+- [TransparentTransferMsgValue](classes/TransparentTransferMsgValue.md)
+- [TxResponseMsgValue](classes/TxResponseMsgValue.md)
+- [UnbondMsgValue](classes/UnbondMsgValue.md)
+- [VoteProposalMsgValue](classes/VoteProposalMsgValue.md)
+- [WithdrawMsgValue](classes/WithdrawMsgValue.md)
+- [WrapperTxMsgValue](classes/WrapperTxMsgValue.md)
+
+### Interfaces
+
+- [IMessage](interfaces/IMessage.md)
+- [Namada](interfaces/Namada.md)
+- [Signer](interfaces/Signer.md)
+
+### Type Aliases
+
+- [Account](modules.md#account)
+- [AddRemove](modules.md#addremove)
+- [BalancesProps](modules.md#balancesprops)
+- [BatchTxResultProps](modules.md#batchtxresultprops)
+- [Bip44Path](modules.md#bip44path)
+- [BondProps](modules.md#bondprops)
+- [Chain](modules.md#chain)
+- [ChainKey](modules.md#chainkey)
+- [CosmosMinDenom](modules.md#cosmosmindenom)
+- [CosmosTokenType](modules.md#cosmostokentype)
+- [Currency](modules.md#currency)
+- [Default](modules.md#default)
+- [DefaultWithWasm](modules.md#defaultwithwasm)
+- [DelegatorVote](modules.md#delegatorvote)
+- [DerivedAccount](modules.md#derivedaccount)
+- [EthBridgeTransferProps](modules.md#ethbridgetransferprops)
+- [ExtensionInfo](modules.md#extensioninfo)
+- [ExtensionKey](modules.md#extensionkey)
+- [IbcTransferProps](modules.md#ibctransferprops)
+- [JsonCompatibleArray](modules.md#jsoncompatiblearray)
+- [JsonCompatibleDictionary](modules.md#jsoncompatibledictionary)
+- [PgfActions](modules.md#pgfactions)
+- [PgfPayment](modules.md#pgfpayment)
+- [PgfSteward](modules.md#pgfsteward)
+- [PgfTarget](modules.md#pgftarget)
+- [Proposal](modules.md#proposal)
+- [ProposalStatus](modules.md#proposalstatus)
+- [ProposalType](modules.md#proposaltype)
+- [ProposalTypeString](modules.md#proposaltypestring)
+- [RedelegateProps](modules.md#redelegateprops)
+- [Schema](modules.md#schema)
+- [SignArbitraryProps](modules.md#signarbitraryprops)
+- [SignArbitraryResponse](modules.md#signarbitraryresponse)
+- [SignProps](modules.md#signprops)
+- [SignatureProps](modules.md#signatureprops)
+- [TallyType](modules.md#tallytype)
+- [TokenBalances](modules.md#tokenbalances)
+- [TokenInfo](modules.md#tokeninfo)
+- [TokenType](modules.md#tokentype)
+- [TransparentTransferProps](modules.md#transparenttransferprops)
+- [TxData](modules.md#txdata)
+- [TxResponseProps](modules.md#txresponseprops)
+- [UnbondProps](modules.md#unbondprops)
+- [ValidatorVote](modules.md#validatorvote)
+- [VerifyArbitraryProps](modules.md#verifyarbitraryprops)
+- [Vote](modules.md#vote)
+- [VoteProposalProps](modules.md#voteproposalprops)
+- [VoteType](modules.md#votetype)
+- [Votes](modules.md#votes)
+- [WindowWithNamada](modules.md#windowwithnamada)
+- [WithdrawProps](modules.md#withdrawprops)
+- [WrapperTxProps](modules.md#wrappertxprops)
+
+### Variables
+
+- [BigNumberSerializer](modules.md#bignumberserializer)
+- [CosmosSymbols](modules.md#cosmossymbols)
+- [CosmosTokens](modules.md#cosmostokens)
+- [Extensions](modules.md#extensions)
+- [Symbols](modules.md#symbols)
+- [Tokens](modules.md#tokens)
+- [proposalStatuses](modules.md#proposalstatuses)
+- [tallyTypes](modules.md#tallytypes)
+- [voteTypes](modules.md#votetypes)
+
+### Functions
+
+- [isDelegatorVote](modules.md#isdelegatorvote)
+- [isProposalStatus](modules.md#isproposalstatus)
+- [isTallyType](modules.md#istallytype)
+- [isValidatorVote](modules.md#isvalidatorvote)
+- [isVoteType](modules.md#isvotetype)
+- [minDenomByToken](modules.md#mindenombytoken)
+- [tokenByMinDenom](modules.md#tokenbymindenom)
+
+## Type Aliases
+
+### Account
+
+Ƭ **Account**: `Pick`\<[`DerivedAccount`](modules.md#derivedaccount), ``"address"`` \| ``"alias"`` \| ``"type"`` \| ``"publicKey"``\> & \{ `chainId`: `string` ; `chainKey`: [`ChainKey`](modules.md#chainkey) ; `isShielded`: `boolean`  }
+
+#### Defined in
+
+[account.ts:32](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/account.ts#L32)
+
+___
+
+### AddRemove
+
+Ƭ **AddRemove**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `add?` | `string` |
+| `remove` | `string`[] |
+
+#### Defined in
+
+[proposals.ts:33](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L33)
+
+___
+
+### BalancesProps
+
+Ƭ **BalancesProps**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `owner` | `string` |
+| `tokens` | `string`[] |
+
+#### Defined in
+
+[namada.ts:23](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/namada.ts#L23)
+
+___
+
+### BatchTxResultProps
+
+Ƭ **BatchTxResultProps**: [`BatchTxResultMsgValue`](classes/BatchTxResultMsgValue.md)
+
+#### Defined in
+
+[tx/types.ts:16](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/types.ts#L16)
+
+___
+
+### Bip44Path
+
+Ƭ **Bip44Path**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `account` | `number` |
+| `change` | `number` |
+| `index` | `number` |
+
+#### Defined in
+
+[account.ts:3](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/account.ts#L3)
+
+___
+
+### BondProps
+
+Ƭ **BondProps**: [`BondMsgValue`](classes/BondMsgValue.md)
+
+#### Defined in
+
+[tx/types.ts:18](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/types.ts#L18)
+
+___
+
+### Chain
+
+Ƭ **Chain**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `alias` | `string` |
+| `bech32Prefix` | `string` |
+| `bip44` | \{ `coinType`: `number`  } |
+| `bip44.coinType` | `number` |
+| `bridgeType` | [`BridgeType`](enums/BridgeType.md)[] |
+| `chainId` | `string` |
+| `currency` | [`Currency`](modules.md#currency) |
+| `extension` | [`ExtensionInfo`](modules.md#extensioninfo) |
+| `ibc?` | \{ `portId`: `string`  } |
+| `ibc.portId` | `string` |
+| `id` | [`ChainKey`](modules.md#chainkey) |
+| `rpc` | `string` |
+
+#### Defined in
+
+[chain.ts:49](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/chain.ts#L49)
+
+___
+
+### ChainKey
+
+Ƭ **ChainKey**: ``"namada"`` \| ``"cosmos"`` \| ``"ethereum"``
+
+#### Defined in
+
+[chain.ts:21](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/chain.ts#L21)
+
+___
+
+### CosmosMinDenom
+
+Ƭ **CosmosMinDenom**: typeof `cosmosMinDenoms`[`number`]
+
+#### Defined in
+
+[tokens/Cosmos.ts:13](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tokens/Cosmos.ts#L13)
+
+___
+
+### CosmosTokenType
+
+Ƭ **CosmosTokenType**: typeof [`CosmosSymbols`](modules.md#cosmossymbols)[`number`]
+
+#### Defined in
+
+[tokens/Cosmos.ts:6](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tokens/Cosmos.ts#L6)
+
+___
+
+### Currency
+
+Ƭ **Currency**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `address?` | `string` |
+| `gasPriceStep?` | \{ `average`: `number` ; `high`: `number` ; `low`: `number`  } |
+| `gasPriceStep.average` | `number` |
+| `gasPriceStep.high` | `number` |
+| `gasPriceStep.low` | `number` |
+| `symbol` | `string` |
+| `token` | `string` |
+
+#### Defined in
+
+[chain.ts:1](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/chain.ts#L1)
+
+___
+
+### Default
+
+Ƭ **Default**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `type` | ``"default"`` |
+
+#### Defined in
+
+[proposals.ts:54](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L54)
+
+___
+
+### DefaultWithWasm
+
+Ƭ **DefaultWithWasm**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `data` | `Uint8Array` |
+| `type` | ``"default_with_wasm"`` |
+
+#### Defined in
+
+[proposals.ts:55](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L55)
+
+___
+
+### DelegatorVote
+
+Ƭ **DelegatorVote**: \{ `isValidator`: ``false`` ; `votingPower`: [`string`, `BigNumber`][]  } & `VoteCommonProperties`
+
+#### Defined in
+
+[proposals.ts:83](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L83)
+
+___
+
+### DerivedAccount
+
+Ƭ **DerivedAccount**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `address` | `string` |
+| `alias` | `string` |
+| `id` | `string` |
+| `owner?` | `string` |
+| `parentId?` | `string` |
+| `path` | [`Bip44Path`](modules.md#bip44path) |
+| `publicKey?` | `string` |
+| `type` | [`AccountType`](enums/AccountType.md) |
+
+#### Defined in
+
+[account.ts:21](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/account.ts#L21)
+
+___
+
+### EthBridgeTransferProps
+
+Ƭ **EthBridgeTransferProps**: [`EthBridgeTransferMsgValue`](classes/EthBridgeTransferMsgValue.md)
+
+#### Defined in
+
+[tx/types.ts:24](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/types.ts#L24)
+
+___
+
+### ExtensionInfo
+
+Ƭ **ExtensionInfo**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `alias` | `string` |
+| `id` | [`ExtensionKey`](modules.md#extensionkey) |
+| `url` | `string` |
+
+#### Defined in
+
+[chain.ts:23](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/chain.ts#L23)
+
+___
+
+### ExtensionKey
+
+Ƭ **ExtensionKey**: ``"namada"`` \| ``"keplr"`` \| ``"metamask"``
+
+#### Defined in
+
+[chain.ts:18](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/chain.ts#L18)
+
+___
+
+### IbcTransferProps
+
+Ƭ **IbcTransferProps**: [`IbcTransferMsgValue`](classes/IbcTransferMsgValue.md)
+
+#### Defined in
+
+[tx/types.ts:27](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/types.ts#L27)
+
+___
+
+### JsonCompatibleArray
+
+Ƭ **JsonCompatibleArray**: (`string` \| `number` \| `boolean`)[]
+
+#### Defined in
+
+[utils.ts:1](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/utils.ts#L1)
+
+___
+
+### JsonCompatibleDictionary
+
+Ƭ **JsonCompatibleDictionary**: `Object`
+
+#### Index signature
+
+▪ [key: `string`]: `string` \| [`JsonCompatibleArray`](modules.md#jsoncompatiblearray)
+
+#### Defined in
+
+[utils.ts:2](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/utils.ts#L2)
+
+___
+
+### PgfActions
+
+Ƭ **PgfActions**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `continuous` | \{ `add`: [`PgfTarget`](modules.md#pgftarget)[] ; `remove`: [`PgfTarget`](modules.md#pgftarget)[]  } |
+| `continuous.add` | [`PgfTarget`](modules.md#pgftarget)[] |
+| `continuous.remove` | [`PgfTarget`](modules.md#pgftarget)[] |
+| `retro` | [`PgfTarget`](modules.md#pgftarget)[] |
+
+#### Defined in
+
+[proposals.ts:46](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L46)
+
+___
+
+### PgfPayment
+
+Ƭ **PgfPayment**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `data` | [`PgfActions`](modules.md#pgfactions) |
+| `type` | ``"pgf_payment"`` |
+
+#### Defined in
+
+[proposals.ts:57](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L57)
+
+___
+
+### PgfSteward
+
+Ƭ **PgfSteward**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `data` | [`AddRemove`](modules.md#addremove) |
+| `type` | ``"pgf_steward"`` |
+
+#### Defined in
+
+[proposals.ts:56](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L56)
+
+___
+
+### PgfTarget
+
+Ƭ **PgfTarget**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `internal` | \{ `amount`: `BigNumber` ; `target`: `string`  } |
+| `internal.amount` | `BigNumber` |
+| `internal.target` | `string` |
+
+#### Defined in
+
+[proposals.ts:39](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L39)
+
+___
+
+### Proposal
+
+Ƭ **Proposal**: \{ `activationEpoch`: `bigint` ; `author`: `string` ; `content`: \{ `[key: string]`: `string` \| `undefined`;  } ; `currentTime`: `bigint` ; `endEpoch`: `bigint` ; `endTime`: `bigint` ; `id`: `bigint` ; `proposalType`: [`ProposalType`](modules.md#proposaltype) ; `startEpoch`: `bigint` ; `startTime`: `bigint` ; `status`: [`ProposalStatus`](modules.md#proposalstatus) ; `tallyType`: [`TallyType`](modules.md#tallytype) ; `totalVotingPower`: `BigNumber`  } & \{ [VT in VoteType]: BigNumber }
+
+#### Defined in
+
+[proposals.ts:15](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L15)
+
+___
+
+### ProposalStatus
+
+Ƭ **ProposalStatus**: typeof [`proposalStatuses`](modules.md#proposalstatuses)[`number`]
+
+#### Defined in
+
+[proposals.ts:10](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L10)
+
+___
+
+### ProposalType
+
+Ƭ **ProposalType**: [`Default`](modules.md#default) \| [`DefaultWithWasm`](modules.md#defaultwithwasm) \| [`PgfSteward`](modules.md#pgfsteward) \| [`PgfPayment`](modules.md#pgfpayment)
+
+#### Defined in
+
+[proposals.ts:58](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L58)
+
+___
+
+### ProposalTypeString
+
+Ƭ **ProposalTypeString**: [`ProposalType`](modules.md#proposaltype)[``"type"``]
+
+#### Defined in
+
+[proposals.ts:60](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L60)
+
+___
+
+### RedelegateProps
+
+Ƭ **RedelegateProps**: [`RedelegateMsgValue`](classes/RedelegateMsgValue.md)
+
+#### Defined in
+
+[tx/types.ts:21](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/types.ts#L21)
+
+___
+
+### Schema
+
+Ƭ **Schema**: [`BatchTxResultMsgValue`](classes/BatchTxResultMsgValue.md) \| [`EthBridgeTransferMsgValue`](classes/EthBridgeTransferMsgValue.md) \| [`IbcTransferMsgValue`](classes/IbcTransferMsgValue.md) \| [`SignatureMsgValue`](classes/SignatureMsgValue.md) \| [`BondMsgValue`](classes/BondMsgValue.md) \| [`UnbondMsgValue`](classes/UnbondMsgValue.md) \| [`VoteProposalMsgValue`](classes/VoteProposalMsgValue.md) \| [`WithdrawMsgValue`](classes/WithdrawMsgValue.md) \| [`TransparentTransferMsgValue`](classes/TransparentTransferMsgValue.md) \| [`TxResponseMsgValue`](classes/TxResponseMsgValue.md) \| [`WrapperTxMsgValue`](classes/WrapperTxMsgValue.md) \| [`RedelegateMsgValue`](classes/RedelegateMsgValue.md)
+
+#### Defined in
+
+[tx/schema/index.ts:28](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/index.ts#L28)
+
+___
+
+### SignArbitraryProps
+
+Ƭ **SignArbitraryProps**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `data` | `string` |
+| `signer` | `string` |
+
+#### Defined in
+
+[namada.ts:5](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/namada.ts#L5)
+
+___
+
+### SignArbitraryResponse
+
+Ƭ **SignArbitraryResponse**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `hash` | `string` |
+| `signature` | `string` |
+
+#### Defined in
+
+[signer.ts:3](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/signer.ts#L3)
+
+___
+
+### SignProps
+
+Ƭ **SignProps**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `signer` | `string` |
+| `tx` | [`TxData`](modules.md#txdata) |
+| `txType` | `unknown` |
+| `wrapperTxMsg` | `Uint8Array` |
+
+#### Defined in
+
+[namada.ts:10](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/namada.ts#L10)
+
+___
+
+### SignatureProps
+
+Ƭ **SignatureProps**: [`SignatureMsgValue`](classes/SignatureMsgValue.md)
+
+#### Defined in
+
+[tx/types.ts:25](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/types.ts#L25)
+
+___
+
+### TallyType
+
+Ƭ **TallyType**: typeof [`tallyTypes`](modules.md#tallytypes)[`number`]
+
+#### Defined in
+
+[proposals.ts:99](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L99)
+
+___
+
+### TokenBalances
+
+Ƭ **TokenBalances**\<`T`\>: `Partial`\<`Record`\<`T`, `BigNumber`\>\>
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `string` = [`TokenType`](modules.md#tokentype) |
+
+#### Defined in
+
+[tokens/types.ts:19](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tokens/types.ts#L19)
+
+___
+
+### TokenInfo
+
+Ƭ **TokenInfo**\<`D`\>: `Object`
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `D` | extends `string` = `string` |
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `address` | `string` |
+| `coin` | `string` |
+| `coinGeckoId?` | `string` |
+| `decimals` | `number` |
+| `isNut?` | `boolean` |
+| `minDenom` | `D` |
+| `nativeAddress?` | `string` |
+| `path` | `number` |
+| `symbol` | `string` |
+| `type` | `number` |
+| `url?` | `string` |
+
+#### Defined in
+
+[tokens/types.ts:5](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tokens/types.ts#L5)
+
+___
+
+### TokenType
+
+Ƭ **TokenType**: typeof [`Symbols`](modules.md#symbols)[`number`]
+
+#### Defined in
+
+[tokens/Namada.ts:21](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tokens/Namada.ts#L21)
+
+___
+
+### TransparentTransferProps
+
+Ƭ **TransparentTransferProps**: [`TransparentTransferMsgValue`](classes/TransparentTransferMsgValue.md)
+
+#### Defined in
+
+[tx/types.ts:22](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/types.ts#L22)
+
+___
+
+### TxData
+
+Ƭ **TxData**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `signingDataBytes` | `Uint8Array` |
+| `txBytes` | `Uint8Array` |
+
+#### Defined in
+
+[signer.ts:8](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/signer.ts#L8)
+
+___
+
+### TxResponseProps
+
+Ƭ **TxResponseProps**: [`TxResponseMsgValue`](classes/TxResponseMsgValue.md)
+
+#### Defined in
+
+[tx/types.ts:23](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/types.ts#L23)
+
+___
+
+### UnbondProps
+
+Ƭ **UnbondProps**: [`UnbondMsgValue`](classes/UnbondMsgValue.md)
+
+#### Defined in
+
+[tx/types.ts:19](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/types.ts#L19)
+
+___
+
+### ValidatorVote
+
+Ƭ **ValidatorVote**: \{ `isValidator`: ``true`` ; `votingPower`: `BigNumber`  } & `VoteCommonProperties`
+
+#### Defined in
+
+[proposals.ts:75](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L75)
+
+___
+
+### VerifyArbitraryProps
+
+Ƭ **VerifyArbitraryProps**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `hash` | `string` |
+| `publicKey` | `string` |
+| `signature` | `string` |
+
+#### Defined in
+
+[namada.ts:17](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/namada.ts#L17)
+
+___
+
+### Vote
+
+Ƭ **Vote**: [`DelegatorVote`](modules.md#delegatorvote) \| [`ValidatorVote`](modules.md#validatorvote)
+
+#### Defined in
+
+[proposals.ts:91](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L91)
+
+___
+
+### VoteProposalProps
+
+Ƭ **VoteProposalProps**: [`VoteProposalMsgValue`](classes/VoteProposalMsgValue.md)
+
+#### Defined in
+
+[tx/types.ts:26](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/types.ts#L26)
+
+___
+
+### VoteType
+
+Ƭ **VoteType**: typeof [`voteTypes`](modules.md#votetypes)[`number`]
+
+#### Defined in
+
+[proposals.ts:63](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L63)
+
+___
+
+### Votes
+
+Ƭ **Votes**: `Record`\<[`VoteType`](modules.md#votetype), `BigNumber`\>
+
+#### Defined in
+
+[proposals.ts:68](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L68)
+
+___
+
+### WindowWithNamada
+
+Ƭ **WindowWithNamada**: `Window` & typeof `globalThis` & \{ `namada`: [`Namada`](interfaces/Namada.md) & \{ `getSigner`: () => [`Signer`](interfaces/Signer.md)  }  }
+
+#### Defined in
+
+[namada.ts:42](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/namada.ts#L42)
+
+___
+
+### WithdrawProps
+
+Ƭ **WithdrawProps**: [`WithdrawMsgValue`](classes/WithdrawMsgValue.md)
+
+#### Defined in
+
+[tx/types.ts:20](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/types.ts#L20)
+
+___
+
+### WrapperTxProps
+
+Ƭ **WrapperTxProps**: [`WrapperTxMsgValue`](classes/WrapperTxMsgValue.md)
+
+#### Defined in
+
+[tx/types.ts:17](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/types.ts#L17)
+
+## Variables
+
+### BigNumberSerializer
+
+• `Const` **BigNumberSerializer**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `deserialize` | (`reader`: `BinaryReader`) => `BigNumber` |
+| `serialize` | (`value`: `BigNumber`, `writer`: `BinaryWriter`) => `void` |
+
+#### Defined in
+
+[tx/schema/utils.ts:4](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tx/schema/utils.ts#L4)
+
+___
+
+### CosmosSymbols
+
+• `Const` **CosmosSymbols**: readonly [``"ATOM"``, ``"OSMO"``]
+
+#### Defined in
+
+[tokens/Cosmos.ts:5](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tokens/Cosmos.ts#L5)
+
+___
+
+### CosmosTokens
+
+• `Const` **CosmosTokens**: `Record`\<[`CosmosTokenType`](modules.md#cosmostokentype), [`TokenInfo`](modules.md#tokeninfo)\<[`CosmosMinDenom`](modules.md#cosmosmindenom)\>\>
+
+#### Defined in
+
+[tokens/Cosmos.ts:22](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tokens/Cosmos.ts#L22)
+
+___
+
+### Extensions
+
+• `Const` **Extensions**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `keplr` | \{ `alias`: `string` = "Keplr"; `id`: ``"keplr"`` = "keplr"; `url`: `string` = "https://www.keplr.app/" } |
+| `keplr.alias` | `string` |
+| `keplr.id` | ``"keplr"`` |
+| `keplr.url` | `string` |
+| `metamask` | \{ `alias`: `string` = "Metamask"; `id`: ``"metamask"`` = "metamask"; `url`: `string` = "https://metamask.io/" } |
+| `metamask.alias` | `string` |
+| `metamask.id` | ``"metamask"`` |
+| `metamask.url` | `string` |
+| `namada` | \{ `alias`: `string` = "Namada"; `id`: ``"namada"`` = "namada"; `url`: `string` = "https://namada.me" } |
+| `namada.alias` | `string` |
+| `namada.id` | ``"namada"`` |
+| `namada.url` | `string` |
+
+#### Defined in
+
+[chain.ts:30](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/chain.ts#L30)
+
+___
+
+### Symbols
+
+• `Const` **Symbols**: readonly [``"NAM"``, ``"BTC"``, ``"DOT"``, ``"ETH"``, ``"SCH"``, ``"APF"``, ``"KAR"``]
+
+#### Defined in
+
+[tokens/Namada.ts:11](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tokens/Namada.ts#L11)
+
+___
+
+### Tokens
+
+• `Const` **Tokens**: `Record`\<[`TokenType`](modules.md#tokentype), [`TokenInfo`](modules.md#tokeninfo)\>
+
+#### Defined in
+
+[tokens/Namada.ts:23](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tokens/Namada.ts#L23)
+
+___
+
+### proposalStatuses
+
+• `Const` **proposalStatuses**: readonly [``"pending"``, ``"ongoing"``, ``"passed"``, ``"rejected"``]
+
+#### Defined in
+
+[proposals.ts:3](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L3)
+
+___
+
+### tallyTypes
+
+• `Const` **tallyTypes**: readonly [``"two-thirds"``, ``"one-half-over-one-third"``, ``"less-one-half-over-one-third-nay"``]
+
+#### Defined in
+
+[proposals.ts:93](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L93)
+
+___
+
+### voteTypes
+
+• `Const` **voteTypes**: readonly [``"yay"``, ``"nay"``, ``"abstain"``]
+
+#### Defined in
+
+[proposals.ts:62](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L62)
+
+## Functions
+
+### isDelegatorVote
+
+▸ **isDelegatorVote**(`vote`): vote is DelegatorVote
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `vote` | [`Vote`](modules.md#vote) |
+
+#### Returns
+
+vote is DelegatorVote
+
+#### Defined in
+
+[proposals.ts:88](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L88)
+
+___
+
+### isProposalStatus
+
+▸ **isProposalStatus**(`str`): str is "pending" \| "ongoing" \| "passed" \| "rejected"
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `str` | `string` |
+
+#### Returns
+
+str is "pending" \| "ongoing" \| "passed" \| "rejected"
+
+#### Defined in
+
+[proposals.ts:12](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L12)
+
+___
+
+### isTallyType
+
+▸ **isTallyType**(`tallyType`): tallyType is "two-thirds" \| "one-half-over-one-third" \| "less-one-half-over-one-third-nay"
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `tallyType` | `string` |
+
+#### Returns
+
+tallyType is "two-thirds" \| "one-half-over-one-third" \| "less-one-half-over-one-third-nay"
+
+#### Defined in
+
+[proposals.ts:101](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L101)
+
+___
+
+### isValidatorVote
+
+▸ **isValidatorVote**(`vote`): vote is ValidatorVote
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `vote` | [`Vote`](modules.md#vote) |
+
+#### Returns
+
+vote is ValidatorVote
+
+#### Defined in
+
+[proposals.ts:80](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L80)
+
+___
+
+### isVoteType
+
+▸ **isVoteType**(`str`): str is "yay" \| "nay" \| "abstain"
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `str` | `string` |
+
+#### Returns
+
+str is "yay" \| "nay" \| "abstain"
+
+#### Defined in
+
+[proposals.ts:65](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/proposals.ts#L65)
+
+___
+
+### minDenomByToken
+
+▸ **minDenomByToken**(`token`): `undefined` \| ``"uatom"`` \| ``"uosmo"``
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `token` | `string` |
+
+#### Returns
+
+`undefined` \| ``"uatom"`` \| ``"uosmo"``
+
+#### Defined in
+
+[tokens/Cosmos.ts:66](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tokens/Cosmos.ts#L66)
+
+___
+
+### tokenByMinDenom
+
+▸ **tokenByMinDenom**(`minDenom`): `undefined` \| ``"ATOM"`` \| ``"OSMO"``
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `minDenom` | `string` |
+
+#### Returns
+
+`undefined` \| ``"ATOM"`` \| ``"OSMO"``
+
+#### Defined in
+
+[tokens/Cosmos.ts:48](https://github.com/anoma/namada-interface/blob/52e59b9f/packages/types/src/tokens/Cosmos.ts#L48)

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "prepublish": "yarn && yarn build",
     "build": "rimraf ./dist && tsc --build",
+    "build:docs": "typedoc --plugin typedoc-plugin-markdown --out docs src/index.ts",
     "release": "yarn prepublish && release-it --verbose --ci",
     "release:dry-run": "yarn prepublish && release-it --verbose --dry-run --ci",
     "release:no-npm": "yarn prepublish && release-it --verbose --no-npm.publish",
@@ -33,7 +34,9 @@
     "eslint-plugin-react": "^7.33.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "release-it": "^17.0.1",
-    "rimraf": "^5.0.5"
+    "rimraf": "^5.0.5",
+    "typedoc": "^0.25.12",
+    "typedoc-plugin-markdown": "^3.17.1"
   },
   "files": [
     "dist"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8567,6 +8567,8 @@ __metadata:
     release-it: "npm:^17.0.1"
     rimraf: "npm:^5.0.5"
     slip44: "npm:^3.0.11"
+    typedoc: "npm:^0.25.12"
+    typedoc-plugin-markdown: "npm:^3.17.1"
     typescript: "npm:^5.1.3"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Relates to #917 

- [x] Add docs build (`typedoc`) to `packages/types`
- [x] Update `README.md` (this was very out-of-date, did some updates but mostly removed text)
- [x] Generate markdown docs and add to repo