### PR TITLE
feat: improve canWithdraw logic

### DIFF
--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "@anomaorg/namada-indexer-client": "0.0.20",
+    "@anomaorg/namada-indexer-client": "0.0.21",
     "@cosmjs/encoding": "^0.32.3",
     "@tailwindcss/container-queries": "^0.1.1",
     "@tanstack/react-query": "^5.40.0",

--- a/apps/namadillo/src/atoms/validators/functions.ts
+++ b/apps/namadillo/src/atoms/validators/functions.ts
@@ -89,9 +89,9 @@ export const toUnbondingValidators = (
 
     const canWithdraw = indexerUnbond.canWithdraw;
     const timeLeft =
-      // If can't withdraw but estimation is incorrect display n/a
-      !canWithdraw && withdrawTime < timeNow ? "N/A"
-      : canWithdraw ? ""
+      canWithdraw ? ""
+        // If can't withdraw but estimation is incorrect display withdraw epoch
+      : withdrawTime < timeNow ? `Epoch ${indexerUnbond.withdrawEpoch}`
       : singleUnitDurationFromInterval(timeNow, withdrawTime);
 
     const amountValue = BigNumber(indexerUnbond.amount);

--- a/apps/namadillo/src/atoms/validators/functions.ts
+++ b/apps/namadillo/src/atoms/validators/functions.ts
@@ -86,13 +86,13 @@ export const toUnbondingValidators = (
       apr
     );
     const withdrawTime = Number(indexerUnbond.withdrawTime);
-    const currentTime = Number(indexerUnbond.currentTime);
-    const secondsLeft = withdrawTime - currentTime;
 
-    // TODO: later return from the backend
-    const canWithdraw = secondsLeft <= 0;
+    const canWithdraw = indexerUnbond.canWithdraw;
     const timeLeft =
-      canWithdraw ? "" : singleUnitDurationFromInterval(timeNow, withdrawTime);
+      // If can't withdraw but estimation is incorrect display n/a
+      !canWithdraw && withdrawTime < timeNow ? "N/A"
+      : canWithdraw ? ""
+      : singleUnitDurationFromInterval(timeNow, withdrawTime);
 
     const amountValue = BigNumber(indexerUnbond.amount);
     const amount = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,12 +45,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@anomaorg/namada-indexer-client@npm:0.0.20":
-  version: 0.0.20
-  resolution: "@anomaorg/namada-indexer-client@npm:0.0.20"
+"@anomaorg/namada-indexer-client@npm:0.0.21":
+  version: 0.0.21
+  resolution: "@anomaorg/namada-indexer-client@npm:0.0.21"
   dependencies:
     axios: "npm:^0.21.1"
-  checksum: d5cc8cf1691559758e0773379f54e2203f05a44b057f05053c3e21820ff96eb29c502e1a4b0148d6e6b1322ce88ada9fa027f36b88d60eded76d8fc6f8fb66e1
+  checksum: 4b9632145eee1d20672ad65eef447ed90e3abfc2fee09a5c3e40fc5fd9321ff83aff03acf4be75abe1c74c83fc635216f46f5c58155c11a291656bb822f05465
   languageName: node
   linkType: hard
 
@@ -8429,7 +8429,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@namada/namadillo@workspace:apps/namadillo"
   dependencies:
-    "@anomaorg/namada-indexer-client": "npm:0.0.20"
+    "@anomaorg/namada-indexer-client": "npm:0.0.21"
     "@cosmjs/encoding": "npm:^0.32.3"
     "@playwright/test": "npm:^1.24.1"
     "@release-it/keep-a-changelog": "npm:^5.0.0"


### PR DESCRIPTION
From slack:
> Small update regarding withdraw button. So I changed code a bit, now we compare current epoch to withdraw epoch to determine if withdraw is possible(before we were comparing time left to current time). Also if time left is obviously incorrect(this might happen if the genesis parameters are wrong) we will display "N/A". But note that  this is only a fallback. For live version we should never see "N/A" as genesis parameters have to be correct  :smile: So this is only for testing in case someone gets confused because withdraws are not working.

Use branch from this [PR](https://github.com/anoma/namada-indexer/pull/95) or wait for merge :) 🙏 