### PR TITLE
feat./1081 - Namadillo: Check Tx applied status when broadcasting

### DIFF
--- a/apps/namadillo/src/App/Common/Toast.tsx
+++ b/apps/namadillo/src/App/Common/Toast.tsx
@@ -145,9 +145,11 @@ const Toast = ({
         {notification.failedDetails && (viewDetails || forceDetailsOpen) && (
           <>
             <div className="w-full text-xs text-white block my-4">
-              <span className="font-bold">
-                {notification.failedDescription}
-              </span>
+              {notification.failedDescription && (
+                <span className="font-bold">
+                  {notification.failedDescription}
+                </span>
+              )}
               {notification.failedDetails}
             </div>
           </>

--- a/apps/namadillo/src/App/Common/Toast.tsx
+++ b/apps/namadillo/src/App/Common/Toast.tsx
@@ -24,12 +24,7 @@ export const Toasts = (): JSX.Element => {
       <AnimatePresence>
         <Stack gap={2}>
           {notifications.map((n) => (
-            <Toast
-              key={`toast-${n.id}`}
-              notification={n}
-              onClose={onClose}
-              forceDetailsOpen={n.forceDetailsOpen}
-            />
+            <Toast key={`toast-${n.id}`} notification={n} onClose={onClose} />
           ))}
         </Stack>
       </AnimatePresence>
@@ -40,22 +35,15 @@ export const Toasts = (): JSX.Element => {
 type ToastProps = {
   notification: ToastNotification;
   onClose: (notification: ToastNotification) => void;
-  forceDetailsOpen?: boolean;
 };
 
-const Toast = ({
-  notification,
-  onClose,
-  forceDetailsOpen = false,
-}: ToastProps): JSX.Element => {
+const Toast = ({ notification, onClose }: ToastProps): JSX.Element => {
   const [viewDetails, setViewDetails] = useState(false);
   const interval = useRef<NodeJS.Timeout>();
 
   const timeout =
     notification.timeout ??
-    (notification.type === "success" || notification.type === "error" ?
-      5000
-    : undefined);
+    (notification.type === "success" ? 5000 : undefined);
 
   const closeNotification = (): void => {
     onClose(notification);
@@ -129,31 +117,25 @@ const Toast = ({
       >
         <strong className="block text-sm">{notification.title}</strong>
         <div className="leading-tight text-xs">{notification.description}</div>
-        {notification.details && !viewDetails && !forceDetailsOpen && (
-          <button
-            className="text-xs text-white underline"
-            onClick={() => setViewDetails(true)}
-          >
-            View details
-          </button>
-        )}
-        {notification.details && (viewDetails || forceDetailsOpen) && (
-          <div className="w-full text-xs text-white block">
-            {notification.details}
-          </div>
-        )}
-        {notification.failedDetails && (viewDetails || forceDetailsOpen) && (
-          <>
-            <div className="w-full text-xs text-white block my-4">
-              {notification.failedDescription && (
-                <span className="font-bold">
-                  {notification.failedDescription}
-                </span>
-              )}
-              {notification.failedDetails}
+        {notification.type !== "partialSuccess" &&
+          notification.type !== "error" &&
+          notification.details &&
+          !viewDetails && (
+            <button
+              className="text-xs text-white underline"
+              onClick={() => setViewDetails(true)}
+            >
+              View details
+            </button>
+          )}
+        {notification.details &&
+          (viewDetails ||
+            notification.type === "partialSuccess" ||
+            notification.type === "error") && (
+            <div className="w-full text-xs text-white block">
+              {notification.details}
             </div>
-          </>
-        )}
+          )}
       </Stack>
       <i
         onClick={() => onClose(notification)}

--- a/apps/namadillo/src/App/Common/Toast.tsx
+++ b/apps/namadillo/src/App/Common/Toast.tsx
@@ -9,6 +9,7 @@ import { useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { FaCheck, FaTimes } from "react-icons/fa";
 import { FaRegHourglassHalf, FaXmark } from "react-icons/fa6";
+import { GoAlert } from "react-icons/go";
 import { ToastNotification } from "types";
 
 export const Toasts = (): JSX.Element => {
@@ -113,6 +114,11 @@ const Toast = ({
             <FaRegHourglassHalf />
           </i>
         )}
+        {notification.type === "partialSuccess" && (
+          <i className="text-2xl">
+            <GoAlert />
+          </i>
+        )}
       </span>
       <Stack
         gap={0.5}
@@ -137,11 +143,14 @@ const Toast = ({
           </div>
         )}
         {notification.failedDetails && (viewDetails || forceDetailsOpen) && (
-          <div className="w-full text-xs text-red block">
-            <br />
-            <div>The following Tx were not applied:</div>
-            {notification.failedDetails}
-          </div>
+          <>
+            <div className="w-full text-xs text-white block my-4">
+              <span className="font-bold">
+                {notification.failedDescription}
+              </span>
+              {notification.failedDetails}
+            </div>
+          </>
         )}
       </Stack>
       <i

--- a/apps/namadillo/src/App/Common/Toast.tsx
+++ b/apps/namadillo/src/App/Common/Toast.tsx
@@ -86,6 +86,7 @@ const Toast = ({
         "grid grid-cols-[30px_auto] gap-5 z-[9999] leading-[1]",
         {
           "bg-success": notification.type === "success",
+          "bg-intermediate": notification.type === "partialSuccess",
           "bg-fail": notification.type === "error",
           "bg-neutral-500": notification.type === "pending",
         }
@@ -133,6 +134,13 @@ const Toast = ({
         {notification.details && (viewDetails || forceDetailsOpen) && (
           <div className="w-full text-xs text-white block">
             {notification.details}
+          </div>
+        )}
+        {notification.failedDetails && (viewDetails || forceDetailsOpen) && (
+          <div className="w-full text-xs text-red block">
+            <br />
+            <div>The following Tx were not applied:</div>
+            {notification.failedDetails}
           </div>
         )}
       </Stack>

--- a/apps/namadillo/src/App/Common/Toast.tsx
+++ b/apps/namadillo/src/App/Common/Toast.tsx
@@ -23,7 +23,12 @@ export const Toasts = (): JSX.Element => {
       <AnimatePresence>
         <Stack gap={2}>
           {notifications.map((n) => (
-            <Toast key={`toast-${n.id}`} notification={n} onClose={onClose} />
+            <Toast
+              key={`toast-${n.id}`}
+              notification={n}
+              onClose={onClose}
+              forceDetailsOpen={n.forceDetailsOpen}
+            />
           ))}
         </Stack>
       </AnimatePresence>
@@ -34,9 +39,14 @@ export const Toasts = (): JSX.Element => {
 type ToastProps = {
   notification: ToastNotification;
   onClose: (notification: ToastNotification) => void;
+  forceDetailsOpen?: boolean;
 };
 
-const Toast = ({ notification, onClose }: ToastProps): JSX.Element => {
+const Toast = ({
+  notification,
+  onClose,
+  forceDetailsOpen = false,
+}: ToastProps): JSX.Element => {
   const [viewDetails, setViewDetails] = useState(false);
   const interval = useRef<NodeJS.Timeout>();
 
@@ -112,7 +122,7 @@ const Toast = ({ notification, onClose }: ToastProps): JSX.Element => {
       >
         <strong className="block text-sm">{notification.title}</strong>
         <div className="leading-tight text-xs">{notification.description}</div>
-        {notification.details && !viewDetails && (
+        {notification.details && !viewDetails && !forceDetailsOpen && (
           <button
             className="text-xs text-white underline"
             onClick={() => setViewDetails(true)}
@@ -120,7 +130,7 @@ const Toast = ({ notification, onClose }: ToastProps): JSX.Element => {
             View details
           </button>
         )}
-        {notification.details && viewDetails && (
+        {notification.details && (viewDetails || forceDetailsOpen) && (
           <div className="w-full text-xs text-white block">
             {notification.details}
           </div>

--- a/apps/namadillo/src/hooks/useTransactionNotifications.tsx
+++ b/apps/namadillo/src/hooks/useTransactionNotifications.tsx
@@ -111,7 +111,7 @@ export const useTransactionNotifications = (): void => {
     clearPendingNotifications(id);
     dispatchNotification({
       id,
-      title: "Some staking tx failed",
+      title: "Some staking transactions failed",
       description: (
         <>
           Your staking transaction of <NamCurrency amount={total} /> has
@@ -141,6 +141,27 @@ export const useTransactionNotifications = (): void => {
     });
   });
 
+  useTransactionEventListener("Unbond.PartialSuccess", (e) => {
+    const { id, total } = parseTxsData(e.detail.tx, e.detail.data);
+    clearPendingNotifications(id);
+    dispatchNotification({
+      id,
+      title: "Some Unstake transactions failed",
+      description: (
+        <>
+          Your unbonding of <NamCurrency amount={total} /> has succeeded
+        </>
+      ),
+      details: getAmountByValidatorList(e.detail.data),
+      failedDetails:
+        e.detail.failedData ?
+          getAmountByValidatorList(e.detail.failedData)
+        : undefined,
+      type: "partialSuccess",
+      forceDetailsOpen: true,
+    });
+  });
+
   useTransactionEventListener("Unbond.Error", (e) => {
     const { id, total } = parseTxsData(e.detail.tx, e.detail.data);
     clearPendingNotifications(id);
@@ -163,7 +184,7 @@ export const useTransactionNotifications = (): void => {
     dispatchNotification({
       id,
       title: "Withdrawal Success",
-      description: `Your withdrawal transaction has succeeded`,
+      description: <>Your withdrawal transaction has succeeded</>,
       type: "success",
     });
   });
@@ -210,6 +231,27 @@ export const useTransactionNotifications = (): void => {
       ),
       details: getReDelegateDetailList(e.detail.data),
       type: "success",
+    });
+  });
+
+  useTransactionEventListener("ReDelegate.PartialSuccess", (e) => {
+    const { id, total } = parseTxsData(e.detail.tx, e.detail.data);
+    clearPendingNotifications(id);
+    dispatchNotification({
+      id,
+      title: "Some redelegations were not successful",
+      description: (
+        <>
+          Your redelegate transaction of <NamCurrency amount={total} />
+          has succeeded
+        </>
+      ),
+      details: getReDelegateDetailList(e.detail.data),
+      failedDetails:
+        e.detail.failedData ?
+          getReDelegateDetailList(e.detail.failedData)
+        : undefined,
+      type: "partialSuccess",
     });
   });
 

--- a/apps/namadillo/src/hooks/useTransactionNotifications.tsx
+++ b/apps/namadillo/src/hooks/useTransactionNotifications.tsx
@@ -118,6 +118,9 @@ export const useTransactionNotifications = (): void => {
           succeeded
         </>
       ),
+      failedDescription: (
+        <>The following staking transactions were not applied:</>
+      ),
       details: getAmountByValidatorList(e.detail.data),
       failedDetails: getAmountByValidatorList(e.detail.failedData || []),
       type: "partialSuccess",
@@ -149,8 +152,11 @@ export const useTransactionNotifications = (): void => {
       title: "Some Unstake transactions failed",
       description: (
         <>
-          Your unbonding of <NamCurrency amount={total} /> has succeeded
+          Your unstaking of <NamCurrency amount={total} /> has succeeded
         </>
+      ),
+      failedDescription: (
+        <>The following unstaking transactions were not applied:</>
       ),
       details: getAmountByValidatorList(e.detail.data),
       failedDetails:
@@ -246,6 +252,7 @@ export const useTransactionNotifications = (): void => {
           has succeeded
         </>
       ),
+      failedDescription: <>The following redelegations were not applied:</>,
       details: getReDelegateDetailList(e.detail.data),
       failedDetails:
         e.detail.failedData ?

--- a/apps/namadillo/src/hooks/useTransactionNotifications.tsx
+++ b/apps/namadillo/src/hooks/useTransactionNotifications.tsx
@@ -101,8 +101,19 @@ export const useTransactionNotifications = (): void => {
           succeeded
         </>
       ),
-      details: getAmountByValidatorList(e.detail.data),
+      details: (
+        <>
+          {getAmountByValidatorList(e.detail.data)}
+          {e.detail.error && (
+            <b>
+              <br />
+              {`${e.detail.error}`}
+            </b>
+          )}
+        </>
+      ),
       type: "success",
+      forceDetailsOpen: true,
     });
   });
 

--- a/apps/namadillo/src/hooks/useTransactionNotifications.tsx
+++ b/apps/namadillo/src/hooks/useTransactionNotifications.tsx
@@ -101,18 +101,26 @@ export const useTransactionNotifications = (): void => {
           succeeded
         </>
       ),
-      details: (
+      details: getAmountByValidatorList(e.detail.data),
+      type: "success",
+    });
+  });
+
+  useTransactionEventListener("Bond.PartialSuccess", (e) => {
+    const { id, total } = parseTxsData(e.detail.tx, e.detail.data);
+    clearPendingNotifications(id);
+    dispatchNotification({
+      id,
+      title: "Some staking tx failed",
+      description: (
         <>
-          {getAmountByValidatorList(e.detail.data)}
-          {e.detail.error && (
-            <b>
-              <br />
-              {`${e.detail.error}`}
-            </b>
-          )}
+          Your staking transaction of <NamCurrency amount={total} /> has
+          succeeded
         </>
       ),
-      type: "success",
+      details: getAmountByValidatorList(e.detail.data),
+      failedDetails: getAmountByValidatorList(e.detail.failedData || []),
+      type: "partialSuccess",
       forceDetailsOpen: true,
     });
   });

--- a/apps/namadillo/src/hooks/useTransactionNotifications.tsx
+++ b/apps/namadillo/src/hooks/useTransactionNotifications.tsx
@@ -85,7 +85,8 @@ export const useTransactionNotifications = (): void => {
           Your staking transaction of <NamCurrency amount={total} /> has failed
         </>
       ),
-      details: e.detail.error?.message,
+      failedDetails: getAmountByValidatorList(e.detail.data),
+      forceDetailsOpen: true,
     });
   });
 
@@ -180,7 +181,8 @@ export const useTransactionNotifications = (): void => {
           Your request to unstake <NamCurrency amount={total} /> has failed
         </>
       ),
-      details: e.detail.error?.message,
+      failedDetails: getAmountByValidatorList(e.detail.data),
+      forceDetailsOpen: true,
     });
   });
 
@@ -219,7 +221,9 @@ export const useTransactionNotifications = (): void => {
           has failed
         </>
       ),
+      failedDetails: getReDelegateDetailList(e.detail.data),
       type: "error",
+      forceDetailsOpen: true,
     });
   });
 

--- a/apps/namadillo/src/hooks/useTransactionNotifications.tsx
+++ b/apps/namadillo/src/hooks/useTransactionNotifications.tsx
@@ -65,6 +65,32 @@ const getReDelegateDetailList = (
   );
 };
 
+const partialSuccessDetails = (detail: {
+  details: React.ReactNode;
+  failedDescription: React.ReactNode;
+  failedDetails: React.ReactNode;
+}): React.ReactNode => {
+  return (
+    <>
+      <div className="w-full text-xs text-white block">
+        <div className="my-2">{detail.details}</div>
+        <div className="font-bold my-2">{detail.failedDescription}</div>
+        <div>{detail.failedDetails}</div>
+      </div>
+    </>
+  );
+};
+
+const failureDetails = (failedDetails: React.ReactNode): React.ReactNode => {
+  return (
+    <>
+      <div className="w-full text-xs text-white block my-2">
+        <div>{failedDetails}</div>
+      </div>
+    </>
+  );
+};
+
 export const useTransactionNotifications = (): void => {
   const dispatchNotification = useSetAtom(dispatchToastNotificationAtom);
   const filterNotifications = useSetAtom(filterToastNotificationsAtom);
@@ -85,8 +111,10 @@ export const useTransactionNotifications = (): void => {
           Your staking transaction of <NamCurrency amount={total} /> has failed
         </>
       ),
-      failedDetails: getAmountByValidatorList(e.detail.data),
-      forceDetailsOpen: true,
+      details:
+        e.detail.failedData ?
+          failureDetails(getAmountByValidatorList(e.detail.failedData))
+        : e.detail.error?.message,
     });
   });
 
@@ -108,7 +136,7 @@ export const useTransactionNotifications = (): void => {
   });
 
   useTransactionEventListener("Bond.PartialSuccess", (e) => {
-    const { id, total } = parseTxsData(e.detail.tx, e.detail.data);
+    const { id, total } = parseTxsData(e.detail.tx, e.detail.successData!);
     clearPendingNotifications(id);
     dispatchNotification({
       id,
@@ -119,13 +147,14 @@ export const useTransactionNotifications = (): void => {
           succeeded
         </>
       ),
-      failedDescription: (
-        <>The following staking transactions were not applied:</>
-      ),
-      details: getAmountByValidatorList(e.detail.data),
-      failedDetails: getAmountByValidatorList(e.detail.failedData || []),
+      details: partialSuccessDetails({
+        details: getAmountByValidatorList(e.detail.successData!),
+        failedDescription: (
+          <>The following staking transactions were not applied:</>
+        ),
+        failedDetails: getAmountByValidatorList(e.detail.failedData!),
+      }),
       type: "partialSuccess",
-      forceDetailsOpen: true,
     });
   });
 
@@ -146,7 +175,7 @@ export const useTransactionNotifications = (): void => {
   });
 
   useTransactionEventListener("Unbond.PartialSuccess", (e) => {
-    const { id, total } = parseTxsData(e.detail.tx, e.detail.data);
+    const { id, total } = parseTxsData(e.detail.tx, e.detail.successData!);
     clearPendingNotifications(id);
     dispatchNotification({
       id,
@@ -156,16 +185,14 @@ export const useTransactionNotifications = (): void => {
           Your unstaking of <NamCurrency amount={total} /> has succeeded
         </>
       ),
-      failedDescription: (
-        <>The following unstaking transactions were not applied:</>
-      ),
-      details: getAmountByValidatorList(e.detail.data),
-      failedDetails:
-        e.detail.failedData ?
-          getAmountByValidatorList(e.detail.failedData)
-        : undefined,
+      details: partialSuccessDetails({
+        details: getAmountByValidatorList(e.detail.successData!),
+        failedDescription: (
+          <>The following unstaking transactions were not applied:</>
+        ),
+        failedDetails: getAmountByValidatorList(e.detail.failedData!),
+      }),
       type: "partialSuccess",
-      forceDetailsOpen: true,
     });
   });
 
@@ -181,8 +208,10 @@ export const useTransactionNotifications = (): void => {
           Your request to unstake <NamCurrency amount={total} /> has failed
         </>
       ),
-      failedDetails: getAmountByValidatorList(e.detail.data),
-      forceDetailsOpen: true,
+      details:
+        e.detail.failedData ?
+          failureDetails(getAmountByValidatorList(e.detail.failedData))
+        : e.detail.error?.message,
     });
   });
 
