### PR TITLE
Namadillo: fixing message appearing due to wrong string cast

### DIFF
--- a/apps/namadillo/src/App/Common/Setup.tsx
+++ b/apps/namadillo/src/App/Common/Setup.tsx
@@ -54,7 +54,7 @@ export const Setup = (): JSX.Element => {
             label="Indexer URL"
             placeholder="http://example.com:5000"
             value={url}
-            error={error instanceof Error ? error.message : String(error)}
+            error={error instanceof Error && error.message}
             onChange={(e) => {
               setUrl(e.target.value);
               reset();

--- a/apps/namadillo/src/App/Settings/Advanced.tsx
+++ b/apps/namadillo/src/App/Settings/Advanced.tsx
@@ -44,9 +44,8 @@ export const Advanced = (): JSX.Element => {
           type="text"
           value={indexer}
           error={
-            indexerMutation.error instanceof Error ?
-              indexerMutation.error.message
-            : String(indexerMutation.error)
+            indexerMutation.error instanceof Error &&
+            indexerMutation.error.message
           }
           label="Indexer URL"
           className="[&_input]:border-neutral-300"
@@ -60,9 +59,7 @@ export const Advanced = (): JSX.Element => {
           type="text"
           value={rpc}
           error={
-            rpcMutation.error instanceof Error ?
-              rpcMutation.error.message
-            : String(rpcMutation.error)
+            rpcMutation.error instanceof Error && rpcMutation.error.message
           }
           label="RPC URL"
           className="[&_input]:border-neutral-300"


### PR DESCRIPTION
This PR fixes an error introduced in #1067 where Advanced panel starts to display a wrong "null" string.
