### PR TITLE
Show proposal activation time, remove cached proposals

### DIFF
--- a/apps/namadillo/src/App/Governance/ProposalDescription.tsx
+++ b/apps/namadillo/src/App/Governance/ProposalDescription.tsx
@@ -1,13 +1,14 @@
 import { SkeletonLoading, Stack } from "@namada/components";
+import { Proposal } from "@namada/types";
 import { useAtomValue } from "jotai";
 import { useState } from "react";
 
-import { proposalFamilyPersist, StoredProposal } from "atoms/proposals";
+import { proposalFamily } from "atoms/proposals";
 
 export const ProposalDescription: React.FC<{
   proposalId: bigint;
 }> = ({ proposalId }) => {
-  const proposal = useAtomValue(proposalFamilyPersist(proposalId));
+  const proposal = useAtomValue(proposalFamily(proposalId));
 
   return (
     <Stack className="text-sm px-8 -mt-3" gap={4}>
@@ -22,7 +23,7 @@ export const ProposalDescription: React.FC<{
 };
 
 export const Loaded: React.FC<{
-  proposal: StoredProposal;
+  proposal: Proposal;
 }> = ({ proposal }) => {
   const [expanded, setExpanded] = useState(false);
 

--- a/apps/namadillo/src/App/Governance/ProposalStatusSummary.tsx
+++ b/apps/namadillo/src/App/Governance/ProposalStatusSummary.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 
 import { PieChart, PieChartData, Stack } from "@namada/components";
 import { formatPercentage } from "@namada/utils";
-import { proposalFamily, proposalFamilyPersist } from "atoms/proposals";
+import { proposalFamily } from "atoms/proposals";
 import { useAtomValue } from "jotai";
 
 import { ProposalStatus, TallyType, VoteType, voteTypes } from "@namada/types";
@@ -115,53 +115,31 @@ export const ProposalStatusSummary: React.FC<{
   proposalId: bigint;
 }> = ({ proposalId }) => {
   const proposal = useAtomValue(proposalFamily(proposalId));
-  const cachedProposal = useAtomValue(proposalFamilyPersist(proposalId));
 
-  const props: React.ComponentProps<typeof Loaded> | undefined = (() => {
-    if (proposal.status !== "error" && proposal.status !== "pending") {
-      return proposal.data;
-    }
-
-    if (
-      cachedProposal.status !== "error" &&
-      cachedProposal.status !== "pending"
-    ) {
-      const { data } = cachedProposal;
-
-      if (typeof data.status !== "undefined") {
-        return { ...data, status: data.status };
-      }
-    }
-
-    return undefined;
-  })();
-
-  if (typeof props === "undefined") {
-    return (
-      <Layout
-        status="pending"
-        percentages={{
-          yay: "%",
-          nay: "%",
-          abstain: "%",
-        }}
-        amounts={{
-          yay: "NAM",
-          nay: "NAM",
-          abstain: "NAM",
-        }}
-        turnout="%"
-        quorum="%"
-        pieChartMiddle={
-          <div className="text-sm text-[#B0B0B0] animate-pulse">
-            Syncing Data
-          </div>
-        }
-      />
-    );
-  } else {
-    return <Loaded {...props} />;
+  if (proposal.status === "success") {
+    return <Loaded {...proposal.data} />;
   }
+
+  return (
+    <Layout
+      status="pending"
+      percentages={{
+        yay: "%",
+        nay: "%",
+        abstain: "%",
+      }}
+      amounts={{
+        yay: "NAM",
+        nay: "NAM",
+        abstain: "NAM",
+      }}
+      turnout="%"
+      quorum="%"
+      pieChartMiddle={
+        <div className="text-sm text-[#B0B0B0] animate-pulse">Syncing Data</div>
+      }
+    />
+  );
 };
 
 const Loaded: React.FC<{

--- a/apps/namadillo/src/App/Governance/VoteInfoCards.tsx
+++ b/apps/namadillo/src/App/Governance/VoteInfoCards.tsx
@@ -2,9 +2,9 @@ import { NamCurrency } from "App/Common/NamCurrency";
 import { twMerge } from "tailwind-merge";
 
 import { SkeletonLoading } from "@namada/components";
-import { AddRemove, PgfActions } from "@namada/types";
+import { AddRemove, PgfActions, Proposal } from "@namada/types";
 
-import { proposalFamilyPersist, StoredProposal } from "atoms/proposals";
+import { proposalFamily } from "atoms/proposals";
 import { useAtomValue } from "jotai";
 import { epochToString, secondsToDateTimeString } from "utils";
 
@@ -89,7 +89,7 @@ const PgfPaymentInfoCards: React.FC<{
 export const VoteInfoCards: React.FC<{
   proposalId: bigint;
 }> = ({ proposalId }) => {
-  const proposal = useAtomValue(proposalFamilyPersist(proposalId));
+  const proposal = useAtomValue(proposalFamily(proposalId));
 
   return (
     <div className="grid grid-cols-6 gap-2 m-4">
@@ -114,7 +114,7 @@ const LoadingCard: React.FC<{ className?: string }> = ({ className }) => (
 );
 
 const Loaded: React.FC<{
-  proposal: StoredProposal;
+  proposal: Proposal;
 }> = ({ proposal }) => {
   return (
     <>

--- a/apps/namadillo/src/App/Governance/VoteInfoCards.tsx
+++ b/apps/namadillo/src/App/Governance/VoteInfoCards.tsx
@@ -6,7 +6,7 @@ import { AddRemove, PgfActions, Proposal } from "@namada/types";
 
 import { proposalFamily } from "atoms/proposals";
 import { useAtomValue } from "jotai";
-import { epochToString, secondsToDateTimeString } from "utils";
+import { secondsToDateTimeString } from "utils";
 
 const InfoCard: React.FC<
   {
@@ -129,8 +129,8 @@ const Loaded: React.FC<{
         className="col-span-2"
       />
       <InfoCard
-        title="Activation Epoch"
-        content={epochToString(proposal.activationEpoch)}
+        title="Activation Time"
+        content={secondsToDateTimeString(proposal.activationTime)}
         className="col-span-2"
       />
       <InfoCard

--- a/apps/namadillo/src/atoms/proposals/atoms.ts
+++ b/apps/namadillo/src/atoms/proposals/atoms.ts
@@ -1,5 +1,4 @@
 import {
-  Proposal,
   ProposalStatus,
   ProposalTypeString,
   VoteProposalProps,
@@ -36,83 +35,6 @@ export const proposalFamily = atomFamily((id: bigint) =>
     };
   })
 );
-
-export type StoredProposal = Pick<
-  Proposal,
-  | "id"
-  | "author"
-  | "content"
-  | "startEpoch"
-  | "endEpoch"
-  | "activationEpoch"
-  | "startTime"
-  | "endTime"
-  | "proposalType"
-  | "tallyType"
-> &
-  (
-    | { status?: undefined }
-    | Pick<Proposal, "status" | "yay" | "nay" | "abstain" | "totalVotingPower">
-  );
-
-// TODO: switch this back on
-export const proposalFamilyPersist = proposalFamily;
-/*
-export const proposalFamilyPersist = atomFamily((id: bigint) =>
-  atomWithQuery<StoredProposal>(
-    (get) => {
-      const proposal = get(proposalFamily(id));
-
-      return {
-        enabled: proposal.isSuccess,
-        queryKey: ["proposal-persist", id.toString()],
-        queryFn: async () => {
-          const {
-            id,
-            author,
-            content,
-            startEpoch,
-            endEpoch,
-            activationEpoch,
-            startTime,
-            endTime,
-            proposalType,
-            tallyType,
-            status,
-            yay,
-            nay,
-            abstain,
-            totalVotingPower,
-          } = proposal.data!;
-
-          // If proposal is finished, it is safe to store status and voting data
-          const finishedProposalProps =
-            status === "passed" || status === "rejected" ?
-              { status, yay, nay, abstain, totalVotingPower }
-            : {};
-
-          return {
-            id,
-            author,
-            content,
-            startEpoch,
-            endEpoch,
-            activationEpoch,
-            startTime,
-            endTime,
-            proposalType,
-            tallyType,
-            ...finishedProposalProps,
-          };
-        },
-        meta: { persist: true },
-      };
-    },
-    // TODO: It should be possible to avoid passing queryClient manually
-    () => queryClient
-  )
-);
-*/
 
 export const proposalVotedFamily = atomFamily((id: bigint) =>
   atom<boolean | undefined>((get) => {

--- a/apps/namadillo/src/atoms/proposals/functions.ts
+++ b/apps/namadillo/src/atoms/proposals/functions.ts
@@ -212,6 +212,7 @@ const toProposal = (
     activationEpoch: BigInt(proposal.activationEpoch),
     startTime: BigInt(proposal.startTime),
     endTime: BigInt(proposal.endTime),
+    activationTime: BigInt(proposal.activationTime),
     currentTime: BigInt(proposal.currentTime),
     proposalType: decodeProposalType(proposal.type, proposal.data),
     tallyType: toTally(proposal.tallyType),

--- a/packages/types/src/proposals.ts
+++ b/packages/types/src/proposals.ts
@@ -21,6 +21,7 @@ export type Proposal = {
   activationEpoch: bigint;
   startTime: bigint;
   endTime: bigint;
+  activationTime: bigint;
   currentTime: bigint;
   proposalType: ProposalType;
   tallyType: TallyType;


### PR DESCRIPTION
### Changed
- Show proposal activation time instead of activation epoch

### Removed
- Remove unused IndexedDB proposal caching
  - This could be added again later if we need it, but it was complicating the proposal code a bit so I removed it. The ability to cache queries in IndexedDB is still present though.


<!--

Make sure you have read CONTRIBUTING.md before submitting a pull request!

-->
