### PR TITLE
chore: Extension - Update release CI script

### DIFF
--- a/.github/workflows/release-wallet.yml
+++ b/.github/workflows/release-wallet.yml
@@ -1,4 +1,4 @@
-name: Deploy interface and release extension
+name: Release extension
 on:
   workflow_dispatch:
     inputs:
@@ -6,35 +6,8 @@ on:
         required: true
         type: string
         default: "main"
-      NAMADA_INTERFACE_NAMADA_ALIAS:
-        required: true
-        type: string
-        default: "Namada Testnet"
       NAMADA_INTERFACE_NAMADA_CHAIN_ID:
         required: true
-        type: string
-      NAMADA_INTERFACE_NAMADA_URL:
-        required: true
-        type: string
-      NAMADA_INTERFACE_COSMOS_ALIAS:
-        required: false
-        type: string
-        default: "Cosmos Testnet"
-      NAMADA_INTERFACE_COSMOS_CHAIN_ID:
-        required: false
-        type: string
-      NAMADA_INTERFACE_COSMOS_URL:
-        required: false
-        type: string
-      NAMADA_INTERFACE_ETH_ALIAS:
-        required: false
-        type: string
-        default: "Goerli Testnet"
-      NAMADA_INTERFACE_ETH_CHAIN_ID:
-        required: false
-        type: string
-      NAMADA_INTERFACE_ETH_URL:
-        required: false
         type: string
 
 env:
@@ -61,46 +34,6 @@ jobs:
 
       - name: Print workflow inputs
         uses: ./.github/actions/print-workflow-inputs
-
-  build-interface:
-    needs: setup
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.REF }}
-
-      - name: Install yarn dependencies
-        uses: ./.github/actions/yarn-cache
-
-      - name: Restore Rust cache
-        uses: ./.github/actions/rust-cache
-        with:
-          cache-name: build
-
-      - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler
-
-      - name: Build the interface
-        working-directory: ./apps/namadillo
-        run: yarn build
-        env:
-          NAMADA_INTERFACE_NAMADA_ALIAS: ${{ inputs.NAMADA_INTERFACE_NAMADA_ALIAS }}
-          NAMADA_INTERFACE_NAMADA_CHAIN_ID: ${{ inputs.NAMADA_INTERFACE_NAMADA_CHAIN_ID }}
-          NAMADA_INTERFACE_NAMADA_URL: ${{ inputs.NAMADA_INTERFACE_NAMADA_URL }}
-          NAMADA_INTERFACE_COSMOS_ALIAS: ${{ inputs.NAMADA_INTERFACE_COSMOS_ALIAS }}
-          NAMADA_INTERFACE_COSMOS_CHAIN_ID: ${{ inputs.NAMADA_INTERFACE_COSMOS_CHAIN_ID }}
-          NAMADA_INTERFACE_COSMOS_URL: ${{ inputs.NAMADA_INTERFACE_COSMOS_URL }}
-          NAMADA_INTERFACE_ETH_ALIAS: ${{ inputs.NAMADA_INTERFACE_ETH_ALIAS }}
-          NAMADA_INTERFACE_ETH_CHAIN_ID: ${{ inputs.NAMADA_INTERFACE_ETH_CHAIN_ID }}
-          NAMADA_INTERFACE_ETH_URL: ${{ inputs.NAMADA_INTERFACE_ETH_URL }}
-          NAMADA_INTERFACE_EXTENSION_URL: https://github.com/anoma/namada-interface/releases/tag/${{ needs.setup.outputs.VERSION }}/
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: namadillo
-          path: ./apps/namadillo/dist
 
   build-extension-chrome:
     needs: setup
@@ -130,15 +63,7 @@ jobs:
         working-directory: ./apps/extension
         run: yarn build:chrome
         env:
-          NAMADA_INTERFACE_NAMADA_ALIAS: ${{ inputs.NAMADA_INTERFACE_NAMADA_ALIAS }}
           NAMADA_INTERFACE_NAMADA_CHAIN_ID: ${{ inputs.NAMADA_INTERFACE_NAMADA_CHAIN_ID }}
