### PR TITLE
feat: update overview animation

### DIFF
--- a/apps/namadillo/src/App/AccountOverview/AccountBalanceContainer.tsx
+++ b/apps/namadillo/src/App/AccountOverview/AccountBalanceContainer.tsx
@@ -3,51 +3,24 @@ import { AtomErrorBoundary } from "App/Common/AtomErrorBoundary";
 import { NamCurrency } from "App/Common/NamCurrency";
 import { accountBalanceAtom } from "atoms/accounts";
 import clsx from "clsx";
-import { useAnimate } from "framer-motion";
 import { useAtomValue } from "jotai";
-import { useLayoutEffect } from "react";
 import { twMerge } from "tailwind-merge";
-import { easings } from "utils/animations";
 
 export const AccountBalanceContainer = (): JSX.Element => {
-  const [scope, animate] = useAnimate();
   const accountBalance = useAtomValue(accountBalanceAtom);
-  const {
-    data: totalBalance,
-    status,
-    isSuccess: balanceHasLoaded,
-    isLoading: balanceIsLoading,
-  } = accountBalance;
-
-  useLayoutEffect(() => {
-    if (balanceHasLoaded) {
-      animate(
-        scope.current,
-        { minWidth: "min(90vw, 450px)" },
-        { duration: 0.5, ease: easings.expoOut }
-      );
-      animate(
-        "article",
-        {
-          opacity: [0, 1],
-        },
-        { duration: 1, ease: easings.expoOut, delay: 0.15 }
-      );
-    }
-  }, [status]);
+  const { data: totalBalance, isSuccess: balanceHasLoaded } = accountBalance;
 
   return (
     <div
-      ref={scope}
       className={twMerge(
         clsx(
           "flex items-center justify-center min-w-[350px]",
           "relative w-full aspect-square",
           "rounded-full border-[27px]",
-          {
-            "border-neutral-800 animate-pulse": balanceIsLoading,
-            "border-yellow": balanceHasLoaded,
-          }
+          "transition-colors duration-500",
+          balanceHasLoaded ? "border-yellow" : (
+            "border-neutral-800 animate-pulse"
+          )
         )
       )}
     >
@@ -56,22 +29,28 @@ export const AccountBalanceContainer = (): JSX.Element => {
         niceError="Balance couldn't be loaded"
         containerProps={{ className: "text-white" }}
       >
-        {balanceHasLoaded && totalBalance && (
-          <Stack
-            as="article"
-            gap={0}
-            className="text-neutral-400 leading-tight text-center"
-          >
-            <Heading level="h3" className="text-xl neutral-600">
-              NAM Balance
-            </Heading>
+        <Stack
+          as="article"
+          gap={0}
+          className={twMerge(
+            clsx(
+              "text-neutral-400 leading-tight text-center",
+              "transition-opacity duration-500",
+              { "opacity-0": !balanceHasLoaded }
+            )
+          )}
+        >
+          <Heading level="h3" className="text-xl neutral-600">
+            NAM Balance
+          </Heading>
+          {totalBalance && (
             <NamCurrency
               amount={totalBalance}
               className="text-4xl text-white font-medium"
               currencySignClassName="text-xl ml-2"
             />
-          </Stack>
-        )}
+          )}
+        </Stack>
       </AtomErrorBoundary>
     </div>
   );


### PR DESCRIPTION
Closes https://github.com/anoma/namada-interface/issues/967

Update overview animation to preserve the circle dimensions

Please, note that I'm not resolving the flash of the Extension loading. This should be address in another PR as we'll need to update in many other components


https://github.com/user-attachments/assets/7ecaa508-fd36-4349-98e8-995649c4f0ee

