### PR TITLE
Namadillo: fixing some errors on re-delegate flow

### DIFF
--- a/apps/namadillo/src/App/Staking/ReDelegate.tsx
+++ b/apps/namadillo/src/App/Staking/ReDelegate.tsx
@@ -37,10 +37,11 @@ export const ReDelegate = (): JSX.Element => {
   const dispatchNotification = useSetAtom(dispatchToastNotificationAtom);
   const { data: account } = useAtomValue(defaultAccountAtom);
   const validators = useAtomValue(allValidatorsAtom);
+
   const {
     totalStakedAmount,
-    totalUpdatedAmount: totalToRedelegate,
     stakedAmountByAddress,
+    totalUpdatedAmount: totalToRedelegate,
     updatedAmountByAddress: amountsRemovedByAddress,
     onChangeValidatorAmount,
     myValidators,
@@ -101,7 +102,7 @@ export const ReDelegate = (): JSX.Element => {
             errorMessage={
               redelegateTxError instanceof Error ?
                 redelegateTxError.message
-                : undefined
+              : undefined
             }
           />
         ),
@@ -121,8 +122,7 @@ export const ReDelegate = (): JSX.Element => {
     );
   };
 
-  const onSubmit = (e: React.FormEvent): void => {
-    e.preventDefault();
+  const performRedelegate = (): void => {
     invariant(account, `Extension is connected but you don't have an account`);
     invariant(gasPrice, "Gas price loading is still pending");
     invariant(gasLimits.isSuccess, "Gas limit loading is still pending");
@@ -139,6 +139,18 @@ export const ReDelegate = (): JSX.Element => {
       },
       account,
     });
+  };
+
+  const onSubmit = (e: React.FormEvent): void => {
+    e.preventDefault();
+    // Go to next page or do nothing
+    if (step === "remove" && totalToRedelegate) {
+      if (totalToRedelegate.gt(0)) {
+        setStep("assign");
+      }
+      return;
+    }
+    performRedelegate();
   };
 
   const totalAssignedAmounts = BigNumber.sum(

--- a/apps/namadillo/src/lib/staking.ts
+++ b/apps/namadillo/src/lib/staking.ts
@@ -64,10 +64,12 @@ export const buildRedelegateChange = (
 ): RedelegateChange => ({ sourceValidator, destinationValidator, amount });
 
 export const getAmountDistribution = (
-  reducedAmounts: Record<string, BigNumber>,
-  increasedAmounts: Record<string, BigNumber>
+  _reducedAmounts: Record<string, BigNumber>,
+  _increasedAmounts: Record<string, BigNumber>
 ): RedelegateChange[] => {
   const redelegateChanges: RedelegateChange[] = [];
+  const reducedAmounts = { ..._reducedAmounts };
+  const increasedAmounts = { ..._increasedAmounts };
 
   // If two addresses are present in both objects, fix the assigned amounts
   for (const address in reducedAmounts) {


### PR DESCRIPTION
This PR contains the following fixes:
- When Public Key was not revealed, the server was returning 404 and the app was throwing an unhandled exception
- After submitting re-delegate first form, nothing was happening. Now it goes to the next form
- Fixed a reference issue after deleting an object property on re-delegate