@@ -217,13 +246,15 @@ export const useTransactionNotifications = (): void => {
       title: "Redelegate failed",
       description: (
         <>
-          Your redelegate transaction of <NamCurrency amount={total} />
-          has failed
+          Your redelegate transaction of <NamCurrency amount={total} /> has
+          failed
         </>
       ),
-      failedDetails: getReDelegateDetailList(e.detail.data),
+      details:
+        e.detail.failedData ?
+          failureDetails(getReDelegateDetailList(e.detail.failedData))
+        : e.detail.error?.message,
       type: "error",
-      forceDetailsOpen: true,
     });
   });
 
@@ -245,7 +276,7 @@ export const useTransactionNotifications = (): void => {
   });
 
   useTransactionEventListener("ReDelegate.PartialSuccess", (e) => {
-    const { id, total } = parseTxsData(e.detail.tx, e.detail.data);
+    const { id, total } = parseTxsData(e.detail.tx, e.detail.successData!);
     clearPendingNotifications(id);
     dispatchNotification({
       id,
@@ -256,12 +287,11 @@ export const useTransactionNotifications = (): void => {
           has succeeded
         </>
       ),
-      failedDescription: <>The following redelegations were not applied:</>,
-      details: getReDelegateDetailList(e.detail.data),
-      failedDetails:
-        e.detail.failedData ?
-          getReDelegateDetailList(e.detail.failedData)
-        : undefined,
+      details: partialSuccessDetails({
+        details: getReDelegateDetailList(e.detail.successData!),
+        failedDescription: <>The following redelegations were not applied:</>,
+        failedDetails: getReDelegateDetailList(e.detail.failedData!),
+      }),
       type: "partialSuccess",
     });
   });

