### PR TITLE
fix: Extension - Remove unused Chrome permission

### DIFF
--- a/apps/extension/src/manifest/v3/_base.json
+++ b/apps/extension/src/manifest/v3/_base.json
@@ -13,7 +13,7 @@
   "action": {
     "default_popup": "popup.html"
   },
-  "permissions": ["storage", "offscreen"],
+  "permissions": ["storage"],
   "content_security_policy": {
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
   },


### PR DESCRIPTION
Removes the `offscreen` permission, this caused our extension to be rejected.