### PR TITLE
fix/1096: Extension - Fix issue on Delete Accounts with form submit

### DIFF
--- a/apps/extension/src/App/Accounts/DeleteAccount.tsx
+++ b/apps/extension/src/App/Accounts/DeleteAccount.tsx
@@ -101,6 +101,7 @@ export const DeleteAccount = (): JSX.Element => {
               </p>
               <LinkButton
                 color="primary"
+                type="button"
                 className="font-bold mt-4 text-sm underline"
                 onClick={() => navigate(routes.viewAccountMnemonic(accountId))}
               >


### PR DESCRIPTION
Resolves #1096 

A user reported an issue where attempting to Delete Account would redirect to View Mnemonic. This is because the "Backup My Wallet" link is suddenly being treated as a Submit button.

- [x] Set button type on `Backup My Wallet` link to `button`

### TESTING

- In the extension, attempt to `Delete Account` using the Enter/Return key to submit
- This should now work. In the previous version on `main`, this was redirecting to `View Mnemonic`