### PR TITLE
fix: support sending BigNumber messages in Firefox

### DIFF
--- a/apps/extension/src/extension/ExtensionRequester.ts
+++ b/apps/extension/src/extension/ExtensionRequester.ts
@@ -1,3 +1,4 @@
+import BigNumber from "bignumber.js";
 import browser from "webextension-polyfill";
 
 import { Message } from "../router";
@@ -39,7 +40,7 @@ export class ExtensionRequester {
       throw error;
     }
 
-    return result.return;
+    return fixBigNumbers(result.return);
   }
 
   async sendMessageToTab<M extends Message<unknown>>(
@@ -93,3 +94,39 @@ export class ExtensionRequester {
     return tabs.map((tab) => tab.id || browser.tabs.TAB_ID_NONE);
   }
 }
+
+/**
+ * Searches through an object and creates BigNumbers from any object with
+ * the _isBigNumber property. This is needed because BigNumbers lose their
+ * prototype when sent between extension scripts in Firefox.
+ *
+ * Returns the object with the BigNumbers reconstructed.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const fixBigNumbers = (result: any): any => {
+  if (typeof result !== "object" || result === null) {
+    return result;
+  }
+
+  if (result["_isBigNumber"]) {
+    return BigNumber(result as BigNumber.Value);
+  }
+
+  const unseenValues = [result];
+
+  while (unseenValues.length !== 0) {
+    const obj = unseenValues.pop();
+    Object.entries(obj).forEach(([key, value]) => {
+      if (typeof value === "object" && value !== null) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        if ((value as any)["_isBigNumber"]) {
+          obj[key] = BigNumber(value as BigNumber.Value);
+        } else {
+          unseenValues.push(value);
+        }
+      }
+    });
+  }
+
+  return result;
+};


### PR DESCRIPTION
This fixes NAM amounts showing as NaN when approving a tx in Firefox.

Fixes #952.

Before:
![2024-07-30-115844_345x315_scrot](https://github.com/user-attachments/assets/f70667a2-3523-42e3-b5db-418e6d79b890)
![2024-07-30-115849_475x186_scrot](https://github.com/user-attachments/assets/9f5cab22-9af1-4b59-8b54-a8175354bc59)

After:
![2024-07-31-175031_758x496_scrot](https://github.com/user-attachments/assets/089aba8e-fcb8-47f1-9e4a-2010295d6499)
![2024-07-31-175046_757x1102_scrot](https://github.com/user-attachments/assets/693203f4-b59f-453d-b5d3-c2af4e07f395)
