### PR TITLE
Namadillo: fixing error on loading token

### DIFF
--- a/apps/namadillo/src/App/Common/QueryProvider.tsx
+++ b/apps/namadillo/src/App/Common/QueryProvider.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { getDefaultStore } from "jotai";
 import { queryClientAtom } from "jotai-tanstack-query";
 import { Provider as JotaiProvider } from "jotai/react";
 import { useHydrateAtoms } from "jotai/utils";
@@ -42,7 +43,7 @@ export const QueryProvider = ({
 }): JSX.Element => {
   return (
     <QueryClientProvider client={queryClient}>
-      <JotaiProvider>
+      <JotaiProvider store={getDefaultStore()}>
         <HydrateAtoms>{children}</HydrateAtoms>
       </JotaiProvider>
     </QueryClientProvider>


### PR DESCRIPTION
We've introduced some different default settings for the store in a preview commit, however `getDefaultStore` in some other places started to refer to a store different than the one used by jotai-tanstack-query, leading to some unexpected behaviours. This PR simply adds this reference to the query provider. 