### PR TITLE
Separate NAM with commas + other Namadillo fixes

### DIFF
--- a/apps/extension/webpack.config.js
+++ b/apps/extension/webpack.config.js
@@ -10,8 +10,8 @@ const RemovePlugin = require("remove-files-webpack-plugin");
 const packageJson = require("./package.json");
 const { getProcessEnv } = require("@namada/config/webpack.js");
 
-// Load .env from namada-interface:
-require("dotenv").config({ path: "../namada-interface/.env" });
+// Load .env from namadillo:
+require("dotenv").config({ path: "../namadillo/.env" });
 
 const { NODE_ENV, TARGET, BUNDLE_ANALYZE } = process.env;
 

--- a/apps/namadillo/src/App/Common/ToastErrorDescription.tsx
+++ b/apps/namadillo/src/App/Common/ToastErrorDescription.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { TextLink } from "./TextLink";
 
 export const ToastErrorDescription: React.FC<{
-  basicMessage?: string;
+  basicMessage?: React.ReactNode;
   errorMessage?: string;
 }> = ({ basicMessage, errorMessage }) => {
   const [expanded, setExpanded] = useState<boolean>(false);

--- a/apps/namadillo/src/App/Governance/GovernanceOverview.tsx
+++ b/apps/namadillo/src/App/Governance/GovernanceOverview.tsx
@@ -63,7 +63,7 @@ export const GovernanceOverview: React.FC = () => {
           isEmpty={upcomingProposals.length === 0}
           atoms={[allProposals]}
         >
-          <UpcomingProposals proposals={allProposals.data!} />
+          <UpcomingProposals proposals={upcomingProposals} />
         </ProposalListPanel>
         <ProposalListPanel
           title="All Proposals"

--- a/apps/namadillo/src/App/Governance/ProposalDescription.tsx
+++ b/apps/namadillo/src/App/Governance/ProposalDescription.tsx
@@ -1,5 +1,6 @@
 import { SkeletonLoading, Stack } from "@namada/components";
 import { Proposal } from "@namada/types";
+import clsx from "clsx";
 import { useAtomValue } from "jotai";
 import { useState } from "react";
 
@@ -52,7 +53,10 @@ export const Loaded: React.FC<{
         ))}
 
       <a
-        className="block text-center cursor-pointer after:content-['_+']"
+        className={clsx(
+          "block text-center cursor-pointer",
+          expanded ? "after:content-['_-']" : "after:content-['_+']"
+        )}
         onClick={() => setExpanded(!expanded)}
       >
         Show {expanded ? "Less" : "More"}

