### PR TITLE
chore - Bump shared to namada 0.41.0

### DIFF
--- a/packages/shared/lib/Cargo.lock
+++ b/packages/shared/lib/Cargo.lock
@@ -49,18 +49,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,35 +431,12 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
-dependencies = [
- "borsh-derive 0.10.3",
- "hashbrown 0.13.2",
-]
-
-[[package]]
-name = "borsh"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbe5b10e214954177fb1dc9fbd20a1a2608fe99e6c832033bdc7cea287a20d77"
 dependencies = [
- "borsh-derive 1.5.0",
+ "borsh-derive",
  "cfg_aliases",
-]
-
-[[package]]
-name = "borsh-derive"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0754613691538d51f329cce9af41d7b7ca150bc973056f1156611489475f54f7"
-dependencies = [
- "borsh-derive-internal",
- "borsh-schema-derive-internal",
- "proc-macro-crate 0.1.5",
- "proc-macro2",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -481,7 +446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a8646f94ab393e43e8b35a2558b1624bed28b97ee09c5d15456e3c9463f46d"
 dependencies = [
  "once_cell",
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.65",
@@ -489,33 +454,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "borsh-derive-internal"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "borsh-ext"
 version = "1.2.0"
 source = "git+https://github.com/heliaxdev/borsh-ext?tag=v1.2.0#a62fee3e847e512cad9ac0f1fd5a900e5db9ba37"
 dependencies = [
- "borsh 1.5.0",
-]
-
-[[package]]
-name = "borsh-schema-derive-internal"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "borsh",
 ]
 
 [[package]]
@@ -964,13 +907,13 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.17"
+version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -1016,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1528,6 +1471,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1802,15 +1757,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -1981,8 +1927,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9298a8de81eea8d496672e47f13ab1ae5145b3b554ec3951222197697e1cf82"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -1995,8 +1940,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e4d7728ae132ecb49286f225d0ab6ad56b2a15af47e019da45ad23fd789d76f"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -2006,11 +1950,10 @@ dependencies = [
 [[package]]
 name = "ibc-app-nft-transfer-types"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "333b2fcc0226d150e996fddd3fd2041460c7ed7e7594b65077026c7e38587329"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
- "base64 0.21.7",
- "borsh 0.10.3",
+ "base64 0.22.1",
+ "borsh",
  "derive_more",
  "displaydoc",
  "http 1.1.0",
@@ -2028,8 +1971,7 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf138e322daa7b757b66a8c9a5bcac00773136f4b939b6cfb43bb95576ba59d"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -2039,10 +1981,9 @@ dependencies = [
 [[package]]
 name = "ibc-app-transfer-types"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e8777875777e43f3c18a340ac5ea2223dc87a67b60d99e451142eac3b7b7a46"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
- "borsh 0.10.3",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core",
@@ -2058,8 +1999,7 @@ dependencies = [
 [[package]]
 name = "ibc-apps"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac849a9d4f6097cc81405b00428fd73b04ce5290d806ce7f5c8afd42fbfb9bd"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -2068,8 +2008,7 @@ dependencies = [
 [[package]]
 name = "ibc-client-tendermint"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804dcd81f62608c453e72f669b2df986eb49d4b4381deac2a70bd33ee94cef7f"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -2079,15 +2018,14 @@ dependencies = [
  "ibc-core-host",
  "ibc-primitives",
  "serde",
- "tendermint 0.36.0",
+ "tendermint 0.37.0",
  "tendermint-light-client-verifier",
 ]
 
 [[package]]
 name = "ibc-client-tendermint-types"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b41444137be02cabc484079443f447d23e746fabd9ac6fd5d99faac0b30a5f"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -2096,18 +2034,17 @@ dependencies = [
  "ibc-primitives",
  "ibc-proto",
  "serde",
- "tendermint 0.36.0",
+ "tendermint 0.37.0",
  "tendermint-light-client-verifier",
- "tendermint-proto 0.36.0",
+ "tendermint-proto 0.37.0",
 ]
 
 [[package]]
 name = "ibc-client-wasm-types"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc05b707ee957b1272877606379647ae1e5897316a3406b6a93e1885ee99e68"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "displaydoc",
  "ibc-core-client",
  "ibc-core-host-types",
@@ -2119,8 +2056,7 @@ dependencies = [
 [[package]]
 name = "ibc-clients"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675754a0a5f2f70f71445338fa4d8b49d3c84ce1cf4748ca6c98bf6ede9c4bfc"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -2129,8 +2065,7 @@ dependencies = [
 [[package]]
 name = "ibc-core"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cb69c4ee05d367fa321acf67ec00d3e9f8ecfef013accdb05889db32ff2de3f"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2146,8 +2081,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5dcc1c14a92f01e556d72d834f842bb655043a7e122ebb8aabdb5e9df600aa8"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -2162,10 +2096,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-channel-types"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2744ad32ae7360caefb80f495800f883f5e5687cfbd74ff82a444b59a47af7"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
- "borsh 0.10.3",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core-client-types",
@@ -2180,14 +2113,13 @@ dependencies = [
  "serde",
  "sha2 0.10.8",
  "subtle-encoding",
- "tendermint 0.36.0",
+ "tendermint 0.37.0",
 ]
 
 [[package]]
 name = "ibc-core-client"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80071ac73dd4f3436bf1aef03c9b1715a4db0914f738904c281449dc05a0a9cf"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -2200,8 +2132,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-client-context"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9f751b62cad4195be5347646151020fd27c2924f10d82d6301a675fac544dd"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2211,16 +2142,15 @@ dependencies = [
  "ibc-core-host-types",
  "ibc-primitives",
  "subtle-encoding",
- "tendermint 0.36.0",
+ "tendermint 0.37.0",
 ]
 
 [[package]]
 name = "ibc-core-client-types"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "423e9e9a70b78fabc94c51dae76800459e126f891ae0987e88ac5e12c36e24de"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
- "borsh 0.10.3",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core-commitment-types",
@@ -2232,16 +2162,15 @@ dependencies = [
  "schemars",
  "serde",
  "subtle-encoding",
- "tendermint 0.36.0",
+ "tendermint 0.37.0",
 ]
 
 [[package]]
 name = "ibc-core-commitment-types"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b323c91e58ea7b573e01b8e76d13f146c97c245ada0aab3070576d54288f30"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
- "borsh 0.10.3",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-primitives",
@@ -2257,23 +2186,23 @@ dependencies = [
 [[package]]
 name = "ibc-core-connection"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31271364789ccfc12c25afa21b47274d7e07bf49b1f728fd66cfa6c29daaf4a"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
+ "ibc-client-wasm-types",
  "ibc-core-client",
  "ibc-core-connection-types",
  "ibc-core-handler-types",
  "ibc-core-host",
  "ibc-primitives",
+ "prost",
 ]
 
 [[package]]
 name = "ibc-core-connection-types"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d302a36925469589a911dab66654f390b87e98608d07515e47f5c7e51dffe7"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
- "borsh 0.10.3",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core-client-types",
@@ -2286,14 +2215,13 @@ dependencies = [
  "schemars",
  "serde",
  "subtle-encoding",
- "tendermint 0.36.0",
+ "tendermint 0.37.0",
 ]
 
 [[package]]
 name = "ibc-core-handler"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4523b9f77d3a1a391a3d63737760be44b23bc9b09ed297883a34654383b9b0e2"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2308,10 +2236,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-handler-types"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b229a92aa8b06ab9ccde6e1b3dad597deb97cb40e3bb6a631799b4cd2ad124"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
- "borsh 0.10.3",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core-channel-types",
@@ -2327,14 +2254,13 @@ dependencies = [
  "schemars",
  "serde",
  "subtle-encoding",
- "tendermint 0.36.0",
+ "tendermint 0.37.0",
 ]
 
 [[package]]
 name = "ibc-core-host"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ed7421f285225b78f3d020df6126b61f94b9eb370a83e42fbd4e9c8b04162fa"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2352,8 +2278,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-host-cosmos"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b25b5b45cf47b1e73211a83adf3a753f1acdba887cd3bc5357d6f547d4a3e8c"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2370,16 +2295,15 @@ dependencies = [
  "serde",
  "sha2 0.10.8",
  "subtle-encoding",
- "tendermint 0.36.0",
+ "tendermint 0.37.0",
 ]
 
 [[package]]
 name = "ibc-core-host-types"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "939178939d33e5af1aca19608b019233d753f3734b828d66f40152b382f3db53"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
