### PR TITLE
Namadillo: Adding sortable headers to tables

### DIFF
--- a/apps/namadillo/public/config.toml
+++ b/apps/namadillo/public/config.toml
@@ -1,4 +1,4 @@
 # Uncomment the following lines to define your default indexer and rpc urls
-#indexer_url = ""
-#rpc_url = ""
+indexer_url = "https://indexer.public.heliax.work/internal-devnet-it.14814a0e13c"
+rpc_url = "https://proxy.public.heliax.work/internal-devnet-it.14814a0e13c"
 

--- a/apps/namadillo/public/config.toml
+++ b/apps/namadillo/public/config.toml
@@ -1,4 +1,4 @@
 # Uncomment the following lines to define your default indexer and rpc urls
-indexer_url = "https://indexer.public.heliax.work/internal-devnet-it.14814a0e13c"
-rpc_url = "https://proxy.public.heliax.work/internal-devnet-it.14814a0e13c"
+#indexer_url = ""
+#rpc_url = ""
 

--- a/apps/namadillo/src/App/Staking/AllValidatorsTable.tsx
+++ b/apps/namadillo/src/App/Staking/AllValidatorsTable.tsx
@@ -25,7 +25,7 @@ type AllValidatorsProps = {
   initialPage?: number;
 };
 