-          NAMADA_INTERFACE_NAMADA_URL: ${{ inputs.NAMADA_INTERFACE_NAMADA_URL }}
-          NAMADA_INTERFACE_COSMOS_ALIAS: ${{ inputs.NAMADA_INTERFACE_COSMOS_ALIAS }}
-          NAMADA_INTERFACE_COSMOS_CHAIN_ID: ${{ inputs.NAMADA_INTERFACE_COSMOS_CHAIN_ID }}
-          NAMADA_INTERFACE_COSMOS_URL: ${{ inputs.NAMADA_INTERFACE_COSMOS_URL }}
-          NAMADA_INTERFACE_ETH_ALIAS: ${{ inputs.NAMADA_INTERFACE_ETH_ALIAS }}
-          NAMADA_INTERFACE_ETH_CHAIN_ID: ${{ inputs.NAMADA_INTERFACE_ETH_CHAIN_ID }}
-          NAMADA_INTERFACE_ETH_URL: ${{ inputs.NAMADA_INTERFACE_ETH_URL }}
 
       - uses: actions/upload-artifact@v3
         with:
@@ -173,15 +98,7 @@ jobs:
         working-directory: ./apps/extension
         run: yarn build:firefox
         env:
-          NAMADA_INTERFACE_NAMADA_ALIAS: ${{ inputs.NAMADA_INTERFACE_NAMADA_ALIAS }}
           NAMADA_INTERFACE_NAMADA_CHAIN_ID: ${{ inputs.NAMADA_INTERFACE_NAMADA_CHAIN_ID }}
-          NAMADA_INTERFACE_NAMADA_URL: ${{ inputs.NAMADA_INTERFACE_NAMADA_URL }}
-          NAMADA_INTERFACE_COSMOS_ALIAS: ${{ inputs.NAMADA_INTERFACE_COSMOS_ALIAS }}
-          NAMADA_INTERFACE_COSMOS_CHAIN_ID: ${{ inputs.NAMADA_INTERFACE_COSMOS_CHAIN_ID }}
-          NAMADA_INTERFACE_COSMOS_URL: ${{ inputs.NAMADA_INTERFACE_COSMOS_URL }}
-          NAMADA_INTERFACE_ETH_ALIAS: ${{ inputs.NAMADA_INTERFACE_ETH_ALIAS }}
-          NAMADA_INTERFACE_ETH_CHAIN_ID: ${{ inputs.NAMADA_INTERFACE_ETH_CHAIN_ID }}
-          NAMADA_INTERFACE_ETH_URL: ${{ inputs.NAMADA_INTERFACE_ETH_URL }}
 
       - uses: actions/upload-artifact@v3
         with:
@@ -189,16 +106,9 @@ jobs:
           path: ./apps/extension/build/firefox/namada_extension-*.zip
 
   release:
-    needs:
-      [setup, build-interface, build-extension-chrome, build-extension-firefox]
+    needs: [setup, build-extension-chrome, build-extension-firefox]
     runs-on: ubuntu-latest
     steps:
-      - name: Download interface build
-        uses: actions/download-artifact@v3
-        with:
-          name: namadillo
-          path: ./namadillo
-
       - name: Download Chrome extension build
         uses: actions/download-artifact@v3
         with:
@@ -217,38 +127,11 @@ jobs:
           echo "CHROME_FILENAME=$(ls -1 ./namada-extension-chrome)" >> "$GITHUB_OUTPUT"
           echo "FIREFOX_FILENAME=$(ls -1 ./namada-extension-firefox)" >> "$GITHUB_OUTPUT"
 
-      - name: Deploy interface to Netlify
-        uses: nwtgck/actions-netlify@v1.2.3
-        with:
-          publish-dir: ./namadillo
-          production-branch: main
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: "Deployed release ${{ needs.setup.outputs.VERSION }}"
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_ACCESS_TOKEN_WALLET_PREVIEW }}
-          NETLIFY_SITE_ID: 2380782e-9b20-477a-bc27-b4e9d05e16f3
-
       - name: Make release body text
         run: |
-          echo "NAMADA_INTERFACE_NAMADA_ALIAS: $NAMADA_INTERFACE_NAMADA_ALIAS" >> RELEASE
           echo "NAMADA_INTERFACE_NAMADA_CHAIN_ID: $NAMADA_INTERFACE_NAMADA_CHAIN_ID" >> RELEASE
-          echo "NAMADA_INTERFACE_NAMADA_URL: $NAMADA_INTERFACE_NAMADA_URL" >> RELEASE
-          echo "NAMADA_INTERFACE_COSMOS_ALIAS: $NAMADA_INTERFACE_COSMOS_ALIAS" >> RELEASE
-          echo "NAMADA_INTERFACE_COSMOS_CHAIN_ID: $NAMADA_INTERFACE_COSMOS_CHAIN_ID" >> RELEASE
-          echo "NAMADA_INTERFACE_COSMOS_URL: $NAMADA_INTERFACE_COSMOS_URL" >> RELEASE
-          echo "NAMADA_INTERFACE_ETH_ALIAS: $NAMADA_INTERFACE_ETH_ALIAS" >> RELEASE
-          echo "NAMADA_INTERFACE_ETH_CHAIN_ID: $NAMADA_INTERFACE_ETH_CHAIN_ID" >> RELEASE
-          echo "NAMADA_INTERFACE_ETH_URL: $NAMADA_INTERFACE_ETH_URL" >> RELEASE
         env:
-          NAMADA_INTERFACE_NAMADA_ALIAS: ${{ inputs.NAMADA_INTERFACE_NAMADA_ALIAS }}
           NAMADA_INTERFACE_NAMADA_CHAIN_ID: ${{ inputs.NAMADA_INTERFACE_NAMADA_CHAIN_ID }}
-          NAMADA_INTERFACE_NAMADA_URL: ${{ inputs.NAMADA_INTERFACE_NAMADA_URL }}
-          NAMADA_INTERFACE_COSMOS_ALIAS: ${{ inputs.NAMADA_INTERFACE_COSMOS_ALIAS }}
-          NAMADA_INTERFACE_COSMOS_CHAIN_ID: ${{ inputs.NAMADA_INTERFACE_COSMOS_CHAIN_ID }}
-          NAMADA_INTERFACE_COSMOS_URL: ${{ inputs.NAMADA_INTERFACE_COSMOS_URL }}
-          NAMADA_INTERFACE_ETH_ALIAS: ${{ inputs.NAMADA_INTERFACE_ETH_ALIAS }}
-          NAMADA_INTERFACE_ETH_CHAIN_ID: ${{ inputs.NAMADA_INTERFACE_ETH_CHAIN_ID }}
-          NAMADA_INTERFACE_ETH_URL: ${{ inputs.NAMADA_INTERFACE_ETH_URL }}
 
       - name: Create release
         id: create-release

--- a/apps/extension/.env.sample
+++ b/apps/extension/.env.sample
@@ -1,0 +1,5 @@
+# Specify the following if you wish to override the defaults defined in @namada/chains:
+
+# NAMADA
+NAMADA_INTERFACE_NAMADA_CHAIN_ID=namada-testnet.ddf12d74622ca25f3ad6fe14
+

--- a/apps/extension/.gitignore
+++ b/apps/extension/.gitignore
@@ -1,0 +1,4 @@
+# dependencies
+.env
+/node_modules
+/build

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -4,6 +4,8 @@ This is the Namada Browser Extension project.
 
 ## Usage
 
+Note: if you wish to set a default chain ID in the extension, set this value in `.env`. See [.env.sample](./.env.sample).
+
 ```bash
 # Build wasm dependencies
 yarn wasm:build # This needs to be run initially to ensure wasm dependencies are available

--- a/apps/extension/webpack.config.js
+++ b/apps/extension/webpack.config.js
@@ -11,7 +11,7 @@ const packageJson = require("./package.json");
 const { getProcessEnv } = require("@namada/config/webpack.js");
 
 // Load .env from namadillo:
-require("dotenv").config({ path: "../namadillo/.env" });
+require("dotenv").config({ path: "./.env" });
 
 const { NODE_ENV, TARGET, BUNDLE_ANALYZE } = process.env;
 


### PR DESCRIPTION
This PR simply updates the CI script to release the extension. This will build the Chrome & Firefox extensions with the chain ID set in `apps/extension/.env` and publish the assets to Github.

**NOTE** I removed all but one `.env` var, though in the near future we may be adding a `NAMADA_INTERFACE_LEDGER_TRANSPORT` option, if it is needed to use extension with an emulated Ledger (this is being investigated in https://github.com/anoma/namada-interface/issues/1006) - If so, I will document transport options then.

- [x] Move `.env` into `apps/extension`
- [x] Create `.env.sample`
- [x] Update any unneeded `.env` values across the release script, and remove Namadillo build/deploy 
- [x] Update `README.md`

### Testing

1. Navigate to `Actions` in Github
2. Click `Deploy interface and release Extension` (__NOTE__: This has been renamed, but will appear with the old label until this is merged to `main`)
3. In the options for `Run workflow`, specify `chore/update-extension-ci` in `Use workflow from:`. `REF` can remain `main`
4. Specify value for `NAMADA_INTERFACE_NAMADA_CHAIN_ID`, then click `Run workflow`. Once it is successful, navigate back to the root `namada-interface` and click on the latest release tag. You should see something like the following:

<img width="756" alt="Screen Shot 2024-08-20 at 11 08 19 AM" src="https://github.com/user-attachments/assets/9c81882e-42e2-4902-9bfa-a94761b6b9d2">

5. Finally, install this asset and ensure that the value in `Settings->Network->Chain ID` match the env variable you provided