- "borsh 0.10.3",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-primitives",
@@ -2392,8 +2316,7 @@ dependencies = [
 [[package]]
 name = "ibc-core-router"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328e6db6d3aa7126278c46c3dff779aa961952a63d031d3ddf4c202f4a3faad4"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2407,10 +2330,9 @@ dependencies = [
 [[package]]
 name = "ibc-core-router-types"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4175b57087b28759364572683b335ec4fe63a6f938f1a5d0c383a6297a032155"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
- "borsh 0.10.3",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-core-host-types",
@@ -2421,14 +2343,13 @@ dependencies = [
  "schemars",
  "serde",
  "subtle-encoding",
- "tendermint 0.36.0",
+ "tendermint 0.37.0",
 ]
 
 [[package]]
 name = "ibc-derive"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d961d2194fd5229961835d2eb78091906ef8afbaaa55bce7ad41bf3ead8aa9"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2438,10 +2359,9 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b3340c4908f1a1a36863270ac976e0295fbd1911cbc4609ab406967fd8ccc04"
+source = "git+https://github.com/cosmos/ibc-rs?rev=7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b#7ff41b3804cda649e0d7f7c21389b8d65f8d9b4b"
 dependencies = [
- "borsh 0.10.3",
+ "borsh",
  "derive_more",
  "displaydoc",
  "ibc-proto",
@@ -2450,18 +2370,18 @@ dependencies = [
  "scale-info",
  "schemars",
  "serde",
- "tendermint 0.36.0",
+ "tendermint 0.37.0",
  "time",
 ]
 
 [[package]]
 name = "ibc-proto"
-version = "0.44.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66080040d5a4800d52966d55b055400f86b79c34b854b935bef03c87aacda62a"
+checksum = "6cb09e0b52b8a16e98ce98845e7c15b018440f3c56defa12fa44782cd66bab65"
 dependencies = [
  "base64 0.22.1",
- "borsh 0.10.3",
+ "borsh",
  "bytes",
  "flex-error",
  "ics23",
@@ -2472,7 +2392,7 @@ dependencies = [
  "schemars",
  "serde",
  "subtle-encoding",
- "tendermint-proto 0.36.0",
+ "tendermint-proto 0.37.0",
 ]
 
 [[package]]
@@ -2573,7 +2493,7 @@ name = "index-set"
 version = "0.8.0"
 source = "git+https://github.com/heliaxdev/index-set?tag=v0.8.1#b0d928f83cf0d465ccda299d131e8df2859b5184"
 dependencies = [
- "borsh 1.5.0",
+ "borsh",
  "serde",
 ]
 
@@ -2592,7 +2512,7 @@ name = "indexmap"
 version = "2.2.4"
 source = "git+https://github.com/heliaxdev/indexmap?tag=2.2.4-heliax-1#b5b5b547bd6ab04bbb16e060326a50ddaeb6c909"
 dependencies = [
- "borsh 1.5.0",
+ "borsh",
  "equivalent",
  "hashbrown 0.14.5",
  "serde",
@@ -2811,7 +2731,7 @@ name = "masp_note_encryption"
 version = "1.0.0"
 source = "git+https://github.com/anoma/masp?rev=8d83b172698098fba393006016072bc201ed9ab7#8d83b172698098fba393006016072bc201ed9ab7"
 dependencies = [
- "borsh 1.5.0",
+ "borsh",
  "chacha20",
  "chacha20poly1305",
  "cipher",
@@ -2830,7 +2750,7 @@ dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "bls12_381",
- "borsh 1.5.0",
+ "borsh",
  "byteorder",
  "ff",
  "fpe",
@@ -2922,11 +2842,11 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "namada"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
  "async-trait",
- "borsh 1.5.0",
+ "borsh",
  "borsh-ext",
  "clru",
  "either",
@@ -2970,10 +2890,10 @@ dependencies = [
 
 [[package]]
 name = "namada_account"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
- "borsh 1.5.0",
+ "borsh",
  "namada_core",
  "namada_macros",
  "namada_storage",
@@ -2982,8 +2902,8 @@ dependencies = [
 
 [[package]]
 name = "namada_controller"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
  "namada_core",
  "smooth-operator",
@@ -2992,11 +2912,11 @@ dependencies = [
 
 [[package]]
 name = "namada_core"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
  "bech32 0.8.1",
- "borsh 1.5.0",
+ "borsh",
  "borsh-ext",
  "chrono",
  "data-encoding",
@@ -3027,8 +2947,8 @@ dependencies = [
  "sha2 0.9.9",
  "smooth-operator",
  "sparse-merkle-tree",
- "tendermint 0.36.0",
- "tendermint-proto 0.36.0",
+ "tendermint 0.37.0",
+ "tendermint-proto 0.37.0",
  "thiserror",
  "tiny-keccak",
  "tracing",
@@ -3038,10 +2958,10 @@ dependencies = [
 
 [[package]]
 name = "namada_ethereum_bridge"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
- "borsh 1.5.0",
+ "borsh",
  "ethers",
  "eyre",
  "itertools 0.12.1",
@@ -3063,10 +2983,10 @@ dependencies = [
 
 [[package]]
 name = "namada_events"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
- "borsh 1.5.0",
+ "borsh",
  "namada_core",
  "namada_macros",
  "serde",
@@ -3077,10 +2997,10 @@ dependencies = [
 
 [[package]]
 name = "namada_gas"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
- "borsh 1.5.0",
+ "borsh",
  "namada_core",
  "namada_events",
  "namada_macros",
@@ -3090,10 +3010,10 @@ dependencies = [
 
 [[package]]
 name = "namada_governance"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
- "borsh 1.5.0",
+ "borsh",
  "itertools 0.12.1",
  "konst",
  "namada_core",
@@ -3111,10 +3031,10 @@ dependencies = [
 
 [[package]]
 name = "namada_ibc"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
- "borsh 1.5.0",
+ "borsh",
  "data-encoding",
  "ibc",
  "ibc-derive",
@@ -3141,8 +3061,8 @@ dependencies = [
 
 [[package]]
 name = "namada_macros"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
  "data-encoding",
  "proc-macro2",
@@ -3153,10 +3073,10 @@ dependencies = [
 
 [[package]]
 name = "namada_merkle_tree"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
- "borsh 1.5.0",
+ "borsh",
  "eyre",
  "ics23",
  "namada_core",
@@ -3168,8 +3088,8 @@ dependencies = [
 
 [[package]]
 name = "namada_parameters"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
  "namada_core",
  "namada_macros",
@@ -3180,10 +3100,10 @@ dependencies = [
 
 [[package]]
 name = "namada_proof_of_stake"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
- "borsh 1.5.0",
+ "borsh",
  "konst",
  "namada_account",
  "namada_controller",
@@ -3203,20 +3123,20 @@ dependencies = [
 
 [[package]]
 name = "namada_replay_protection"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
  "namada_core",
 ]
 
 [[package]]
 name = "namada_sdk"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
  "async-trait",
  "bimap",
- "borsh 1.5.0",
+ "borsh",
  "borsh-ext",
  "circular-queue",
  "clap",
@@ -3227,6 +3147,7 @@ dependencies = [
  "ethbridge-bridge-contract",
  "ethers",
  "eyre",
+ "flume",
  "futures",
  "itertools 0.12.1",
  "lazy_static",
@@ -3257,6 +3178,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_core 0.6.4",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2 0.9.9",
@@ -3275,10 +3197,10 @@ dependencies = [
 
 [[package]]
 name = "namada_shielded_token"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
- "borsh 1.5.0",
+ "borsh",
  "lazy_static",
  "masp_primitives",
  "masp_proofs",
@@ -3297,10 +3219,11 @@ dependencies = [
 
 [[package]]
 name = "namada_state"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
- "borsh 1.5.0",
+ "borsh",
+ "clru",
  "itertools 0.12.1",
  "namada_core",
  "namada_events",
@@ -3319,10 +3242,10 @@ dependencies = [
 
 [[package]]
 name = "namada_storage"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
- "borsh 1.5.0",
+ "borsh",
  "itertools 0.12.1",
  "namada_core",
  "namada_macros",
@@ -3337,10 +3260,10 @@ dependencies = [
 
 [[package]]
 name = "namada_token"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
- "borsh 1.5.0",
+ "borsh",
  "namada_core",
  "namada_events",
  "namada_macros",
@@ -3352,8 +3275,8 @@ dependencies = [
 
 [[package]]
 name = "namada_trans_token"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
  "konst",
  "namada_core",
@@ -3363,12 +3286,12 @@ dependencies = [
 
 [[package]]
 name = "namada_tx"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
  "ark-bls12-381",
  "bitflags 2.5.0",
- "borsh 1.5.0",
+ "borsh",
  "data-encoding",
  "either",
  "konst",
@@ -3391,8 +3314,8 @@ dependencies = [
 
 [[package]]
 name = "namada_tx_env"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -3401,10 +3324,10 @@ dependencies = [
 
 [[package]]
 name = "namada_vote_ext"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
- "borsh 1.5.0",
+ "borsh",
  "namada_core",
  "namada_macros",
  "namada_tx",
@@ -3413,8 +3336,8 @@ dependencies = [
 
 [[package]]
 name = "namada_vp_env"
-version = "0.40.0"
-source = "git+https://github.com/anoma/namada#22a4839d84b8e7ff6a909b94d50165d98434ee15"
+version = "0.41.0"
+source = "git+https://github.com/anoma/namada#2f74edfd882a763c06f681450b82a6cc78c76cc4"
 dependencies = [
  "derivative",
  "masp_primitives",
@@ -3424,6 +3347,15 @@ dependencies = [
  "namada_storage",
  "namada_tx",
  "smooth-operator",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -3599,7 +3531,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.65",
@@ -3742,7 +3674,7 @@ version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -4005,15 +3937,6 @@ dependencies = [
  "impl-serde",
  "scale-info",
  "uint",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
-dependencies = [
- "toml 0.5.11",
 ]
 
 [[package]]
@@ -4398,7 +4321,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi",
@@ -4551,7 +4474,7 @@ version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d35494501194174bda522a32605929eefc9ecf7e0a326c26db1fdd85881eb62"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -4568,9 +4491,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0218ceea14babe24a4a5836f86ade86c1effbc198164e619194cb5069187e29"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -4580,9 +4503,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed5a1ccce8ff962e31a165d41f6e2a2dd1245099dc4d594f5574a86cd90f4d3"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4944,7 +4867,7 @@ name = "sparse-merkle-tree"
 version = "0.3.1-pre"
 source = "git+https://github.com/heliaxdev/sparse-merkle-tree?rev=bab8cb96872db22cc9a139b2d3dfc4e00521d097#bab8cb96872db22cc9a139b2d3dfc4e00521d097"
 dependencies = [
- "borsh 1.5.0",
+ "borsh",
  "cfg-if",
  "ics23",
  "itertools 0.12.1",
@@ -4956,6 +4879,15 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -5126,9 +5058,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b50aae6ec24c3429149ad59b5b8d3374d7804d4c7d6125ceb97cb53907fb68d"
+checksum = "954496fbc9716eb4446cdd6d00c071a3e2f22578d62aa03b40c7e5b4fda3ed42"
 dependencies = [
  "bytes",
  "digest 0.10.7",
@@ -5150,7 +5082,7 @@ dependencies = [
  "signature",
  "subtle",
  "subtle-encoding",
- "tendermint-proto 0.36.0",
+ "tendermint-proto 0.37.0",
  "time",
  "zeroize",
 ]
@@ -5171,28 +5103,28 @@ dependencies = [
 
 [[package]]
 name = "tendermint-config"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e07b383dc8780ebbec04cfb603f3fdaba6ea6663d8dd861425b1ffa7761fe90d"
+checksum = "f84b11b57d20ee4492a1452faff85f5c520adc36ca9fe5e701066935255bb89f"
 dependencies = [
  "flex-error",
  "serde",
  "serde_json",
- "tendermint 0.36.0",
+ "tendermint 0.37.0",
  "toml 0.8.13",
  "url",
 ]
 
 [[package]]
 name = "tendermint-light-client-verifier"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4216e487165e5dbd7af79952eaa0d5f06c5bde861eb76c690acd7f2d2a19395c"
+checksum = "3848090df4502a09ee27cb1a00f1835e1111c8993b22c5e1e41ffb7f6f09d57e"
 dependencies = [
  "derive_more",
  "flex-error",
  "serde",
- "tendermint 0.36.0",
+ "tendermint 0.37.0",
  "time",
 ]
 
@@ -5216,9 +5148,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-proto"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f193d04afde6592c20fd70788a10b8cb3823091c07456db70d8a93f5fb99c1"
+checksum = "dc87024548c7f3da479885201e3da20ef29e85a3b13d04606b380ac4c7120d87"
 dependencies = [
  "bytes",
  "flex-error",
@@ -5232,9 +5164,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-rpc"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e3c231a3632cab53f92ad4161c730c468c08cfe4f0aa5a6735b53b390aecbd"
+checksum = "dfdc2281e271277fda184d96d874a6fe59f569b130b634289257baacfc95aa85"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5249,9 +5181,9 @@ dependencies = [
  "serde_json",
  "subtle",
  "subtle-encoding",
- "tendermint 0.36.0",
- "tendermint-config 0.36.0",
- "tendermint-proto 0.36.0",
+ "tendermint 0.37.0",
+ "tendermint-config 0.37.0",
+ "tendermint-proto 0.37.0",
  "thiserror",
  "time",
  "url",
@@ -6104,26 +6036,6 @@ source = "git+https://github.com/zcash/librustzcash?rev=bd7f9d7#bd7f9d7c3ce5cfd1
 dependencies = [
  "byteorder",
  "nonempty",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.7.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.65",
 ]
 
 [[package]]

--- a/packages/shared/lib/Cargo.toml
+++ b/packages/shared/lib/Cargo.toml
@@ -24,7 +24,7 @@ chrono = "0.4.22"
 getrandom = { version = "0.2.7", features = ["js"] }
 gloo-utils = { version = "0.1.5", features = ["serde"] }
 js-sys = "0.3.60"
-namada = { git = "https://github.com/anoma/namada", version = "0.40.0", default-features = false, features = ["namada-sdk"] }
+namada = { git = "https://github.com/anoma/namada", version = "0.41.0", default-features = false, features = ["namada-sdk"] }
 rand = "0.8.5"
 rexie = "0.5"
 serde = "^1.0.181"

--- a/packages/types/docs/classes/BatchTxResultMsgValue.md
+++ b/packages/types/docs/classes/BatchTxResultMsgValue.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[tx/schema/batchTxResult.ts:12](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/batchTxResult.ts#L12)
+[tx/schema/batchTxResult.ts:12](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/batchTxResult.ts#L12)
 
 ## Properties
 
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[tx/schema/batchTxResult.ts:7](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/batchTxResult.ts#L7)
+[tx/schema/batchTxResult.ts:7](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/batchTxResult.ts#L7)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[tx/schema/batchTxResult.ts:10](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/batchTxResult.ts#L10)
+[tx/schema/batchTxResult.ts:10](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/batchTxResult.ts#L10)

--- a/packages/types/docs/classes/BondMsgValue.md
+++ b/packages/types/docs/classes/BondMsgValue.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[tx/schema/bond.ts:17](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/bond.ts#L17)
+[tx/schema/bond.ts:17](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/bond.ts#L17)
 
 ## Properties
 
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[tx/schema/bond.ts:15](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/bond.ts#L15)
+[tx/schema/bond.ts:15](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/bond.ts#L15)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[tx/schema/bond.ts:9](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/bond.ts#L9)
+[tx/schema/bond.ts:9](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/bond.ts#L9)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[tx/schema/bond.ts:12](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/bond.ts#L12)
+[tx/schema/bond.ts:12](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/bond.ts#L12)

--- a/packages/types/docs/classes/ClaimRewardsMsgValue.md
+++ b/packages/types/docs/classes/ClaimRewardsMsgValue.md
@@ -1,0 +1,54 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / ClaimRewardsMsgValue
+
+# Class: ClaimRewardsMsgValue
+
+## Table of contents
+
+### Constructors
+
+- [constructor](ClaimRewardsMsgValue.md#constructor)
+
+### Properties
+
+- [source](ClaimRewardsMsgValue.md#source)
+- [validator](ClaimRewardsMsgValue.md#validator)
+
+## Constructors
+
+### constructor
+
+• **new ClaimRewardsMsgValue**(`data`): [`ClaimRewardsMsgValue`](ClaimRewardsMsgValue.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | [`ClaimRewardsMsgValue`](ClaimRewardsMsgValue.md) |
+
+#### Returns
+
+[`ClaimRewardsMsgValue`](ClaimRewardsMsgValue.md)
+
+#### Defined in
+
+[tx/schema/claimRewards.ts:12](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/claimRewards.ts#L12)
+
+## Properties
+
+### source
+
+• `Optional` **source**: `string`
+
+#### Defined in
+
+[tx/schema/claimRewards.ts:10](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/claimRewards.ts#L10)
+
+___
+
+### validator
+
+• **validator**: `string`
+
+#### Defined in
+
+[tx/schema/claimRewards.ts:7](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/claimRewards.ts#L7)

--- a/packages/types/docs/classes/CommitmentMsgValue.md
+++ b/packages/types/docs/classes/CommitmentMsgValue.md
@@ -34,7 +34,7 @@
 
 #### Defined in
 
-[tx/schema/txDetails.ts:19](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/txDetails.ts#L19)
+[tx/schema/txDetails.ts:19](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/txDetails.ts#L19)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:10](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/txDetails.ts#L10)
+[tx/schema/txDetails.ts:10](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/txDetails.ts#L10)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:16](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/txDetails.ts#L16)
+[tx/schema/txDetails.ts:16](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/txDetails.ts#L16)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:13](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/txDetails.ts#L13)
+[tx/schema/txDetails.ts:13](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/txDetails.ts#L13)
 
 ___
 
@@ -74,4 +74,4 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:7](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/txDetails.ts#L7)
+[tx/schema/txDetails.ts:7](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/txDetails.ts#L7)

--- a/packages/types/docs/classes/EthBridgeTransferMsgValue.md
+++ b/packages/types/docs/classes/EthBridgeTransferMsgValue.md
@@ -37,7 +37,7 @@
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:32](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/ethBridgeTransfer.ts#L32)
+[tx/schema/ethBridgeTransfer.ts:32](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/ethBridgeTransfer.ts#L32)
 
 ## Properties
 
@@ -47,7 +47,7 @@
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:21](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/ethBridgeTransfer.ts#L21)
+[tx/schema/ethBridgeTransfer.ts:21](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/ethBridgeTransfer.ts#L21)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:12](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/ethBridgeTransfer.ts#L12)
+[tx/schema/ethBridgeTransfer.ts:12](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/ethBridgeTransfer.ts#L12)
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:24](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/ethBridgeTransfer.ts#L24)
+[tx/schema/ethBridgeTransfer.ts:24](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/ethBridgeTransfer.ts#L24)
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:27](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/ethBridgeTransfer.ts#L27)
+[tx/schema/ethBridgeTransfer.ts:27](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/ethBridgeTransfer.ts#L27)
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:30](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/ethBridgeTransfer.ts#L30)
+[tx/schema/ethBridgeTransfer.ts:30](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/ethBridgeTransfer.ts#L30)
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:9](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/ethBridgeTransfer.ts#L9)
+[tx/schema/ethBridgeTransfer.ts:9](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/ethBridgeTransfer.ts#L9)
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:15](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/ethBridgeTransfer.ts#L15)
+[tx/schema/ethBridgeTransfer.ts:15](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/ethBridgeTransfer.ts#L15)
 
 ___
 
@@ -117,4 +117,4 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:18](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/ethBridgeTransfer.ts#L18)
+[tx/schema/ethBridgeTransfer.ts:18](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/ethBridgeTransfer.ts#L18)

--- a/packages/types/docs/classes/IbcTransferMsgValue.md
+++ b/packages/types/docs/classes/IbcTransferMsgValue.md
@@ -15,6 +15,7 @@
 - [memo](IbcTransferMsgValue.md#memo)
 - [portId](IbcTransferMsgValue.md#portid)
 - [receiver](IbcTransferMsgValue.md#receiver)
+- [shieldingData](IbcTransferMsgValue.md#shieldingdata)
 - [source](IbcTransferMsgValue.md#source)
 - [timeoutHeight](IbcTransferMsgValue.md#timeoutheight)
 - [timeoutSecOffset](IbcTransferMsgValue.md#timeoutsecoffset)
@@ -38,7 +39,7 @@
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:35](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/ibcTransfer.ts#L35)
+[tx/schema/ibcTransfer.ts:38](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/ibcTransfer.ts#L38)
 
 ## Properties
 
@@ -48,7 +49,7 @@
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:18](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/ibcTransfer.ts#L18)
+[tx/schema/ibcTransfer.ts:18](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/ibcTransfer.ts#L18)
 
 ___
 
@@ -58,7 +59,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:24](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/ibcTransfer.ts#L24)
+[tx/schema/ibcTransfer.ts:24](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/ibcTransfer.ts#L24)
 
 ___
 
@@ -68,7 +69,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:33](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/ibcTransfer.ts#L33)
+[tx/schema/ibcTransfer.ts:33](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/ibcTransfer.ts#L33)
 
 ___
 
@@ -78,7 +79,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:21](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/ibcTransfer.ts#L21)
+[tx/schema/ibcTransfer.ts:21](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/ibcTransfer.ts#L21)
 
 ___
 
@@ -88,7 +89,17 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:12](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/ibcTransfer.ts#L12)
+[tx/schema/ibcTransfer.ts:12](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/ibcTransfer.ts#L12)
+
+___
+
+### shieldingData
+
+• `Optional` **shieldingData**: `Uint8Array`
+
+#### Defined in
+
+[tx/schema/ibcTransfer.ts:36](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/ibcTransfer.ts#L36)
 
 ___
 
@@ -98,7 +109,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:9](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/ibcTransfer.ts#L9)
+[tx/schema/ibcTransfer.ts:9](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/ibcTransfer.ts#L9)
 
 ___
 
@@ -108,7 +119,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:27](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/ibcTransfer.ts#L27)
+[tx/schema/ibcTransfer.ts:27](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/ibcTransfer.ts#L27)
 
 ___
 
@@ -118,7 +129,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:30](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/ibcTransfer.ts#L30)
+[tx/schema/ibcTransfer.ts:30](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/ibcTransfer.ts#L30)
 
 ___
 
@@ -128,4 +139,4 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:15](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/ibcTransfer.ts#L15)
+[tx/schema/ibcTransfer.ts:15](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/ibcTransfer.ts#L15)

--- a/packages/types/docs/classes/Message.md
+++ b/packages/types/docs/classes/Message.md
@@ -61,7 +61,7 @@
 
 #### Defined in
 
-[tx/messages/index.ts:9](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/messages/index.ts#L9)
+[tx/messages/index.ts:9](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/messages/index.ts#L9)
 
 ___
 
@@ -88,4 +88,4 @@ ___
 
 #### Defined in
 
-[tx/messages/index.ts:17](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/messages/index.ts#L17)
+[tx/messages/index.ts:17](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/messages/index.ts#L17)

--- a/packages/types/docs/classes/RedelegateMsgValue.md
+++ b/packages/types/docs/classes/RedelegateMsgValue.md
@@ -33,7 +33,7 @@
 
 #### Defined in
 
-[tx/schema/redelegate.ts:19](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/redelegate.ts#L19)
+[tx/schema/redelegate.ts:19](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/redelegate.ts#L19)
 
 ## Properties
 
@@ -43,7 +43,7 @@
 
 #### Defined in
 
-[tx/schema/redelegate.ts:17](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/redelegate.ts#L17)
+[tx/schema/redelegate.ts:17](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/redelegate.ts#L17)
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 #### Defined in
 
-[tx/schema/redelegate.ts:14](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/redelegate.ts#L14)
+[tx/schema/redelegate.ts:14](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/redelegate.ts#L14)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[tx/schema/redelegate.ts:8](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/redelegate.ts#L8)
+[tx/schema/redelegate.ts:8](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/redelegate.ts#L8)
 
 ___
 
@@ -73,4 +73,4 @@ ___
 
 #### Defined in
 
-[tx/schema/redelegate.ts:11](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/redelegate.ts#L11)
+[tx/schema/redelegate.ts:11](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/redelegate.ts#L11)

--- a/packages/types/docs/classes/RevealPkMsgValue.md
+++ b/packages/types/docs/classes/RevealPkMsgValue.md
@@ -30,7 +30,7 @@
 
 #### Defined in
 
-[tx/schema/revealPk.ts:8](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/revealPk.ts#L8)
+[tx/schema/revealPk.ts:8](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/revealPk.ts#L8)
 
 ## Properties
 
@@ -40,4 +40,4 @@
 
 #### Defined in
 
-[tx/schema/revealPk.ts:6](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/revealPk.ts#L6)
+[tx/schema/revealPk.ts:6](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/revealPk.ts#L6)

--- a/packages/types/docs/classes/SignatureMsgValue.md
+++ b/packages/types/docs/classes/SignatureMsgValue.md
@@ -34,7 +34,7 @@
 
 #### Defined in
 
-[tx/schema/signature.ts:21](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/signature.ts#L21)
+[tx/schema/signature.ts:21](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/signature.ts#L21)
 
 ## Properties
 
@@ -44,7 +44,7 @@
 
 #### Defined in
 
-[tx/schema/signature.ts:7](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/signature.ts#L7)
+[tx/schema/signature.ts:7](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/signature.ts#L7)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[tx/schema/signature.ts:10](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/signature.ts#L10)
+[tx/schema/signature.ts:10](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/signature.ts#L10)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[tx/schema/signature.ts:13](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/signature.ts#L13)
+[tx/schema/signature.ts:13](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/signature.ts#L13)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[tx/schema/signature.ts:16](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/signature.ts#L16)
+[tx/schema/signature.ts:16](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/signature.ts#L16)
 
 ___
 
@@ -84,4 +84,4 @@ ___
 
 #### Defined in
 
-[tx/schema/signature.ts:19](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/signature.ts#L19)
+[tx/schema/signature.ts:19](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/signature.ts#L19)

--- a/packages/types/docs/classes/TransferDataMsgValue.md
+++ b/packages/types/docs/classes/TransferDataMsgValue.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:49](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/transfer.ts#L49)
+[tx/schema/transfer.ts:49](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/transfer.ts#L49)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:43](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/transfer.ts#L43)
+[tx/schema/transfer.ts:43](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/transfer.ts#L43)
 
 ___
 
@@ -52,4 +52,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:46](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/transfer.ts#L46)
+[tx/schema/transfer.ts:46](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/transfer.ts#L46)

--- a/packages/types/docs/classes/TransferMsgValue.md
+++ b/packages/types/docs/classes/TransferMsgValue.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:60](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/transfer.ts#L60)
+[tx/schema/transfer.ts:60](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/transfer.ts#L60)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:54](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/transfer.ts#L54)
+[tx/schema/transfer.ts:54](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/transfer.ts#L54)
 
 ___
 
@@ -52,4 +52,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:57](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/transfer.ts#L57)
+[tx/schema/transfer.ts:57](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/transfer.ts#L57)

--- a/packages/types/docs/classes/TransparentTransferDataMsgValue.md
+++ b/packages/types/docs/classes/TransparentTransferDataMsgValue.md
@@ -33,7 +33,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:23](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/transfer.ts#L23)
+[tx/schema/transfer.ts:23](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/transfer.ts#L23)
 
 ## Properties
 
@@ -43,7 +43,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:21](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/transfer.ts#L21)
+[tx/schema/transfer.ts:21](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/transfer.ts#L21)
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:12](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/transfer.ts#L12)
+[tx/schema/transfer.ts:12](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/transfer.ts#L12)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:15](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/transfer.ts#L15)
+[tx/schema/transfer.ts:15](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/transfer.ts#L15)
 
 ___
 
@@ -73,4 +73,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:18](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/transfer.ts#L18)
+[tx/schema/transfer.ts:18](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/transfer.ts#L18)

--- a/packages/types/docs/classes/TransparentTransferMsgValue.md
+++ b/packages/types/docs/classes/TransparentTransferMsgValue.md
@@ -30,7 +30,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:32](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/transfer.ts#L32)
+[tx/schema/transfer.ts:32](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/transfer.ts#L32)
 
 ## Properties
 
@@ -40,4 +40,4 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:30](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/transfer.ts#L30)
+[tx/schema/transfer.ts:30](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/transfer.ts#L30)

--- a/packages/types/docs/classes/TxDetailsMsgValue.md
+++ b/packages/types/docs/classes/TxDetailsMsgValue.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[tx/schema/txDetails.ts:27](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/txDetails.ts#L27)
+[tx/schema/txDetails.ts:27](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/txDetails.ts#L27)
 
 ___
 
@@ -41,4 +41,4 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:24](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/txDetails.ts#L24)
+[tx/schema/txDetails.ts:24](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/txDetails.ts#L24)

--- a/packages/types/docs/classes/TxResponseMsgValue.md
+++ b/packages/types/docs/classes/TxResponseMsgValue.md
@@ -36,7 +36,7 @@
 
 #### Defined in
 
-[tx/schema/txResponse.ts:28](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/txResponse.ts#L28)
+[tx/schema/txResponse.ts:28](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/txResponse.ts#L28)
 
 ## Properties
 
@@ -46,7 +46,7 @@
 
 #### Defined in
 
-[tx/schema/txResponse.ts:8](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/txResponse.ts#L8)
+[tx/schema/txResponse.ts:8](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/txResponse.ts#L8)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:11](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/txResponse.ts#L11)
+[tx/schema/txResponse.ts:11](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/txResponse.ts#L11)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:14](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/txResponse.ts#L14)
+[tx/schema/txResponse.ts:14](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/txResponse.ts#L14)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:17](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/txResponse.ts#L17)
+[tx/schema/txResponse.ts:17](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/txResponse.ts#L17)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:20](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/txResponse.ts#L20)
+[tx/schema/txResponse.ts:20](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/txResponse.ts#L20)
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:23](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/txResponse.ts#L23)
+[tx/schema/txResponse.ts:23](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/txResponse.ts#L23)
 
 ___
 
@@ -106,4 +106,4 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:26](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/txResponse.ts#L26)
+[tx/schema/txResponse.ts:26](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/txResponse.ts#L26)

--- a/packages/types/docs/classes/UnbondMsgValue.md
+++ b/packages/types/docs/classes/UnbondMsgValue.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[tx/schema/unbond.ts:17](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/unbond.ts#L17)
+[tx/schema/unbond.ts:17](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/unbond.ts#L17)
 
 ## Properties
 
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[tx/schema/unbond.ts:15](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/unbond.ts#L15)
+[tx/schema/unbond.ts:15](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/unbond.ts#L15)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[tx/schema/unbond.ts:9](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/unbond.ts#L9)
+[tx/schema/unbond.ts:9](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/unbond.ts#L9)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[tx/schema/unbond.ts:12](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/unbond.ts#L12)
+[tx/schema/unbond.ts:12](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/unbond.ts#L12)

--- a/packages/types/docs/classes/VoteProposalMsgValue.md
+++ b/packages/types/docs/classes/VoteProposalMsgValue.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[tx/schema/voteProposal.ts:15](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/voteProposal.ts#L15)
+[tx/schema/voteProposal.ts:15](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/voteProposal.ts#L15)
 
 ## Properties
 
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[tx/schema/voteProposal.ts:10](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/voteProposal.ts#L10)
+[tx/schema/voteProposal.ts:10](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/voteProposal.ts#L10)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[tx/schema/voteProposal.ts:7](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/voteProposal.ts#L7)
+[tx/schema/voteProposal.ts:7](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/voteProposal.ts#L7)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[tx/schema/voteProposal.ts:13](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/voteProposal.ts#L13)
+[tx/schema/voteProposal.ts:13](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/voteProposal.ts#L13)

--- a/packages/types/docs/classes/WithdrawMsgValue.md
+++ b/packages/types/docs/classes/WithdrawMsgValue.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[tx/schema/withdraw.ts:12](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/withdraw.ts#L12)
+[tx/schema/withdraw.ts:12](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/withdraw.ts#L12)
 
 ## Properties
 
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[tx/schema/withdraw.ts:7](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/withdraw.ts#L7)
+[tx/schema/withdraw.ts:7](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/withdraw.ts#L7)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[tx/schema/withdraw.ts:10](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/withdraw.ts#L10)
+[tx/schema/withdraw.ts:10](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/withdraw.ts#L10)

--- a/packages/types/docs/classes/WrapperTxMsgValue.md
+++ b/packages/types/docs/classes/WrapperTxMsgValue.md
@@ -35,7 +35,7 @@
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:26](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/wrapperTx.ts#L26)
+[tx/schema/wrapperTx.ts:26](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/wrapperTx.ts#L26)
 
 ## Properties
 
@@ -45,7 +45,7 @@
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:18](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/wrapperTx.ts#L18)
+[tx/schema/wrapperTx.ts:18](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/wrapperTx.ts#L18)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:12](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/wrapperTx.ts#L12)
+[tx/schema/wrapperTx.ts:12](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/wrapperTx.ts#L12)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:15](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/wrapperTx.ts#L15)
+[tx/schema/wrapperTx.ts:15](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/wrapperTx.ts#L15)
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:24](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/wrapperTx.ts#L24)
+[tx/schema/wrapperTx.ts:24](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/wrapperTx.ts#L24)
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:21](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/wrapperTx.ts#L21)
+[tx/schema/wrapperTx.ts:21](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/wrapperTx.ts#L21)
 
 ___
 
@@ -95,4 +95,4 @@ ___
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:9](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/wrapperTx.ts#L9)
+[tx/schema/wrapperTx.ts:9](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/wrapperTx.ts#L9)

--- a/packages/types/docs/enums/AccountType.md
+++ b/packages/types/docs/enums/AccountType.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[account.ts:18](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/account.ts#L18)
+[account.ts:18](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/account.ts#L18)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[account.ts:12](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/account.ts#L12)
+[account.ts:12](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/account.ts#L12)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[account.ts:14](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/account.ts#L14)
+[account.ts:14](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/account.ts#L14)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[account.ts:16](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/account.ts#L16)
+[account.ts:16](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/account.ts#L16)

--- a/packages/types/docs/enums/BridgeType.md
+++ b/packages/types/docs/enums/BridgeType.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[chain.ts:14](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/chain.ts#L14)
+[chain.ts:14](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/chain.ts#L14)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[chain.ts:13](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/chain.ts#L13)
+[chain.ts:13](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/chain.ts#L13)

--- a/packages/types/docs/enums/Events.md
+++ b/packages/types/docs/enums/Events.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[events.ts:5](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/events.ts#L5)
+[events.ts:5](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/events.ts#L5)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[events.ts:8](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/events.ts#L8)
+[events.ts:8](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/events.ts#L8)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[events.ts:7](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/events.ts#L7)
+[events.ts:7](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/events.ts#L7)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[events.ts:6](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/events.ts#L6)
+[events.ts:6](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/events.ts#L6)

--- a/packages/types/docs/enums/KeplrEvents.md
+++ b/packages/types/docs/enums/KeplrEvents.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[events.ts:13](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/events.ts#L13)
+[events.ts:13](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/events.ts#L13)

--- a/packages/types/docs/enums/MetamaskEvents.md
+++ b/packages/types/docs/enums/MetamaskEvents.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[events.ts:18](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/events.ts#L18)
+[events.ts:18](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/events.ts#L18)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[events.ts:19](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/events.ts#L19)
+[events.ts:19](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/events.ts#L19)

--- a/packages/types/docs/interfaces/IMessage.md
+++ b/packages/types/docs/interfaces/IMessage.md
@@ -36,4 +36,4 @@
 
 #### Defined in
 
-[tx/messages/index.ts:5](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/messages/index.ts#L5)
+[tx/messages/index.ts:5](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/messages/index.ts#L5)

--- a/packages/types/docs/interfaces/Namada.md
+++ b/packages/types/docs/interfaces/Namada.md
@@ -35,7 +35,7 @@
 
 #### Defined in
 
-[namada.ts:41](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/namada.ts#L41)
+[namada.ts:41](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/namada.ts#L41)
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 #### Defined in
 
-[namada.ts:42](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/namada.ts#L42)
+[namada.ts:42](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/namada.ts#L42)
 
 ## Methods
 
@@ -73,7 +73,7 @@ ___
 
 #### Defined in
 
-[namada.ts:32](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/namada.ts#L32)
+[namada.ts:32](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/namada.ts#L32)
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 #### Defined in
 
-[namada.ts:33](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/namada.ts#L33)
+[namada.ts:33](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/namada.ts#L33)
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 #### Defined in
 
-[namada.ts:35](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/namada.ts#L35)
+[namada.ts:35](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/namada.ts#L35)
 
 ___
 
@@ -121,7 +121,7 @@ ___
 
 #### Defined in
 
-[namada.ts:34](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/namada.ts#L34)
+[namada.ts:34](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/namada.ts#L34)
 
 ___
 
@@ -141,7 +141,7 @@ ___
 
 #### Defined in
 
-[namada.ts:36](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/namada.ts#L36)
+[namada.ts:36](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/namada.ts#L36)
 
 ___
 
@@ -161,7 +161,7 @@ ___
 
 #### Defined in
 
-[namada.ts:37](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/namada.ts#L37)
+[namada.ts:37](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/namada.ts#L37)
 
 ___
 
@@ -181,4 +181,4 @@ ___
 
 #### Defined in
 
-[namada.ts:40](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/namada.ts#L40)
+[namada.ts:40](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/namada.ts#L40)

--- a/packages/types/docs/interfaces/Signer.md
+++ b/packages/types/docs/interfaces/Signer.md
@@ -34,7 +34,7 @@
 
 #### Defined in
 
-[signer.ts:14](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/signer.ts#L14)
+[signer.ts:14](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/signer.ts#L14)
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 #### Defined in
 
-[signer.ts:15](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/signer.ts#L15)
+[signer.ts:15](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/signer.ts#L15)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[signer.ts:18](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/signer.ts#L18)
+[signer.ts:18](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/signer.ts#L18)
 
 ___
 
@@ -111,7 +111,7 @@ ___
 
 #### Defined in
 
-[signer.ts:25](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/signer.ts#L25)
+[signer.ts:25](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/signer.ts#L25)
 
 ___
 
@@ -137,4 +137,4 @@ ___
 
 #### Defined in
 
-[signer.ts:29](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/signer.ts#L29)
+[signer.ts:29](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/signer.ts#L29)

--- a/packages/types/docs/modules.md
+++ b/packages/types/docs/modules.md
@@ -16,6 +16,7 @@
 
 - [BatchTxResultMsgValue](classes/BatchTxResultMsgValue.md)
 - [BondMsgValue](classes/BondMsgValue.md)
+- [ClaimRewardsMsgValue](classes/ClaimRewardsMsgValue.md)
 - [CommitmentMsgValue](classes/CommitmentMsgValue.md)
 - [EthBridgeTransferMsgValue](classes/EthBridgeTransferMsgValue.md)
 - [IbcTransferMsgValue](classes/IbcTransferMsgValue.md)
@@ -50,6 +51,7 @@
 - [BondProps](modules.md#bondprops)
 - [Chain](modules.md#chain)
 - [ChainKey](modules.md#chainkey)
+- [ClaimRewardsProps](modules.md#claimrewardsprops)
 - [CommitmentDetailProps](modules.md#commitmentdetailprops)
 - [CosmosMinDenom](modules.md#cosmosmindenom)
 - [CosmosTokenType](modules.md#cosmostokentype)
@@ -131,7 +133,7 @@
 
 #### Defined in
 
-[account.ts:32](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/account.ts#L32)
+[account.ts:32](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/account.ts#L32)
 
 ___
 
@@ -148,7 +150,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:33](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L33)
+[proposals.ts:33](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L33)
 
 ___
 
@@ -165,7 +167,7 @@ ___
 
 #### Defined in
 
-[namada.ts:26](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/namada.ts#L26)
+[namada.ts:26](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/namada.ts#L26)
 
 ___
 
@@ -175,7 +177,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:19](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/types.ts#L19)
+[tx/types.ts:20](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/types.ts#L20)
 
 ___
 
@@ -193,7 +195,7 @@ ___
 
 #### Defined in
 
-[account.ts:3](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/account.ts#L3)
+[account.ts:3](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/account.ts#L3)
 
 ___
 
@@ -203,7 +205,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:20](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/types.ts#L20)
+[tx/types.ts:21](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/types.ts#L21)
 
 ___
 
@@ -230,7 +232,7 @@ ___
 
 #### Defined in
 
-[chain.ts:49](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/chain.ts#L49)
+[chain.ts:49](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/chain.ts#L49)
 
 ___
 
@@ -240,7 +242,17 @@ ___
 
 #### Defined in
 
-[chain.ts:21](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/chain.ts#L21)
+[chain.ts:21](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/chain.ts#L21)
+
+___
+
+### ClaimRewardsProps
+
+Ƭ **ClaimRewardsProps**: [`ClaimRewardsMsgValue`](classes/ClaimRewardsMsgValue.md)
+
+#### Defined in
+
+[tx/types.ts:32](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/types.ts#L32)
 
 ___
 
@@ -250,7 +262,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:46](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/types.ts#L46)
+[tx/types.ts:49](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/types.ts#L49)
 
 ___
 
@@ -260,7 +272,7 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:13](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tokens/Cosmos.ts#L13)
+[tokens/Cosmos.ts:13](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tokens/Cosmos.ts#L13)
 
 ___
 
@@ -270,7 +282,7 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:6](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tokens/Cosmos.ts#L6)
+[tokens/Cosmos.ts:6](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tokens/Cosmos.ts#L6)
 
 ___
 
@@ -292,7 +304,7 @@ ___
 
 #### Defined in
 
-[chain.ts:1](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/chain.ts#L1)
+[chain.ts:1](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/chain.ts#L1)
 
 ___
 
@@ -308,7 +320,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:54](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L54)
+[proposals.ts:54](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L54)
 
 ___
 
@@ -325,7 +337,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:55](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L55)
+[proposals.ts:55](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L55)
 
 ___
 
@@ -335,7 +347,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:83](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L83)
+[proposals.ts:83](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L83)
 
 ___
 
@@ -358,7 +370,7 @@ ___
 
 #### Defined in
 
-[account.ts:21](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/account.ts#L21)
+[account.ts:21](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/account.ts#L21)
 
 ___
 
@@ -368,7 +380,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:21](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/types.ts#L21)
+[tx/types.ts:22](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/types.ts#L22)
 
 ___
 
@@ -386,7 +398,7 @@ ___
 
 #### Defined in
 
-[chain.ts:23](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/chain.ts#L23)
+[chain.ts:23](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/chain.ts#L23)
 
 ___
 
@@ -396,7 +408,7 @@ ___
 
 #### Defined in
 
-[chain.ts:18](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/chain.ts#L18)
+[chain.ts:18](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/chain.ts#L18)
 
 ___
 
@@ -406,7 +418,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:22](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/types.ts#L22)
+[tx/types.ts:23](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/types.ts#L23)
 
 ___
 
@@ -416,7 +428,7 @@ ___
 
 #### Defined in
 
-[utils.ts:1](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/utils.ts#L1)
+[utils.ts:1](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/utils.ts#L1)
 
 ___
 
@@ -430,7 +442,7 @@ ___
 
 #### Defined in
 
-[utils.ts:2](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/utils.ts#L2)
+[utils.ts:2](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/utils.ts#L2)
 
 ___
 
@@ -449,7 +461,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:46](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L46)
+[proposals.ts:46](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L46)
 
 ___
 
@@ -466,7 +478,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:57](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L57)
+[proposals.ts:57](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L57)
 
 ___
 
@@ -483,7 +495,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:56](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L56)
+[proposals.ts:56](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L56)
 
 ___
 
@@ -501,7 +513,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:39](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L39)
+[proposals.ts:39](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L39)
 
 ___
 
@@ -511,7 +523,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:15](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L15)
+[proposals.ts:15](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L15)
 
 ___
 
@@ -521,7 +533,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:10](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L10)
+[proposals.ts:10](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L10)
 
 ___
 
@@ -531,7 +543,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:58](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L58)
+[proposals.ts:58](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L58)
 
 ___
 
@@ -541,7 +553,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:60](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L60)
+[proposals.ts:60](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L60)
 
 ___
 
@@ -551,7 +563,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:23](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/types.ts#L23)
+[tx/types.ts:24](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/types.ts#L24)
 
 ___
 
@@ -561,17 +573,17 @@ ___
 
 #### Defined in
 
-[tx/types.ts:33](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/types.ts#L33)
+[tx/types.ts:35](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/types.ts#L35)
 
 ___
 
 ### Schema
 
-Ƭ **Schema**: [`BatchTxResultMsgValue`](classes/BatchTxResultMsgValue.md) \| [`EthBridgeTransferMsgValue`](classes/EthBridgeTransferMsgValue.md) \| [`IbcTransferMsgValue`](classes/IbcTransferMsgValue.md) \| [`SignatureMsgValue`](classes/SignatureMsgValue.md) \| [`BondMsgValue`](classes/BondMsgValue.md) \| [`UnbondMsgValue`](classes/UnbondMsgValue.md) \| [`VoteProposalMsgValue`](classes/VoteProposalMsgValue.md) \| [`WithdrawMsgValue`](classes/WithdrawMsgValue.md) \| [`TransferMsgValue`](classes/TransferMsgValue.md) \| [`TransferDataMsgValue`](classes/TransferDataMsgValue.md) \| [`TransparentTransferMsgValue`](classes/TransparentTransferMsgValue.md) \| [`TransparentTransferDataMsgValue`](classes/TransparentTransferDataMsgValue.md) \| [`TxResponseMsgValue`](classes/TxResponseMsgValue.md) \| [`WrapperTxMsgValue`](classes/WrapperTxMsgValue.md) \| [`RedelegateMsgValue`](classes/RedelegateMsgValue.md) \| [`CommitmentMsgValue`](classes/CommitmentMsgValue.md) \| [`TxDetailsMsgValue`](classes/TxDetailsMsgValue.md) \| [`RevealPkMsgValue`](classes/RevealPkMsgValue.md)
+Ƭ **Schema**: [`BatchTxResultMsgValue`](classes/BatchTxResultMsgValue.md) \| [`EthBridgeTransferMsgValue`](classes/EthBridgeTransferMsgValue.md) \| [`IbcTransferMsgValue`](classes/IbcTransferMsgValue.md) \| [`SignatureMsgValue`](classes/SignatureMsgValue.md) \| [`BondMsgValue`](classes/BondMsgValue.md) \| [`UnbondMsgValue`](classes/UnbondMsgValue.md) \| [`VoteProposalMsgValue`](classes/VoteProposalMsgValue.md) \| [`ClaimRewardsMsgValue`](classes/ClaimRewardsMsgValue.md) \| [`WithdrawMsgValue`](classes/WithdrawMsgValue.md) \| [`TransferMsgValue`](classes/TransferMsgValue.md) \| [`TransferDataMsgValue`](classes/TransferDataMsgValue.md) \| [`TransparentTransferMsgValue`](classes/TransparentTransferMsgValue.md) \| [`TransparentTransferDataMsgValue`](classes/TransparentTransferDataMsgValue.md) \| [`TxResponseMsgValue`](classes/TxResponseMsgValue.md) \| [`WrapperTxMsgValue`](classes/WrapperTxMsgValue.md) \| [`RedelegateMsgValue`](classes/RedelegateMsgValue.md) \| [`CommitmentMsgValue`](classes/CommitmentMsgValue.md) \| [`TxDetailsMsgValue`](classes/TxDetailsMsgValue.md) \| [`RevealPkMsgValue`](classes/RevealPkMsgValue.md)
 
 #### Defined in
 
-[tx/schema/index.ts:37](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/index.ts#L37)
+[tx/schema/index.ts:39](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/index.ts#L39)
 
 ___
 
@@ -588,7 +600,7 @@ ___
 
 #### Defined in
 
-[namada.ts:5](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/namada.ts#L5)
+[namada.ts:5](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/namada.ts#L5)
 
 ___
 
@@ -605,7 +617,7 @@ ___
 
 #### Defined in
 
-[signer.ts:3](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/signer.ts#L3)
+[signer.ts:3](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/signer.ts#L3)
 
 ___
 
@@ -625,7 +637,7 @@ ___
 
 #### Defined in
 
-[namada.ts:10](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/namada.ts#L10)
+[namada.ts:10](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/namada.ts#L10)
 
 ___
 
@@ -635,17 +647,17 @@ ___
 
 #### Defined in
 
-[tx/types.ts:24](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/types.ts#L24)
+[tx/types.ts:25](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/types.ts#L25)
 
 ___
 
 ### SupportedTxProps
 
-Ƭ **SupportedTxProps**: [`BondProps`](modules.md#bondprops) \| [`UnbondProps`](modules.md#unbondprops) \| [`WithdrawProps`](modules.md#withdrawprops) \| [`RedelegateProps`](modules.md#redelegateprops) \| [`EthBridgeTransferProps`](modules.md#ethbridgetransferprops) \| [`IbcTransferProps`](modules.md#ibctransferprops) \| [`VoteProposalProps`](modules.md#voteproposalprops) \| [`TransferProps`](modules.md#transferprops) \| [`RevealPkProps`](modules.md#revealpkprops)
+Ƭ **SupportedTxProps**: [`BondProps`](modules.md#bondprops) \| [`UnbondProps`](modules.md#unbondprops) \| [`WithdrawProps`](modules.md#withdrawprops) \| [`RedelegateProps`](modules.md#redelegateprops) \| [`EthBridgeTransferProps`](modules.md#ethbridgetransferprops) \| [`IbcTransferProps`](modules.md#ibctransferprops) \| [`VoteProposalProps`](modules.md#voteproposalprops) \| [`ClaimRewardsProps`](modules.md#claimrewardsprops) \| [`TransferProps`](modules.md#transferprops) \| [`RevealPkProps`](modules.md#revealpkprops)
 
 #### Defined in
 
-[tx/types.ts:35](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/types.ts#L35)
+[tx/types.ts:37](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/types.ts#L37)
 
 ___
 
@@ -655,7 +667,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:99](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L99)
+[proposals.ts:99](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L99)
 
 ___
 
@@ -671,7 +683,7 @@ ___
 
 #### Defined in
 
-[tokens/types.ts:19](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tokens/types.ts#L19)
+[tokens/types.ts:19](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tokens/types.ts#L19)
 
 ___
 
@@ -703,7 +715,7 @@ ___
 
 #### Defined in
 
-[tokens/types.ts:5](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tokens/types.ts#L5)
+[tokens/types.ts:5](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tokens/types.ts#L5)
 
 ___
 
@@ -713,7 +725,7 @@ ___
 
 #### Defined in
 
-[tokens/Namada.ts:21](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tokens/Namada.ts#L21)
+[tokens/Namada.ts:21](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tokens/Namada.ts#L21)
 
 ___
 
@@ -723,7 +735,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:25](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/types.ts#L25)
+[tx/types.ts:26](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/types.ts#L26)
 
 ___
 
@@ -733,7 +745,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:27](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/types.ts#L27)
+[tx/types.ts:28](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/types.ts#L28)
 
 ___
 
@@ -743,7 +755,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:26](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/types.ts#L26)
+[tx/types.ts:27](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/types.ts#L27)
 
 ___
 
@@ -760,7 +772,7 @@ ___
 
 #### Defined in
 
-[signer.ts:8](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/signer.ts#L8)
+[signer.ts:8](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/signer.ts#L8)
 
 ___
 
@@ -770,7 +782,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:52](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/types.ts#L52)
+[tx/types.ts:55](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/types.ts#L55)
 
 ___
 
@@ -780,7 +792,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:28](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/types.ts#L28)
+[tx/types.ts:29](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/types.ts#L29)
 
 ___
 
@@ -790,7 +802,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:29](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/types.ts#L29)
+[tx/types.ts:30](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/types.ts#L30)
 
 ___
 
@@ -800,7 +812,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:75](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L75)
+[proposals.ts:75](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L75)
 
 ___
 
@@ -818,7 +830,7 @@ ___
 
 #### Defined in
 
-[namada.ts:20](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/namada.ts#L20)
+[namada.ts:20](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/namada.ts#L20)
 
 ___
 
@@ -828,7 +840,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:91](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L91)
+[proposals.ts:91](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L91)
 
 ___
 
@@ -838,7 +850,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:30](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/types.ts#L30)
+[tx/types.ts:31](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/types.ts#L31)
 
 ___
 
@@ -848,7 +860,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:63](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L63)
+[proposals.ts:63](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L63)
 
 ___
 
@@ -858,7 +870,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:68](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L68)
+[proposals.ts:68](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L68)
 
 ___
 
@@ -868,7 +880,7 @@ ___
 
 #### Defined in
 
-[namada.ts:45](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/namada.ts#L45)
+[namada.ts:45](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/namada.ts#L45)
 
 ___
 
@@ -878,7 +890,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:31](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/types.ts#L31)
+[tx/types.ts:33](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/types.ts#L33)
 
 ___
 
@@ -888,7 +900,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:32](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/types.ts#L32)
+[tx/types.ts:34](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/types.ts#L34)
 
 ## Variables
 
@@ -905,7 +917,7 @@ ___
 
 #### Defined in
 
-[tx/schema/utils.ts:4](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tx/schema/utils.ts#L4)
+[tx/schema/utils.ts:4](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tx/schema/utils.ts#L4)
 
 ___
 
@@ -915,7 +927,7 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:5](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tokens/Cosmos.ts#L5)
+[tokens/Cosmos.ts:5](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tokens/Cosmos.ts#L5)
 
 ___
 
@@ -925,7 +937,7 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:22](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tokens/Cosmos.ts#L22)
+[tokens/Cosmos.ts:22](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tokens/Cosmos.ts#L22)
 
 ___
 
@@ -952,7 +964,7 @@ ___
 
 #### Defined in
 
-[chain.ts:30](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/chain.ts#L30)
+[chain.ts:30](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/chain.ts#L30)
 
 ___
 
@@ -962,7 +974,7 @@ ___
 
 #### Defined in
 
-[tokens/Namada.ts:11](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tokens/Namada.ts#L11)
+[tokens/Namada.ts:11](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tokens/Namada.ts#L11)
 
 ___
 
@@ -972,7 +984,7 @@ ___
 
 #### Defined in
 
-[tokens/Namada.ts:23](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tokens/Namada.ts#L23)
+[tokens/Namada.ts:23](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tokens/Namada.ts#L23)
 
 ___
 
@@ -982,7 +994,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:3](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L3)
+[proposals.ts:3](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L3)
 
 ___
 
@@ -992,7 +1004,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:93](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L93)
+[proposals.ts:93](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L93)
 
 ___
 
@@ -1002,7 +1014,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:62](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L62)
+[proposals.ts:62](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L62)
 
 ## Functions
 
@@ -1022,7 +1034,7 @@ vote is DelegatorVote
 
 #### Defined in
 
-[proposals.ts:88](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L88)
+[proposals.ts:88](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L88)
 
 ___
 
@@ -1042,7 +1054,7 @@ str is "pending" \| "ongoing" \| "passed" \| "rejected"
 
 #### Defined in
 
-[proposals.ts:12](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L12)
+[proposals.ts:12](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L12)
 
 ___
 
@@ -1062,7 +1074,7 @@ tallyType is "two-thirds" \| "one-half-over-one-third" \| "less-one-half-over-on
 
 #### Defined in
 
-[proposals.ts:101](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L101)
+[proposals.ts:101](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L101)
 
 ___
 
@@ -1082,7 +1094,7 @@ vote is ValidatorVote
 
 #### Defined in
 
-[proposals.ts:80](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L80)
+[proposals.ts:80](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L80)
 
 ___
 
@@ -1102,7 +1114,7 @@ str is "yay" \| "nay" \| "abstain"
 
 #### Defined in
 
-[proposals.ts:65](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/proposals.ts#L65)
+[proposals.ts:65](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/proposals.ts#L65)
 
 ___
 
@@ -1122,7 +1134,7 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:66](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tokens/Cosmos.ts#L66)
+[tokens/Cosmos.ts:66](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tokens/Cosmos.ts#L66)
 
 ___
 
@@ -1142,4 +1154,4 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:48](https://github.com/anoma/namada-interface/blob/8d368aaf/packages/types/src/tokens/Cosmos.ts#L48)
+[tokens/Cosmos.ts:48](https://github.com/anoma/namada-interface/blob/cebcdd13/packages/types/src/tokens/Cosmos.ts#L48)

--- a/packages/types/src/tx/schema/ibcTransfer.ts
+++ b/packages/types/src/tx/schema/ibcTransfer.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { field, option } from "@dao-xyz/borsh";
+import { field, option, vec } from "@dao-xyz/borsh";
 import BigNumber from "bignumber.js";
 import { IbcTransferProps } from "../types";
 import { BigNumberSerializer } from "./utils";
@@ -31,6 +31,9 @@ export class IbcTransferMsgValue {
 
   @field({ type: option("string") })
   memo?: string;
+
+  @field({ type: option(vec("u8")) })
+  shieldingData?: Uint8Array;
 
   constructor(data: IbcTransferProps) {
     Object.assign(this, data);


### PR DESCRIPTION
Update to support Namada `v0.41.0` (mainnet release)

- Bump Namada to `v0.41.0`
- Updated args for IBC Transfer
- some changes to shielded sync - left comments as we can't implement shielded sync the same way now, so this could be a new issue to look into
- Regenerate docs for `packages/types` to catch latest changes