### PR TITLE
Fix gas price and gas limit in tx details

### DIFF
--- a/apps/namadillo/src/App/Sidebars/ValidatorDiversification.tsx
+++ b/apps/namadillo/src/App/Sidebars/ValidatorDiversification.tsx
@@ -19,6 +19,7 @@ export const ValidatorDiversification = (): JSX.Element => {
         textHoverColor="black"
         backgroundHoverColor="cyan"
         href="https://namada.net"
+        target="_blank"
         borderRadius="sm"
         size="xs"
       >

--- a/packages/shared/lib/src/sdk/tx.rs
+++ b/packages/shared/lib/src/sdk/tx.rs
@@ -151,7 +151,7 @@ impl TxDetails {
 
         let tx_details = match tx.header().tx_type {
             tx::data::TxType::Wrapper(wrapper) => {
-                let fee_amount = wrapper.get_tx_fee()?.to_string();
+                let fee_amount = wrapper.fee.amount_per_gas_unit.to_string();
                 let gas_limit = Uint::from(wrapper.gas_limit).to_string();
                 let token = wrapper.fee.token.to_string();
 

--- a/packages/shared/lib/src/sdk/tx.rs
+++ b/packages/shared/lib/src/sdk/tx.rs
@@ -9,7 +9,6 @@ use namada::sdk::tx::{
     TX_UNBOND_WASM, TX_VOTE_PROPOSAL, TX_WITHDRAW_WASM,
 };
 use namada::sdk::uint::Uint;
-use namada::token::Amount;
 use namada::tx;
 use namada::{address::Address, key::common::PublicKey};
 use wasm_bindgen::{prelude::wasm_bindgen, JsError, JsValue};
@@ -153,9 +152,7 @@ impl TxDetails {
         let tx_details = match tx.header().tx_type {
             tx::data::TxType::Wrapper(wrapper) => {
                 let fee_amount = wrapper.get_tx_fee()?.to_string();
-                let gas_limit = Amount::from_uint(Uint::from(wrapper.gas_limit), 0)?
-                    .native_denominated()
-                    .to_string();
+                let gas_limit = Uint::from(wrapper.gas_limit).to_string();
                 let token = wrapper.fee.token.to_string();
 
                 let wrapper_tx =


### PR DESCRIPTION
Closes #972.

### Fixed
- Show tx detail gas limit in gas units, not NAM
- Show gas price, not total fees, in tx details
  - This field is still named `feeAmount`, but I was wondering about changing it to `gasPrice`, which would match what Namada CLI calls it and I think is a less confusing name. I can add it to this PR or do it later if we decide to change the name.

---

Example transaction with gas price 0.00001 NAM and gas limit 1000000:

![2024-08-07-163707_484x784_scrot](https://github.com/user-attachments/assets/94e698fa-53d8-465c-a3c2-60841f68d574)