### PR TITLE
feat/1061: Firefox - Move durability warning out of main App view

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -68,6 +68,7 @@
     "@types/react": "^17.0.39",
     "@types/react-dom": "^17.0.11",
     "@types/uuid": "^8.3.4",
+    "@types/w3c-web-usb": "^1.0.10",
     "@types/webextension-polyfill": "^0.10.6",
     "@types/zxcvbn": "^4.4.1",
     "copy-webpack-plugin": "^11.0.0",

--- a/apps/extension/src/App/Accounts/DeleteAccount.tsx
+++ b/apps/extension/src/App/Accounts/DeleteAccount.tsx
@@ -94,7 +94,7 @@ export const DeleteAccount = (): JSX.Element => {
       >
         <Stack className="flex-1 justify-center" gap={4} full>
           <Stack as="header" gap={4}>
-            <Alert type="warning" title="Alert!">
+            <Alert type="warning" title="Alert!" className="max-w-84">
               <p className="mb-4">
                 Make sure that you&apos;ve backed up your seed phrase and
                 private key.
@@ -108,7 +108,7 @@ export const DeleteAccount = (): JSX.Element => {
               </LinkButton>
             </Alert>
           </Stack>
-          <p className="text-white leading-5 text-sm px-2 font-medium mb-10">
+          <p className="text-white leading-5 text-sm px-2 font-medium mb-10 max-w-84">
             After deletion, you will be required to import your seed phrase to
             restore your access to it
           </p>

--- a/apps/extension/src/App/Accounts/ViewMnemonic.tsx
+++ b/apps/extension/src/App/Accounts/ViewMnemonic.tsx
@@ -72,7 +72,7 @@ export const ViewMnemonic = (): JSX.Element => {
       {!passwordChecked && (
         <>
           <Stack className="mt-12" full gap={GapPatterns.FormFields}>
-            <Alert type="info">
+            <Alert type="info" className="max-w-84">
               Please provide your password in order to view your seed phrase
             </Alert>
             <Input
@@ -94,7 +94,7 @@ export const ViewMnemonic = (): JSX.Element => {
       {passwordChecked && (
         <>
           <Stack className="flex-1 justify-center" full gap={1}>
-            <div className="text-sm -mt-1.5">
+            <div className="text-sm -mt-1.5 max-w-84">
               <SeedPhraseInstructions />
             </div>
             <Input

--- a/apps/extension/src/App/App.tsx
+++ b/apps/extension/src/App/App.tsx
@@ -1,13 +1,36 @@
 import { Container } from "@namada/components";
 import { useVaultContext } from "context/VaultContext";
+import { useRequester } from "hooks/useRequester";
+import { CheckDurabilityMsg } from "provider";
+import { useEffect, useState } from "react";
 import { matchPath, useLocation } from "react-router-dom";
+import { Ports } from "router";
 import { AppContent } from "./AppContent";
 import { AppHeader } from "./Common/AppHeader";
 import { Login } from "./Login";
 import routes from "./routes";
 
+const STORE_DURABILITY_INFO =
+  'Store is not durable. This might cause problems when persisting data on disk.\
+ To fix this issue, please navigate to "about:config" and set "dom.indexedDB.experimental" to true.';
+
 export const App: React.FC = () => {
   const location = useLocation();
+
+  const [warnings, setWarnings] = useState<string[]>([]);
+  const requester = useRequester();
+
+  useEffect(() => {
+    void (async () => {
+      const isDurable = await requester.sendMessage(
+        Ports.Background,
+        new CheckDurabilityMsg()
+      );
+      if (!isDurable) {
+        setWarnings([...warnings, STORE_DURABILITY_INFO]);
+      }
+    })();
+  }, []);
 
   const { lockStatus, unlock, passwordInitialized } = useVaultContext();
 
@@ -39,12 +62,13 @@ export const App: React.FC = () => {
             !displayReturnButton()
           }
           returnButton={displayReturnButton()}
+          warnings={warnings}
         />
       }
     >
       {shouldLock ?
         <Login onLogin={unlock} />
-      : <AppContent />}
+      : <AppContent warnings={warnings} />}
     </Container>
   );
 };

--- a/apps/extension/src/App/Common/AppHeader.tsx
+++ b/apps/extension/src/App/Common/AppHeader.tsx
@@ -9,12 +9,14 @@ type AppHeaderProps = {
   returnButton: boolean;
   settingsButton: boolean;
   lockButton: boolean;
+  warnings?: string[];
 };
 
 export const AppHeader = ({
   returnButton,
   settingsButton,
   lockButton,
+  warnings,
 }: AppHeaderProps): JSX.Element => {
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
@@ -50,7 +52,11 @@ export const AppHeader = ({
           <GoGear />
         </i>
       )}
-      <AppHeaderNavigation onClose={() => setOpen(false)} open={open} />
+      <AppHeaderNavigation
+        onClose={() => setOpen(false)}
+        open={open}
+        warnings={warnings}
+      />
     </>
   );
 };

--- a/apps/extension/src/App/Common/AppHeaderNavigation.tsx
+++ b/apps/extension/src/App/Common/AppHeaderNavigation.tsx
@@ -3,17 +3,19 @@ import routes from "App/routes";
 import clsx from "clsx";
 import { useVaultContext } from "context";
 import { FaDiscord, FaXTwitter } from "react-icons/fa6";
-import { GoQuestion } from "react-icons/go";
+import { GoAlert, GoQuestion } from "react-icons/go";
 import { useNavigate } from "react-router-dom";
 
 type AppHeaderNavigationProps = {
   open: boolean;
   onClose: () => void;
+  warnings?: string[];
 };
 
 export const AppHeaderNavigation = ({
   open,
   onClose,
+  warnings,
 }: AppHeaderNavigationProps): JSX.Element => {
   const { lock } = useVaultContext();
   const navigate = useNavigate();
@@ -47,6 +49,19 @@ export const AppHeaderNavigation = ({
           { "!translate-x-0": open }
         )}
       >
+        {warnings && warnings.length > 0 && (
+          <i
+            className={clsx(
+              "text-[1.85em] cursor-pointer leading-[0] absolute left-0 px-6 py-5 not-italic",
+              "top-0 transition-colors duration-100 ease-out select-none hover:text-black active:top-px"
+            )}
+            role="button"
+            aria-label="Warnings menu"
+            onClick={() => goTo(routes.warnings)}
+          >
+            <GoAlert />
+          </i>
+        )}
         <i
           className={clsx(
             "text-[1.85em] cursor-pointer leading-[0] absolute right-0 px-5 py-8 not-italic",
@@ -106,14 +121,21 @@ export const AppHeaderNavigation = ({
                 <FaXTwitter />
               </a>
             </Stack>
-            <a
-              href="https://discord.com/channels/833618405537218590/1074984397599678534"
-              target="_blank"
-              className="transition-colors hover:text-cyan"
-              rel="noreferrer nofollow"
+            <Stack
+              as="ul"
+              gap={4}
+              direction="horizontal"
+              className="items-center"
             >
-              <GoQuestion />
-            </a>
+              <a
+                href="https://discord.com/channels/833618405537218590/1074984397599678534"
+                target="_blank"
+                className="transition-colors hover:text-cyan"
+                rel="noreferrer nofollow"
+              >
+                <GoQuestion />
+              </a>
+            </Stack>
           </footer>
         </div>
       </nav>

--- a/apps/extension/src/App/Settings/Warnings.tsx
+++ b/apps/extension/src/App/Settings/Warnings.tsx
@@ -1,6 +1,5 @@
 import { Alert, GapPatterns, Stack } from "@namada/components";
 import { PageHeader } from "App/Common";
-import clsx from "clsx";
 
 type Props = {
   warnings?: string[];
@@ -13,7 +12,7 @@ export const Warnings = ({ warnings }: Props): JSX.Element => {
       <Stack className="justify-top" full gap={GapPatterns.FormFields}>
         {warnings &&
           warnings.map((warning, i) => (
-            <Alert key={i} type="warning" className={clsx("max-w-84")}>
+            <Alert key={i} type="warning" className="max-w-84">
               {warning}
             </Alert>
           ))}

--- a/apps/extension/src/App/Settings/Warnings.tsx
+++ b/apps/extension/src/App/Settings/Warnings.tsx
@@ -1,0 +1,23 @@
+import { Alert, GapPatterns, Stack } from "@namada/components";
+import { PageHeader } from "App/Common";
+import clsx from "clsx";
+
+type Props = {
+  warnings?: string[];
+};
+
+export const Warnings = ({ warnings }: Props): JSX.Element => {
+  return (
+    <Stack gap={GapPatterns.TitleContent} full>
+      <PageHeader title="Warnings" />
+      <Stack className="justify-top" full gap={GapPatterns.FormFields}>
+        {warnings &&
+          warnings.map((warning, i) => (
+            <Alert key={i} type="warning" className={clsx("max-w-84")}>
+              {warning}
+            </Alert>
+          ))}
+      </Stack>
+    </Stack>
+  );
+};

--- a/apps/extension/src/App/routes.ts
+++ b/apps/extension/src/App/routes.ts
@@ -6,6 +6,7 @@ export default {
   changePassword: (): string => `/change-password`,
   connectedSites: (): string => `/connected-sites`,
   network: (): string => `/network`,
+  warnings: (): string => `/warnings`,
   viewAccountList: () => `/accounts/view`,
   viewAccountMnemonic: (accountId: string = ":accountId") =>
     `/accounts/mnemonic/${accountId}`,

--- a/apps/extension/src/Setup/Start.tsx
+++ b/apps/extension/src/Setup/Start.tsx
@@ -44,14 +44,16 @@ export const Start: React.FC = () => {
         >
           Import existing keys
         </ActionButton>
-        <LinkButton
-          className="py-3"
-          color="white"
-          hoverColor="primary"
-          onClick={() => navigate(routes.ledgerConnect())}
-        >
-          Connect Hardware Wallet
-        </LinkButton>
+        {navigator.usb && (
+          <LinkButton
+            className="py-3"
+            color="white"
+            hoverColor="primary"
+            onClick={() => navigate(routes.ledgerConnect())}
+          >
+            Connect Hardware Wallet
+          </LinkButton>
+        )}
       </Stack>
     </div>
   );

--- a/apps/extension/src/utils/index.ts
+++ b/apps/extension/src/utils/index.ts
@@ -16,10 +16,15 @@ export const closeCurrentTab = async (): Promise<void> => {
   }
 };
 
+/**
+ * Launch the Setup tab, close existing popup
+ */
 export const openSetupTab = async (): Promise<void> => {
-  await browser.tabs.create({
-    url: browser.runtime.getURL("setup.html"),
-  });
+  await browser.tabs
+    .create({
+      url: browser.runtime.getURL("setup.html"),
+    })
+    .then(() => close());
 };
 
 export const fillArray = (arr: string[], length: number): string[] => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8303,6 +8303,7 @@ __metadata:
     "@types/react": "npm:^17.0.39"
     "@types/react-dom": "npm:^17.0.11"
     "@types/uuid": "npm:^8.3.4"
+    "@types/w3c-web-usb": "npm:^1.0.10"
     "@types/webextension-polyfill": "npm:^0.10.6"
     "@types/zxcvbn": "npm:^4.4.1"
     "@zondax/ledger-namada": "npm:^0.0.6"
@@ -10976,6 +10977,13 @@ __metadata:
   version: 8.3.4
   resolution: "@types/uuid@npm:8.3.4"
   checksum: b9ac98f82fcf35962317ef7dc44d9ac9e0f6fdb68121d384c88fe12ea318487d5585d3480fa003cf28be86a3bbe213ca688ba786601dce4a97724765eb5b1cf2
+  languageName: node
+  linkType: hard
+
+"@types/w3c-web-usb@npm:^1.0.10":
+  version: 1.0.10
+  resolution: "@types/w3c-web-usb@npm:1.0.10"
+  checksum: 3df5733a334c5fd22ef3fa1e97a70c029542591058d11905d1304c26bab8705d975168818b5b7ec21fef5591cdea776dbdb31d4c04aa433e7fe7d61dd7ebdecf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves #1061 

This PR moves the indexedDB durability warning out of the main view, and fixes the width. What I did is add a alert icon to the Settings menu, which will appear in Firefox if the DB is determined to not be durable. This navigates to a general `Warnings` page that shows any warnings (in this case, just the indexed DB warning)

**NOTE** I also applied some similar styles to fix width issues in certain views. Checked these again in Chrome to ensure that it didn't introduce any issues.

- [x] Add warnings view to display durability warning if browser IndexedDB storage durability cannot be guaranteed
- [x] Fix styles issues for Firefox
- [x] Fix bug on Setup tab launch, where empty popup is displayed
- [x] Remove `Connect Hardware Wallet` if USB transport is unavailable (Firefox) 

### Testing

- Install add-on in Firefox, then navigate to `about:config`
- Set `dom.indexedDB.experimental` to `false` (if it isn't already), and the alert icon should be available in the Settings menu
- Set `dom.indexedDB.experimental` to `true`, then this alert will go away

### Screenshots

Menu when store is _not_ durable (Note the triangle with `!` in the top left)
<img width="377" alt="Screen Shot 2024-09-04 at 11 08 28 AM" src="https://github.com/user-attachments/assets/a80d6858-9119-4044-a675-f71baaf46167">

Warnings page, with fixed width of warning message (preserves normal layout):
<img width="373" alt="Screen Shot 2024-09-04 at 10 42 42 AM" src="https://github.com/user-attachments/assets/6296de94-1f00-4a49-a579-b0bf2a1fad05">

Menu when store is durable:
<img width="376" alt="Screen Shot 2024-09-04 at 10 43 03 AM" src="https://github.com/user-attachments/assets/8cd12049-a67a-48af-9607-f89f0661835f">
