### PR TITLE
fix - Update faucet app

### DIFF
--- a/apps/faucet/package.json
+++ b/apps/faucet/package.json
@@ -20,8 +20,8 @@
     "buffer": "^6.0.3",
     "dompurify": "^3.0.2",
     "node-forge": "^1.3.1",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^6.0.0",
     "styled-components": "^5.3.5",
     "typescript": "^5.1.3"

--- a/apps/faucet/src/App/App.tsx
+++ b/apps/faucet/src/App/App.tsx
@@ -213,7 +213,7 @@ export const App: React.FC = () => {
           <ContentContainer>
             <TopSection>
               <Heading className="uppercase text-black text-4xl" level="h1">
-                Namada Shielded Expedition Faucet
+                Namada Faucet
               </Heading>
             </TopSection>
             <FaucetContainer>

--- a/apps/faucet/src/App/App.tsx
+++ b/apps/faucet/src/App/App.tsx
@@ -21,7 +21,7 @@ import { FaucetForm } from "App/Faucet";
 
 import { chains } from "@namada/chains";
 import { useUntil } from "@namada/hooks";
-import { Account, AccountType } from "@namada/types";
+import { Account } from "@namada/types";
 import { API } from "utils";
 import dotsBackground from "../../public/bg-dots.svg";
 import { CallToActionCard } from "./CallToActionCard";
@@ -174,12 +174,7 @@ export const App: React.FC = () => {
         await integration.connect();
         const accounts = await integration.accounts();
         if (accounts) {
-          setAccounts(
-            accounts.filter(
-              (account) =>
-                !account.isShielded && account.type !== AccountType.Ledger
-            )
-          );
+          setAccounts(accounts.filter((account) => !account.isShielded));
         }
         setIsExtensionConnected(true);
       } catch (e) {

--- a/apps/faucet/src/App/Faucet.tsx
+++ b/apps/faucet/src/App/Faucet.tsx
@@ -133,17 +133,10 @@ export const FaucetForm: React.FC<Props> = ({
         throw new Error("signer not defined");
       }
 
-      const sig = await signer.signArbitrary(account.address, challenge);
-      if (!sig) {
-        throw new Error("Signature was rejected");
-      }
-
       const submitData = {
         solution,
         tag,
         challenge,
-        player_id: account.publicKey,
-        challenge_signature: sig.signature,
         transfer: {
           target: account.address,
           token: sanitizedToken,

--- a/apps/faucet/src/App/Faucet.tsx
+++ b/apps/faucet/src/App/Faucet.tsx
@@ -121,7 +121,7 @@ export const FaucetForm: React.FC<Props> = ({
       }
 
       const { challenge, tag } = await api
-        .challenge(account.publicKey)
+        .challenge()
         .catch(({ message, code }) => {
           throw new Error(`Unable to request challenge: ${code} - ${message}`);
         });
@@ -133,7 +133,7 @@ export const FaucetForm: React.FC<Props> = ({
         throw new Error("signer not defined");
       }
 
-      const sig = await signer.sign(account.address, challenge);
+      const sig = await signer.signArbitrary(account.address, challenge);
       if (!sig) {
         throw new Error("Signature was rejected");
       }
@@ -247,15 +247,12 @@ export const FaucetForm: React.FC<Props> = ({
 
       <ButtonContainer>
         <ActionButton
-          style={{
-            fontSize: "1.25rem",
-            lineHeight: "1.6",
-            padding: "0.6em 2.5em",
-            margin: 0,
-          }}
+          backgroundHoverColor="yellow"
+          textHoverColor="black"
+          borderRadius="sm"
+          outlineColor="yellow"
           className={`max-w-fit ${!isFormValid && "opacity-50"}`}
           color="cyan"
-          borderRadius="lg"
           onClick={handleSubmit}
           disabled={!isFormValid}
         >

--- a/apps/faucet/src/index.tsx
+++ b/apps/faucet/src/index.tsx
@@ -1,12 +1,12 @@
 import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import "./index.css";
 import "./tailwind.css";
 
-ReactDOM.render(
+const container = document.getElementById("root")!;
+createRoot(container).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  document.getElementById("root")
+  </React.StrictMode>
 );

--- a/apps/faucet/src/utils/api.ts
+++ b/apps/faucet/src/utils/api.ts
@@ -8,7 +8,7 @@ import {
 
 enum Endpoint {
   Settings = "/setting",
-  Challenge = "/challenge",
+  Challenge = "",
   Transfer = "",
 }
 
@@ -69,11 +69,10 @@ export class API {
   /**
    * Request challenge from endpoint url
    *
-   * @param {string} publicKey
    * @returns Object
    */
-  async challenge(publicKey: string): Promise<ChallengeResponse> {
-    return this.request(`${Endpoint.Challenge}/${publicKey}`);
+  async challenge(): Promise<ChallengeResponse> {
+    return this.request(Endpoint.Challenge);
   }
 
   /**

--- a/apps/faucet/src/utils/types.ts
+++ b/apps/faucet/src/utils/types.ts
@@ -20,9 +20,7 @@ export type Data = {
   solution: string;
   tag: string;
   challenge: unknown;
-  challenge_signature: string;
   transfer: TransferDetails;
-  player_id: string;
 };
 
 export type TransferResponse = {

--- a/apps/faucet/webpack.config.js
+++ b/apps/faucet/webpack.config.js
@@ -137,6 +137,8 @@ module.exports = {
     fallback: {
       buffer: require.resolve("buffer/"),
       crypto: require.resolve("crypto-browserify"),
+      stream: require.resolve("stream-browserify"),
+      path: require.resolve("path-browserify"),
     },
     plugins: [
       new TsconfigPathsPlugin({

--- a/yarn.lock
+++ b/yarn.lock
@@ -8381,8 +8381,8 @@ __metadata:
     postcss: "npm:^8.4.33"
     postcss-loader: "npm:^8.1.0"
     postcss-preset-env: "npm:^9.3.0"
-    react: "npm:^17.0.2"
-    react-dom: "npm:^17.0.2"
+    react: "npm:^18.0.0"
+    react-dom: "npm:^18.0.0"
     react-router-dom: "npm:^6.0.0"
     styled-components: "npm:^5.3.5"
     tailwindcss: "npm:^3.4.1"
@@ -30727,19 +30727,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^17.0.2":
-  version: 17.0.2
-  resolution: "react-dom@npm:17.0.2"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-    object-assign: "npm:^4.1.1"
-    scheduler: "npm:^0.20.2"
-  peerDependencies:
-    react: 17.0.2
-  checksum: 51abbcb72450fe527ebf978c3bc989ba266630faaa53f47a2fae5392369729e8de62b2e4683598cbe651ea7873cd34ec7d5127e2f50bf4bfe6bd0c3ad9bddcb0
-  languageName: node
-  linkType: hard
-
 "react-dom@npm:^18.0.0":
   version: 18.3.0
   resolution: "react-dom@npm:18.3.0"
@@ -30911,16 +30898,6 @@ __metadata:
   bin:
     react-scripts: bin/react-scripts.js
   checksum: 1776e7139261019eb4a2adece8fb997913040c6b4e9170902ffed95c3ff311ded623189bb1582ecddb3a5a15d6afd871fb68dbed72080d50f635e31c4ff5fff5
-  languageName: node
-  linkType: hard
-
-"react@npm:^17.0.2":
-  version: 17.0.2
-  resolution: "react@npm:17.0.2"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-    object-assign: "npm:^4.1.1"
-  checksum: 07ae8959acf1596f0550685102fd6097d461a54a4fd46a50f88a0cd7daaa97fdd6415de1dcb4bfe0da6aa43221a6746ce380410fa848acc60f8ac41f6649c148
   languageName: node
   linkType: hard
 
@@ -32121,16 +32098,6 @@ __metadata:
   dependencies:
     xmlchars: "npm:^2.2.0"
   checksum: 3847b839f060ef3476eb8623d099aa502ad658f5c40fd60c105ebce86d244389b0d76fcae30f4d0c728d7705ceb2f7e9b34bb54717b6a7dbedaf5dad2d9a4b74
-  languageName: node
-  linkType: hard
-
-"scheduler@npm:^0.20.2":
-  version: 0.20.2
-  resolution: "scheduler@npm:0.20.2"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-    object-assign: "npm:^4.1.1"
-  checksum: b0982e4b0f34f4ffa4f2f486161c0fd9ce9b88680b045dccbf250eb1aa4fd27413570645455187a83535e2370f5c667a251045547765408492bd883cbe95fcdb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR takes the current faucet app (last updated for SE) and makes it work again

- [x] API updated to remove PK from endpoint
- [x] Fix endpoint for `challenge`
- [x] Update React/Webpack
- [x] Remove `Shielded Expedition`
- [x] Remove sign arbitrary request, and enable Ledger accounts in the dropdown

### Testing

- Edit `apps/faucet/.env` with the following:
(Not sure if all of these are necessary, but the URL definitely is)
```bash
NAMADA_INTERFACE_FAUCET_API_URL=https://faucet.public.heliax.work/internal-devnet-it.14814a0e13c
NAMADA_INTERFACE_FAUCET_API_ENDPOINT=/api/v1/faucet
NAMADA_INTERFACE_FAUCET_LIMIT=1000
```
- It would be useful to also connect the Namadillo to this indexer so you can see and user your funds:
  - Set namadillo indexer to: `https://indexer.public.heliax.work/internal-devnet-it.14814a0e13c`
  - Set RPC to `https://proxy.public.heliax.work/internal-devnet-it.14814a0e13c` (the RPC returned by this indexer is incorrect, so override it)
  - Set `Network` to `internal-devnet-it.14814a0e13c` in extension to be able to sign properly
- Select account in faucet, set an amount (up to 1000), and click `Get Testnet Tokens` - in the extension, approve the SIgn Arbitrary message and submit. After a brief period, you should get a success message!

### Screenshots

<img width="851" alt="Screen Shot 2024-08-02 at 8 23 47 AM" src="https://github.com/user-attachments/assets/dd5dafbb-e1cf-40d7-8aac-89f65258f65b">


<img width="802" alt="Screen Shot 2024-08-02 at 8 24 01 AM" src="https://github.com/user-attachments/assets/c044d3f7-8e6a-4266-be9d-dd3dc446d381">


<img width="890" alt="Screen Shot 2024-08-02 at 8 23 35 AM" src="https://github.com/user-attachments/assets/52f3c94d-51c9-4318-bff9-35d07dd09b88">
