### PR TITLE
feat(namadillo): adding validation to unstake amounts

### DIFF
--- a/apps/namadillo/src/App/Staking/Unstake.tsx
+++ b/apps/namadillo/src/App/Staking/Unstake.tsx
@@ -141,6 +141,12 @@ const Unstake = (): JSX.Element => {
 
   const validationMessage = ((): string => {
     if (totalStakedAmount.lt(totalUpdatedAmount)) return "Invalid amount";
+
+    for (const address in updatedAmountByAddress) {
+      if (stakedAmountByAddress[address].lt(updatedAmountByAddress[address])) {
+        return "Invalid amount";
+      }
+    }
     return "";
   })();
 

--- a/apps/namadillo/src/App/Staking/UnstakeBondingTable.tsx
+++ b/apps/namadillo/src/App/Staking/UnstakeBondingTable.tsx
@@ -70,6 +70,7 @@ export const UnstakeBondingTable = ({
       updatedAmountByAddress[validator.address] ?? new BigNumber(0);
 
     const hasNewAmounts = amountToUnstake.gt(0);
+    const newAmount = stakedAmount.minus(amountToUnstake);
 
     return {
       className: "",
@@ -114,9 +115,15 @@ export const UnstakeBondingTable = ({
             <NamCurrency amount={stakedAmount} />
           </span>
           {hasNewAmounts && (
-            <span className="text-orange text-sm">
+            <span
+              className={twMerge(
+                clsx("text-orange text-sm", {
+                  "text-fail": newAmount.lt(0),
+                })
+              )}
+            >
               =
-              <NamCurrency amount={stakedAmount.minus(amountToUnstake)} />
+              <NamCurrency amount={newAmount} />
             </span>
           )}
         </div>,


### PR DESCRIPTION
This PR won't let users to unbond more than what they have in a validator, causing an error. Displays a simple "Invalid amount" message and changes the color to red for the invalid amounts.