### PR TITLE
Extension - address feedback

### DIFF
--- a/apps/extension/src/App/Accounts/ViewAccount.tsx
+++ b/apps/extension/src/App/Accounts/ViewAccount.tsx
@@ -61,6 +61,7 @@ export const ViewAccount = (): JSX.Element => {
               publicKeyAddress={parentAccount.publicKey ?? ""}
               transparentAccountAddress={transparentAddress}
               shieldedAccountAddress={shieldedAddress}
+              trimCharacters={21}
             />
           </Stack>
           <ActionButton size="md" onClick={() => navigate(-1)}>

--- a/apps/extension/src/Setup/Common/Completion.tsx
+++ b/apps/extension/src/Setup/Common/Completion.tsx
@@ -134,6 +134,7 @@ export const Completion: React.FC<Props> = (props) => {
             publicKeyAddress={publicKeyAddress}
             transparentAccountAddress={transparentAccountAddress}
             shieldedAccountAddress={shieldedAccountAddress}
+            trimCharacters={35}
             footer={
               <ActionButton
                 size="lg"

--- a/apps/namadillo/src/atoms/chain/atoms.ts
+++ b/apps/namadillo/src/atoms/chain/atoms.ts
@@ -1,10 +1,8 @@
 import namada from "@namada/chains/chains/namada";
-import { integrations } from "@namada/integrations";
 import { indexerApiAtom } from "atoms/api";
 import {
   defaultServerConfigAtom,
   indexerUrlAtom,
-  namadaExtensionConnectedAtom,
   rpcUrlAtom,
 } from "atoms/settings";
 import { queryDependentFn } from "atoms/utils";
@@ -18,31 +16,20 @@ export const chainAtom = atomWithQuery<ChainSettings>((get) => {
   const rpcUrl = get(rpcUrlAtom);
   const indexerUrl = get(indexerUrlAtom);
   const tomlConfig = get(defaultServerConfigAtom);
-  const extensionConnected = get(namadaExtensionConnectedAtom);
 
   return {
-    queryKey: [
-      "chain",
-      rpcUrl,
-      chainParameters,
-      indexerRpcUrl,
-      extensionConnected,
-    ],
+    queryKey: ["chain", rpcUrl, chainParameters, indexerRpcUrl],
     staleTime: Infinity,
     retry: false,
     ...queryDependentFn(async () => {
       const rpcUrl = get(rpcUrlAtom);
-      const extensionChainId =
-        extensionConnected ?
-          (await integrations.namada.getChain())?.chainId
-        : "";
 
       return {
         id: namada.id,
         extensionId: namada.extension.id,
         bench32Prefix: namada.bech32Prefix,
         rpcUrl,
-        chainId: extensionChainId || chainParameters.data!.chainId,
+        chainId: chainParameters.data!.chainId,
         unbondingPeriodInEpochs:
           chainParameters.data!.epochInfo.unbondingPeriodInEpochs,
         nativeTokenAddress: chainParameters.data!.nativeTokenAddress,

--- a/packages/components/src/ViewKeys.tsx
+++ b/packages/components/src/ViewKeys.tsx
@@ -9,6 +9,7 @@ type ViewKeysProps = {
   shieldedAccountAddress?: string;
   viewingKeys?: string;
   footer?: React.ReactNode;
+  trimCharacters?: number;
 };
 
 export const ViewKeys = ({
@@ -17,6 +18,7 @@ export const ViewKeys = ({
   shieldedAccountAddress,
   viewingKeys,
   footer,
+  trimCharacters = 16,
 }: ViewKeysProps): JSX.Element => {
   return (
     <Stack
@@ -29,7 +31,10 @@ export const ViewKeys = ({
           <Input
             label="Your Transparent Address"
             variant="ReadOnlyCopy"
-            valueToDisplay={shortenAddress(transparentAccountAddress, 16)}
+            valueToDisplay={shortenAddress(
+              transparentAccountAddress,
+              trimCharacters
+            )}
             value={transparentAccountAddress}
             theme={"primary"}
           />
@@ -38,7 +43,7 @@ export const ViewKeys = ({
           <Input
             label="Public Key"
             variant="ReadOnlyCopy"
-            valueToDisplay={shortenAddress(publicKeyAddress, 16)}
+            valueToDisplay={shortenAddress(publicKeyAddress, trimCharacters)}
             value={publicKeyAddress}
             theme={"primary"}
           />
@@ -48,7 +53,10 @@ export const ViewKeys = ({
             label="Your Shielded Address"
             variant="ReadOnlyCopy"
             readOnly={true}
-            valueToDisplay={shortenAddress(shieldedAccountAddress, 16)}
+            valueToDisplay={shortenAddress(
+              shieldedAccountAddress,
+              trimCharacters
+            )}
             value={shieldedAccountAddress}
             theme={"secondary"}
           />


### PR DESCRIPTION
Resolves #1015 

- [x] Namadillo should use chain ID from indexer only
- [x] Lengthen "shortened" address in set up (Key import) - Note: I updated the component to accept a trim value for `shortenAddress()`, otherwise it will default to 16, and tried to find values in Setup and View Keys that would work well with different keys through trial and error. It should be close, but I imagine with some keys it may be _possible_ that part of a character clips, if so, we can reduce the trim in that case.

### Screenshots

Lengthen keys in Setup view:
<img width="581" alt="Screen Shot 2024-08-20 at 11 30 47 AM" src="https://github.com/user-attachments/assets/0824d137-3b9e-43b3-b797-a04690645452">

Lengthen keys in `View Keys` view:
<img width="372" alt="Screen Shot 2024-08-20 at 11 32 59 AM" src="https://github.com/user-attachments/assets/de745e77-df4c-4312-b6af-3f725348172c">
