### PR TITLE
fix: fix notifications were not being removed

### DIFF
--- a/apps/namadillo/src/hooks/useTransactionCallbacks.tsx
+++ b/apps/namadillo/src/hooks/useTransactionCallbacks.tsx
@@ -1,16 +1,11 @@
-import { useEffectSkipFirstRender } from "@namada/hooks";
 import { accountBalanceAtom } from "atoms/accounts";
 import { shouldUpdateBalanceAtom } from "atoms/etc";
 import { useAtomValue, useSetAtom } from "jotai";
-import { addTransactionEvent } from "utils";
+import { useTransactionEventListener } from "utils";
 
 export const useTransactionCallback = (): void => {
   const { refetch: refetchBalances } = useAtomValue(accountBalanceAtom);
   const shouldUpdateBalance = useSetAtom(shouldUpdateBalanceAtom);
-
-  useEffectSkipFirstRender(() => {
-    initEvents();
-  }, []);
 
   const onBalanceUpdate = (): void => {
     // TODO: refactor this after event subscription is enabled on indexer
@@ -21,9 +16,7 @@ export const useTransactionCallback = (): void => {
     setTimeout(() => shouldUpdateBalance(false), timePolling);
   };
 
-  const initEvents = (): void => {
-    addTransactionEvent("Bond.Success", onBalanceUpdate);
-    addTransactionEvent("Unbond.Success", onBalanceUpdate);
-    addTransactionEvent("Withdraw.Success", onBalanceUpdate);
-  };
+  useTransactionEventListener("Bond.Success", onBalanceUpdate);
+  useTransactionEventListener("Unbond.Success", onBalanceUpdate);
+  useTransactionEventListener("Withdraw.Success", onBalanceUpdate);
 };

--- a/apps/namadillo/src/hooks/useTransactionNotifications.tsx
+++ b/apps/namadillo/src/hooks/useTransactionNotifications.tsx
@@ -1,10 +1,3 @@
-import {
-  BondProps,
-  RedelegateProps,
-  UnbondProps,
-  VoteProposalProps,
-  WithdrawProps,
-} from "@namada/types";
 import { shortenAddress } from "@namada/utils";
 import { NamCurrency } from "App/Common/NamCurrency";
 import { ToastErrorDescription } from "App/Common/ToastErrorDescription";
@@ -13,7 +6,6 @@ import {
   filterToastNotificationsAtom,
 } from "atoms/notifications";
 import { useSetAtom } from "jotai";
-import { EventData } from "types/events";
 import { useTransactionEventListener } from "utils";
 
 export const useTransactionNotifications = (): void => {
@@ -24,7 +16,7 @@ export const useTransactionNotifications = (): void => {
     filterNotifications((notification) => notification.type !== "pending");
   };
 
-  useTransactionEventListener("Bond.Error", (e: EventData<BondProps>): void => {
+  useTransactionEventListener("Bond.Error", (e) => {
     const address = shortenAddress(e.detail.data.validator, 8, 8);
     clearPendingNotifications();
     dispatchNotification({
@@ -40,185 +32,158 @@ export const useTransactionNotifications = (): void => {
     });
   });
 
-  useTransactionEventListener(
-    "Bond.Success",
-    (e: EventData<BondProps>): void => {
-      const address = shortenAddress(e.detail.data.validator, 8, 8);
-      clearPendingNotifications();
-      dispatchNotification({
-        id: e.detail.transactionId,
-        title: "Staking transaction succeeded",
-        description: (
-          <>
-            Your staking transaction of{" "}
-            <NamCurrency amount={e.detail.data.amount} /> to {address} has
-            succeeded
-          </>
-        ),
-        type: "success",
-        timeout: 5000,
-      });
-    }
-  );
+  useTransactionEventListener("Bond.Success", (e) => {
+    const address = shortenAddress(e.detail.data.validator, 8, 8);
+    clearPendingNotifications();
+    dispatchNotification({
+      id: e.detail.transactionId,
+      title: "Staking transaction succeeded",
+      description: (
+        <>
+          Your staking transaction of{" "}
+          <NamCurrency amount={e.detail.data.amount} /> to {address} has
+          succeeded
+        </>
+      ),
+      type: "success",
+      timeout: 5000,
+    });
+  });
 
-  useTransactionEventListener(
-    "Unbond.Success",
-    (e: EventData<UnbondProps>): void => {
-      const address = shortenAddress(e.detail.data.validator, 8, 8);
-      clearPendingNotifications();
-      dispatchNotification({
-        id: e.detail.transactionId,
-        title: "Unstake transaction succeeded",
-        description: (
-          <>
-            You{"'"}ve removed <NamCurrency amount={e.detail.data.amount} />{" "}
-            from validator {address}
-          </>
-        ),
-        type: "success",
-        timeout: 5000,
-      });
-    }
-  );
+  useTransactionEventListener("Unbond.Success", (e) => {
+    const address = shortenAddress(e.detail.data.validator, 8, 8);
+    clearPendingNotifications();
+    dispatchNotification({
+      id: e.detail.transactionId,
+      title: "Unstake transaction succeeded",
+      description: (
+        <>
+          You{"'"}ve removed <NamCurrency amount={e.detail.data.amount} /> from
+          validator {address}
+        </>
+      ),
+      type: "success",
+      timeout: 5000,
+    });
+  });
 
-  useTransactionEventListener(
-    "Unbond.Error",
-    (e: EventData<UnbondProps>): void => {
-      const address = shortenAddress(e.detail.data.validator, 8, 8);
-      clearPendingNotifications();
-      dispatchNotification({
-        id: e.detail.transactionId,
-        title: "Unstake transaction failed",
-        type: "error",
-        description: (
-          <ToastErrorDescription
-            basicMessage={
-              <>
-                Your request to unstake{" "}
-                <NamCurrency amount={e.detail.data.amount} /> from {address} has
-                failed
-              </>
-            }
-            errorMessage={e.detail.error?.message}
-          />
-        ),
-      });
-    }
-  );
+  useTransactionEventListener("Unbond.Error", (e) => {
+    const address = shortenAddress(e.detail.data.validator, 8, 8);
+    clearPendingNotifications();
+    dispatchNotification({
+      id: e.detail.transactionId,
+      title: "Unstake transaction failed",
+      type: "error",
+      description: (
+        <ToastErrorDescription
+          basicMessage={
+            <>
+              Your request to unstake{" "}
+              <NamCurrency amount={e.detail.data.amount} /> from {address} has
+              failed
+            </>
+          }
+          errorMessage={e.detail.error?.message}
+        />
+      ),
+    });
+  });
 
-  useTransactionEventListener(
-    "ReDelegate.Error",
-    (e: EventData<RedelegateProps>): void => {
-      const sourceAddress = shortenAddress(e.detail.data.sourceValidator);
-      const destAddress = shortenAddress(e.detail.data.destinationValidator);
-      clearPendingNotifications();
-      dispatchNotification({
-        id: e.detail.transactionId,
-        title: "Re-delegate failed",
-        description: (
-          <ToastErrorDescription
-            basicMessage={
-              <>
-                Your re-delegate transaction of{" "}
-                <NamCurrency amount={e.detail.data.amount} /> from{" "}
-                {sourceAddress} to {destAddress} has failed
-              </>
-            }
-            errorMessage={e.detail.error?.message}
-          />
-        ),
-        type: "error",
-      });
-    }
-  );
+  useTransactionEventListener("ReDelegate.Error", (e) => {
+    const sourceAddress = shortenAddress(e.detail.data.sourceValidator);
+    const destAddress = shortenAddress(e.detail.data.destinationValidator);
+    clearPendingNotifications();
+    dispatchNotification({
+      id: e.detail.transactionId,
+      title: "Re-delegate failed",
+      description: (
+        <ToastErrorDescription
+          basicMessage={
+            <>
+              Your re-delegate transaction of{" "}
+              <NamCurrency amount={e.detail.data.amount} /> from {sourceAddress}{" "}
+              to {destAddress} has failed
+            </>
+          }
+          errorMessage={e.detail.error?.message}
+        />
+      ),
+      type: "error",
+    });
+  });
 
-  useTransactionEventListener(
-    "ReDelegate.Success",
-    (e: EventData<RedelegateProps>): void => {
-      const sourceAddress = shortenAddress(e.detail.data.sourceValidator);
-      const destAddress = shortenAddress(e.detail.data.destinationValidator);
-      dispatchNotification({
-        id: e.detail.transactionId,
-        title: "Re-delegate succeeded",
-        description: (
-          <>
-            Your re-delegate transaction of{" "}
-            <NamCurrency amount={e.detail.data.amount} /> from {sourceAddress}{" "}
-            to {destAddress} has succeeded
-          </>
-        ),
-        type: "success",
-        timeout: 5000,
-      });
-    }
-  );
+  useTransactionEventListener("ReDelegate.Success", (e) => {
+    const sourceAddress = shortenAddress(e.detail.data.sourceValidator);
+    const destAddress = shortenAddress(e.detail.data.destinationValidator);
+    dispatchNotification({
+      id: e.detail.transactionId,
+      title: "Re-delegate succeeded",
+      description: (
+        <>
+          Your re-delegate transaction of{" "}
+          <NamCurrency amount={e.detail.data.amount} /> from {sourceAddress} to{" "}
+          {destAddress} has succeeded
+        </>
+      ),
+      type: "success",
+      timeout: 5000,
+    });
+  });
 
-  useTransactionEventListener(
-    "Withdraw.Success",
-    (e: EventData<WithdrawProps>): void => {
-      const address = shortenAddress(e.detail.data.source, 8, 8);
-      clearPendingNotifications();
-      dispatchNotification({
-        id: e.detail.transactionId,
-        title: "Withdrawal Success",
-        description:
-          `Your withdrawal transaction ` + ` from ${address} has succeeded`,
-        type: "success",
-        timeout: 5000,
-      });
-    }
-  );
+  useTransactionEventListener("Withdraw.Success", (e) => {
+    const address = shortenAddress(e.detail.data.source, 8, 8);
+    clearPendingNotifications();
+    dispatchNotification({
+      id: e.detail.transactionId,
+      title: "Withdrawal Success",
+      description:
+        `Your withdrawal transaction ` + ` from ${address} has succeeded`,
+      type: "success",
+      timeout: 5000,
+    });
+  });
 
-  useTransactionEventListener(
-    "Withdraw.Error",
-    (e: EventData<WithdrawProps>): void => {
-      const address = shortenAddress(e.detail.data.source, 8, 8);
-      clearPendingNotifications();
-      dispatchNotification({
-        id: e.detail.transactionId,
-        title: "Withdrawal Error",
-        description: (
-          <ToastErrorDescription
-            basicMessage={
-              `Your withdrawal transaction ` + ` from ${address} has failed`
-            }
-            errorMessage={e.detail.error?.message}
-          />
-        ),
-        type: "error",
-      });
-    }
-  );
+  useTransactionEventListener("Withdraw.Error", (e) => {
+    const address = shortenAddress(e.detail.data.source, 8, 8);
+    clearPendingNotifications();
+    dispatchNotification({
+      id: e.detail.transactionId,
+      title: "Withdrawal Error",
+      description: (
+        <ToastErrorDescription
+          basicMessage={
+            `Your withdrawal transaction ` + ` from ${address} has failed`
+          }
+          errorMessage={e.detail.error?.message}
+        />
+      ),
+      type: "error",
+    });
+  });
 
-  useTransactionEventListener(
-    "VoteProposal.Error",
-    (e: EventData<VoteProposalProps>): void => {
-      clearPendingNotifications();
-      dispatchNotification({
-        id: e.detail.transactionId,
-        type: "error",
-        title: "Staking transaction failed",
-        description: (
-          <ToastErrorDescription
-            basicMessage={`Your vote transaction for proposal ${e.detail.data.proposalId} has failed.`}
-            errorMessage={e.detail.error?.message}
-          />
-        ),
-      });
-    }
-  );
+  useTransactionEventListener("VoteProposal.Error", (e) => {
+    clearPendingNotifications();
+    dispatchNotification({
+      id: e.detail.transactionId,
+      type: "error",
+      title: "Staking transaction failed",
+      description: (
+        <ToastErrorDescription
+          basicMessage={`Your vote transaction for proposal ${e.detail.data.proposalId} has failed.`}
+          errorMessage={e.detail.error?.message}
+        />
+      ),
+    });
+  });
 
-  useTransactionEventListener(
-    "VoteProposal.Success",
-    (e: EventData<VoteProposalProps>): void => {
-      clearPendingNotifications();
-      dispatchNotification({
-        id: e.detail.transactionId,
-        title: "Staking transaction succeeded",
-        description: `Your vote transaction for proposal ${e.detail.data.proposalId} has succeeded`,
-        type: "success",
-        timeout: 5000,
-      });
-    }
-  );
+  useTransactionEventListener("VoteProposal.Success", (e) => {
+    clearPendingNotifications();
+    dispatchNotification({
+      id: e.detail.transactionId,
+      title: "Staking transaction succeeded",
+      description: `Your vote transaction for proposal ${e.detail.data.proposalId} has succeeded`,
+      type: "success",
+      timeout: 5000,
+    });
+  });
 };

--- a/apps/namadillo/src/hooks/useTransactionNotifications.tsx
+++ b/apps/namadillo/src/hooks/useTransactionNotifications.tsx
@@ -1,4 +1,3 @@
-import { useEffectSkipFirstRender } from "@namada/hooks";
 import {
   BondProps,
   RedelegateProps,
@@ -15,38 +14,35 @@ import {
 } from "atoms/notifications";
 import { useSetAtom } from "jotai";
 import { EventData } from "types/events";
-import { addTransactionEvent } from "utils";
+import { useTransactionEventListener } from "utils";
 
 export const useTransactionNotifications = (): void => {
   const dispatchNotification = useSetAtom(dispatchToastNotificationAtom);
   const filterNotifications = useSetAtom(filterToastNotificationsAtom);
 
-  useEffectSkipFirstRender(() => {
-    initEvents();
-  }, []);
-
   const clearPendingNotifications = (): void => {
     filterNotifications((notification) => notification.type !== "pending");
   };
 
-  function initEvents(): void {
-    addTransactionEvent("Bond.Error", (e: EventData<BondProps>): void => {
-      const address = shortenAddress(e.detail.data.validator, 8, 8);
-      clearPendingNotifications();
-      dispatchNotification({
-        id: e.detail.transactionId,
-        type: "error",
-        title: "Staking transaction failed",
-        description: (
-          <ToastErrorDescription
-            basicMessage={`Your staking transaction to ${address} has failed.`}
-            errorMessage={e.detail.error?.message}
-          />
-        ),
-      });
+  useTransactionEventListener("Bond.Error", (e: EventData<BondProps>): void => {
+    const address = shortenAddress(e.detail.data.validator, 8, 8);
+    clearPendingNotifications();
+    dispatchNotification({
+      id: e.detail.transactionId,
+      type: "error",
+      title: "Staking transaction failed",
+      description: (
+        <ToastErrorDescription
+          basicMessage={`Your staking transaction to ${address} has failed.`}
+          errorMessage={e.detail.error?.message}
+        />
+      ),
     });
+  });
 
-    addTransactionEvent("Bond.Success", (e: EventData<BondProps>): void => {
+  useTransactionEventListener(
+    "Bond.Success",
+    (e: EventData<BondProps>): void => {
       const address = shortenAddress(e.detail.data.validator, 8, 8);
       clearPendingNotifications();
       dispatchNotification({
@@ -62,9 +58,12 @@ export const useTransactionNotifications = (): void => {
         type: "success",
         timeout: 5000,
       });
-    });
+    }
+  );
 
-    addTransactionEvent("Unbond.Success", (e: EventData<UnbondProps>): void => {
+  useTransactionEventListener(
+    "Unbond.Success",
+    (e: EventData<UnbondProps>): void => {
       const address = shortenAddress(e.detail.data.validator, 8, 8);
       clearPendingNotifications();
       dispatchNotification({
@@ -79,9 +78,12 @@ export const useTransactionNotifications = (): void => {
         type: "success",
         timeout: 5000,
       });
-    });
+    }
+  );
 
-    addTransactionEvent("Unbond.Error", (e: EventData<UnbondProps>): void => {
+  useTransactionEventListener(
+    "Unbond.Error",
+    (e: EventData<UnbondProps>): void => {
       const address = shortenAddress(e.detail.data.validator, 8, 8);
       clearPendingNotifications();
       dispatchNotification({
@@ -101,122 +103,122 @@ export const useTransactionNotifications = (): void => {
           />
         ),
       });
-    });
+    }
+  );
 
-    addTransactionEvent(
-      "ReDelegate.Error",
-      (e: EventData<RedelegateProps>): void => {
-        const sourceAddress = shortenAddress(e.detail.data.sourceValidator);
-        const destAddress = shortenAddress(e.detail.data.destinationValidator);
-        clearPendingNotifications();
-        dispatchNotification({
-          id: e.detail.transactionId,
-          title: "Re-delegate failed",
-          description: (
-            <ToastErrorDescription
-              basicMessage={
-                <>
-                  Your re-delegate transaction of{" "}
-                  <NamCurrency amount={e.detail.data.amount} /> from{" "}
-                  {sourceAddress} to {destAddress} has failed
-                </>
-              }
-              errorMessage={e.detail.error?.message}
-            />
-          ),
-          type: "error",
-        });
-      }
-    );
+  useTransactionEventListener(
+    "ReDelegate.Error",
+    (e: EventData<RedelegateProps>): void => {
+      const sourceAddress = shortenAddress(e.detail.data.sourceValidator);
+      const destAddress = shortenAddress(e.detail.data.destinationValidator);
+      clearPendingNotifications();
+      dispatchNotification({
+        id: e.detail.transactionId,
+        title: "Re-delegate failed",
+        description: (
+          <ToastErrorDescription
+            basicMessage={
+              <>
+                Your re-delegate transaction of{" "}
+                <NamCurrency amount={e.detail.data.amount} /> from{" "}
+                {sourceAddress} to {destAddress} has failed
+              </>
+            }
+            errorMessage={e.detail.error?.message}
+          />
+        ),
+        type: "error",
+      });
+    }
+  );
 
-    addTransactionEvent(
-      "ReDelegate.Success",
-      (e: EventData<RedelegateProps>): void => {
-        const sourceAddress = shortenAddress(e.detail.data.sourceValidator);
-        const destAddress = shortenAddress(e.detail.data.destinationValidator);
-        dispatchNotification({
-          id: e.detail.transactionId,
-          title: "Re-delegate succeeded",
-          description: (
-            <>
-              Your re-delegate transaction of{" "}
-              <NamCurrency amount={e.detail.data.amount} /> from {sourceAddress}{" "}
-              to {destAddress} has succeeded
-            </>
-          ),
-          type: "success",
-          timeout: 5000,
-        });
-      }
-    );
+  useTransactionEventListener(
+    "ReDelegate.Success",
+    (e: EventData<RedelegateProps>): void => {
+      const sourceAddress = shortenAddress(e.detail.data.sourceValidator);
+      const destAddress = shortenAddress(e.detail.data.destinationValidator);
+      dispatchNotification({
+        id: e.detail.transactionId,
+        title: "Re-delegate succeeded",
+        description: (
+          <>
+            Your re-delegate transaction of{" "}
+            <NamCurrency amount={e.detail.data.amount} /> from {sourceAddress}{" "}
+            to {destAddress} has succeeded
+          </>
+        ),
+        type: "success",
+        timeout: 5000,
+      });
+    }
+  );
 
-    addTransactionEvent(
-      "Withdraw.Success",
-      (e: EventData<WithdrawProps>): void => {
-        const address = shortenAddress(e.detail.data.source, 8, 8);
-        clearPendingNotifications();
-        dispatchNotification({
-          id: e.detail.transactionId,
-          title: "Withdrawal Success",
-          description:
-            `Your withdrawal transaction ` + ` from ${address} has succeeded`,
-          type: "success",
-          timeout: 5000,
-        });
-      }
-    );
+  useTransactionEventListener(
+    "Withdraw.Success",
+    (e: EventData<WithdrawProps>): void => {
+      const address = shortenAddress(e.detail.data.source, 8, 8);
+      clearPendingNotifications();
+      dispatchNotification({
+        id: e.detail.transactionId,
+        title: "Withdrawal Success",
+        description:
+          `Your withdrawal transaction ` + ` from ${address} has succeeded`,
+        type: "success",
+        timeout: 5000,
+      });
+    }
+  );
 
-    addTransactionEvent(
-      "Withdraw.Error",
-      (e: EventData<WithdrawProps>): void => {
-        const address = shortenAddress(e.detail.data.source, 8, 8);
-        clearPendingNotifications();
-        dispatchNotification({
-          id: e.detail.transactionId,
-          title: "Withdrawal Error",
-          description: (
-            <ToastErrorDescription
-              basicMessage={
-                `Your withdrawal transaction ` + ` from ${address} has failed`
-              }
-              errorMessage={e.detail.error?.message}
-            />
-          ),
-          type: "error",
-        });
-      }
-    );
+  useTransactionEventListener(
+    "Withdraw.Error",
+    (e: EventData<WithdrawProps>): void => {
+      const address = shortenAddress(e.detail.data.source, 8, 8);
+      clearPendingNotifications();
+      dispatchNotification({
+        id: e.detail.transactionId,
+        title: "Withdrawal Error",
+        description: (
+          <ToastErrorDescription
+            basicMessage={
+              `Your withdrawal transaction ` + ` from ${address} has failed`
+            }
+            errorMessage={e.detail.error?.message}
+          />
+        ),
+        type: "error",
+      });
+    }
+  );
 
-    addTransactionEvent(
-      "VoteProposal.Error",
-      (e: EventData<VoteProposalProps>): void => {
-        clearPendingNotifications();
-        dispatchNotification({
-          id: e.detail.transactionId,
-          type: "error",
-          title: "Staking transaction failed",
-          description: (
-            <ToastErrorDescription
-              basicMessage={`Your vote transaction for proposal ${e.detail.data.proposalId} has failed.`}
-              errorMessage={e.detail.error?.message}
-            />
-          ),
-        });
-      }
-    );
+  useTransactionEventListener(
+    "VoteProposal.Error",
+    (e: EventData<VoteProposalProps>): void => {
+      clearPendingNotifications();
+      dispatchNotification({
+        id: e.detail.transactionId,
+        type: "error",
+        title: "Staking transaction failed",
+        description: (
+          <ToastErrorDescription
+            basicMessage={`Your vote transaction for proposal ${e.detail.data.proposalId} has failed.`}
+            errorMessage={e.detail.error?.message}
+          />
+        ),
+      });
+    }
+  );
 
-    addTransactionEvent(
-      "VoteProposal.Success",
-      (e: EventData<VoteProposalProps>): void => {
-        clearPendingNotifications();
-        dispatchNotification({
-          id: e.detail.transactionId,
-          title: "Staking transaction succeeded",
-          description: `Your vote transaction for proposal ${e.detail.data.proposalId} has succeeded`,
-          type: "success",
-          timeout: 5000,
-        });
-      }
-    );
-  }
+  useTransactionEventListener(
+    "VoteProposal.Success",
+    (e: EventData<VoteProposalProps>): void => {
+      clearPendingNotifications();
+      dispatchNotification({
+        id: e.detail.transactionId,
+        title: "Staking transaction succeeded",
+        description: `Your vote transaction for proposal ${e.detail.data.proposalId} has succeeded`,
+        type: "success",
+        timeout: 5000,
+      });
+    }
+  );
 };

--- a/apps/namadillo/src/types/events.ts
+++ b/apps/namadillo/src/types/events.ts
@@ -1,3 +1,11 @@
+import {
+  BondProps,
+  RedelegateProps,
+  UnbondProps,
+  VoteProposalProps,
+  WithdrawProps,
+} from "@namada/types";
+
 export type TransactionEventsClasses =
   | "Bond"
   | "Unbond"
@@ -22,4 +30,19 @@ export interface EventData<T> extends CustomEvent {
     data: T;
     error?: Error;
   };
+}
+
+declare global {
+  interface WindowEventMap {
+    "Bond.Success": EventData<BondProps>;
+    "Bond.Error": EventData<BondProps>;
+    "Unbond.Success": EventData<UnbondProps>;
+    "Unbond.Error": EventData<UnbondProps>;
+    "ReDelegate.Success": EventData<RedelegateProps>;
+    "ReDelegate.Error": EventData<RedelegateProps>;
+    "Withdraw.Success": EventData<WithdrawProps>;
+    "Withdraw.Error": EventData<WithdrawProps>;
+    "VoteProposal.Success": EventData<VoteProposalProps>;
+    "VoteProposal.Error": EventData<VoteProposalProps>;
+  }
 }

--- a/apps/namadillo/src/utils/index.ts
+++ b/apps/namadillo/src/utils/index.ts
@@ -2,7 +2,6 @@ import { ProposalStatus, ProposalTypeString } from "@namada/types";
 import * as fns from "date-fns";
 import { DateTime } from "luxon";
 import { useEffect } from "react";
-import { EventData, TransactionEvent } from "types/events";
 
 export const proposalStatusToString = (status: ProposalStatus): string => {
   const statusText: Record<ProposalStatus, string> = {
@@ -34,14 +33,14 @@ export const epochToString = (epoch: bigint): string =>
 export const proposalIdToString = (proposalId: bigint): string =>
   `#${proposalId.toString()}`;
 
-export const useTransactionEventListener = <T>(
-  handle: TransactionEvent,
-  callback: (e: EventData<T>) => void
+export const useTransactionEventListener = <T extends keyof WindowEventMap>(
+  event: T,
+  handler: (this: Window, ev: WindowEventMap[T]) => void
 ): void => {
   useEffect(() => {
-    window.addEventListener(handle, callback as EventListener);
+    window.addEventListener(event, handler);
     return () => {
-      window.removeEventListener(handle, callback as EventListener);
+      window.removeEventListener(event, handler);
     };
   }, []);
 };

--- a/apps/namadillo/src/utils/index.ts
+++ b/apps/namadillo/src/utils/index.ts
@@ -1,6 +1,7 @@
 import { ProposalStatus, ProposalTypeString } from "@namada/types";
 import * as fns from "date-fns";
 import { DateTime } from "luxon";
+import { useEffect } from "react";
 import { EventData, TransactionEvent } from "types/events";
 
 export const proposalStatusToString = (status: ProposalStatus): string => {
@@ -33,11 +34,16 @@ export const epochToString = (epoch: bigint): string =>
 export const proposalIdToString = (proposalId: bigint): string =>
   `#${proposalId.toString()}`;
 
-export const addTransactionEvent = <T>(
+export const useTransactionEventListener = <T>(
   handle: TransactionEvent,
   callback: (e: EventData<T>) => void
 ): void => {
-  window.addEventListener(handle, callback as EventListener, false);
+  useEffect(() => {
+    window.addEventListener(handle, callback as EventListener);
+    return () => {
+      window.removeEventListener(handle, callback as EventListener);
+    };
+  }, []);
 };
 
 const secondsToDateTime = (seconds: bigint): DateTime =>


### PR DESCRIPTION
Fix the notifications were not being removed when deploying the Namadillo

The issue was caused because the transaction event listeners weren't initialized due to the hook `useEffectSkipFirstRender`, which skips the listener creation on first render.

I'm not aware why it was implemented like this in the past, maybe it was to fix another issue of a concurrency listener creation.

Anyway, I created the individual hook listener `useTransactionEventListener` that handle the subscribe and also the unsubscribe with `useEffect`, which allow us to reinvoke the method anytime we want and it's more a "react oriented" solution