### PR TITLE
bug: Namadillo - Click to copy address should copy address, not public key

### DIFF
--- a/apps/namadillo/src/App/Common/ActiveAccount.tsx
+++ b/apps/namadillo/src/App/Common/ActiveAccount.tsx
@@ -21,7 +21,7 @@ export const ActiveAccount = (): JSX.Element => {
         <span className="flex items-center gap-2 ">
           <CopyToClipboardControl
             className="opacity-80 transition-opacity duration-150 hover:opacity-100"
-            value={account.publicKey || ""}
+            value={account.address || ""}
           >
             {account.alias}
           </CopyToClipboardControl>


### PR DESCRIPTION
Simple PR to allow clicking to copy address instead of public key in Namadillo

### Testing

- In Namadillo, click upper-right-most button with selected account name, then check the copied value - this should be the account's address, not the public key