### PR TITLE
feat/1060 - Faucet: Move computePowSolution into web worker

### DIFF
--- a/.github/workflows/release-faucet.yml
+++ b/.github/workflows/release-faucet.yml
@@ -14,10 +14,6 @@ on:
         required: true
         type: string
         default: "/api/v1/faucet"
-      NAMADA_INTERFACE_FAUCET_LIMIT:
-        required: true
-        type: string
-        default: "1000"
       NAMADA_INTERFACE_PROXY_PORT:
         type: string
 

--- a/apps/faucet/.env.sample
+++ b/apps/faucet/.env.sample
@@ -1,9 +1,8 @@
-# Faucet API Endpoint override
+# Faucet API URL Default
 NAMADA_INTERFACE_FAUCET_API_URL=http://127.0.0.1:5000
-NAMADA_INTERFACE_FAUCET_API_ENDPOINT=/api/v1/faucet
 
-# Faucet limit, as defined in genesis toml
-NAMADA_INTERFACE_FAUCET_LIMIT=1000
+# Override the endpoint
+NAMADA_INTERFACE_FAUCET_API_ENDPOINT=/api/v1/faucet
 
 # Specify a proxy port, if proxy is needed (defaults to 9000)
 NAMADA_INTERFACE_PROXY_PORT=1234

--- a/apps/faucet/README.md
+++ b/apps/faucet/README.md
@@ -21,24 +21,19 @@ yarn
 Then, look at the potential variables you may override in [.env.sample](./.env.sample) in `apps/faucet`. You can copy these variables into a `.env` file,
 and they will be used when the application is built.
 
-As an example, if all you want to override the the API url and faucet limit, you can override the following default values in a `.env`:
+As an example, if all you want to override the the API url or endpoint, you can override the following default values in a `.env`:
 
 ```bash
 # Faucet API Endpoint override
 NAMADA_INTERFACE_FAUCET_API_URL=http://127.0.0.1:5000
 NAMADA_INTERFACE_FAUCET_API_ENDPOINT=/api/v1/faucet
-
-# Faucet limit, as defined in genesis toml
-NAMADA_INTERFACE_FAUCET_LIMIT=1000
 ```
