### PR TITLE
fix: fix console warning of p descendant

### DIFF
--- a/apps/namadillo/src/App/Common/Toast.tsx
+++ b/apps/namadillo/src/App/Common/Toast.tsx
@@ -78,7 +78,7 @@ const Toast = ({ notification, onClose }: ToastProps): JSX.Element => {
       </span>
       <div className="relative">
         <strong className="block text-sm mb-1">{notification.title}</strong>
-        <p className="leading-tight text-xs">{notification.description}</p>
+        <div className="leading-tight text-xs">{notification.description}</div>
       </div>
       <i
         onClick={() => onClose(notification)}


### PR DESCRIPTION
Fix console warning of `<p>` descendant

![Screenshot 2024-08-05 at 14 53 40](https://github.com/user-attachments/assets/f3d91465-6593-4678-a7b9-28ce088f4a77)
