### PR TITLE
Rename Extension in manifest

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@namada/extension",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Namada Browser Extension",
   "repository": "https://github.com/anoma/namada-interface/",
   "author": "Heliax Dev <info@heliax.dev>",

--- a/apps/extension/src/manifest/_base.json
+++ b/apps/extension/src/manifest/_base.json
@@ -1,4 +1,4 @@
 {
-  "name": "Namada Extension",
-  "description": "The Namada Extension manages a user's wallet for the Namada ecosystem."
+  "name": "Namada Keychain",
+  "description": "The Namada Keychain manages a user's wallet for the Namada ecosystem."
 }


### PR DESCRIPTION
This PR simply renames the extension the base manifest file. This should now apply to both extension (FF & Chrome)

- Rename extension
- Bump minor version so this can be submitted