### PR TITLE
Namadillo: Add proposals table pagination, fix pagination bugs

### DIFF
--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "@anomaorg/namada-indexer-client": "0.0.15",
+    "@anomaorg/namada-indexer-client": "0.0.17",
     "@cosmjs/encoding": "^0.32.3",
     "@tailwindcss/container-queries": "^0.1.1",
     "@tanstack/react-query": "^5.40.0",

--- a/apps/namadillo/src/App/Staking/ValidatorsTable.tsx
+++ b/apps/namadillo/src/App/Staking/ValidatorsTable.tsx
@@ -28,6 +28,8 @@ export const ValidatorsTable = ({
   initialPage = 0,
   tableClassName,
 }: ValidatorsTableProps): JSX.Element => {
+  const [page, setPage] = useState(initialPage);
+
   const [selectedValidator, setSelectedValidator] = useState<
     Validator | undefined
   >();
@@ -62,14 +64,26 @@ export const ValidatorsTable = ({
     [renderRow, setSelectedValidator]
   );
 
+  useEffect(() => {
+    setPage(0);
+  }, [validatorList]);
+
+  const paginatedItems = validatorList.slice(
+    page * resultsPerPage,
+    page * resultsPerPage + resultsPerPage
+  );
+
+  const pageCount = Math.ceil(validatorList.length / resultsPerPage);
+
   return (
     <TableWithPaginator
       id={id}
       headers={headers.concat("")}
       renderRow={mapValidatorRow}
-      itemList={validatorList}
-      resultsPerPage={resultsPerPage}
-      initialPage={initialPage}
+      itemList={paginatedItems}
+      page={page}
+      pageCount={pageCount}
+      onPageChange={setPage}
       tableProps={{
         className: twMerge(
           "w-full flex-1 [&_td]:px-1 [&_th]:px-1 [&_td:first-child]:pl-4 [&_td]:h-[64px]",

--- a/apps/namadillo/src/atoms/proposals/atoms.ts
+++ b/apps/namadillo/src/atoms/proposals/atoms.ts
@@ -17,6 +17,7 @@ import { GasConfig } from "types";
 import {
   createVoteProposalTx,
   fetchAllProposals,
+  fetchPaginatedProposals,
   fetchProposalById,
   fetchVotedProposalIds,
 } from "./functions";
@@ -134,9 +135,9 @@ export const allProposalsAtom = atomWithQuery((get) => {
   };
 });
 
-// TODO: this is a bad way to filter/search
-export const allProposalsFamily = atomFamily(
+export const paginatedProposalsFamily = atomFamily(
   (options?: {
+    page?: number;
     status?: ProposalStatus;
     type?: ProposalTypeString;
     search?: string;
@@ -146,14 +147,16 @@ export const allProposalsFamily = atomFamily(
 
       return {
         queryKey: [
-          "all-proposals",
+          "paginated-proposals",
+          options?.page,
           options?.status,
           options?.type,
           options?.search,
         ],
         queryFn: () =>
-          fetchAllProposals(
+          fetchPaginatedProposals(
             api,
+            options?.page,
             options?.status,
             options?.type,
             options?.search
@@ -161,7 +164,11 @@ export const allProposalsFamily = atomFamily(
       };
     }),
   (a, b) =>
-    a?.status === b?.status && a?.type === b?.type && a?.search === b?.search
+    // TODO: there might be a better way to do this equality check
+    a?.page === b?.page &&
+    a?.status === b?.status &&
+    a?.type === b?.type &&
+    a?.search === b?.search
 );
 
 export const votedProposalIdsAtom = atomWithQuery((get) => {

--- a/apps/namadillo/src/atoms/validators/services.ts
+++ b/apps/namadillo/src/atoms/validators/services.ts
@@ -31,12 +31,11 @@ export const fetchAllValidators = async (
 ): Promise<Validator[]> => {
   const epochInfo = chainParameters.epochInfo;
   const nominalApr = chainParameters.apr;
-  const validatorsResponse = await api.apiV1PosValidatorGet(1, [
+  const validatorsResponse = await api.apiV1PosValidatorAllGet([
     IndexerValidatorStatus.Consensus,
   ]);
 
-  // TODO: rename one data to items?
-  const validators = validatorsResponse.data.data;
+  const validators = validatorsResponse.data;
   return validators.map((v) =>
     toValidator(v, votingPower, epochInfo, nominalApr)
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,12 +45,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@anomaorg/namada-indexer-client@npm:0.0.15":
-  version: 0.0.15
-  resolution: "@anomaorg/namada-indexer-client@npm:0.0.15"
+"@anomaorg/namada-indexer-client@npm:0.0.17":
+  version: 0.0.17
+  resolution: "@anomaorg/namada-indexer-client@npm:0.0.17"
   dependencies:
     axios: "npm:^0.21.1"
-  checksum: af42db9c2ad99e378327b1f569c150c53757c569a3ad046c212227d1fb11b3ced7c4be62f707806dedea4804137eebe2fdb5ab232a10990447502b2469c99b91
+  checksum: 315c907867c8c84e04cafb24efce9c38aa22717f78d4965637ccd8477ad9af3ee312098d5cf621bd9003147017568ea8ea5aa064b91455bb196b66a46ce3c8c5
   languageName: node
   linkType: hard
 
@@ -8429,7 +8429,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@namada/namadillo@workspace:apps/namadillo"
   dependencies:
-    "@anomaorg/namada-indexer-client": "npm:0.0.15"
+    "@anomaorg/namada-indexer-client": "npm:0.0.17"
     "@cosmjs/encoding": "npm:^0.32.3"
     "@playwright/test": "npm:^1.24.1"
     "@release-it/keep-a-changelog": "npm:^5.0.0"


### PR DESCRIPTION
Note for testing: Needs the latest version of namada-indexer including https://github.com/anoma/namada-indexer/pull/75.

---

### Changed
- Bump indexer to 0.0.17 to get the all proposals endpoint.
- Refactor TableWithPaginator to not create its own pages. It now just receives pages of items and lets its parent handle creating pages.

### Added
- Add pagination to the All Proposals table.

### Fixed
- Fix proposal count by counting all proposals, not just one page of proposals. These numbers are shown on the right panel of the Governance page under "Total Proposals", "Proposals in Voting Period" etc.
- Fetch all validators, not just the first page.