### PR TITLE
Fix vote tx details on Firefox + uncaught error

### DIFF
--- a/apps/extension/src/Approvals/Commitment.tsx
+++ b/apps/extension/src/Approvals/Commitment.tsx
@@ -89,10 +89,11 @@ const renderContent = (tx: CommitmentDetailProps): ReactNode => {
       );
 
     case TxType.VoteProposal:
+      // TODO: On Chrome, this cast is wrong because tx.proposalId is a string
       const voteTx = tx as VoteProposalProps;
       return (
         <>
-          Vote {voteTx.vote} on proposal #{voteTx.proposalId}
+          Vote {voteTx.vote} on proposal #{voteTx.proposalId.toString()}
         </>
       );
 

--- a/apps/extension/src/Approvals/index.tsx
+++ b/apps/extension/src/Approvals/index.tsx
@@ -11,6 +11,9 @@ import "@namada/components/src/base.css";
 import "../global.css";
 import "../tailwind.css";
 
+// Needed to allow displaying tx details containing bigints e.g. proposals
+import "@namada/utils/bigint-to-json-polyfill";
+
 const container = document.getElementById("root")!;
 createRoot(container).render(
   <React.StrictMode>

--- a/apps/namadillo/src/App/Governance/ProposalHeader.tsx
+++ b/apps/namadillo/src/App/Governance/ProposalHeader.tsx
@@ -234,7 +234,7 @@ const TimeRemaining: React.FC<{
           proposal.currentTime,
           proposal.endTime
         );
-        return `${timeRemaining} Remaining`;
+        return timeRemaining ? `${timeRemaining} Remaining` : "";
       }
     }
 

--- a/apps/namadillo/src/utils/index.ts
+++ b/apps/namadillo/src/utils/index.ts
@@ -60,11 +60,10 @@ export const secondsToDateTimeString = (seconds: bigint): string =>
 export const secondsToTimeRemainingString = (
   startTimeInSeconds: bigint,
   endTimeInSeconds: bigint
-): string => {
+): string | undefined => {
+  return;
   if (endTimeInSeconds < startTimeInSeconds) {
-    throw new Error(
-      `endTimeInSeconds ${endTimeInSeconds} is before startTimeInSeconds ${startTimeInSeconds}`
-    );
+    return undefined;
   }
 
   const toMilliNumber = (n: bigint): number =>


### PR DESCRIPTION
### Fixed
- Namadillo: fix uncaught error in proposal time remaining
- Extension: show proposal id and vote tx details in Firefox
  - This is another case of a Firefox bug due to the difference in how Firefox and Chrome serialize messages passed between the background and content scripts. Firefox uses the structured clone algorithm but Chrome uses JSON serialization.