### PR TITLE
Sdk: add claim rewards

### DIFF
--- a/apps/extension/src/Approvals/Commitment.tsx
+++ b/apps/extension/src/Approvals/Commitment.tsx
@@ -32,6 +32,7 @@ const IconMap: Record<TxType, React.ReactNode> = {
   [TxType.EthBridgeTransfer]: <FaWallet />,
   [TxType.VoteProposal]: <FaVoteYea />,
   [TxType.Batch]: <PiDotsNineBold />,
+  [TxType.ClaimRewards]: <GoStack />,
 };
 
 const TitleMap: Record<TxType, string> = {
@@ -45,6 +46,7 @@ const TitleMap: Record<TxType, string> = {
   [TxType.EthBridgeTransfer]: "ETH Transfer",
   [TxType.VoteProposal]: "Vote",
   [TxType.Batch]: "Batch",
+  [TxType.ClaimRewards]: "Claim Rewards",
 };
 
 const formatAddress = (address: string): string =>

--- a/apps/namadillo/src/App/Governance/AllProposalsTable.tsx
+++ b/apps/namadillo/src/App/Governance/AllProposalsTable.tsx
@@ -10,7 +10,12 @@ import { useAtomValue } from "jotai";
 import { useEffect, useState } from "react";
 import { GoCheckCircleFill, GoInfo } from "react-icons/go";
 import { useNavigate } from "react-router-dom";
-import { showProposalStatus, showProposalTypeString } from "utils";
+import {
+  proposalStatusToString,
+  proposalTypeStringToString,
+  secondsToDateString,
+  secondsToTimeString,
+} from "utils";
 import { StatusLabel, TypeLabel } from "./ProposalLabels";
 import GovernanceRoutes from "./routes";
 
@@ -171,7 +176,7 @@ export const AllProposalsTable: React.FC<ExtensionConnectedProps> = (props) => {
               id: status,
               value: (
                 <TableSelectOption>
-                  {showProposalStatus(status)}
+                  {proposalStatusToString(status)}
                 </TableSelectOption>
               ),
               ariaLabel: status,
@@ -207,7 +212,7 @@ export const AllProposalsTable: React.FC<ExtensionConnectedProps> = (props) => {
               id: type,
               value: (
                 <TableSelectOption>
-                  {showProposalTypeString(type)}
+                  {proposalTypeStringToString(type)}
                 </TableSelectOption>
               ),
               ariaLabel: type,
@@ -299,6 +304,9 @@ const Status: React.FC<CellProps> = ({ proposal }) => (
   <StatusLabel status={proposal.status} className="ml-auto" />
 );
 
-const VotingEnd: React.FC<CellProps> = ({ proposal }) => (
-  <div className="text-right">Epoch {proposal.endEpoch.toString()}</div>
+const VotingEnd: React.FC<CellProps> = ({ proposal: { endTime } }) => (
+  <div className="text-right">
+    <div>{secondsToTimeString(endTime)}</div>
+    <div className="text-neutral-450">{secondsToDateString(endTime)}</div>
+  </div>
 );

--- a/apps/namadillo/src/App/Governance/LiveGovernanceProposals.tsx
+++ b/apps/namadillo/src/App/Governance/LiveGovernanceProposals.tsx
@@ -4,6 +4,7 @@ import BigNumber from "bignumber.js";
 import clsx from "clsx";
 import { GoInfo } from "react-icons/go";
 import { useNavigate } from "react-router-dom";
+import { secondsToDateTimeString } from "utils";
 import { StatusLabel, TypeLabel, VotedLabel } from "./ProposalLabels";
 import GovernanceRoutes from "./routes";
 import { colors } from "./types";
@@ -41,7 +42,7 @@ const ProposalListItem: React.FC<{
       <div className="flex items-center justify-between gap-4">
         <StatusLabel className="text-[10px] min-w-38" status={status} />
         <div className="text-xs text-neutral-400">
-          Voting End on epoch {proposal.endEpoch.toString()}
+          Voting End on {secondsToDateTimeString(proposal.endTime)}
         </div>
       </div>
       <div className="flex items-center justify-between gap-4">

--- a/apps/namadillo/src/App/Governance/ProposalLabels.tsx
+++ b/apps/namadillo/src/App/Governance/ProposalLabels.tsx
@@ -3,7 +3,7 @@ import { ProposalStatus, ProposalType } from "@namada/types";
 import { assertNever } from "@namada/utils";
 import { GoCheckCircleFill } from "react-icons/go";
 import { twMerge } from "tailwind-merge";
-import { showProposalStatus, showProposalTypeString } from "utils";
+import { proposalStatusToString, proposalTypeStringToString } from "utils";
 
 export const StatusLabel: React.FC<
   {
@@ -19,7 +19,7 @@ export const StatusLabel: React.FC<
 
   return (
     <RoundedLabel className={twMerge(className, statusClassName)} {...rest}>
-      {showProposalStatus(status)}
+      {proposalStatusToString(status)}
     </RoundedLabel>
   );
 };
@@ -50,6 +50,6 @@ export const TypeLabel: React.FC<
   } & React.ComponentProps<typeof InsetLabel>
 > = ({ proposalType, ...rest }) => (
   <InsetLabel className="text-xs leading-[1.65em]" {...rest}>
-    {showProposalTypeString(proposalType.type)}
+    {proposalTypeStringToString(proposalType.type)}
   </InsetLabel>
 );

--- a/apps/namadillo/src/App/Governance/VoteInfoCards.tsx
+++ b/apps/namadillo/src/App/Governance/VoteInfoCards.tsx
@@ -6,7 +6,7 @@ import { AddRemove, PgfActions } from "@namada/types";
 
 import { proposalFamilyPersist, StoredProposal } from "atoms/proposals";
 import { useAtomValue } from "jotai";
-import { showEpoch } from "utils";
+import { epochToString, secondsToDateTimeString } from "utils";
 
 const InfoCard: React.FC<
   {
@@ -120,17 +120,17 @@ const Loaded: React.FC<{
     <>
       <InfoCard
         title="Voting Start"
-        content={showEpoch(proposal.startEpoch)}
+        content={secondsToDateTimeString(proposal.startTime)}
         className="col-span-2"
       />
       <InfoCard
         title="Voting End"
-        content={showEpoch(proposal.endEpoch)}
+        content={secondsToDateTimeString(proposal.endTime)}
         className="col-span-2"
       />
       <InfoCard
         title="Activation Epoch"
-        content={showEpoch(proposal.activationEpoch)}
+        content={epochToString(proposal.activationEpoch)}
         className="col-span-2"
       />
       <InfoCard

--- a/apps/namadillo/src/utils/index.ts
+++ b/apps/namadillo/src/utils/index.ts
@@ -1,7 +1,9 @@
 import { ProposalStatus, ProposalTypeString } from "@namada/types";
+import * as fns from "date-fns";
+import { DateTime } from "luxon";
 import { EventData, TransactionEvent } from "types/events";
 
-export const showProposalStatus = (status: ProposalStatus): string => {
+export const proposalStatusToString = (status: ProposalStatus): string => {
   const statusText: Record<ProposalStatus, string> = {
     pending: "Upcoming",
     ongoing: "Ongoing",
@@ -12,7 +14,9 @@ export const showProposalStatus = (status: ProposalStatus): string => {
   return statusText[status];
 };
 
-export const showProposalTypeString = (type: ProposalTypeString): string => {
+export const proposalTypeStringToString = (
+  type: ProposalTypeString
+): string => {
   const typeText: Record<ProposalTypeString, string> = {
     default: "Default",
     default_with_wasm: "Default with Wasm",
@@ -23,9 +27,10 @@ export const showProposalTypeString = (type: ProposalTypeString): string => {
   return typeText[type];
 };
 
-export const showEpoch = (epoch: bigint): string => `Epoch ${epoch.toString()}`;
+export const epochToString = (epoch: bigint): string =>
+  `Epoch ${epoch.toString()}`;
 
-export const showProposalId = (proposalId: bigint): string =>
+export const proposalIdToString = (proposalId: bigint): string =>
   `#${proposalId.toString()}`;
 
 export const addTransactionEvent = <T>(
@@ -33,4 +38,50 @@ export const addTransactionEvent = <T>(
   callback: (e: EventData<T>) => void
 ): void => {
   window.addEventListener(handle, callback as EventListener, false);
+};
+
+const secondsToDateTime = (seconds: bigint): DateTime =>
+  DateTime.fromSeconds(Number(seconds));
+
+export const secondsToTimeString = (seconds: bigint): string =>
+  secondsToDateTime(seconds).toLocaleString(DateTime.TIME_24_SIMPLE);
+
+export const secondsToDateString = (seconds: bigint): string =>
+  secondsToDateTime(seconds).toLocaleString(DateTime.DATE_MED);
+
+export const secondsToDateTimeString = (seconds: bigint): string =>
+  `${secondsToDateString(seconds)}, ${secondsToTimeString(seconds)}`;
+
+export const secondsToTimeRemainingString = (
+  startTimeInSeconds: bigint,
+  endTimeInSeconds: bigint
+): string => {
+  if (endTimeInSeconds < startTimeInSeconds) {
+    throw new Error(
+      `endTimeInSeconds ${endTimeInSeconds} is before startTimeInSeconds ${startTimeInSeconds}`
+    );
+  }
+
+  const toMilliNumber = (n: bigint): number =>
+    fns.secondsToMilliseconds(Number(n));
+  const interval = {
+    start: toMilliNumber(startTimeInSeconds),
+    end: toMilliNumber(endTimeInSeconds),
+  };
+  const format: fns.DurationUnit[] = ["days", "hours", "minutes"];
+  const timeLeft = fns.intervalToDuration(interval);
+  const formatted = fns.formatDuration(timeLeft, {
+    format,
+    zero: true,
+    delimiter: ": ",
+  });
+
+  if (formatted === "") {
+    return "< 1 Min";
+  }
+
+  return formatted
+    .replace("day", "Day")
+    .replace("hour", "Hr")
+    .replace("minute", "Min");
 };

--- a/packages/sdk/docs/classes/BuiltTx.md
+++ b/packages/sdk/docs/classes/BuiltTx.md
@@ -39,7 +39,7 @@
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:71
+shared/src/shared/shared.d.ts:72
 
 ## Methods
 
@@ -53,7 +53,7 @@ shared/src/shared/shared.d.ts:71
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:64
+shared/src/shared/shared.d.ts:65
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:87
+shared/src/shared/shared.d.ts:88
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:75
+shared/src/shared/shared.d.ts:76
 
 ___
 
@@ -95,7 +95,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:79
+shared/src/shared/shared.d.ts:80
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:83
+shared/src/shared/shared.d.ts:84
 
 ___
 
@@ -123,7 +123,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:91
+shared/src/shared/shared.d.ts:92
 
 ___
 
@@ -137,4 +137,4 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:95
+shared/src/shared/shared.d.ts:96

--- a/packages/sdk/docs/classes/Crypto.md
+++ b/packages/sdk/docs/classes/Crypto.md
@@ -40,7 +40,7 @@ Class Crypto handles AES encryption tasks
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/crypto/crypto.ts#L20)
+[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/crypto/crypto.ts#L20)
 
 ## Properties
 
@@ -52,7 +52,7 @@ WebAssembly Memory for crypto
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/crypto/crypto.ts#L20)
+[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/crypto/crypto.ts#L20)
 
 ## Methods
 
@@ -75,7 +75,7 @@ decrypted text
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:115](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/crypto/crypto.ts#L115)
+[sdk/src/crypto/crypto.ts:115](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/crypto/crypto.ts#L115)
 
 ___
 
@@ -100,7 +100,7 @@ crypto record
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:61](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/crypto/crypto.ts#L61)
+[sdk/src/crypto/crypto.ts:61](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/crypto/crypto.ts#L61)
 
 ___
 
@@ -126,7 +126,7 @@ array of encrypted bytes
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:98](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/crypto/crypto.ts#L98)
+[sdk/src/crypto/crypto.ts:98](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/crypto/crypto.ts#L98)
 
 ___
 
@@ -153,7 +153,7 @@ crypto record used for storage
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:30](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/crypto/crypto.ts#L30)
+[sdk/src/crypto/crypto.ts:30](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/crypto/crypto.ts#L30)
 
 ___
 
@@ -178,4 +178,4 @@ encryption parameters
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:73](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/crypto/crypto.ts#L73)
+[sdk/src/crypto/crypto.ts:73](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/crypto/crypto.ts#L73)

--- a/packages/sdk/docs/classes/EncodedTx.md
+++ b/packages/sdk/docs/classes/EncodedTx.md
@@ -42,7 +42,7 @@ Create an EncodedTx class
 
 #### Defined in
 
-[sdk/src/tx/types.ts:12](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/types.ts#L12)
+[sdk/src/tx/types.ts:12](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/types.ts#L12)
 
 ## Properties
 
@@ -54,7 +54,7 @@ Specific tx struct instance
 
 #### Defined in
 
-[sdk/src/tx/types.ts:14](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/types.ts#L14)
+[sdk/src/tx/types.ts:14](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/types.ts#L14)
 
 ___
 
@@ -66,7 +66,7 @@ Borsh-serialized wrapper tx args
 
 #### Defined in
 
-[sdk/src/tx/types.ts:13](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/types.ts#L13)
+[sdk/src/tx/types.ts:13](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/types.ts#L13)
 
 ## Methods
 
@@ -82,7 +82,7 @@ Clear tx bytes resource
 
 #### Defined in
 
-[sdk/src/tx/types.ts:39](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/types.ts#L39)
+[sdk/src/tx/types.ts:39](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/types.ts#L39)
 
 ___
 
@@ -100,7 +100,7 @@ string of tx hash
 
 #### Defined in
 
-[sdk/src/tx/types.ts:32](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/types.ts#L32)
+[sdk/src/tx/types.ts:32](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/types.ts#L32)
 
 ___
 
@@ -119,4 +119,4 @@ Serialized tx bytes
 
 #### Defined in
 
-[sdk/src/tx/types.ts:22](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/types.ts#L22)
+[sdk/src/tx/types.ts:22](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/types.ts#L22)

--- a/packages/sdk/docs/classes/Ledger.md
+++ b/packages/sdk/docs/classes/Ledger.md
@@ -42,7 +42,7 @@ Functionality for interacting with NamadaApp for Ledger Hardware Wallets
 
 #### Defined in
 
-[sdk/src/ledger.ts:54](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/ledger.ts#L54)
+[sdk/src/ledger.ts:54](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/ledger.ts#L54)
 
 ## Properties
 
@@ -54,7 +54,7 @@ Inititalized NamadaApp class from Zondax package
 
 #### Defined in
 
-[sdk/src/ledger.ts:54](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/ledger.ts#L54)
+[sdk/src/ledger.ts:54](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/ledger.ts#L54)
 
 ## Methods
 
@@ -75,7 +75,7 @@ void
 
 #### Defined in
 
-[sdk/src/ledger.ts:176](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/ledger.ts#L176)
+[sdk/src/ledger.ts:176](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/ledger.ts#L176)
 
 ___
 
@@ -102,7 +102,7 @@ Address and public key
 
 #### Defined in
 
-[sdk/src/ledger.ts:97](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/ledger.ts#L97)
+[sdk/src/ledger.ts:97](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/ledger.ts#L97)
 
 ___
 
@@ -123,7 +123,7 @@ Error message if error is found
 
 #### Defined in
 
-[sdk/src/ledger.ts:159](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/ledger.ts#L159)
+[sdk/src/ledger.ts:159](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/ledger.ts#L159)
 
 ___
 
@@ -150,7 +150,7 @@ Address and public key
 
 #### Defined in
 
-[sdk/src/ledger.ts:118](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/ledger.ts#L118)
+[sdk/src/ledger.ts:118](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/ledger.ts#L118)
 
 ___
 
@@ -178,7 +178,7 @@ Response signature
 
 #### Defined in
 
-[sdk/src/ledger.ts:144](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/ledger.ts#L144)
+[sdk/src/ledger.ts:144](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/ledger.ts#L144)
 
 ___
 
@@ -199,7 +199,7 @@ Version and info of NamadaApp
 
 #### Defined in
 
-[sdk/src/ledger.ts:80](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/ledger.ts#L80)
+[sdk/src/ledger.ts:80](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/ledger.ts#L80)
 
 ___
 
@@ -225,4 +225,4 @@ Ledger class instance
 
 #### Defined in
 
-[sdk/src/ledger.ts:62](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/ledger.ts#L62)
+[sdk/src/ledger.ts:62](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/ledger.ts#L62)

--- a/packages/sdk/docs/classes/Masp.md
+++ b/packages/sdk/docs/classes/Masp.md
@@ -41,7 +41,7 @@ Class representing utilities related to MASP
 
 #### Defined in
 
-[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/masp.ts#L10)
+[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/masp.ts#L10)
 
 ## Properties
 
@@ -53,7 +53,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/masp.ts#L10)
+[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/masp.ts#L10)
 
 ## Methods
 
@@ -80,7 +80,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:69](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/masp.ts#L69)
+[sdk/src/masp.ts:69](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/masp.ts#L69)
 
 ___
 
@@ -107,7 +107,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:47](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/masp.ts#L47)
+[sdk/src/masp.ts:47](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/masp.ts#L47)
 
 ___
 
@@ -134,7 +134,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:58](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/masp.ts#L58)
+[sdk/src/masp.ts:58](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/masp.ts#L58)
 
 ___
 
@@ -154,7 +154,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:26](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/masp.ts#L26)
+[sdk/src/masp.ts:26](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/masp.ts#L26)
 
 ___
 
@@ -174,7 +174,7 @@ True if MASP parameters are loaded
 
 #### Defined in
 
-[sdk/src/masp.ts:17](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/masp.ts#L17)
+[sdk/src/masp.ts:17](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/masp.ts#L17)
 
 ___
 
@@ -200,4 +200,4 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:36](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/masp.ts#L36)
+[sdk/src/masp.ts:36](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/masp.ts#L36)

--- a/packages/sdk/docs/classes/Mnemonic.md
+++ b/packages/sdk/docs/classes/Mnemonic.md
@@ -38,7 +38,7 @@ Class for accessing mnemonic functionality from wasm
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/mnemonic.ts#L18)
+[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/mnemonic.ts#L18)
 
 ## Properties
 
@@ -50,7 +50,7 @@ Memory accessor for crypto lib
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/mnemonic.ts#L18)
+[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/mnemonic.ts#L18)
 
 ## Methods
 
@@ -76,7 +76,7 @@ Promise that resolves to array of words
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:26](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/mnemonic.ts#L26)
+[sdk/src/mnemonic.ts:26](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/mnemonic.ts#L26)
 
 ___
 
@@ -101,7 +101,7 @@ Seed bytes
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:44](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/mnemonic.ts#L44)
+[sdk/src/mnemonic.ts:44](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/mnemonic.ts#L44)
 
 ___
 
@@ -131,4 +131,4 @@ Object with validation result and error message if invalid
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:62](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/mnemonic.ts#L62)
+[sdk/src/mnemonic.ts:62](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/mnemonic.ts#L62)

--- a/packages/sdk/docs/classes/Rpc.md
+++ b/packages/sdk/docs/classes/Rpc.md
@@ -51,7 +51,7 @@ API for executing RPC requests with Namada
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:31](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/rpc.ts#L31)
+[sdk/src/rpc/rpc.ts:31](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/rpc.ts#L31)
 
 ## Properties
 
@@ -63,7 +63,7 @@ Instance of Query struct from wasm lib
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:33](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/rpc.ts#L33)
+[sdk/src/rpc/rpc.ts:33](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/rpc.ts#L33)
 
 ___
 
@@ -75,7 +75,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:32](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/rpc.ts#L32)
+[sdk/src/rpc/rpc.ts:32](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/rpc.ts#L32)
 
 ## Methods
 
@@ -101,7 +101,7 @@ TxResponseProps object
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:217](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/rpc.ts#L217)
+[sdk/src/rpc/rpc.ts:217](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/rpc.ts#L217)
 
 ___
 
@@ -121,7 +121,7 @@ Array of all validator addresses
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:73](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/rpc.ts#L73)
+[sdk/src/rpc/rpc.ts:73](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/rpc.ts#L73)
 
 ___
 
@@ -148,7 +148,7 @@ Query balances from chain
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:43](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/rpc.ts#L43)
+[sdk/src/rpc/rpc.ts:43](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/rpc.ts#L43)
 
 ___
 
@@ -168,7 +168,7 @@ Object
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:198](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/rpc.ts#L198)
+[sdk/src/rpc/rpc.ts:198](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/rpc.ts#L198)
 
 ___
 
@@ -194,7 +194,7 @@ Promise resolving to delegators votes
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:97](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/rpc.ts#L97)
+[sdk/src/rpc/rpc.ts:97](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/rpc.ts#L97)
 
 ___
 
@@ -214,7 +214,7 @@ Query gas costs
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:189](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/rpc.ts#L189)
+[sdk/src/rpc/rpc.ts:189](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/rpc.ts#L189)
 
 ___
 
@@ -234,7 +234,7 @@ Address of native token
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:52](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/rpc.ts#L52)
+[sdk/src/rpc/rpc.ts:52](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/rpc.ts#L52)
 
 ___
 
@@ -261,7 +261,7 @@ String of public key if found
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:63](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/rpc.ts#L63)
+[sdk/src/rpc/rpc.ts:63](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/rpc.ts#L63)
 
 ___
 
@@ -287,7 +287,7 @@ Promise resolving to pending ethereum transfers
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:180](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/rpc.ts#L180)
+[sdk/src/rpc/rpc.ts:180](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/rpc.ts#L180)
 
 ___
 
@@ -313,7 +313,7 @@ Promise resolving to staking positions
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:134](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/rpc.ts#L134)
+[sdk/src/rpc/rpc.ts:134](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/rpc.ts#L134)
 
 ___
 
@@ -339,7 +339,7 @@ Promise resolving to staking totals
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:107](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/rpc.ts#L107)
+[sdk/src/rpc/rpc.ts:107](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/rpc.ts#L107)
 
 ___
 
@@ -363,7 +363,7 @@ Total bonds amount
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:170](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/rpc.ts#L170)
+[sdk/src/rpc/rpc.ts:170](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/rpc.ts#L170)
 
 ___
 
@@ -390,7 +390,7 @@ Promise resolving to total delegations
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:84](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/rpc.ts#L84)
+[sdk/src/rpc/rpc.ts:84](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/rpc.ts#L84)
 
 ___
 
@@ -414,4 +414,4 @@ Sync the shielded context
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:229](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/rpc.ts#L229)
+[sdk/src/rpc/rpc.ts:229](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/rpc.ts#L229)

--- a/packages/sdk/docs/classes/Sdk.md
+++ b/packages/sdk/docs/classes/Sdk.md
@@ -62,7 +62,7 @@ API for interacting with Namada SDK
 
 #### Defined in
 
-[sdk/src/sdk.ts:23](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/sdk.ts#L23)
+[sdk/src/sdk.ts:23](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/sdk.ts#L23)
 
 ## Properties
 
@@ -74,7 +74,7 @@ Memory accessor for crypto lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:26](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/sdk.ts#L26)
+[sdk/src/sdk.ts:26](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/sdk.ts#L26)
 
 ___
 
@@ -86,7 +86,7 @@ Address of chain's native token
 
 #### Defined in
 
-[sdk/src/sdk.ts:28](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/sdk.ts#L28)
+[sdk/src/sdk.ts:28](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/sdk.ts#L28)
 
 ___
 
@@ -98,7 +98,7 @@ Instance of Query struct from wasm lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:25](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/sdk.ts#L25)
+[sdk/src/sdk.ts:25](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/sdk.ts#L25)
 
 ___
 
@@ -110,7 +110,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:24](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/sdk.ts#L24)
+[sdk/src/sdk.ts:24](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/sdk.ts#L24)
 
 ___
 
@@ -122,7 +122,7 @@ RPC url
 
 #### Defined in
 
-[sdk/src/sdk.ts:27](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/sdk.ts#L27)
+[sdk/src/sdk.ts:27](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/sdk.ts#L27)
 
 ## Accessors
 
@@ -140,7 +140,7 @@ Utilities for encrypting and decrypting data
 
 #### Defined in
 
-[sdk/src/sdk.ts:166](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/sdk.ts#L166)
+[sdk/src/sdk.ts:166](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/sdk.ts#L166)
 
 ___
 
@@ -158,7 +158,7 @@ key-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:142](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/sdk.ts#L142)
+[sdk/src/sdk.ts:142](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/sdk.ts#L142)
 
 ___
 
@@ -176,7 +176,7 @@ Masp utilities for handling params
 
 #### Defined in
 
-[sdk/src/sdk.ts:158](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/sdk.ts#L158)
+[sdk/src/sdk.ts:158](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/sdk.ts#L158)
 
 ___
 
@@ -194,7 +194,7 @@ mnemonic-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:134](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/sdk.ts#L134)
+[sdk/src/sdk.ts:134](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/sdk.ts#L134)
 
 ___
 
@@ -212,7 +212,7 @@ rpc client
 
 #### Defined in
 
-[sdk/src/sdk.ts:118](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/sdk.ts#L118)
+[sdk/src/sdk.ts:118](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/sdk.ts#L118)
 
 ___
 
@@ -230,7 +230,7 @@ Non-Tx signing functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:150](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/sdk.ts#L150)
+[sdk/src/sdk.ts:150](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/sdk.ts#L150)
 
 ___
 
@@ -248,7 +248,7 @@ tx-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:126](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/sdk.ts#L126)
+[sdk/src/sdk.ts:126](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/sdk.ts#L126)
 
 ## Methods
 
@@ -266,7 +266,7 @@ Utilities for encrypting and decrypting data
 
 #### Defined in
 
-[sdk/src/sdk.ts:100](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/sdk.ts#L100)
+[sdk/src/sdk.ts:100](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/sdk.ts#L100)
 
 ___
 
@@ -284,7 +284,7 @@ key-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:76](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/sdk.ts#L76)
+[sdk/src/sdk.ts:76](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/sdk.ts#L76)
 
 ___
 
@@ -302,7 +302,7 @@ Masp utilities for handling params
 
 #### Defined in
 
-[sdk/src/sdk.ts:92](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/sdk.ts#L92)
+[sdk/src/sdk.ts:92](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/sdk.ts#L92)
 
 ___
 
@@ -320,7 +320,7 @@ mnemonic-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:68](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/sdk.ts#L68)
+[sdk/src/sdk.ts:68](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/sdk.ts#L68)
 
 ___
 
@@ -338,7 +338,7 @@ Namada RPC client
 
 #### Defined in
 
-[sdk/src/sdk.ts:52](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/sdk.ts#L52)
+[sdk/src/sdk.ts:52](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/sdk.ts#L52)
 
 ___
 
@@ -356,7 +356,7 @@ Non-Tx signing functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:84](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/sdk.ts#L84)
+[sdk/src/sdk.ts:84](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/sdk.ts#L84)
 
 ___
 
@@ -374,7 +374,7 @@ Tx-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:60](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/sdk.ts#L60)
+[sdk/src/sdk.ts:60](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/sdk.ts#L60)
 
 ___
 
@@ -400,7 +400,7 @@ Class for interacting with NamadaApp for Ledger Hardware Wallets
 
 #### Defined in
 
-[sdk/src/sdk.ts:110](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/sdk.ts#L110)
+[sdk/src/sdk.ts:110](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/sdk.ts#L110)
 
 ___
 
@@ -425,4 +425,4 @@ this instance of Sdk
 
 #### Defined in
 
-[sdk/src/sdk.ts:37](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/sdk.ts#L37)
+[sdk/src/sdk.ts:37](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/sdk.ts#L37)

--- a/packages/sdk/docs/classes/SignedTx.md
+++ b/packages/sdk/docs/classes/SignedTx.md
@@ -34,7 +34,7 @@ Wrap results of tx signing to simplify passing between Sdk functions
 
 #### Defined in
 
-[sdk/src/tx/types.ts:52](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/types.ts#L52)
+[sdk/src/tx/types.ts:52](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/types.ts#L52)
 
 ## Properties
 
@@ -46,7 +46,7 @@ Serialized tx bytes
 
 #### Defined in
 
-[sdk/src/tx/types.ts:56](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/types.ts#L56)
+[sdk/src/tx/types.ts:56](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/types.ts#L56)
 
 ___
 
@@ -58,4 +58,4 @@ Serialized wrapper tx msg bytes
 
 #### Defined in
 
-[sdk/src/tx/types.ts:54](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/types.ts#L54)
+[sdk/src/tx/types.ts:54](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/types.ts#L54)

--- a/packages/sdk/docs/classes/Signing.md
+++ b/packages/sdk/docs/classes/Signing.md
@@ -40,7 +40,7 @@ Signing constructor
 
 #### Defined in
 
-[sdk/src/signing.ts:13](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/signing.ts#L13)
+[sdk/src/signing.ts:13](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/signing.ts#L13)
 
 ## Properties
 
@@ -52,7 +52,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/signing.ts:13](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/signing.ts#L13)
+[sdk/src/signing.ts:13](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/signing.ts#L13)
 
 ## Methods
 
@@ -78,7 +78,7 @@ signed tx bytes - Promise resolving to Uint8Array
 
 #### Defined in
 
-[sdk/src/signing.ts:22](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/signing.ts#L22)
+[sdk/src/signing.ts:22](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/signing.ts#L22)
 
 ___
 
@@ -103,7 +103,7 @@ hash and signature
 
 #### Defined in
 
-[sdk/src/signing.ts:36](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/signing.ts#L36)
+[sdk/src/signing.ts:36](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/signing.ts#L36)
 
 ___
 
@@ -129,4 +129,4 @@ void
 
 #### Defined in
 
-[sdk/src/signing.ts:47](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/signing.ts#L47)
+[sdk/src/signing.ts:47](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/signing.ts#L47)

--- a/packages/sdk/docs/classes/Tx.md
+++ b/packages/sdk/docs/classes/Tx.md
@@ -19,6 +19,7 @@ SDK functionality related to transactions
 - [appendSignature](Tx.md#appendsignature)
 - [buildBatch](Tx.md#buildbatch)
 - [buildBond](Tx.md#buildbond)
+- [buildClaimRewards](Tx.md#buildclaimrewards)
 - [buildEthBridgeTransfer](Tx.md#buildethbridgetransfer)
 - [buildIbcTransfer](Tx.md#buildibctransfer)
 - [buildRedelegate](Tx.md#buildredelegate)
@@ -49,7 +50,7 @@ SDK functionality related to transactions
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:46](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/tx.ts#L46)
+[sdk/src/tx/tx.ts:48](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/tx.ts#L48)
 
 ## Properties
 
@@ -61,7 +62,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:46](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/tx.ts#L46)
+[sdk/src/tx/tx.ts:48](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/tx.ts#L48)
 
 ## Methods
 
@@ -86,7 +87,7 @@ Append signature for transactions signed by Ledger Hardware Wallet
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:280](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/tx.ts#L280)
+[sdk/src/tx/tx.ts:306](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/tx.ts#L306)
 
 ___
 
@@ -111,7 +112,7 @@ a BuiltTx type
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:253](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/tx.ts#L253)
+[sdk/src/tx/tx.ts:279](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/tx.ts#L279)
 
 ___
 
@@ -138,7 +139,34 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:94](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/tx.ts#L94)
+[sdk/src/tx/tx.ts:96](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/tx.ts#L96)
+
+___
+
+### buildClaimRewards
+
+▸ **buildClaimRewards**(`wrapperTxProps`, `claimRewardsProps`): `Promise`\<[`EncodedTx`](EncodedTx.md)\>
+
+Build Claim Rewards Tx
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `wrapperTxProps` | `WrapperTxMsgValue` | properties of the transaction |
+| `claimRewardsProps` | `ClaimRewardsMsgValue` | properties of the claim rewards tx |
+
+#### Returns
+
+`Promise`\<[`EncodedTx`](EncodedTx.md)\>
+
+promise that resolves to an EncodedTx
+
+**`Async`**
+
+#### Defined in
+
+[sdk/src/tx/tx.ts:256](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/tx.ts#L256)
 
 ___
 
@@ -165,7 +193,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:206](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/tx.ts#L206)
+[sdk/src/tx/tx.ts:208](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/tx.ts#L208)
 
 ___
 
@@ -192,7 +220,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:182](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/tx.ts#L182)
+[sdk/src/tx/tx.ts:184](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/tx.ts#L184)
 
 ___
 
@@ -219,7 +247,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:158](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/tx.ts#L158)
+[sdk/src/tx/tx.ts:160](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/tx.ts#L160)
 
 ___
 
@@ -245,7 +273,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:80](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/tx.ts#L80)
+[sdk/src/tx/tx.ts:82](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/tx.ts#L82)
 
 ___
 
@@ -272,7 +300,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:55](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/tx.ts#L55)
+[sdk/src/tx/tx.ts:57](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/tx.ts#L57)
 
 ___
 
@@ -299,7 +327,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:113](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/tx.ts#L113)
+[sdk/src/tx/tx.ts:115](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/tx.ts#L115)
 
 ___
 
@@ -307,7 +335,7 @@ ___
 
 ▸ **buildVoteProposal**(`wrapperTxProps`, `voteProposalProps`): `Promise`\<[`EncodedTx`](EncodedTx.md)\>
 
-Built Vote Proposal Tx
+Build Vote Proposal Tx
 
 #### Parameters
 
@@ -326,7 +354,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:230](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/tx.ts#L230)
+[sdk/src/tx/tx.ts:232](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/tx.ts#L232)
 
 ___
 
@@ -353,7 +381,7 @@ promise that resolves to an EncodedTx
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:136](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/tx.ts#L136)
+[sdk/src/tx/tx.ts:138](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/tx.ts#L138)
 
 ___
 
@@ -378,7 +406,7 @@ a TxDetails object
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:333](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/tx.ts#L333)
+[sdk/src/tx/tx.ts:359](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/tx.ts#L359)
 
 ___
 
@@ -402,7 +430,7 @@ Serialized WrapperTxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:321](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/tx.ts#L321)
+[sdk/src/tx/tx.ts:347](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/tx.ts#L347)
 
 ___
 
@@ -430,4 +458,4 @@ void
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:265](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/tx/tx.ts#L265)
+[sdk/src/tx/tx.ts:291](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/tx/tx.ts#L291)

--- a/packages/sdk/docs/enums/KdfType.md
+++ b/packages/sdk/docs/enums/KdfType.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:38](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/crypto/types.ts#L38)
+[sdk/src/crypto/types.ts:38](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/crypto/types.ts#L38)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:39](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/crypto/types.ts#L39)
+[sdk/src/crypto/types.ts:39](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/crypto/types.ts#L39)

--- a/packages/sdk/docs/enums/PhraseSize.md
+++ b/packages/sdk/docs/enums/PhraseSize.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-crypto/src/crypto/crypto.d.ts:13
+crypto/src/crypto/crypto.d.ts:6
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-crypto/src/crypto/crypto.d.ts:14
+crypto/src/crypto/crypto.d.ts:7

--- a/packages/sdk/docs/enums/TxType.md
+++ b/packages/sdk/docs/enums/TxType.md
@@ -8,6 +8,7 @@
 
 - [Batch](TxType.md#batch)
 - [Bond](TxType.md#bond)
+- [ClaimRewards](TxType.md#claimrewards)
 - [EthBridgeTransfer](TxType.md#ethbridgetransfer)
 - [IBCTransfer](TxType.md#ibctransfer)
 - [Redelegate](TxType.md#redelegate)
@@ -36,6 +37,16 @@ ___
 #### Defined in
 
 shared/src/shared/shared.d.ts:23
+
+___
+
+### ClaimRewards
+
+• **ClaimRewards** = ``11``
+
+#### Defined in
+
+shared/src/shared/shared.d.ts:33
 
 ___
 

--- a/packages/sdk/docs/modules.md
+++ b/packages/sdk/docs/modules.md
@@ -72,7 +72,7 @@ Address and public key type
 
 #### Defined in
 
-[sdk/src/keys/types.ts:4](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/keys/types.ts#L4)
+[sdk/src/keys/types.ts:4](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/keys/types.ts#L4)
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:17](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/ledger.ts#L17)
+[sdk/src/ledger.ts:17](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/ledger.ts#L17)
 
 ___
 
@@ -99,7 +99,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:23](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/crypto/types.ts#L23)
+[sdk/src/crypto/types.ts:23](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/crypto/types.ts#L23)
 
 ___
 
@@ -112,7 +112,7 @@ Balance
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:69](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/types.ts#L69)
+[sdk/src/rpc/types.ts:69](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/types.ts#L69)
 
 ___
 
@@ -131,7 +131,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:27](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/types.ts#L27)
+[sdk/src/rpc/types.ts:27](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/types.ts#L27)
 
 ___
 
@@ -159,7 +159,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:42](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/crypto/types.ts#L42)
+[sdk/src/crypto/types.ts:42](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/crypto/types.ts#L42)
 
 ___
 
@@ -172,7 +172,7 @@ Record<address, totalDelegations>
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:51](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/types.ts#L51)
+[sdk/src/rpc/types.ts:51](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/types.ts#L51)
 
 ___
 
@@ -185,7 +185,7 @@ Record<address, boolean>
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:57](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/types.ts#L57)
+[sdk/src/rpc/types.ts:57](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/types.ts#L57)
 
 ___
 
@@ -204,7 +204,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:30](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/crypto/types.ts#L30)
+[sdk/src/crypto/types.ts:30](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/crypto/types.ts#L30)
 
 ___
 
@@ -221,7 +221,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:18](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/ledger.ts#L18)
+[sdk/src/ledger.ts:18](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/ledger.ts#L18)
 
 ___
 
@@ -241,7 +241,7 @@ Shielded keys and address
 
 #### Defined in
 
-[sdk/src/keys/types.ts:19](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/keys/types.ts#L19)
+[sdk/src/keys/types.ts:19](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/keys/types.ts#L19)
 
 ___
 
@@ -258,7 +258,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:42](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/types.ts#L42)
+[sdk/src/rpc/types.ts:42](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/types.ts#L42)
 
 ___
 
@@ -278,7 +278,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:19](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/types.ts#L19)
+[sdk/src/rpc/types.ts:19](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/types.ts#L19)
 
 ___
 
@@ -288,7 +288,7 @@ ___
 
 #### Defined in
 
-[shared/src/types.ts:3](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/shared/src/types.ts#L3)
+[shared/src/types.ts:3](https://github.com/anoma/namada-interface/blob/316cbce5/packages/shared/src/types.ts#L3)
 
 ___
 
@@ -300,7 +300,7 @@ Public and private keypair with address
 
 #### Defined in
 
-[sdk/src/keys/types.ts:12](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/keys/types.ts#L12)
+[sdk/src/keys/types.ts:12](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/keys/types.ts#L12)
 
 ___
 
@@ -320,7 +320,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:34](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/rpc/types.ts#L34)
+[sdk/src/rpc/types.ts:34](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/rpc/types.ts#L34)
 
 ## Variables
 
@@ -338,7 +338,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:3](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/crypto/types.ts#L3)
+[sdk/src/crypto/types.ts:3](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/crypto/types.ts#L3)
 
 ___
 
@@ -348,7 +348,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:41](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/ledger.ts#L41)
+[sdk/src/ledger.ts:41](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/ledger.ts#L41)
 
 ___
 
@@ -358,7 +358,7 @@ ___
 
 #### Defined in
 
-[shared/src/types.ts:27](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/shared/src/types.ts#L27)
+[shared/src/types.ts:28](https://github.com/anoma/namada-interface/blob/316cbce5/packages/shared/src/types.ts#L28)
 
 ## Functions
 
@@ -378,7 +378,7 @@ Transport object
 
 #### Defined in
 
-[sdk/src/ledger.ts:37](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/ledger.ts#L37)
+[sdk/src/ledger.ts:37](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/ledger.ts#L37)
 
 ___
 
@@ -398,7 +398,7 @@ Transport object
 
 #### Defined in
 
-[sdk/src/ledger.ts:28](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/ledger.ts#L28)
+[sdk/src/ledger.ts:28](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/ledger.ts#L28)
 
 ___
 
@@ -418,4 +418,4 @@ ___
 
 #### Defined in
 
-[sdk/src/keys/keys.ts:173](https://github.com/anoma/namada-interface/blob/4f0a4dbf/packages/sdk/src/keys/keys.ts#L173)
+[sdk/src/keys/keys.ts:173](https://github.com/anoma/namada-interface/blob/316cbce5/packages/sdk/src/keys/keys.ts#L173)

--- a/packages/sdk/src/tx/tx.ts
+++ b/packages/sdk/src/tx/tx.ts
@@ -8,6 +8,8 @@ import {
 import {
   BondMsgValue,
   BondProps,
+  ClaimRewardsMsgValue,
+  ClaimRewardsProps,
   EthBridgeTransferMsgValue,
   EthBridgeTransferProps,
   IbcTransferMsgValue,
@@ -221,7 +223,7 @@ export class Tx {
   }
 
   /**
-   * Built Vote Proposal Tx
+   * Build Vote Proposal Tx
    * @async
    * @param wrapperTxProps - properties of the transaction
    * @param voteProposalProps - properties of the vote proposal tx
@@ -239,6 +241,30 @@ export class Tx {
 
     const builtTx = await this.sdk.build_vote_proposal(
       encodedVoteProposal,
+      encodedWrapperArgs
+    );
+    return new EncodedTx(encodedWrapperArgs, builtTx);
+  }
+
+  /**
+   * Build Claim Rewards Tx
+   * @async
+   * @param wrapperTxProps - properties of the transaction
+   * @param claimRewardsProps - properties of the claim rewards tx
+   * @returns promise that resolves to an EncodedTx
+   */
+  async buildClaimRewards(
+    wrapperTxProps: WrapperTxProps,
+    claimRewardsProps: ClaimRewardsProps
+  ): Promise<EncodedTx> {
+    const claimRewardsMsg = new Message<ClaimRewardsProps>();
+    const encodedWrapperArgs = this.encodeTxArgs(wrapperTxProps);
+    const encodedClaimRewards = claimRewardsMsg.encode(
+      new ClaimRewardsMsgValue(claimRewardsProps)
+    );
+
+    const builtTx = await this.sdk.build_claim_rewards(
+      encodedClaimRewards,
       encodedWrapperArgs
     );
     return new EncodedTx(encodedWrapperArgs, builtTx);
@@ -356,6 +382,8 @@ export class Tx {
           return deserialize(data, RedelegateMsgValue);
         case TxType.VoteProposal:
           return deserialize(data, VoteProposalMsgValue);
+        case TxType.ClaimRewards:
+          return deserialize(data, ClaimRewardsMsgValue);
         case TxType.Transfer:
           return deserialize(data, TransferMsgValue);
         case TxType.RevealPK:

--- a/packages/shared/lib/src/query.rs
+++ b/packages/shared/lib/src/query.rs
@@ -28,7 +28,7 @@ use namada::sdk::rpc::{
 use namada::sdk::state::Key;
 use namada::sdk::tx::{
     TX_BOND_WASM, TX_REDELEGATE_WASM, TX_REVEAL_PK, TX_TRANSFER_WASM, TX_UNBOND_WASM,
-    TX_VOTE_PROPOSAL, TX_WITHDRAW_WASM,
+    TX_VOTE_PROPOSAL, TX_WITHDRAW_WASM, TX_CLAIM_REWARDS_WASM
 };
 use namada::token;
 use namada::uint::I256;
@@ -749,7 +749,7 @@ impl Query {
             TX_REDELEGATE_WASM.to_string(),
             TX_UNBOND_WASM.to_string(),
             TX_WITHDRAW_WASM.to_string(),
-            // TX_CLAIM_REWARDS_WASM.to_string(),
+            TX_CLAIM_REWARDS_WASM.to_string(),
             TX_REVEAL_PK.to_string(),
             TX_VOTE_PROPOSAL.to_string(),
         ]

--- a/packages/shared/lib/src/sdk/args.rs
+++ b/packages/shared/lib/src/sdk/args.rs
@@ -333,6 +333,58 @@ pub fn vote_proposal_tx_args(
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
 #[borsh(crate = "namada::core::borsh")]
+pub struct ClaimRewardsMsg {
+    validator: String,
+    source: Option<String>,
+}
+
+impl ClaimRewardsMsg {
+    pub fn new(validator: String, source: Option<String>) -> ClaimRewardsMsg {
+        ClaimRewardsMsg {
+            validator,
+            source,
+        }
+    }
+}
+
+/// Maps serialized tx_msg into ClaimRewardsTx args.
+///
+/// # Arguments
+///
+/// * `claim_rewards_msg` - Borsh serialized claim_rewards_msg.
+/// * `tx_msg` - Borsh serialized tx_msg.
+///
+/// # Errors
+///
+/// Returns JsError if the tx_msg can't be deserialized or
+/// Rust structs can't be created.
+pub fn claim_rewards_tx_args(
+    claim_rewards_msg: &[u8],
+    tx_msg: &[u8],
+) -> Result<args::ClaimRewards, JsError> {
+    let claim_rewards_msg = ClaimRewardsMsg::try_from_slice(claim_rewards_msg)?;
+
+    let ClaimRewardsMsg {
+        validator,
+        source,
+    } = claim_rewards_msg;
+    let tx = tx_msg_into_args(tx_msg)?;
+
+    let validator_address = Address::from_str(&validator)?;
+    let source_address = source.map(|str| Address::from_str(&str).expect("valid address"));
+
+    let args = args::ClaimRewards {
+        tx,
+        validator: validator_address,
+        source: source_address,
+        tx_code_path: PathBuf::from("tx_claim_rewards.wasm"),
+    };
+
+    Ok(args)
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[borsh(crate = "namada::core::borsh")]
 pub struct TransferDataMsg {
     owner: String,
     token: String,

--- a/packages/shared/lib/src/sdk/mod.rs
+++ b/packages/shared/lib/src/sdk/mod.rs
@@ -25,7 +25,7 @@ use namada::sdk::signing::SigningTxData;
 use namada::sdk::tx::{
     build_batch, build_bond, build_ibc_transfer, build_redelegation, build_reveal_pk,
     build_transparent_transfer, build_unbond, build_vote_proposal, build_withdraw,
-    is_reveal_pk_needed, process_tx, ProcessTxResponse,
+    build_claim_rewards, is_reveal_pk_needed, process_tx, ProcessTxResponse,
 };
 use namada::sdk::wallet::{Store, Wallet};
 use namada::sdk::{Namada, NamadaImpl};
@@ -471,6 +471,24 @@ impl Sdk {
 
         Ok(BuiltTx {
             tx_type: TxType::VoteProposal,
+            tx,
+            signing_data: vec![signing_data],
+            wrapper_tx_msg: Vec::from(wrapper_tx_msg),
+        })
+    }
+
+    pub async fn build_claim_rewards(
+        &self,
+        claim_rewards_msg: &[u8],
+        wrapper_tx_msg: &[u8],
+    ) -> Result<BuiltTx, JsError> {
+        let args = args::claim_rewards_tx_args(claim_rewards_msg, wrapper_tx_msg)?;
+        let (tx, signing_data) = build_claim_rewards(&self.namada, &args)
+            .await
+            .map_err(JsError::from)?;
+
+        Ok(BuiltTx {
+            tx_type: TxType::ClaimRewards,
             tx,
             signing_data: vec![signing_data],
             wrapper_tx_msg: Vec::from(wrapper_tx_msg),

--- a/packages/shared/lib/src/sdk/tx.rs
+++ b/packages/shared/lib/src/sdk/tx.rs
@@ -6,7 +6,7 @@ use namada::core::borsh::{self, BorshDeserialize, BorshSerialize};
 use namada::sdk::signing::SigningTxData;
 use namada::sdk::tx::{
     TX_BOND_WASM, TX_REDELEGATE_WASM, TX_REVEAL_PK, TX_TRANSFER_WASM, TX_UNBOND_WASM,
-    TX_VOTE_PROPOSAL, TX_WITHDRAW_WASM,
+    TX_VOTE_PROPOSAL, TX_WITHDRAW_WASM, TX_CLAIM_REWARDS_WASM
 };
 use namada::sdk::uint::Uint;
 use namada::tx;
@@ -31,6 +31,7 @@ pub enum TxType {
     VoteProposal = 8,
     Redelegate = 9,
     Batch = 10,
+    ClaimRewards = 11,
 }
 
 #[derive(BorshSerialize, BorshDeserialize)]
@@ -101,7 +102,7 @@ pub fn wasm_hash_to_tx_type(wasm_hash: &str, wasm_hashes: &Vec<WasmHash>) -> Opt
         (TX_REDELEGATE_WASM.to_string(), TxType::Redelegate),
         (TX_UNBOND_WASM.to_string(), TxType::Unbond),
         (TX_WITHDRAW_WASM.to_string(), TxType::Withdraw),
-        // (TX_CLAIM_REWARDS_WASM.to_string(), TxType::ClaimRewards),
+        (TX_CLAIM_REWARDS_WASM.to_string(), TxType::ClaimRewards),
         (TX_REVEAL_PK.to_string(), TxType::RevealPK),
         (TX_VOTE_PROPOSAL.to_string(), TxType::VoteProposal),
     ]);

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -21,6 +21,7 @@ export type TxLabel =
   | "Withdraw"
   | "RevealPK"
   | "Vote Proposal"
+  | "Claim Rewards"
   | "Redelegate"
   | "Batch";
 
@@ -33,6 +34,7 @@ export const TxTypeLabel: Record<TxType, TxLabel> = {
   [TxType.EthBridgeTransfer]: "Add to Eth Bridge Pool",
   [TxType.RevealPK]: "RevealPK",
   [TxType.VoteProposal]: "Vote Proposal",
+  [TxType.ClaimRewards]: "Claim Rewards",
   [TxType.Redelegate]: "Redelegate",
   [TxType.Batch]: "Batch",
 };

--- a/packages/types/src/tx/schema/claimRewards.ts
+++ b/packages/types/src/tx/schema/claimRewards.ts
@@ -1,0 +1,15 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { field, option } from "@dao-xyz/borsh";
+import { ClaimRewardsProps } from "../types";
+
+export class ClaimRewardsMsgValue {
+  @field({ type: "string" })
+  validator!: string;
+
+  @field({ type: option("string") })
+  source?: string;
+
+  constructor(data: ClaimRewardsProps) {
+    Object.assign(this, data);
+  }
+}

--- a/packages/types/src/tx/schema/index.ts
+++ b/packages/types/src/tx/schema/index.ts
@@ -1,5 +1,6 @@
 export * from "./batchTxResult";
 export * from "./bond";
+export * from "./claimRewards";
 export * from "./ethBridgeTransfer";
 export * from "./ibcTransfer";
 export * from "./redelegate";
@@ -16,6 +17,7 @@ export * from "./wrapperTx";
 
 import { BatchTxResultMsgValue } from "./batchTxResult";
 import { BondMsgValue } from "./bond";
+import { ClaimRewardsMsgValue } from "./claimRewards";
 import { EthBridgeTransferMsgValue } from "./ethBridgeTransfer";
 import { IbcTransferMsgValue } from "./ibcTransfer";
 import { RedelegateMsgValue } from "./redelegate";
@@ -42,6 +44,7 @@ export type Schema =
   | BondMsgValue
   | UnbondMsgValue
   | VoteProposalMsgValue
+  | ClaimRewardsMsgValue
   | WithdrawMsgValue
   | TransferMsgValue
   | TransferDataMsgValue

--- a/packages/types/src/tx/types.ts
+++ b/packages/types/src/tx/types.ts
@@ -1,6 +1,7 @@
 import {
   BatchTxResultMsgValue,
   BondMsgValue,
+  ClaimRewardsMsgValue,
   EthBridgeTransferMsgValue,
   IbcTransferMsgValue,
   RedelegateMsgValue,
@@ -28,6 +29,7 @@ export type TransparentTransferDataProps = TransparentTransferDataMsgValue;
 export type TxResponseProps = TxResponseMsgValue;
 export type UnbondProps = UnbondMsgValue;
 export type VoteProposalProps = VoteProposalMsgValue;
+export type ClaimRewardsProps = ClaimRewardsMsgValue;
 export type WithdrawProps = WithdrawMsgValue;
 export type WrapperTxProps = WrapperTxMsgValue;
 export type RevealPkProps = RevealPkMsgValue;
@@ -40,6 +42,7 @@ export type SupportedTxProps =
   | EthBridgeTransferProps
   | IbcTransferProps
   | VoteProposalProps
+  | ClaimRewardsProps
   | TransferProps
   | RevealPkProps;
 

--- a/packages/utils/src/helpers/index.ts
+++ b/packages/utils/src/helpers/index.ts
@@ -1,9 +1,5 @@
 import { JsonRpcRequest } from "@cosmjs/json-rpc";
-import {
-  JsonCompatibleArray,
-  JsonCompatibleDictionary,
-  Tokens,
-} from "@namada/types";
+import { JsonCompatibleArray, JsonCompatibleDictionary } from "@namada/types";
 import { bech32m } from "bech32";
 import BigNumber from "bignumber.js";
 import * as fns from "date-fns";
@@ -291,10 +287,6 @@ export const mapUndefined = <A, B>(
   f: (a: A) => B,
   a: A | undefined
 ): B | undefined => (typeof a === "undefined" ? undefined : f(a));
-
-export const showMaybeNam = (maybeNam: BigNumber | undefined): string =>
-  mapUndefined((nam) => `${Tokens.NAM.symbol} ${nam.toString()}`, maybeNam) ??
-  "-";
 
 export const isEmptyObject = (object: Record<string, unknown>): boolean => {
   return Object.keys(object).length === 0;


### PR DESCRIPTION
Closes #679.

---

### Added
- Support claim rewards tx in SDK

## Testing

1. Stake some NAM.
2. Check that you have rewards available with `namadac rewards`.
3. In Namadillo, add `window.sdk = sdk; window.BigNumber = BigNumber;` and then in the console something like:
```
var built = await sdk.tx.buildClaimRewards(
  {
    token: sdk.nativeToken,
    feeAmount: BigNumber(0),
    gasLimit: BigNumber(20_000),
    chainId: "localnet.4918ab9bafd7c5a6ac91c",
    publicKey: "tpknam1qptrn64myunqr4847yq4cn0uwek5ecwc7eeexjfc5npmd5kmg6ex563n5as"
  },
  {
    validator: "tnam1q9vhfdur7gadtwx4r223agpal0fvlqhywylf2mzx",
    source: "tnam1qz4sdx5jlh909j44uz46pf29ty0ztftfzc98s8dx"
  }
);

var signed = await namada.sign({
  txType: built.tx.tx_type(),
  signer: "tnam1qz4sdx5jlh909j44uz46pf29ty0ztftfzc98s8dx",
  tx: {
    txBytes: built.tx.tx_bytes(),
    signingDataBytes: built.tx.signing_data_bytes(),
  },
  wrapperTxMsg: built.tx.wrapper_tx_msg()
});

var processed = await sdk.rpc.broadcastTx({
  wrapperTxMsg: built.tx.wrapper_tx_msg(),
  tx: signed
})
```
4. Refresh Namadillo and check that your balance has increased.