-
-Each token address used in this form may be overridden via values specified in `.env` (see [.env.sample](./.env.sample)).
 
 [ [Table of Contents](#table-of-contents) ]
 
 ## Local Development
 
-In `apps/faucet`, you can run the following scripts to test locally:
+In `apps/faucet`, you can run the following scripts to run locally:
 
 ```bash
 yarn dev
@@ -76,11 +71,8 @@ as a static HTML website.
 
 ## Notes
 
-The logic for the API calls, as well as the mining logic can be found in [utils/index.ts](./src/utils/index.ts).
+The logic for the API calls, as well as the mining logic can be found in [utils/](./src/utils/).
 
 The form interface where these calls are invoked is located in [Faucet.tsx](./src/App/Faucet.tsx).
-
-The default token address definitions can be found in [tokens.ts](./src/config/tokens.ts). Note that each of these token definitions has a corresponding [.env](./.env.sample) variable override
-that can be used at build-time to modify the address.
 
 [ [Table of Contents](#table-of-contents) ]

--- a/apps/faucet/README.md
+++ b/apps/faucet/README.md
@@ -33,7 +33,7 @@ NAMADA_INTERFACE_FAUCET_API_ENDPOINT=/api/v1/faucet
 
 ## Local Development
 
-In `apps/faucet`, you can run the following scripts to run locally:
+In `apps/faucet`, you can issue the following command to run the Faucet app locally in development mode:
 
 ```bash
 yarn dev

--- a/apps/faucet/src/App/App.tsx
+++ b/apps/faucet/src/App/App.tsx
@@ -230,10 +230,10 @@ export const App: React.FC = () => {
 
               {extensionAttachStatus ===
                 ExtensionAttachStatus.PendingDetection && (
-                <InfoContainer>
-                  <Alert type="info">Detecting extension...</Alert>
-                </InfoContainer>
-              )}
+                  <InfoContainer>
+                    <Alert type="info">Detecting extension...</Alert>
+                  </InfoContainer>
+                )}
               {extensionAttachStatus === ExtensionAttachStatus.NotInstalled && (
                 <InfoContainer>
                   <Alert type="error">You must download the extension!</Alert>

--- a/apps/faucet/src/App/App.tsx
+++ b/apps/faucet/src/App/App.tsx
@@ -230,10 +230,10 @@ export const App: React.FC = () => {
 
               {extensionAttachStatus ===
                 ExtensionAttachStatus.PendingDetection && (
-                  <InfoContainer>
-                    <Alert type="info">Detecting extension...</Alert>
-                  </InfoContainer>
-                )}
+                <InfoContainer>
+                  <Alert type="info">Detecting extension...</Alert>
+                </InfoContainer>
+              )}
               {extensionAttachStatus === ExtensionAttachStatus.NotInstalled && (
                 <InfoContainer>
                   <Alert type="error">You must download the extension!</Alert>
@@ -241,11 +241,7 @@ export const App: React.FC = () => {
               )}
 
               {isExtensionConnected && (
-                <FaucetForm
-                  accounts={accounts}
-                  integration={integration}
-                  isTestnetLive={isTestnetLive}
-                />
+                <FaucetForm accounts={accounts} isTestnetLive={isTestnetLive} />
               )}
               {extensionAttachStatus === ExtensionAttachStatus.Installed &&
                 !isExtensionConnected && (

--- a/apps/faucet/src/App/App.tsx
+++ b/apps/faucet/src/App/App.tsx
@@ -110,6 +110,25 @@ export const App: React.FC = () => {
   const [settingsError, setSettingsError] = useState<string>();
   const theme = getTheme(colorMode);
 
+  const fetchSettings = async (api: API): Promise<void> => {
+    const {
+      difficulty,
+      tokens_alias_to_address: tokens,
+      withdraw_limit: withdrawLimit = DEFAULT_LIMIT,
+    } = await api.settings().catch((e) => {
+      const message = e.errors?.message;
+      setSettingsError(`Error requesting settings: ${message?.join(" ")}`);
+      throw new Error(e);
+    });
+    // Append difficulty level and tokens to settings
+    setSettings({
+      ...settings,
+      difficulty,
+      tokens,
+      withdrawLimit: toNam(withdrawLimit),
+    });
+  };
+
   useUntil(
     {
       predFn: async () => Promise.resolve(integration.detect()),
@@ -144,29 +163,9 @@ export const App: React.FC = () => {
     }
 
     // Fetch settings from faucet API
-    (async () => {
-      try {
-        const {
-          difficulty,
-          tokens_alias_to_address: tokens,
-          withdraw_limit: withdrawLimit = DEFAULT_LIMIT,
-        } = await api.settings().catch((e) => {
-          const message = e.errors?.message;
-          setSettingsError(`Error requesting settings: ${message?.join(" ")}`);
-          throw new Error(e);
-        });
-        // Append difficulty level and tokens to settings
-        setSettings({
-          ...settings,
-          difficulty,
-          tokens,
-          withdrawLimit: toNam(withdrawLimit),
-        });
-        setSettingsError(undefined);
-      } catch (e) {
-        setSettingsError(`Failed to load settings! ${e}`);
-      }
-    })();
+    fetchSettings(api)
+      .then(() => setSettingsError(undefined))
+      .catch((e) => setSettingsError(`Failed to load settings! ${e}`));
   }, [url]);
 
   const handleConnectExtensionClick = useCallback(async (): Promise<void> => {
@@ -230,10 +229,10 @@ export const App: React.FC = () => {
 
               {extensionAttachStatus ===
                 ExtensionAttachStatus.PendingDetection && (
-                  <InfoContainer>
-                    <Alert type="info">Detecting extension...</Alert>
-                  </InfoContainer>
-                )}
+                <InfoContainer>
+                  <Alert type="info">Detecting extension...</Alert>
+                </InfoContainer>
+              )}
               {extensionAttachStatus === ExtensionAttachStatus.NotInstalled && (
                 <InfoContainer>
                   <Alert type="error">You must download the extension!</Alert>

--- a/apps/faucet/src/App/Faucet.tsx
+++ b/apps/faucet/src/App/Faucet.tsx
@@ -15,7 +15,6 @@ import {
   Input,
   Select,
 } from "@namada/components";
-import { Namada } from "@namada/integrations";
 import { Account } from "@namada/types";
 import { bech32mValidation, shortenAddress } from "@namada/utils";
 
@@ -40,17 +39,12 @@ enum Status {
 
 type Props = {
   accounts: Account[];
-  integration: Namada;
   isTestnetLive: boolean;
 };
 
 const bech32mPrefix = "tnam";
 
-export const FaucetForm: React.FC<Props> = ({
-  accounts,
-  integration,
-  isTestnetLive,
-}) => {
+export const FaucetForm: React.FC<Props> = ({ accounts, isTestnetLive }) => {
   const {
     api,
     settings: { difficulty, tokens, withdrawLimit },
@@ -192,7 +186,7 @@ export const FaucetForm: React.FC<Props> = ({
             label="Account"
             onChange={(e) => setAccount(accountLookup[e.target.value])}
           />
-          : <div>
+        : <div>
             You have no signing accounts! Import or create an account in the
             extension, then reload this page.
           </div>
@@ -220,7 +214,7 @@ export const FaucetForm: React.FC<Props> = ({
           error={
             amount && amount > withdrawLimit ?
               `Amount must be less than or equal to ${withdrawLimit}`
-              : ""
+            : ""
           }
         />
       </InputContainer>

--- a/apps/faucet/src/App/Faucet.tsx
+++ b/apps/faucet/src/App/Faucet.tsx
@@ -1,6 +1,12 @@
 import BigNumber from "bignumber.js";
 import { sanitize } from "dompurify";
-import React, { useCallback, useContext, useEffect, useState } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 
 import {
   ActionButton,
@@ -70,6 +76,11 @@ export const FaucetForm: React.FC<Props> = ({
     value: address,
   }));
 
+  const powSolver: Worker = useMemo(
+    () => new Worker(new URL("../workers/powWorker.ts", import.meta.url)),
+    []
+  );
+
   useEffect(() => {
     if (tokens?.NAM) {
       setTokenAddress(tokens.NAM);
@@ -131,11 +142,6 @@ export const FaucetForm: React.FC<Props> = ({
         });
 
       const solution = computePowSolution(challenge, difficulty || 0);
-
-      const signer = integration.signer();
-      if (!signer) {
-        throw new Error("signer not defined");
-      }
 
       const submitData = {
         solution,

--- a/apps/faucet/src/App/SettingsForm.tsx
+++ b/apps/faucet/src/App/SettingsForm.tsx
@@ -13,8 +13,6 @@ export const SettingsForm: React.FC = () => {
   const [isFormValid, setIsFormValid] = useState(false);
   const { setIsModalOpen, baseUrl, setUrl } = useContext(AppContext)!;
   const [apiUrl, setApiUrl] = useState(baseUrl);
-  const handleFocus = (e: React.ChangeEvent<HTMLInputElement>): void =>
-    e.target.select();
 
   useEffect(() => {
     validateUrl(baseUrl);
@@ -31,7 +29,7 @@ export const SettingsForm: React.FC = () => {
 
   const handleSetUrl = (url: string): void => {
     // Strip endpoint from URL if it was provided
-    setUrl(url.replace(endpoint, ""));
+    setUrl(url.replace(endpoint, "").replace(/\/$/, ""));
     setIsModalOpen(false);
   };
 
@@ -42,11 +40,11 @@ export const SettingsForm: React.FC = () => {
           <Input
             label="Set Faucet API URL"
             value={apiUrl}
-            onFocus={handleFocus}
             onChange={(e) => {
               setApiUrl(e.target.value);
               validateUrl(e.target.value);
             }}
+            autoFocus={true}
           />
         </InputContainer>
         <ButtonContainer>

--- a/apps/faucet/src/App/index.ts
+++ b/apps/faucet/src/App/index.ts
@@ -1,4 +1,4 @@
-export { App } from "./App"
+export { App } from "./App";
+export * from "./App.components";
 export { FaucetForm } from "./Faucet";
-export * from "./App.components"
-export * from "./Faucet.components"
+export * from "./Faucet.components";

--- a/apps/faucet/src/utils/api.ts
+++ b/apps/faucet/src/utils/api.ts
@@ -11,7 +11,7 @@ export const {
 } = process.env;
 
 export class API {
-  constructor(public readonly baseUrl: string) { }
+  constructor(public readonly baseUrl: string) {}
 
   /**
    * Wrapper for fetch requests to handle ReadableStream response when errors are received from API

--- a/apps/faucet/src/utils/types.ts
+++ b/apps/faucet/src/utils/types.ts
@@ -1,3 +1,8 @@
+export type PowChallenge = {
+  challenge: string;
+  difficulty: number;
+};
+
 export type ChallengeResponse = {
   challenge: string;
   tag: string;

--- a/apps/faucet/src/workers/index.ts
+++ b/apps/faucet/src/workers/index.ts
@@ -1,0 +1,1 @@
+export * from "./powWorker";

--- a/apps/faucet/src/workers/powWorker.ts
+++ b/apps/faucet/src/workers/powWorker.ts
@@ -1,0 +1,9 @@
+import { PowChallenge, computePowSolution } from "utils";
+
+// Worker script to handle computePowSolution
+self.onmessage = (e: MessageEvent<string>) => {
+  const { challenge, difficulty } = JSON.parse(e.data) as PowChallenge;
+  const solution = computePowSolution(challenge, difficulty);
+
+  self.postMessage(JSON.stringify(solution));
+};

--- a/apps/faucet/src/workers/powWorker.ts
+++ b/apps/faucet/src/workers/powWorker.ts
@@ -1,9 +1,8 @@
 import { PowChallenge, computePowSolution } from "utils";
 
 // Worker script to handle computePowSolution
-self.onmessage = (e: MessageEvent<string>) => {
-  const { challenge, difficulty } = JSON.parse(e.data) as PowChallenge;
+self.onmessage = (e: MessageEvent<PowChallenge>) => {
+  const { challenge, difficulty } = e.data;
   const solution = computePowSolution(challenge, difficulty);
-
-  self.postMessage(JSON.stringify(solution));
+  self.postMessage(solution);
 };


### PR DESCRIPTION
Resolves #1060 

When the Faucet API returns a high `difficulty` (e.g., 3) the `computePowSolution` method causes the tab to hang, which can issue warnings to the user. This PR moves that computation into a web-worker.

### Testing

- Load the faucet app and connect to extension
- Ensure that on submit, it displays `Computing POW Solution`, followed by `Processing Faucet Transfer` (Not sure if there's a better way to inspect what is going on while computing

**NOTE**

Testing against our API should finish very quickly, as `difficulty` is set at zero: https://faucet.public.heliax.work/internal-devnet-431.4e30980eee

Testing against the Housefire API will likely take several minutes, with the `difficulty` set at 3 (hence this PR): https://api.faucet.knowable.run