### PR TITLE
feat/891: Adding info to broadcast Tx response

### DIFF
--- a/packages/types/src/tx/schema/batchTxResult.ts
+++ b/packages/types/src/tx/schema/batchTxResult.ts
@@ -6,9 +6,6 @@ export class BatchTxResultMsgValue {
   @field({ type: "string" })
   hash!: string;
 
-  @field({ type: "string" })
-  gasUsed!: string;
-
   @field({ type: "bool" })
   isApplied!: string;
 

--- a/packages/types/src/tx/schema/txResponse.ts
+++ b/packages/types/src/tx/schema/txResponse.ts
@@ -5,13 +5,25 @@ import { BatchTxResultMsgValue } from "./batchTxResult";
 
 export class TxResponseMsgValue {
   @field({ type: "string" })
-  hash!: string;
+  code!: string;
+
+  @field({ type: vec(BatchTxResultMsgValue) })
+  commitments!: BatchTxResultMsgValue[];
 
   @field({ type: "string" })
   gasUsed!: string;
 
-  @field({ type: vec(BatchTxResultMsgValue) })
-  commitments!: BatchTxResultMsgValue[];
+  @field({ type: "string" })
+  hash!: string;
+
+  @field({ type: "string" })
+  height!: string;
+
+  @field({ type: "string" })
+  info!: string;
+
+  @field({ type: "string" })
+  log!: string;
 
   constructor(data: TxResponseProps) {
     Object.assign(this, data);


### PR DESCRIPTION
Resolves #891 

This adds the remaining details in the `ProcessTxResponse::Applied(resp)`, so the result of `rpc.broadcastTx()` can return this data to the client.

- [x] Invoking `rpc.broadcastTx` should return an object containing details of the `TxResponse`, as well as applied status of each commitment

### Testing

- In `apps/namadillo/src/lib/query.ts`, when invoking `rpc.broadcastTx()`, assign response to a variable and log it (the interface currently doesn't do anything with this data, but we will likely want to, at least to display `gasUsed` & `height`)