--- a/apps/namadillo/src/App/Governance/ProposalDescription.tsx
+++ b/apps/namadillo/src/App/Governance/ProposalDescription.tsx
@@ -29,13 +29,15 @@ export const Loaded: React.FC<{
 
   const { abstract, ...details } = proposal.content;
 
-  const formattedDetails = Object.entries(details).map(([key, value]) => {
-    const spacedKey = key.replaceAll("-", " ");
-    const capitalizedKey =
-      spacedKey.charAt(0).toUpperCase() + spacedKey.slice(1);
+  const formattedDetails = Object.entries(details)
+    .filter(([key]) => key !== "title")
+    .map(([key, value]) => {
+      const spacedKey = key.replaceAll("-", " ");
+      const capitalizedKey =
+        spacedKey.charAt(0).toUpperCase() + spacedKey.slice(1);
 
-    return [capitalizedKey, value];
-  });
+      return [capitalizedKey, value];
+    });
 
   return (
     <>

--- a/apps/namadillo/src/App/Governance/ProposalStatusSummary.tsx
+++ b/apps/namadillo/src/App/Governance/ProposalStatusSummary.tsx
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import clsx from "clsx";
-import { motion } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 import { useState } from "react";
 
 import { PieChart, PieChartData, Stack } from "@namada/components";
@@ -9,7 +9,7 @@ import { proposalFamily } from "atoms/proposals";
 import { useAtomValue } from "jotai";
 
 import { ProposalStatus, TallyType, VoteType, voteTypes } from "@namada/types";
-import { AnimatePresence } from "framer-motion";
+import { NamCurrency } from "App/Common/NamCurrency";
 import { colors } from "./types";
 
 // TODO: is this a good enough way to represent rational numbers?
@@ -23,7 +23,7 @@ const StatusListItem: React.FC<{
   color: string;
   leftContent: string;
   rightContent: string;
-  rightSubContent: string;
+  rightSubContent: React.ReactNode;
   selected: boolean;
 }> = ({ color, leftContent, rightContent, rightSubContent, selected }) => {
   return (
@@ -53,7 +53,7 @@ const Layout: React.FC<{
   status: ProposalStatus;
   pieChartData?: PieChartData[];
   percentages: Record<VoteType, string>;
-  amounts: Record<VoteType, string>;
+  amounts: Record<VoteType, React.ReactNode>;
   turnout: string;
   quorum: string;
   pieChartMiddle?: React.ReactNode;
@@ -221,13 +221,14 @@ const Loaded: React.FC<{
     abstain: percentageString(abstain),
   };
 
-  const amountString = (voteType: VoteType): string =>
-    props[voteType].toString() + " NAM";
+  const formattedAmount = (voteType: VoteType): React.ReactNode => (
+    <NamCurrency amount={props[voteType]} forceBalanceDisplay />
+  );
 
   const amounts = {
-    yay: amountString("yay"),
-    nay: amountString("nay"),
-    abstain: amountString("abstain"),
+    yay: formattedAmount("yay"),
+    nay: formattedAmount("nay"),
+    abstain: formattedAmount("abstain"),
   };
 
   return (

--- a/apps/namadillo/src/App/Staking/AllValidatorsTable.tsx
+++ b/apps/namadillo/src/App/Staking/AllValidatorsTable.tsx
@@ -1,6 +1,7 @@
 import { ActionButton, TableRow } from "@namada/components";
 import { formatPercentage } from "@namada/utils";
 import { AtomErrorBoundary } from "App/Common/AtomErrorBoundary";
+import { NamCurrency } from "App/Common/NamCurrency";
 import { Search } from "App/Common/Search";
 import { TableRowLoading } from "App/Common/TableRowLoading";
 import { WalletAddress } from "App/Common/WalletAddress";
@@ -75,7 +76,10 @@ export const AllValidatorsTable = ({
         key={`validator-voting-power-${validator.address}`}
       >
         {validator.votingPowerInNAM && (
-          <span>{validator.votingPowerInNAM?.toString()} NAM</span>
+          <NamCurrency
+            amount={validator.votingPowerInNAM}
+            forceBalanceDisplay
+          />
         )}
         <span className="text-neutral-600 text-sm">
           {formatPercentage(BigNumber(validator.votingPowerPercentage || 0))}

--- a/apps/namadillo/src/App/Staking/IncrementBondingTable.tsx
+++ b/apps/namadillo/src/App/Staking/IncrementBondingTable.tsx
@@ -109,7 +109,10 @@ export const IncrementBondingTable = ({
           key={`validator-voting-power-${validator.address}`}
         >
           {validator.votingPowerInNAM && (
-            <span>{validator.votingPowerInNAM?.toString()} NAM</span>
+            <NamCurrency
+              amount={validator.votingPowerInNAM}
+              forceBalanceDisplay
+            />
           )}
           <span className="text-neutral-600 text-sm">
             {formatPercentage(BigNumber(validator.votingPowerPercentage || 0))}

--- a/apps/namadillo/src/App/Staking/MyValidatorsTable.tsx
+++ b/apps/namadillo/src/App/Staking/MyValidatorsTable.tsx
@@ -58,7 +58,10 @@ export const MyValidatorsTable = (): JSX.Element => {
           key={`my-validator-voting-power-${validator.address}`}
         >
           {validator.votingPowerInNAM && (
-            <span>{validator.votingPowerInNAM?.toString()} NAM</span>
+            <NamCurrency
+              amount={validator.votingPowerInNAM}
+              forceBalanceDisplay
+            />
           )}
           <span className="text-neutral-600 text-sm">
             {formatPercentage(BigNumber(validator.votingPowerPercentage || 0))}

--- a/apps/namadillo/src/App/Staking/ReDelegateTable.tsx
+++ b/apps/namadillo/src/App/Staking/ReDelegateTable.tsx
@@ -103,7 +103,10 @@ export const ReDelegateTable = ({
           key={`validator-voting-power-${validator.address}`}
         >
           {validator.votingPowerInNAM && (
-            <span>{validator.votingPowerInNAM?.toString()} NAM</span>
+            <NamCurrency
+              amount={validator.votingPowerInNAM}
+              forceBalanceDisplay
+            />
           )}
           <span className="text-neutral-600 text-sm">
             {formatPercentage(BigNumber(validator.votingPowerPercentage || 0))}

--- a/apps/namadillo/src/App/Staking/UnstakeBondingTable.tsx
+++ b/apps/namadillo/src/App/Staking/UnstakeBondingTable.tsx
@@ -102,7 +102,10 @@ export const UnstakeBondingTable = ({
           key={`validator-voting-power-${validator.address}`}
         >
           {validator.votingPowerInNAM && (
-            <span>{validator.votingPowerInNAM?.toString()} NAM</span>
+            <NamCurrency
+              amount={validator.votingPowerInNAM}
+              forceBalanceDisplay
+            />
           )}
           <span className="text-neutral-600 text-sm">
             {formatPercentage(BigNumber(validator.votingPowerPercentage || 0))}

--- a/apps/namadillo/src/hooks/useTransactionNotifications.tsx
+++ b/apps/namadillo/src/hooks/useTransactionNotifications.tsx
@@ -7,6 +7,7 @@ import {
   WithdrawProps,
 } from "@namada/types";
 import { shortenAddress } from "@namada/utils";
+import { NamCurrency } from "App/Common/NamCurrency";
 import { ToastErrorDescription } from "App/Common/ToastErrorDescription";
 import {
   dispatchToastNotificationAtom,
@@ -51,7 +52,13 @@ export const useTransactionNotifications = (): void => {
       dispatchNotification({
         id: e.detail.transactionId,
         title: "Staking transaction succeeded",
-        description: `Your staking transaction of ${e.detail.data.amount} NAM to ${address} has succeeded`,
+        description: (
+          <>
+            Your staking transaction of{" "}
+            <NamCurrency amount={e.detail.data.amount} /> to {address} has
+            succeeded
+          </>
+        ),
         type: "success",
         timeout: 5000,
       });
@@ -63,7 +70,12 @@ export const useTransactionNotifications = (): void => {
       dispatchNotification({
         id: e.detail.transactionId,
         title: "Unstake transaction succeeded",
-        description: `You've removed ${e.detail.data.amount} NAM from validator ${address}`,
+        description: (
+          <>
+            You{"'"}ve removed <NamCurrency amount={e.detail.data.amount} />{" "}
+            from validator {address}
+          </>
+        ),
         type: "success",
         timeout: 5000,
       });
@@ -78,7 +90,13 @@ export const useTransactionNotifications = (): void => {
         type: "error",
         description: (
           <ToastErrorDescription
-            basicMessage={`Your request to unstake ${e.detail.data.amount} NAM from ${address} has failed`}
+            basicMessage={
+              <>
+                Your request to unstake{" "}
+                <NamCurrency amount={e.detail.data.amount} /> from {address} has
+                failed
+              </>
+            }
             errorMessage={e.detail.error?.message}
           />
         ),
@@ -97,8 +115,11 @@ export const useTransactionNotifications = (): void => {
           description: (
             <ToastErrorDescription
               basicMessage={
-                `Your re-delegate transaction of ${e.detail.data.amount}` +
-                ` NAM from ${sourceAddress} to ${destAddress} has failed`
+                <>
+                  Your re-delegate transaction of{" "}
+                  <NamCurrency amount={e.detail.data.amount} /> from{" "}
+                  {sourceAddress} to {destAddress} has failed
+                </>
               }
               errorMessage={e.detail.error?.message}
             />
@@ -116,9 +137,13 @@ export const useTransactionNotifications = (): void => {
         dispatchNotification({
           id: e.detail.transactionId,
           title: "Re-delegate succeeded",
-          description:
-            `Your re-delegate transaction of ${e.detail.data.amount}` +
-            ` NAM from ${sourceAddress} to ${destAddress} has succeeded`,
+          description: (
+            <>
+              Your re-delegate transaction of{" "}
+              <NamCurrency amount={e.detail.data.amount} /> from {sourceAddress}{" "}
+              to {destAddress} has succeeded
+            </>
+          ),
           type: "success",
           timeout: 5000,
         });

--- a/packages/components/src/Currency.tsx
+++ b/packages/components/src/Currency.tsx
@@ -27,7 +27,7 @@ export const Currency = ({
   ...containerRest
 }: CurrencyProps): JSX.Element => {
   const currencyObj = KnownCurrencies[currency];
-  const amountParts = BigNumber(amount).toString().split(".");
+  const amountParts = BigNumber(amount).toFormat().split(".");
   const baseAmount = hideBalances ? "✳✳✳✳" : amountParts[0] || "0";
   const fraction =
     amountParts.length > 1 && !hideBalances ? amountParts[1] : "";


### PR DESCRIPTION
### Fixed
- Separate long NAM values with commas. Fixes #942.
- Don't show all proposals as upcoming proposals
  - This bug will show up if there are both upcoming and non-upcoming proposals and causes all proposals to be listed as upcoming. If there are no upcoming proposals, the bug will not appear. 
- Hide redundant title in proposal description. Fixes #951.
- Use "-" in show less proposal description link
- Use correct .env to get chain ID in extension
  - The webpack config was still pointing to app/namada-inteface/.env.
<!--

Make sure you have read CONTRIBUTING.md before submitting a pull request!

-->
