### PR TITLE
feat: resolve forceBalanceDisplay warning

### DIFF
--- a/apps/namadillo/src/App/Common/NamCurrency.tsx
+++ b/apps/namadillo/src/App/Common/NamCurrency.tsx
@@ -3,7 +3,7 @@ import { Currency, CurrencyProps } from "@namada/components";
 type NamCurrencyProps = Omit<
   CurrencyProps,
   "currency" | "currencyPosition" | "spaceAroundSign"
-> & { forceBalanceDisplay?: boolean };
+>;
 
 export const NamCurrency = ({ ...props }: NamCurrencyProps): JSX.Element => {
   return (

--- a/apps/namadillo/src/App/Common/TransactionFees.tsx
+++ b/apps/namadillo/src/App/Common/TransactionFees.tsx
@@ -18,11 +18,7 @@ export const TransactionFees = ({
   return (
     <div className={clsx("text-white text-sm", className)}>
       <TextLink>Transaction fee:</TextLink>{" "}
-      <NamCurrency
-        className="font-medium"
-        amount={minimumGas}
-        forceBalanceDisplay={true}
-      />
+      <NamCurrency className="font-medium" amount={minimumGas} />
     </div>
   );
 };

--- a/apps/namadillo/src/App/Governance/ProposalStatusSummary.tsx
+++ b/apps/namadillo/src/App/Governance/ProposalStatusSummary.tsx
@@ -222,7 +222,7 @@ const Loaded: React.FC<{
   };
 
   const formattedAmount = (voteType: VoteType): React.ReactNode => (
-    <NamCurrency amount={props[voteType]} forceBalanceDisplay />
+    <NamCurrency amount={props[voteType]} />
   );
 
   const amounts = {

--- a/apps/namadillo/src/App/Governance/VoteInfoCards.tsx
+++ b/apps/namadillo/src/App/Governance/VoteInfoCards.tsx
@@ -55,8 +55,7 @@ const PgfPaymentInfoCards: React.FC<{
         content={pgfActions.continuous.add.map(
           ({ internal: { amount, target } }) => (
             <span key={`info-card-continuous-add-${target}`}>
-              {target}{" "}
-              <NamCurrency amount={amount} forceBalanceDisplay={true} />
+              {target} <NamCurrency amount={amount} />
             </span>
           )
         )}
@@ -67,8 +66,7 @@ const PgfPaymentInfoCards: React.FC<{
         content={pgfActions.continuous.remove.map(
           ({ internal: { amount, target } }) => (
             <span key={`info-card-continuous-remove-${target}`}>
-              {target}{" "}
-              <NamCurrency amount={amount} forceBalanceDisplay={true} />
+              {target} <NamCurrency amount={amount} />
             </span>
           )
         )}
@@ -78,7 +76,7 @@ const PgfPaymentInfoCards: React.FC<{
         className="col-span-full"
         content={pgfActions.retro.map(({ internal: { amount, target } }) => (
           <span key={`info-card-retro-${target}`}>
-            {target} <NamCurrency amount={amount} forceBalanceDisplay={true} />
+            {target} <NamCurrency amount={amount} />
           </span>
         ))}
       />

--- a/apps/namadillo/src/App/Staking/AllValidatorsTable.tsx
+++ b/apps/namadillo/src/App/Staking/AllValidatorsTable.tsx
@@ -88,10 +88,7 @@ export const AllValidatorsTable = ({
         key={`validator-voting-power-${validator.address}`}
       >
         {validator.votingPowerInNAM && (
-          <NamCurrency
-            amount={validator.votingPowerInNAM}
-            forceBalanceDisplay
-          />
+          <NamCurrency amount={validator.votingPowerInNAM} />
         )}
         <span className="text-neutral-600 text-sm">
           {formatPercentage(BigNumber(validator.votingPowerPercentage || 0))}

--- a/apps/namadillo/src/App/Staking/IncrementBondingTable.tsx
+++ b/apps/namadillo/src/App/Staking/IncrementBondingTable.tsx
@@ -122,10 +122,7 @@ export const IncrementBondingTable = ({
           key={`validator-voting-power-${validator.address}`}
         >
           {validator.votingPowerInNAM && (
-            <NamCurrency
-              amount={validator.votingPowerInNAM}
-              forceBalanceDisplay
-            />
+            <NamCurrency amount={validator.votingPowerInNAM} />
           )}
           <span className="text-neutral-600 text-sm">
             {formatPercentage(BigNumber(validator.votingPowerPercentage || 0))}

--- a/apps/namadillo/src/App/Staking/MyValidatorsTable.tsx
+++ b/apps/namadillo/src/App/Staking/MyValidatorsTable.tsx
@@ -85,10 +85,7 @@ export const MyValidatorsTable = (): JSX.Element => {
           key={`my-validator-voting-power-${validator.address}`}
         >
           {validator.votingPowerInNAM && (
-            <NamCurrency
-              amount={validator.votingPowerInNAM}
-              forceBalanceDisplay
-            />
+            <NamCurrency amount={validator.votingPowerInNAM} />
           )}
           <span className="text-neutral-600 text-sm">
             {formatPercentage(BigNumber(validator.votingPowerPercentage || 0))}

--- a/apps/namadillo/src/App/Staking/ReDelegateTable.tsx
+++ b/apps/namadillo/src/App/Staking/ReDelegateTable.tsx
@@ -118,10 +118,7 @@ export const ReDelegateTable = ({
           key={`validator-voting-power-${validator.address}`}
         >
           {validator.votingPowerInNAM && (
-            <NamCurrency
-              amount={validator.votingPowerInNAM}
-              forceBalanceDisplay
-            />
+            <NamCurrency amount={validator.votingPowerInNAM} />
           )}
           <span className="text-neutral-600 text-sm">
             {formatPercentage(BigNumber(validator.votingPowerPercentage || 0))}

--- a/apps/namadillo/src/App/Staking/UnstakeBondingTable.tsx
+++ b/apps/namadillo/src/App/Staking/UnstakeBondingTable.tsx
@@ -134,10 +134,7 @@ export const UnstakeBondingTable = ({
           key={`validator-voting-power-${validator.address}`}
         >
           {validator.votingPowerInNAM && (
-            <NamCurrency
-              amount={validator.votingPowerInNAM}
-              forceBalanceDisplay
-            />
+            <NamCurrency amount={validator.votingPowerInNAM} />
           )}
           <span className="text-neutral-600 text-sm">
             {formatPercentage(BigNumber(validator.votingPowerPercentage || 0))}

--- a/packages/config/eslint/react.js
+++ b/packages/config/eslint/react.js
@@ -33,6 +33,7 @@ module.exports = {
         varsIgnorePattern: "^_",
         caughtErrorsIgnorePattern: "^_",
         args: "all",
+        ignoreRestSiblings: true,
       },
     ],
     "max-len": [


### PR DESCRIPTION
Resolve `forceBalanceDisplay` warning

Also, enable the `ignoreRestSiblings: true` which is great for removing one prop from `props` to pass to children and could help on future issues similar to this one:

```tsx
({ forceBalanceDisplay, ...props })  => <div {...props} />
```

![Screenshot 2024-08-21 at 14 55 51](https://github.com/user-attachments/assets/05ba0267-730b-4f54-b558-5c55ea2eb373)