-type SortableColumns = "votingPowerInNAM" | "expectedApr";
+type SortableColumns = "votingPowerInNAM" | "commission";
 
 export const AllValidatorsTable = ({
   resultsPerPage = 100,
@@ -68,7 +68,7 @@ export const AllValidatorsTable = ({
       <div key={`all-validators-comission`} className="text-right w-full">
         Commission
       </div>,
-      "expectedApr",
+      "commission",
       setSorting,
       sorting
     ),

--- a/apps/namadillo/src/App/Staking/IncrementBondingTable.tsx
+++ b/apps/namadillo/src/App/Staking/IncrementBondingTable.tsx
@@ -4,8 +4,10 @@ import { NamCurrency } from "App/Common/NamCurrency";
 import { NamInput } from "App/Common/NamInput";
 import BigNumber from "bignumber.js";
 import clsx from "clsx";
+import { useMemo, useState } from "react";
 import { twMerge } from "tailwind-merge";
-import { Validator } from "types";
+import { SortedColumnPair, Validator } from "types";
+import { createSortableHeaderOption, sortCollection } from "utils/sorting";
 import { ValidatorCard } from "./ValidatorCard";
 import { ValidatorsTable } from "./ValidatorsTable";
 
@@ -17,6 +19,8 @@ type IncrementBondingTableProps = {
   resultsPerPage?: number;
 };
 
+type SortableColumns = "votingPowerInNAM" | "expectedApr";
+
 export const IncrementBondingTable = ({
   validators,
   updatedAmountByAddress,
@@ -24,6 +28,13 @@ export const IncrementBondingTable = ({
   onChangeValidatorAmount,
   resultsPerPage = 100,
 }: IncrementBondingTableProps): JSX.Element => {
+  const [sorting, setSorting] = useState<SortedColumnPair<SortableColumns>>();
+
+  const sortedValidators = useMemo(() => {
+    if (!sorting) return validators;
+    return sortCollection<Validator, SortableColumns>(validators, sorting);
+  }, [sorting, validators]);
+
   const headers = [
     { children: "Validator" },
     "Amount to Stake",
@@ -36,8 +47,18 @@ export const IncrementBondingTable = ({
       ),
       className: "text-right",
     },
-    { children: "Voting Power", className: "text-right" },
-    { children: "Commission", className: "text-right" },
+    createSortableHeaderOption<Validator, SortableColumns>(
+      <div className="w-full text-right">Voting Power</div>,
+      "votingPowerInNAM",
+      setSorting,
+      sorting
+    ),
+    createSortableHeaderOption<Validator, SortableColumns>(
+      <div className="w-full text-right">Commission</div>,
+      "expectedApr",
+      setSorting,
+      sorting
+    ),
   ];
 
   const renderRow = (validator: Validator): TableRow => {
@@ -136,7 +157,7 @@ export const IncrementBondingTable = ({
     <ValidatorsTable
       id="increment-bonding-table"
       tableClassName="flex-1 overflow-auto mt-2"
-      validatorList={validators}
+      validatorList={sortedValidators}
       updatedAmountByAddress={updatedAmountByAddress}
       headers={headers}
       renderRow={renderRow}

--- a/apps/namadillo/src/App/Staking/IncrementBondingTable.tsx
+++ b/apps/namadillo/src/App/Staking/IncrementBondingTable.tsx
@@ -4,10 +4,9 @@ import { NamCurrency } from "App/Common/NamCurrency";
 import { NamInput } from "App/Common/NamInput";
 import BigNumber from "bignumber.js";
 import clsx from "clsx";
-import { useMemo, useState } from "react";
+import { useValidatorTableSorting } from "hooks/useValidatorTableSorting";
 import { twMerge } from "tailwind-merge";
-import { SortedColumnPair, Validator } from "types";
-import { createSortableHeaderOption, sortCollection } from "utils/sorting";
+import { Validator } from "types";
 import { ValidatorCard } from "./ValidatorCard";
 import { ValidatorsTable } from "./ValidatorsTable";
 
@@ -19,8 +18,6 @@ type IncrementBondingTableProps = {
   resultsPerPage?: number;
 };
 
-type SortableColumns = "votingPowerInNAM" | "expectedApr";
-
 export const IncrementBondingTable = ({
   validators,
   updatedAmountByAddress,
@@ -28,12 +25,10 @@ export const IncrementBondingTable = ({
   onChangeValidatorAmount,
   resultsPerPage = 100,
 }: IncrementBondingTableProps): JSX.Element => {
-  const [sorting, setSorting] = useState<SortedColumnPair<SortableColumns>>();
-
-  const sortedValidators = useMemo(() => {
-    if (!sorting) return validators;
-    return sortCollection<Validator, SortableColumns>(validators, sorting);
-  }, [sorting, validators]);
+  const { sortableColumns, sortedValidators } = useValidatorTableSorting({
+    validators,
+    stakedAmountByAddress,
+  });
 
   const headers = [
     { children: "Validator" },
@@ -46,19 +41,16 @@ export const IncrementBondingTable = ({
         </div>
       ),
       className: "text-right",
+      ...sortableColumns["stakedAmount"],
     },
-    createSortableHeaderOption<Validator, SortableColumns>(
-      <div className="w-full text-right">Voting Power</div>,
-      "votingPowerInNAM",
-      setSorting,
-      sorting
-    ),
-    createSortableHeaderOption<Validator, SortableColumns>(
-      <div className="w-full text-right">Commission</div>,
-      "expectedApr",
-      setSorting,
-      sorting
-    ),
+    {
+      children: <div className="w-full text-right">Voting Power</div>,
+      ...sortableColumns["votingPowerInNAM"],
+    },
+    {
+      children: <div className="w-full text-right">Commission</div>,
+      ...sortableColumns["commission"],
+    },
   ];
 
   const renderRow = (validator: Validator): TableRow => {

--- a/apps/namadillo/src/App/Staking/ReDelegateTable.tsx
+++ b/apps/namadillo/src/App/Staking/ReDelegateTable.tsx
@@ -4,6 +4,7 @@ import { NamCurrency } from "App/Common/NamCurrency";
 import { NamInput } from "App/Common/NamInput";
 import BigNumber from "bignumber.js";
 import clsx from "clsx";
+import { useValidatorTableSorting } from "hooks/useValidatorTableSorting";
 import { twMerge } from "tailwind-merge";
 import { Validator } from "types";
 import { ValidatorCard } from "./ValidatorCard";
@@ -27,6 +28,11 @@ export const ReDelegateTable = ({
   renderInfoColumn,
   onChangeValidatorAmount,
 }: IncrementBondingTableProps): JSX.Element => {
+  const { sortableColumns, sortedValidators } = useValidatorTableSorting({
+    validators,
+    stakedAmountByAddress,
+  });
+
   const headers = [
     { children: "Validator" },
     "Amount to Re-delegate",
@@ -40,9 +46,18 @@ export const ReDelegateTable = ({
         </div>
       ),
       className: "text-right",
+      ...sortableColumns["stakedAmount"],
     },
-    { children: "Voting Power", className: "text-right" },
-    { children: "Commission", className: "text-right" },
+    {
+      children: "Voting Power",
+      className: "text-right",
+      ...sortableColumns["votingPowerInNAM"],
+    },
+    {
+      children: "Commission",
+      className: "text-right",
+      ...sortableColumns["commission"],
+    },
   ];
 
   const renderRow = (validator: Validator): TableRow => {
@@ -128,7 +143,7 @@ export const ReDelegateTable = ({
     <ValidatorsTable
       id="increment-bonding-table"
       tableClassName="mt-2"
-      validatorList={validators}
+      validatorList={sortedValidators}
       updatedAmountByAddress={updatedAmountByAddress}
       headers={headers}
       renderRow={renderRow}

--- a/apps/namadillo/src/App/Staking/UnstakeBondingTable.tsx
+++ b/apps/namadillo/src/App/Staking/UnstakeBondingTable.tsx
@@ -4,6 +4,7 @@ import { NamCurrency } from "App/Common/NamCurrency";
 import { NamInput } from "App/Common/NamInput";
 import BigNumber from "bignumber.js";
 import clsx from "clsx";
+import { useValidatorTableSorting } from "hooks/useValidatorTableSorting";
 import { twMerge } from "tailwind-merge";
 import { MyValidator, Validator } from "types";
 import { ValidatorCard } from "./ValidatorCard";
@@ -22,19 +23,43 @@ export const UnstakeBondingTable = ({
   stakedAmountByAddress,
   onChangeValidatorAmount,
 }: UnstakeBondingTableProps): JSX.Element => {
+  const validators = myValidators.map((mv) => mv.validator);
+
+  const { sortableColumns, sortedValidators } = useValidatorTableSorting({
+    validators,
+    stakedAmountByAddress,
+  });
+
   const headers = [
     { children: "Validator" },
     "Amount to Unstake",
-    <div key={`unstake-new-total`} className="text-right">
-      <span className="block">Stake</span>
-      <small className="text-xs text-neutral-500 block">New total Stake</small>
-    </div>,
-    <div key={`unstake-voting-power`} className="text-right">
-      Voting Power
-    </div>,
-    <div key={`unstake-commission`} className="text-right">
-      Commission
-    </div>,
+    {
+      children: (
+        <div key={`unstake-new-total`} className="text-right">
+          <span className="block">Stake</span>
+          <small className="text-xs text-neutral-500 block">
+            New total Stake
+          </small>
+        </div>
+      ),
+      ...sortableColumns["stakedAmount"],
+    },
+    {
+      children: (
+        <div key={`unstake-voting-power`} className="text-right">
+          Voting Power
+        </div>
+      ),
+      ...sortableColumns["stakedAmount"],
+    },
+    {
+      children: (
+        <div key={`unstake-commission`} className="text-right">
+          Commission
+        </div>
+      ),
+      ...sortableColumns["commission"],
+    },
   ];
 
   const renderRow = (validator: Validator): TableRow => {
@@ -127,7 +152,7 @@ export const UnstakeBondingTable = ({
     <ValidatorsTable
       id="increment-bonding-table"
       tableClassName="mt-2"
-      validatorList={myValidators.map((mv) => mv.validator)}
+      validatorList={sortedValidators}
       headers={headers}
       renderRow={renderRow}
     />

--- a/apps/namadillo/src/hooks/useValidatorTableSorting.tsx
+++ b/apps/namadillo/src/hooks/useValidatorTableSorting.tsx
@@ -37,7 +37,7 @@ export const useValidatorTableSorting = ({
 
   const onSortCallback =
     (key: SortableColumns) => (order: SortableHeaderOptions) =>
-      setSorting([key, order]);
+      order ? setSorting([key, order]) : setSorting(undefined);
 
   const makeSortableColumn = (key: SortableColumns): Partial<TableHeader> => {
     return {

--- a/apps/namadillo/src/hooks/useValidatorTableSorting.tsx
+++ b/apps/namadillo/src/hooks/useValidatorTableSorting.tsx
@@ -1,0 +1,83 @@
+import { SortableHeaderOptions, TableHeader } from "@namada/components";
+import BigNumber from "bignumber.js";
+import { useMemo, useState } from "react";
+import { SortOptions, SortedColumnPair, Validator } from "types";
+import { compareBigNumbers, sortCollection } from "utils/sorting";
+
+const ValidatorSortableColumnsList = [
+  "votingPowerInNAM",
+  "commission",
+] as const;
+
+type ValidatorSortableColumns = (typeof ValidatorSortableColumnsList)[number];
+
+const isValidatorColumn = (value: string): value is ValidatorSortableColumns =>
+  ValidatorSortableColumnsList.includes(value as ValidatorSortableColumns);
+
+type SortableColumns = ValidatorSortableColumns | "stakedAmount";
+
+type useValidatorTableSortingProps = {
+  validators: Validator[];
+  stakedAmountByAddress: Record<string, BigNumber>;
+};
+
+type useValidatorTableSortingOutput = {
+  sortedValidators: Validator[];
+  sortableColumns: Record<SortableColumns, Partial<TableHeader>>;
+};
+
+export const useValidatorTableSorting = ({
+  validators,
+  stakedAmountByAddress,
+}: useValidatorTableSortingProps): useValidatorTableSortingOutput => {
+  const [sorting, setSorting] = useState<SortedColumnPair<SortableColumns>>();
+
+  const getSortingParam = (key: SortableColumns): SortOptions | undefined =>
+    sorting && sorting[0] === key ? sorting[1] : undefined;
+
+  const onSortCallback =
+    (key: SortableColumns) => (order: SortableHeaderOptions) =>
+      setSorting([key, order]);
+
+  const makeSortableColumn = (key: SortableColumns): Partial<TableHeader> => {
+    return {
+      sortable: true,
+      sorting: getSortingParam(key),
+      onSort: onSortCallback(key),
+    };
+  };
+
+  const sortedValidators = useMemo(() => {
+    if (!sorting) return validators;
+
+    if (isValidatorColumn(sorting[0])) {
+      return sortCollection<Validator, ValidatorSortableColumns>(
+        validators,
+        sorting as SortedColumnPair<ValidatorSortableColumns>
+      );
+    }
+
+    if (sorting[0] === "stakedAmount") {
+      return validators.sort((v1: Validator, v2: Validator) => {
+        return compareBigNumbers(
+          stakedAmountByAddress[v1.address],
+          stakedAmountByAddress[v2.address],
+          sorting[1] === "desc"
+        );
+      });
+    }
+
+    return validators;
+  }, [sorting, validators]);
+
+  const sortableColumns: Record<SortableColumns, Partial<TableHeader>> = {
+    stakedAmount: makeSortableColumn("stakedAmount"),
+    commission: makeSortableColumn("commission"),
+    votingPowerInNAM: makeSortableColumn("votingPowerInNAM"),
+  };
+
+  return {
+    sortedValidators,
+    sortableColumns,
+  };
+};

--- a/apps/namadillo/src/types.d.ts
+++ b/apps/namadillo/src/types.d.ts
@@ -125,3 +125,7 @@ export type TxKind =
   | "ClaimRewards"
   | "VoteProposal"
   | "Unknown";
+
+export type SortOptions = "asc" | "desc" | undefined;
+
+export type SortedColumnPair<T> = [id: T, SortOptions] | undefined;

--- a/apps/namadillo/src/utils/sorting.ts
+++ b/apps/namadillo/src/utils/sorting.ts
@@ -1,0 +1,73 @@
+import { SortableHeaderOptions, TableHeader } from "@namada/components";
+import BigNumber from "bignumber.js";
+import { SortedColumnPair } from "types";
+
+export const compareBigNumbers = (
+  n1: BigNumber | undefined,
+  n2: BigNumber | undefined,
+  isDescending: boolean
+): number => {
+  if (n1 === undefined && n2 === undefined) return 0;
+  if (!n1) return isDescending ? 1 : -1;
+  if (!n2) return isDescending ? -1 : 1;
+  return isDescending ? n2.minus(n1).toNumber() : n1.minus(n2).toNumber();
+};
+
+export const compareStrings = (
+  str1: string,
+  str2: string,
+  isDescending: boolean
+): number => {
+  return isDescending ? str2.localeCompare(str1) : str1.localeCompare(str2);
+};
+
+const compareNumbers = (
+  a: number,
+  b: number,
+  isDescending: boolean
+): number => {
+  if (a > b) return isDescending ? -1 : 1;
+  if (a < b) return isDescending ? 1 : -1;
+  return 0;
+};
+
+export const sortCollection = <T, S extends keyof T>(
+  collection: T[],
+  sortablePair?: SortedColumnPair<S>
+): T[] => {
+  if (collection.length === 0 || !sortablePair) return collection;
+
+  const [key, sortOrder] = sortablePair;
+  const isDescending = sortOrder === "desc";
+
+  return collection.sort((a: T, b: T) => {
+    const aValue = a[key];
+    const bValue = b[key];
+
+    if (aValue instanceof BigNumber && bValue instanceof BigNumber) {
+      return compareBigNumbers(aValue, bValue, isDescending);
+    } else if (typeof aValue === "number" && typeof bValue === "number") {
+      return compareNumbers(aValue, bValue, isDescending);
+    } else if (typeof aValue === "string" && typeof bValue === "string") {
+      return compareStrings(aValue, bValue, isDescending);
+    }
+
+    return 0;
+  });
+};
+
+export const createSortableHeaderOption = <T, S extends keyof T>(
+  children: React.ReactNode,
+  key: S,
+  onSort: (pair: SortedColumnPair<S>) => void,
+  sortablePair?: SortedColumnPair<S>
+): TableHeader => {
+  const sorting =
+    sortablePair && sortablePair[0] === key ? sortablePair[1] : undefined;
+  return {
+    children,
+    sortable: true,
+    sorting,
+    onSort: (order: SortableHeaderOptions) => onSort([key, order]),
+  };
+};

--- a/apps/namadillo/src/utils/sorting.ts
+++ b/apps/namadillo/src/utils/sorting.ts
@@ -1,4 +1,3 @@
-import { SortableHeaderOptions, TableHeader } from "@namada/components";
 import BigNumber from "bignumber.js";
 import { SortedColumnPair } from "types";
 
@@ -54,20 +53,4 @@ export const sortCollection = <T, S extends keyof T>(
 
     return 0;
   });
-};
-
-export const createSortableHeaderOption = <T, S extends keyof T>(
-  children: React.ReactNode,
-  key: S,
-  onSort: (pair: SortedColumnPair<S>) => void,
-  sortablePair?: SortedColumnPair<S>
-): TableHeader => {
-  const sorting =
-    sortablePair && sortablePair[0] === key ? sortablePair[1] : undefined;
-  return {
-    children,
-    sortable: true,
-    sorting,
-    onSort: (order: SortableHeaderOptions) => onSort([key, order]),
-  };
 };

--- a/packages/components/src/StyledTable.tsx
+++ b/packages/components/src/StyledTable.tsx
@@ -3,7 +3,7 @@ import { twMerge } from "tailwind-merge";
 import { StyledTableHead, TableHeader } from "./StyledTableHead";
 import { StyledTableRow, TableRow } from "./StyledTableRow";
 
-type StyledTableProps = {
+export type StyledTableProps = {
   id: string;
   containerClassName?: string;
   tableProps?: React.ComponentPropsWithoutRef<"table">;
@@ -29,7 +29,7 @@ export const StyledTable = ({
       headers && (
         <StyledTableHead id={id} headers={headers} headProps={headProps} />
       ),
-    []
+    [headers]
   );
 
   return (

--- a/packages/components/src/StyledTableHead.tsx
+++ b/packages/components/src/StyledTableHead.tsx
@@ -1,9 +1,9 @@
 import clsx from "clsx";
 import { MouseEvent, ReactNode } from "react";
-import { GoChevronDown, GoChevronUp } from "react-icons/go";
+import { FaSort, FaSortDown, FaSortUp } from "react-icons/fa6";
 import { twMerge } from "tailwind-merge";
 
-export type SortableHeaderOptions = "desc" | "asc";
+export type SortableHeaderOptions = "desc" | "asc" | undefined;
 
 export type TableHeader = {
   children: ReactNode;
@@ -54,17 +54,24 @@ const renderTableHeaderElement = (
         key={key}
         className={twMerge(
           clsx(baseClassName, additionalClassName, {
-            "cursor-pointer flex items-center justify-between": sortable,
+            "cursor-pointer": sortable,
           })
         )}
         onClick={_onClick}
         {...props}
       >
-        {children}
-        <span className="pl-4">
-          {sorting === "desc" && <GoChevronUp />}
-          {sorting === "asc" && <GoChevronDown />}
-        </span>
+        <div className="flex items-center justify-between">
+          <span className="w-full">{children}</span>
+          {sortable && (
+            <span
+              className={clsx("pl-2", { "text-white": sorting !== undefined })}
+            >
+              {sorting === "desc" && <FaSortUp className="mt-[0.5em]" />}
+              {sorting === "asc" && <FaSortDown className="mt-[-0.5em]" />}
+              {sorting === undefined && <FaSort />}
+            </span>
+          )}
+        </div>
       </th>
     );
   }

--- a/packages/components/src/StyledTableHead.tsx
+++ b/packages/components/src/StyledTableHead.tsx
@@ -1,8 +1,15 @@
-import { ReactNode } from "react";
+import clsx from "clsx";
+import { MouseEvent, ReactNode } from "react";
+import { GoChevronDown, GoChevronUp } from "react-icons/go";
 import { twMerge } from "tailwind-merge";
+
+export type SortableHeaderOptions = "desc" | "asc";
 
 export type TableHeader = {
   children: ReactNode;
+  sortable?: boolean;
+  sorting?: SortableHeaderOptions;
+  onSort?: (sorting: SortableHeaderOptions) => void;
 } & React.ComponentPropsWithoutRef<"th">;
 
 type StyledTableHeadProps = {
@@ -25,14 +32,39 @@ const renderTableHeaderElement = (
   const baseClassName = `px-6 py-2`;
 
   if (checkIsTableHeader(h)) {
-    const { className: additionalClassName, children, ...props } = h;
+    const {
+      className: additionalClassName,
+      children,
+      onClick,
+      sortable,
+      onSort,
+      sorting,
+      ...props
+    } = h;
+
+    const _onClick = (e: MouseEvent<HTMLTableCellElement>): void => {
+      if (sortable && onSort) {
+        onSort(sorting === "desc" ? "asc" : "desc");
+      }
+      if (onClick) onClick(e);
+    };
+
     return (
       <th
         key={key}
-        className={twMerge(baseClassName, additionalClassName)}
+        className={twMerge(
+          clsx(baseClassName, additionalClassName, {
+            "cursor-pointer flex items-center justify-between": sortable,
+          })
+        )}
+        onClick={_onClick}
         {...props}
       >
         {children}
+        <span className="pl-4">
+          {sorting === "desc" && <GoChevronUp />}
+          {sorting === "asc" && <GoChevronDown />}
+        </span>
       </th>
     );
   }

--- a/packages/components/src/StyledTableHead.tsx
+++ b/packages/components/src/StyledTableHead.tsx
@@ -44,7 +44,11 @@ const renderTableHeaderElement = (
 
     const _onClick = (e: MouseEvent<HTMLTableCellElement>): void => {
       if (sortable && onSort) {
-        onSort(sorting === "desc" ? "asc" : "desc");
+        onSort(
+          sorting === undefined ? "desc"
+          : sorting === "desc" ? "asc"
+          : undefined
+        );
       }
       if (onClick) onClick(e);
     };

--- a/storybook/src/stories/StyledTable.stories.tsx
+++ b/storybook/src/stories/StyledTable.stories.tsx
@@ -1,5 +1,10 @@
-import { StyledTable } from "@namada/components";
+import {
+  SortableHeaderOptions,
+  StyledTable,
+  StyledTableProps,
+} from "@namada/components";
 import type { StoryObj } from "@storybook/react";
+import { useMemo, useState } from "react";
 import cosmostationLogo from "../../public/images/cosmostation.png";
 import everstakeLogo from "../../public/images/everstake.png";
 
@@ -50,6 +55,51 @@ export const Default: Story = {
       },
     ],
   },
+};
+
+const SortableTitlesExample = (props: StyledTableProps): JSX.Element => {
+  const [nameSort, setNameSort] = useState<SortableHeaderOptions | undefined>();
+  const data = [
+    { id: 1, name: "Justin" },
+    { id: 2, name: "Mateusz" },
+    { id: 3, name: "Pedro" },
+    { id: 4, name: "Eric" },
+    { id: 5, name: "Harri" },
+  ];
+
+  const rows = useMemo(() => {
+    if (!nameSort) return data;
+    return data.sort((entry1, entry2) => {
+      if (nameSort === "asc") return entry2.name.localeCompare(entry1.name);
+      return entry1.name.localeCompare(entry2.name);
+    });
+  }, [nameSort]);
+
+  return (
+    <StyledTable
+      {...props}
+      headers={[
+        "ID",
+        {
+          children: "Name",
+          sortable: true,
+          onSort: (order: SortableHeaderOptions) => {
+            setNameSort(order);
+          },
+          sorting: nameSort,
+        },
+      ]}
+      rows={rows.map((row) => ({ cells: [row.id, row.name] }))}
+    />
+  );
+};
+
+export const WithSortableTitles: Story = {
+  decorators: [
+    (_Story, context) => {
+      return <SortableTitlesExample {...context.args} />;
+    },
+  ],
 };
 
 export const WithEmptyTitles: Story = {


### PR DESCRIPTION
This PR introduces a way to add sortable headers to tables, and implement the functionality to the staking tables.
Closes #786 