### PR TITLE
feat/946: Consistent denom in Tx Details

### DIFF
--- a/packages/shared/lib/src/sdk/transaction.rs
+++ b/packages/shared/lib/src/sdk/transaction.rs
@@ -2,7 +2,7 @@ use namada::token::Transfer;
 use serde::Serialize;
 
 use namada::governance::VoteProposalData;
-use namada::tx::data::pos::{Bond, Redelegation, Unbond, Withdraw, ClaimRewards};
+use namada::tx::data::pos::{Bond, ClaimRewards, Redelegation, Unbond, Withdraw};
 use namada::{
     core::borsh::{self, BorshDeserialize},
     key::common::PublicKey,
@@ -11,8 +11,8 @@ use wasm_bindgen::JsError;
 
 use crate::sdk::{
     args::{
-        BondMsg, RedelegateMsg, RevealPkMsg, TransferDataMsg, TransferMsg, UnbondMsg,
-        VoteProposalMsg, WithdrawMsg, ClaimRewardsMsg
+        BondMsg, ClaimRewardsMsg, RedelegateMsg, RevealPkMsg, TransferDataMsg, TransferMsg,
+        UnbondMsg, VoteProposalMsg, WithdrawMsg,
     },
     tx::TxType,
 };
@@ -79,7 +79,7 @@ impl TransactionKind {
                 let bond = BondMsg::new(
                     source.clone().unwrap().to_string(),
                     validator.to_string(),
-                    amount.to_string(),
+                    amount.native_denominated().to_string(),
                 );
                 borsh::to_vec(&bond)?
             }
@@ -97,7 +97,7 @@ impl TransactionKind {
                 let unbond = UnbondMsg::new(
                     source.clone().unwrap().to_string(),
                     validator.to_string(),
-                    amount.to_string(),
+                    amount.native_denominated().to_string(),
                 );
                 borsh::to_vec(&unbond)?
             }
@@ -124,7 +124,7 @@ impl TransactionKind {
                     owner.to_string(),
                     src_validator.to_string(),
                     dest_validator.to_string(),
-                    amount.to_string(),
+                    amount.native_denominated().to_string(),
                 );
                 borsh::to_vec(&redelegation)?
             }
@@ -146,14 +146,14 @@ impl TransactionKind {
                 for (source, amount) in sources {
                     let owner = source.owner.to_string();
                     let token = source.token.to_string();
-                    let amount = amount.to_string();
+                    let amount = amount.amount().native_denominated().to_string();
                     sources_data.push(TransferDataMsg::new(owner, token, amount))
                 }
 
                 for (target, amount) in targets {
                     let owner = target.owner.to_string();
                     let token = target.token.to_string();
-                    let amount = amount.to_string();
+                    let amount = amount.amount().native_denominated().to_string();
                     targets_data.push(TransferDataMsg::new(owner, token, amount))
                 }
 
@@ -168,7 +168,7 @@ impl TransactionKind {
                 let ClaimRewards { validator, source } = claim_rewards;
                 let claim_rewards = ClaimRewardsMsg::new(
                     validator.to_string(),
-                    source.clone().map(|addr| addr.to_string())
+                    source.clone().map(|addr| addr.to_string()),
                 );
                 borsh::to_vec(&claim_rewards)?
             }

--- a/packages/shared/lib/src/sdk/tx.rs
+++ b/packages/shared/lib/src/sdk/tx.rs
@@ -5,10 +5,11 @@ use gloo_utils::format::JsValueSerdeExt;
 use namada::core::borsh::{self, BorshDeserialize, BorshSerialize};
 use namada::sdk::signing::SigningTxData;
 use namada::sdk::tx::{
-    TX_BOND_WASM, TX_REDELEGATE_WASM, TX_REVEAL_PK, TX_TRANSFER_WASM, TX_UNBOND_WASM,
-    TX_VOTE_PROPOSAL, TX_WITHDRAW_WASM, TX_CLAIM_REWARDS_WASM
+    TX_BOND_WASM, TX_CLAIM_REWARDS_WASM, TX_REDELEGATE_WASM, TX_REVEAL_PK, TX_TRANSFER_WASM,
+    TX_UNBOND_WASM, TX_VOTE_PROPOSAL, TX_WITHDRAW_WASM,
 };
 use namada::sdk::uint::Uint;
+use namada::token::Amount;
 use namada::tx;
 use namada::{address::Address, key::common::PublicKey};
 use wasm_bindgen::{prelude::wasm_bindgen, JsError, JsValue};
@@ -152,7 +153,9 @@ impl TxDetails {
         let tx_details = match tx.header().tx_type {
             tx::data::TxType::Wrapper(wrapper) => {
                 let fee_amount = wrapper.get_tx_fee()?.to_string();
-                let gas_limit = Uint::from(wrapper.gas_limit).to_string();
+                let gas_limit = Amount::from_uint(Uint::from(wrapper.gas_limit), 0)?
+                    .native_denominated()
+                    .to_string();
                 let token = wrapper.fee.token.to_string();
 
                 let wrapper_tx =


### PR DESCRIPTION
Resolves #946 

Currently, the denomination displayed in the extension approvals is inconsistent. Should be in `NAM`.

- [x] Use proper denomination when representing amounts in extension (amounts should match exactly what user entered)
- [x] Display `gas_limit` in same denomination

### Screenshots

<img width="339" alt="Screen Shot 2024-07-26 at 11 31 08 AM" src="https://github.com/user-attachments/assets/3e2a6313-0769-4ca9-9c9b-76caf6846884">

<img width="384" alt="Screen Shot 2024-07-26 at 11 31 16 AM" src="https://github.com/user-attachments/assets/4bc5e85b-ca47-4f8f-9b27-dc343adbe44c">

<img width="388" alt="Screen Shot 2024-07-26 at 11 31 42 AM" src="https://github.com/user-attachments/assets/b6cbb665-fc10-4ea0-ad35-4c90e69afd02">

