### PR TITLE
WIP: feat/1078 - Extension - Enable chain approval

### DIFF
--- a/apps/extension/src/Approvals/ApproveConnection.tsx
+++ b/apps/extension/src/Approvals/ApproveConnection.tsx
@@ -1,8 +1,11 @@
 import { ActionButton, Alert, GapPatterns, Stack } from "@namada/components";
+import { Chain } from "@namada/types";
 import { PageHeader } from "App/Common";
 import { ConnectInterfaceResponseMsg } from "background/approvals";
 import { useQuery } from "hooks";
 import { useRequester } from "hooks/useRequester";
+import { GetChainMsg } from "provider";
+import { useEffect, useState } from "react";
 import { Ports } from "router";
 import { closeCurrentTab } from "utils";
 
@@ -10,12 +13,36 @@ export const ApproveConnection: React.FC = () => {
   const requester = useRequester();
   const params = useQuery();
   const interfaceOrigin = params.get("interfaceOrigin");
+  const chainId = params.get("chainId") || undefined;
+  const [chain, setChain] = useState<Chain>();
+
+  const fetchChain = async (): Promise<Chain> => {
+    const chainResponse = await requester.sendMessage(
+      Ports.Background,
+      new GetChainMsg()
+    );
+    return chainResponse;
+  };
+
+  useEffect(() => {
+    if (chainId) {
+      fetchChain()
+        .then((chain) => {
+          setChain(chain);
+        })
+        .catch((e) => console.error(e));
+    }
+  }, [chainId]);
 
   const handleResponse = async (allowConnection: boolean): Promise<void> => {
     if (interfaceOrigin) {
       await requester.sendMessage(
         Ports.Background,
-        new ConnectInterfaceResponseMsg(interfaceOrigin, allowConnection)
+        new ConnectInterfaceResponseMsg(
+          interfaceOrigin,
+          allowConnection,
+          chainId
+        )
       );
       await closeCurrentTab();
     }
@@ -28,6 +55,9 @@ export const ApproveConnection: React.FC = () => {
         <Alert type="warning">
           Approve connection for <strong>{interfaceOrigin}</strong>?
         </Alert>
+        {chainId && chain && chain.chainId !== chainId && (
+          <Alert type="warning">Enable signing for {chainId}?</Alert>
+        )}
         <Stack gap={2}>
           <ActionButton onClick={() => handleResponse(true)}>
             Approve

--- a/apps/extension/src/background/approvals/handler.ts
+++ b/apps/extension/src/background/approvals/handler.ts
@@ -125,8 +125,8 @@ const handleIsConnectionApprovedMsg: (
 const handleApproveConnectInterfaceMsg: (
   service: ApprovalsService
 ) => InternalHandler<ApproveConnectInterfaceMsg> = (service) => {
-  return async (_, { origin }) => {
-    return await service.approveConnection(origin);
+  return async (_, { origin, chainId }) => {
+    return await service.approveConnection(origin, chainId);
   };
 };
 
@@ -135,12 +135,13 @@ const handleConnectInterfaceResponseMsg: (
 ) => InternalHandler<ConnectInterfaceResponseMsg> = (service) => {
   return async (
     { senderTabId: popupTabId },
-    { interfaceOrigin, allowConnection }
+    { interfaceOrigin, allowConnection, chainId }
   ) => {
     return await service.approveConnectionResponse(
       popupTabId,
       interfaceOrigin,
-      allowConnection
+      allowConnection,
+      chainId
     );
   };
 };

--- a/apps/extension/src/background/approvals/messages.ts
+++ b/apps/extension/src/background/approvals/messages.ts
@@ -147,7 +147,8 @@ export class ConnectInterfaceResponseMsg extends Message<void> {
 
   constructor(
     public readonly interfaceOrigin: string,
-    public readonly allowConnection: boolean
+    public readonly allowConnection: boolean,
+    public readonly chainId?: string
   ) {
     super();
   }

--- a/apps/extension/src/provider/InjectedNamada.ts
+++ b/apps/extension/src/provider/InjectedNamada.ts
@@ -14,8 +14,8 @@ import { Signer } from "./Signer";
 export class InjectedNamada implements INamada {
   constructor(private readonly _version: string) {}
 
-  public async connect(): Promise<void> {
-    return await InjectedProxy.requestMethod<string, void>("connect");
+  public async connect(chainId?: string): Promise<void> {
+    return await InjectedProxy.requestMethod<string, void>("connect", chainId);
   }
 
   public async disconnect(): Promise<void> {

--- a/apps/extension/src/provider/Namada.ts
+++ b/apps/extension/src/provider/Namada.ts
@@ -30,10 +30,10 @@ export class Namada implements INamada {
     protected readonly requester?: MessageRequester
   ) {}
 
-  public async connect(): Promise<void> {
+  public async connect(chainId?: string): Promise<void> {
     return await this.requester?.sendMessage(
       Ports.Background,
-      new ApproveConnectInterfaceMsg()
+      new ApproveConnectInterfaceMsg(chainId)
     );
   }
 

--- a/apps/extension/src/provider/messages.ts
+++ b/apps/extension/src/provider/messages.ts
@@ -118,7 +118,7 @@ export class ApproveConnectInterfaceMsg extends Message<void> {
     return MessageType.ApproveConnectInterface;
   }
 
-  constructor() {
+  constructor(public readonly chainId?: string) {
     super();
   }
 

--- a/apps/namadillo/src/App/Common/ConnectExtensionButton.tsx
+++ b/apps/namadillo/src/App/Common/ConnectExtensionButton.tsx
@@ -13,7 +13,11 @@ export const ConnectExtensionButton = (): JSX.Element => {
   return (
     <>
       {extensionAttachStatus === "attached" && !isConnected && (
-        <ActionButton backgroundColor="yellow" size="sm" onClick={connect}>
+        <ActionButton
+          backgroundColor="yellow"
+          size="sm"
+          onClick={() => connect("todo")}
+        >
           Connect Keychain
         </ActionButton>
       )}

--- a/apps/namadillo/src/hooks/useExtensionConnect.ts
+++ b/apps/namadillo/src/hooks/useExtensionConnect.ts
@@ -7,7 +7,7 @@ import { useEffect } from "react";
 type UseConnectOutput = {
   connectionStatus: ConnectStatus;
   isConnected: boolean;
-  connect: () => Promise<void>;
+  connect: (chainId: string) => Promise<void>;
 };
 
 export const useExtensionConnect = (
@@ -26,11 +26,12 @@ export const useExtensionConnect = (
     }
   }, [isConnectingToExtension]);
 
-  const handleConnectExtension = async (): Promise<void> => {
+  const handleConnectExtension = async (chainId: string): Promise<void> => {
     if (connectionStatus === "connected") return;
     withConnection(
       () => setConnectionStatus("connected"),
-      () => setConnectionStatus("error")
+      () => setConnectionStatus("error"),
+      chainId
     );
   };
 

--- a/packages/integrations/src/Namada.ts
+++ b/packages/integrations/src/Namada.ts
@@ -28,8 +28,8 @@ export default class Namada implements Integration<Account, Signer> {
     return !!this._namada;
   }
 
-  public async connect(): Promise<void> {
-    await this._namada?.connect();
+  public async connect(chainId?: string): Promise<void> {
+    await this._namada?.connect(chainId);
   }
 
   public async disconnect(): Promise<void> {

--- a/packages/integrations/src/hooks/useIntegration.ts
+++ b/packages/integrations/src/hooks/useIntegration.ts
@@ -16,7 +16,8 @@ import {
 
 type ExtensionConnection<T, U> = (
   onSuccess: () => T,
-  onFail?: () => U
+  onFail?: () => U,
+  chainId?: string
 ) => Promise<void>;
 
 export const IntegrationsContext = createContext<Integrations>(integrations);
@@ -49,19 +50,19 @@ export const useIntegrationConnection = <
 >(
   extensionKey: K
 ): [
-  IntegrationFromExtensionKey<K>,
-  boolean,
-  ExtensionConnection<TSuccess, TFail>,
-] => {
+    IntegrationFromExtensionKey<K>,
+    boolean,
+    ExtensionConnection<TSuccess, TFail>,
+  ] => {
   const integration = useIntegration(extensionKey);
   const [isConnectingToExtension, setIsConnectingToExtension] = useState(false);
 
   const connect: ExtensionConnection<TSuccess, TFail> = useCallback(
-    async (onSuccess, onFail) => {
+    async (onSuccess, onFail, chainId) => {
       setIsConnectingToExtension(true);
       try {
         if (integration.detect()) {
-          await integration.connect();
+          await integration.connect(chainId);
           await onSuccess();
         }
       } catch {

--- a/packages/types/src/namada.ts
+++ b/packages/types/src/namada.ts
@@ -27,7 +27,7 @@ export type BalancesProps = {
 
 export interface Namada {
   accounts(chainId?: string): Promise<DerivedAccount[] | undefined>;
-  connect(): Promise<void>;
+  connect(chainId?: string): Promise<void>;
   disconnect(): Promise<void>;
   isConnected(): Promise<boolean | undefined>;
   defaultAccount(chainId?: string): Promise<DerivedAccount | undefined>;


### PR DESCRIPTION
Resolves #1078 

- [x] When approving connection, if interface is attempting to use a different chain ID, alert user, and if approved, save this in extension
- [ ] When the interface is later connected to an indexer that returns a different chain ID, display a new approval to allow updating the extension