--- a/apps/namadillo/src/lib/query.ts
+++ b/apps/namadillo/src/lib/query.ts
@@ -200,7 +200,24 @@ export const broadcastTx = async <T>(
         })
       );
     try {
-      await rpc.broadcastTx(signedTx, encodedTx.wrapperTxProps);
+      const response = await rpc.broadcastTx(
+        signedTx,
+        encodedTx.wrapperTxProps
+      );
+
+      const commitmentErrors: string[] = [];
+      response.commitments.forEach(({ hash, isApplied }) => {
+        if (!isApplied) {
+          commitmentErrors.push(hash);
+        }
+      });
+
+      if (commitmentErrors.length) {
+        throw new Error(
+          `The following Txs were not applied: ${commitmentErrors.join(" ")}`
+        );
+      }
+
       eventType &&
         window.dispatchEvent(
           new CustomEvent(`${eventType}.Success`, {

--- a/apps/namadillo/src/lib/query.ts
+++ b/apps/namadillo/src/lib/query.ts
@@ -233,18 +233,24 @@ export const broadcastTx = async <T>(
       });
 
       if (commitmentErrors.length) {
-        //Filter successful Tx, and display a success notification
         const successData = dataWithHash?.filter((data) => {
           return !commitmentErrors.includes(data.hash);
         });
 
+        const failedData = dataWithHash?.filter((data) => {
+          return commitmentErrors.includes(data.hash);
+        });
+
+        console.log({ successData, failedData });
+
         if (successData?.length) {
           eventType &&
             window.dispatchEvent(
-              new CustomEvent(`${eventType}.Success`, {
+              new CustomEvent(`${eventType}.PartialSuccess`, {
                 detail: {
                   tx,
                   data: successData,
+                  failedData,
                   error: `The following Txs were not applied: ${commitmentErrors.join(" ")}`,
                 },
               })

--- a/apps/namadillo/src/lib/query.ts
+++ b/apps/namadillo/src/lib/query.ts
@@ -246,7 +246,8 @@ export const broadcastTx = async <T>(
               new CustomEvent(`${eventType}.PartialSuccess`, {
                 detail: {
                   tx,
-                  data: successData,
+                  data,
+                  successData,
                   failedData,
                 },
               })

--- a/apps/namadillo/src/lib/query.ts
+++ b/apps/namadillo/src/lib/query.ts
@@ -9,7 +9,6 @@ import {
 } from "@namada/types";
 import { getIndexerApi } from "atoms/api";
 import { chainParametersAtom } from "atoms/chain";
-import BigNumber from "bignumber.js";
 import { getSdkInstance } from "hooks";
 import invariant from "invariant";
 import { getDefaultStore } from "jotai";
@@ -59,7 +58,7 @@ const getTxProps = (
   return {
     token: chain.nativeTokenAddress,
     feeAmount: gasConfig.gasPrice,
-    gasLimit: BigNumber(200),
+    gasLimit: gasConfig.gasLimit,
     chainId: chain.chainId,
     publicKey: account.publicKey!,
     memo: "",
@@ -241,8 +240,6 @@ export const broadcastTx = async <T>(
           return commitmentErrors.includes(data.hash);
         });
 
-        console.log({ successData, failedData });
-
         if (successData?.length) {
           eventType &&
             window.dispatchEvent(
@@ -251,7 +248,6 @@ export const broadcastTx = async <T>(
                   tx,
                   data: successData,
                   failedData,
-                  error: `The following Txs were not applied: ${commitmentErrors.join(" ")}`,
                 },
               })
             );

--- a/apps/namadillo/src/lib/query.ts
+++ b/apps/namadillo/src/lib/query.ts
@@ -252,13 +252,17 @@ export const broadcastTx = async <T>(
               })
             );
         } else {
-          throw new Error(
-            `The following Txs were not applied: ${commitmentErrors.join(" ")}`
-          );
+          eventType &&
+            window.dispatchEvent(
+              new CustomEvent(`${eventType}.Error`, {
+                detail: { tx, data, failedData },
+              })
+            );
         }
         return;
       }
 
+      // If no errors were reported, display Success toast
       eventType &&
         window.dispatchEvent(
           new CustomEvent(`${eventType}.Success`, {

--- a/apps/namadillo/src/types.d.ts
+++ b/apps/namadillo/src/types.d.ts
@@ -146,6 +146,7 @@ export type ToastNotification = {
   type: "pending" | "success" | "partialSuccess" | "error";
   title: React.ReactNode;
   description: React.ReactNode;
+  failedDescription?: React.ReactNode;
   details?: React.ReactNode;
   failedDetails?: React.ReactNode;
   timeout?: number;

--- a/apps/namadillo/src/types.d.ts
+++ b/apps/namadillo/src/types.d.ts
@@ -148,6 +148,7 @@ export type ToastNotification = {
   description: React.ReactNode;
   details?: React.ReactNode;
   timeout?: number;
+  forceDetailsOpen?: boolean;
 };
 
 export type ToastNotificationEntryFilter = (

--- a/apps/namadillo/src/types.d.ts
+++ b/apps/namadillo/src/types.d.ts
@@ -143,10 +143,11 @@ export type SortedColumnPair<T> = [id: T, SortOptions] | undefined;
 
 export type ToastNotification = {
   id: string;
-  type: "pending" | "success" | "error";
+  type: "pending" | "success" | "partialSuccess" | "error";
   title: React.ReactNode;
   description: React.ReactNode;
   details?: React.ReactNode;
+  failedDetails?: React.ReactNode;
   timeout?: number;
   forceDetailsOpen?: boolean;
 };

--- a/apps/namadillo/src/types.d.ts
+++ b/apps/namadillo/src/types.d.ts
@@ -148,9 +148,7 @@ export type ToastNotification = {
   description: React.ReactNode;
   failedDescription?: React.ReactNode;
   details?: React.ReactNode;
-  failedDetails?: React.ReactNode;
   timeout?: number;
-  forceDetailsOpen?: boolean;
 };
 
 export type ToastNotificationEntryFilter = (

--- a/apps/namadillo/src/types/events.ts
+++ b/apps/namadillo/src/types/events.ts
@@ -33,6 +33,8 @@ export interface EventData<T> extends CustomEvent {
   detail: {
     tx: TxProps;
     data: T[];
+    // If event is for PartialSuccess, use the following:
+    successData?: T[];
     failedData?: T[];
     error?: Error;
   };

--- a/apps/namadillo/src/types/events.ts
+++ b/apps/namadillo/src/types/events.ts
@@ -14,7 +14,11 @@ export type TransactionEventsClasses =
   | "Withdraw"
   | "VoteProposal";
 
-export type TransactionEventsStatus = "Pending" | "Error" | "Success";
+export type TransactionEventsStatus =
+  | "Pending"
+  | "Error"
+  | "Success"
+  | "PartialSuccess";
 
 export type TransactionEvent =
   `${TransactionEventsClasses}.${TransactionEventsStatus}`;
@@ -29,6 +33,7 @@ export interface EventData<T> extends CustomEvent {
   detail: {
     tx: TxProps;
     data: T[];
+    failedData?: T[];
     error?: Error;
   };
 }
@@ -36,10 +41,13 @@ export interface EventData<T> extends CustomEvent {
 declare global {
   interface WindowEventMap {
     "Bond.Success": EventData<BondProps>;
+    "Bond.PartialSuccess": EventData<BondProps>;
     "Bond.Error": EventData<BondProps>;
     "Unbond.Success": EventData<UnbondProps>;
+    "Unbond.PartialSuccess": EventData<UnbondProps>;
     "Unbond.Error": EventData<UnbondProps>;
     "ReDelegate.Success": EventData<RedelegateProps>;
+    "ReDelegate.PartialSuccess": EventData<RedelegateProps>;
     "ReDelegate.Error": EventData<RedelegateProps>;
     "Withdraw.Success": EventData<WithdrawProps>;
     "Withdraw.Error": EventData<WithdrawProps>;

--- a/packages/sdk/src/tx/tx.ts
+++ b/packages/sdk/src/tx/tx.ts
@@ -1,5 +1,10 @@
 import { deserialize } from "@dao-xyz/borsh";
-import { Sdk as SdkWasm, TxType, deserialize_tx } from "@namada/shared";
+import {
+  Sdk as SdkWasm,
+  TxType,
+  deserialize_tx,
+  get_inner_tx_hashes,
+} from "@namada/shared";
 import {
   BondMsgValue,
   BondProps,
@@ -41,7 +46,7 @@ export class Tx {
   /**
    * @param sdk - Instance of Sdk struct from wasm lib
    */
-  constructor(protected readonly sdk: SdkWasm) {}
+  constructor(protected readonly sdk: SdkWasm) { }
 
   /**
    * Build Transfer Tx
@@ -384,5 +389,14 @@ export class Tx {
         })
       ),
     };
+  }
+
+  /**
+   * Return the inner tx hashes from the provided tx bytes
+   * @param bytes - Uint8Array
+   * @returns array of inner Tx hashes
+   */
+  getInnerTxHashes(bytes: Uint8Array): string[] {
+    return get_inner_tx_hashes(bytes);
   }
 }

--- a/packages/sdk/src/tx/tx.ts
+++ b/packages/sdk/src/tx/tx.ts
@@ -46,7 +46,7 @@ export class Tx {
   /**
    * @param sdk - Instance of Sdk struct from wasm lib
    */
-  constructor(protected readonly sdk: SdkWasm) { }
+  constructor(protected readonly sdk: SdkWasm) {}
 
   /**
    * Build Transfer Tx

--- a/packages/shared/lib/src/sdk/tx.rs
+++ b/packages/shared/lib/src/sdk/tx.rs
@@ -128,14 +128,6 @@ impl Tx {
             signing_data.push(sd);
         }
         let hash = tx.wrapper_hash();
-        let cmts = tx.commitments();
-        let mut inner_tx_hashes: Vec<String> = vec![];
-
-        for cmt in cmts {
-            let inner_tx_hash = compute_inner_tx_hash(hash.as_ref(), Either::Right(&cmt));
-            inner_tx_hashes.push(inner_tx_hash.to_string());
-        }
-
         let bytes: Vec<u8> = borsh::to_vec(&tx)?;
 
         Ok(Tx {

--- a/packages/shared/lib/src/sdk/tx.rs
+++ b/packages/shared/lib/src/sdk/tx.rs
@@ -4,6 +4,8 @@ use std::str::FromStr;
 use gloo_utils::format::JsValueSerdeExt;
 use namada_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use namada_sdk::signing::SigningTxData;
+use namada_sdk::tx::data::compute_inner_tx_hash;
+use namada_sdk::tx::either::Either;
 use namada_sdk::tx::{
     self, TX_BOND_WASM, TX_CLAIM_REWARDS_WASM, TX_REDELEGATE_WASM, TX_REVEAL_PK, TX_TRANSFER_WASM,
     TX_UNBOND_WASM, TX_VOTE_PROPOSAL, TX_WITHDRAW_WASM,
@@ -125,12 +127,20 @@ impl Tx {
             let sd = SigningData::from_signing_tx_data(sd)?;
             signing_data.push(sd);
         }
-        let hash = tx.header_hash().to_string();
+        let hash = tx.wrapper_hash();
+        let cmts = tx.commitments();
+        let mut inner_tx_hashes: Vec<String> = vec![];
+
+        for cmt in cmts {
+            let inner_tx_hash = compute_inner_tx_hash(hash.as_ref(), Either::Right(&cmt));
+            inner_tx_hashes.push(inner_tx_hash.to_string());
+        }
+
         let bytes: Vec<u8> = borsh::to_vec(&tx)?;
 
         Ok(Tx {
             args,
-            hash,
+            hash: hash.unwrap().to_string(),
             bytes,
             signing_data,
         })
@@ -152,6 +162,22 @@ impl Tx {
     pub fn args(&self) -> WrapperTxMsg {
         self.args.clone()
     }
+}
+
+// Given the bytes of a Namada Tx, return all inner Tx hashes
+#[wasm_bindgen]
+pub fn get_inner_tx_hashes(tx_bytes: &[u8]) -> Result<Vec<String>, JsError> {
+    let nam_tx: tx::Tx = borsh::from_slice(tx_bytes)?;
+    let hash = nam_tx.wrapper_hash();
+    let cmts = nam_tx.commitments();
+    let mut inner_tx_hashes: Vec<String> = vec![];
+
+    for cmt in cmts {
+        let inner_tx_hash = compute_inner_tx_hash(hash.as_ref(), Either::Right(&cmt));
+        inner_tx_hashes.push(inner_tx_hash.to_string());
+    }
+
+    Ok(inner_tx_hashes)
 }
 
 pub fn wasm_hash_to_tx_type(wasm_hash: &str, wasm_hashes: &Vec<WasmHash>) -> Option<TxType> {


### PR DESCRIPTION
Resolves #1081 

Using the response from `rpc.broadcastTx()`, check the `isApplied` value for each commitment, raise error if any are not applied.

- [x] Update SDK to fix issue where we were not getting accurate `isApplied` values if any of the innerTx were not applied
- [x] Export SDK function to return the computed inner Tx hashes of all commitments (this is used later for mapping to inner Tx props)
- [x] Update Toast & Notifications in Namadillo to collect successful/failed Tx and display a new notification to users, `PartialSuccess`, where both successful and failed inner-Tx can be displayed

This makes use of the `ProcessTxResponse` from the SDK's `rpc.broadcastTx()`. Example:
```json
{
    "code": "0",
    "commitments": [
        {
            "hash": "DE979B02CC9014068E09DEFCB26592FB2A992D43B35B57C1CC9643BAE4F392CE",
            "isApplied": true
        },
        {
            "hash": "C91EED4782248D482517AE5C37AEA9895E1469439C42C059789C334FB9F8031C",
            "isApplied": true
        }
    ],
    "gasUsed": "210",
    "hash": "BC99E787272BDD15468E3F5C86EEC2FBAE752C568983086805EDB5286F5BDB95",
    "height": "16602",
    "info": "Check batch for result.",
    "log": ""
}
```

Each commitment in this response has a boolean indicating whether that commitment has been accepted by all VPs and applied on chain.

### Testing

Testing this PR is a bit weird, as you need to trigger a VP rejection _after_ SDK validation passes. An easy way to do this is to hijack the `gasLimit` value. In Namadillo, in `src/lib/query.ts` -> `getTxProps`:
- use (for example)`gasLimit: BigNumber(100)`, then submit 3 staking Tx - all should fail
- Set this value to `BigNumber(285)` and only one will fail.

**NOTE** You can test the results (check the hashes) in the error msg against what is in the console

### Screenshot

Partial success notification, indicates both successful and unsuccessful Tx:
<img width="400" alt="Screen Shot 2024-09-10 at 3 36 34 PM" src="https://github.com/user-attachments/assets/c8330037-a1fc-4508-aa5e-8af25495d3de">

Failed state when SDK validation passes, but the Tx response indicates that commitments were rejected by VPs:
<img width="435" alt="Screen Shot 2024-09-10 at 4 57 21 PM" src="https://github.com/user-attachments/assets/6dcdf4c7-fce6-44a9-8725-34d7b0dfeb9f">


Success notification is unchanged.
