### PR TITLE
fix: enable refetch on try again button

### DIFF
--- a/apps/namadillo/src/App/AppSetup.tsx
+++ b/apps/namadillo/src/App/AppSetup.tsx
@@ -1,5 +1,5 @@
 import { useUntilIntegrationAttached } from "@namada/integrations";
-import { chainAtom } from "atoms/chain";
+import { chainAtomWithRefetch } from "atoms/chain";
 import {
   defaultServerConfigAtom,
   indexerHeartbeatAtom,
@@ -20,7 +20,7 @@ export const AppSetup = ({ children }: AppSetupProps): JSX.Element => {
   const indexerUrl = useAtomValue(indexerUrlAtom);
   const indexerHeartbeat = useAtomValue(indexerHeartbeatAtom);
   const tomlConfig = useAtomValue(defaultServerConfigAtom);
-  const chain = useAtomValue(chainAtom);
+  const chain = useAtomValue(chainAtomWithRefetch);
   const extensionAttachStatus = useUntilIntegrationAttached();
   const extensionReady = extensionAttachStatus !== "pending";
   const errorContainerProps = { className: "text-white h-svh" };


### PR DESCRIPTION
Relates to https://github.com/anoma/namada-interface/issues/970

Enable the `Try Again` button to refetch the chain atom

https://github.com/user-attachments/assets/96d1d49f-eecc-4dfb-9acc-1ae6eb048d68

