### PR TITLE
fix: Faucet - Use relative path for assets in Webpack config

### DIFF
--- a/apps/faucet/webpack.config.js
+++ b/apps/faucet/webpack.config.js
@@ -10,8 +10,7 @@ require("dotenv").config({ path: resolve(__dirname, ".env") });
 
 const { NODE_ENV } = process.env;
 
-const ASSET_PATH =
-  NODE_ENV === "development" ? "/" : "https://faucet.heliax.click/";
+const ASSET_PATH = "/";
 
 const createStyledComponentsTransformer =
   require("typescript-plugin-styled-components").default;


### PR DESCRIPTION
Fixes an issue where the asset URL was set to `https://faucet.heliax.click`. Note that this has introduced a 404 on the `apple-touch-icon.png`, I will see if I can resolve that error, but it's not critical


### TODO

Update this app to Vite!