### PR TITLE
Toast fixes 🍞

### DIFF
--- a/apps/namadillo/src/App/Common/Toast.tsx
+++ b/apps/namadillo/src/App/Common/Toast.tsx
@@ -40,22 +40,28 @@ const Toast = ({ notification, onClose }: ToastProps): JSX.Element => {
   const [viewDetails, setViewDetails] = useState(false);
   const interval = useRef<NodeJS.Timeout>();
 
+  const timeout =
+    notification.timeout ??
+    (notification.type === "success" || notification.type === "error" ?
+      5000
+    : undefined);
+
   const closeNotification = (): void => {
     onClose(notification);
   };
 
   const keepNotification = (): void => {
-    if (notification.timeout && interval.current) {
+    if (interval.current) {
       clearTimeout(interval.current);
       interval.current = undefined;
     }
   };
 
   const startTimeout = (): void => {
-    if (notification.timeout && !interval.current) {
+    if (typeof timeout !== "undefined" && !interval.current) {
       interval.current = setTimeout(() => {
         closeNotification();
-      }, notification.timeout);
+      }, timeout);
     }
   };
 

--- a/apps/namadillo/src/App/Common/Toast.tsx
+++ b/apps/namadillo/src/App/Common/Toast.tsx
@@ -61,7 +61,7 @@ const Toast = ({ notification, onClose }: ToastProps): JSX.Element => {
 
   useEffect(() => {
     startTimeout();
-  }, []);
+  }, [notification.type]);
 
   return (
     <motion.div

--- a/apps/namadillo/src/App/Staking/IncrementBonding.tsx
+++ b/apps/namadillo/src/App/Staking/IncrementBonding.tsx
@@ -151,7 +151,6 @@ const IncrementBonding = (): JSX.Element => {
           bondTransactionError instanceof Error ?
             bondTransactionError.message
           : undefined,
-        timeout: 5000,
         type: "error",
       });
     }

--- a/apps/namadillo/src/App/Staking/ReDelegate.tsx
+++ b/apps/namadillo/src/App/Staking/ReDelegate.tsx
@@ -113,7 +113,6 @@ export const ReDelegate = (): JSX.Element => {
             redelegateTxError.message
           : undefined,
         type: "error",
-        timeout: 5000,
       });
     }
   }, [isError]);

--- a/apps/namadillo/src/hooks/useTransactionNotifications.tsx
+++ b/apps/namadillo/src/hooks/useTransactionNotifications.tsx
@@ -86,7 +86,6 @@ export const useTransactionNotifications = (): void => {
         </>
       ),
       details: e.detail.error?.message,
-      timeout: 5000,
     });
   });
 
@@ -104,7 +103,6 @@ export const useTransactionNotifications = (): void => {
       ),
       details: getAmountByValidatorList(e.detail.data),
       type: "success",
-      timeout: 5000,
     });
   });
 
@@ -121,7 +119,6 @@ export const useTransactionNotifications = (): void => {
       ),
       details: getAmountByValidatorList(e.detail.data),
       type: "success",
-      timeout: 5000,
     });
   });
 
@@ -149,7 +146,6 @@ export const useTransactionNotifications = (): void => {
       title: "Withdrawal Success",
       description: `Your withdrawal transaction has succeeded`,
       type: "success",
-      timeout: 5000,
     });
   });
 
@@ -162,7 +158,6 @@ export const useTransactionNotifications = (): void => {
       description: <>Your withdrawal transaction has failed</>,
       details: e.detail.error?.message,
       type: "error",
-      timeout: 5000,
     });
   });
 
@@ -179,7 +174,6 @@ export const useTransactionNotifications = (): void => {
         </>
       ),
       type: "error",
-      timeout: 5000,
     });
   });
 
@@ -197,7 +191,6 @@ export const useTransactionNotifications = (): void => {
       ),
       details: getReDelegateDetailList(e.detail.data),
       type: "success",
-      timeout: 5000,
     });
   });
 
@@ -210,7 +203,6 @@ export const useTransactionNotifications = (): void => {
       title: "Staking transaction failed",
       description: <>Your vote transaction has failed.</>,
       details: e.detail.error?.message,
-      timeout: 5000,
     });
   });
 
@@ -222,7 +214,6 @@ export const useTransactionNotifications = (): void => {
       title: "Staking transaction succeeded",
       description: `Your vote transaction has succeeded`,
       type: "success",
-      timeout: 5000,
     });
   });
 };


### PR DESCRIPTION
- Start toast timeout when toast type changes
  - This fixes toasts not automatically closing when a pending toast turns into a success/failure toast
- Set default timeout for success/error toasts
  - This fixes some toasts missing the timeout property e.g. the success toast in SubmitVote