### PR TITLE
feat/1098 - SDK: Add remaining Transfer types

### DIFF
--- a/packages/sdk/docs/classes/Crypto.md
+++ b/packages/sdk/docs/classes/Crypto.md
@@ -40,7 +40,7 @@ Class Crypto handles AES encryption tasks
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/crypto/crypto.ts#L20)
+[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/crypto/crypto.ts#L20)
 
 ## Properties
 
@@ -52,7 +52,7 @@ WebAssembly Memory for crypto
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/crypto/crypto.ts#L20)
+[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/crypto/crypto.ts#L20)
 
 ## Methods
 
@@ -75,7 +75,7 @@ decrypted text
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:115](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/crypto/crypto.ts#L115)
+[sdk/src/crypto/crypto.ts:115](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/crypto/crypto.ts#L115)
 
 ___
 
@@ -100,7 +100,7 @@ crypto record
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:61](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/crypto/crypto.ts#L61)
+[sdk/src/crypto/crypto.ts:61](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/crypto/crypto.ts#L61)
 
 ___
 
@@ -126,7 +126,7 @@ array of encrypted bytes
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:98](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/crypto/crypto.ts#L98)
+[sdk/src/crypto/crypto.ts:98](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/crypto/crypto.ts#L98)
 
 ___
 
@@ -153,7 +153,7 @@ crypto record used for storage
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:30](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/crypto/crypto.ts#L30)
+[sdk/src/crypto/crypto.ts:30](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/crypto/crypto.ts#L30)
 
 ___
 
@@ -178,4 +178,4 @@ encryption parameters
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:73](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/crypto/crypto.ts#L73)
+[sdk/src/crypto/crypto.ts:73](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/crypto/crypto.ts#L73)

--- a/packages/sdk/docs/classes/Ledger.md
+++ b/packages/sdk/docs/classes/Ledger.md
@@ -42,7 +42,7 @@ Functionality for interacting with NamadaApp for Ledger Hardware Wallets
 
 #### Defined in
 
-[sdk/src/ledger.ts:53](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/ledger.ts#L53)
+[sdk/src/ledger.ts:53](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/ledger.ts#L53)
 
 ## Properties
 
@@ -54,7 +54,7 @@ Inititalized NamadaApp class from Zondax package
 
 #### Defined in
 
-[sdk/src/ledger.ts:53](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/ledger.ts#L53)
+[sdk/src/ledger.ts:53](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/ledger.ts#L53)
 
 ## Methods
 
@@ -75,7 +75,7 @@ void
 
 #### Defined in
 
-[sdk/src/ledger.ts:174](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/ledger.ts#L174)
+[sdk/src/ledger.ts:174](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/ledger.ts#L174)
 
 ___
 
@@ -102,7 +102,7 @@ Address and public key
 
 #### Defined in
 
-[sdk/src/ledger.ts:96](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/ledger.ts#L96)
+[sdk/src/ledger.ts:96](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/ledger.ts#L96)
 
 ___
 
@@ -123,7 +123,7 @@ Error message if error is found
 
 #### Defined in
 
-[sdk/src/ledger.ts:157](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/ledger.ts#L157)
+[sdk/src/ledger.ts:157](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/ledger.ts#L157)
 
 ___
 
@@ -150,7 +150,7 @@ Address and public key
 
 #### Defined in
 
-[sdk/src/ledger.ts:116](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/ledger.ts#L116)
+[sdk/src/ledger.ts:116](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/ledger.ts#L116)
 
 ___
 
@@ -178,7 +178,7 @@ Response signature
 
 #### Defined in
 
-[sdk/src/ledger.ts:142](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/ledger.ts#L142)
+[sdk/src/ledger.ts:142](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/ledger.ts#L142)
 
 ___
 
@@ -199,7 +199,7 @@ Version and info of NamadaApp
 
 #### Defined in
 
-[sdk/src/ledger.ts:79](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/ledger.ts#L79)
+[sdk/src/ledger.ts:79](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/ledger.ts#L79)
 
 ___
 
@@ -225,4 +225,4 @@ Ledger class instance
 
 #### Defined in
 
-[sdk/src/ledger.ts:61](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/ledger.ts#L61)
+[sdk/src/ledger.ts:61](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/ledger.ts#L61)

--- a/packages/sdk/docs/classes/Masp.md
+++ b/packages/sdk/docs/classes/Masp.md
@@ -41,7 +41,7 @@ Class representing utilities related to MASP
 
 #### Defined in
 
-[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/masp.ts#L10)
+[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/masp.ts#L10)
 
 ## Properties
 
@@ -53,7 +53,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/masp.ts#L10)
+[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/masp.ts#L10)
 
 ## Methods
 
@@ -80,7 +80,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:69](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/masp.ts#L69)
+[sdk/src/masp.ts:69](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/masp.ts#L69)
 
 ___
 
@@ -107,7 +107,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:47](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/masp.ts#L47)
+[sdk/src/masp.ts:47](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/masp.ts#L47)
 
 ___
 
@@ -134,7 +134,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:58](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/masp.ts#L58)
+[sdk/src/masp.ts:58](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/masp.ts#L58)
 
 ___
 
@@ -154,7 +154,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:26](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/masp.ts#L26)
+[sdk/src/masp.ts:26](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/masp.ts#L26)
 
 ___
 
@@ -174,7 +174,7 @@ True if MASP parameters are loaded
 
 #### Defined in
 
-[sdk/src/masp.ts:17](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/masp.ts#L17)
+[sdk/src/masp.ts:17](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/masp.ts#L17)
 
 ___
 
@@ -200,4 +200,4 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:36](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/masp.ts#L36)
+[sdk/src/masp.ts:36](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/masp.ts#L36)

--- a/packages/sdk/docs/classes/Mnemonic.md
+++ b/packages/sdk/docs/classes/Mnemonic.md
@@ -38,7 +38,7 @@ Class for accessing mnemonic functionality from wasm
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/mnemonic.ts#L18)
+[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/mnemonic.ts#L18)
 
 ## Properties
 
@@ -50,7 +50,7 @@ Memory accessor for crypto lib
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/mnemonic.ts#L18)
+[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/mnemonic.ts#L18)
 
 ## Methods
 
@@ -76,7 +76,7 @@ Promise that resolves to array of words
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:26](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/mnemonic.ts#L26)
+[sdk/src/mnemonic.ts:26](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/mnemonic.ts#L26)
 
 ___
 
@@ -101,7 +101,7 @@ Seed bytes
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:44](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/mnemonic.ts#L44)
+[sdk/src/mnemonic.ts:44](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/mnemonic.ts#L44)
 
 ___
 
@@ -131,4 +131,4 @@ Object with validation result and error message if invalid
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:62](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/mnemonic.ts#L62)
+[sdk/src/mnemonic.ts:62](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/mnemonic.ts#L62)

--- a/packages/sdk/docs/classes/Rpc.md
+++ b/packages/sdk/docs/classes/Rpc.md
@@ -51,7 +51,7 @@ API for executing RPC requests with Namada
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:36](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/rpc.ts#L36)
+[sdk/src/rpc/rpc.ts:36](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/rpc.ts#L36)
 
 ## Properties
 
@@ -63,7 +63,7 @@ Instance of Query struct from wasm lib
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:38](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/rpc.ts#L38)
+[sdk/src/rpc/rpc.ts:38](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/rpc.ts#L38)
 
 ___
 
@@ -75,7 +75,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:37](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/rpc.ts#L37)
+[sdk/src/rpc/rpc.ts:37](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/rpc.ts#L37)
 
 ## Methods
 
@@ -102,7 +102,7 @@ TxResponseProps object
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:223](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/rpc.ts#L223)
+[sdk/src/rpc/rpc.ts:223](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/rpc.ts#L223)
 
 ___
 
@@ -122,7 +122,7 @@ Array of all validator addresses
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:78](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/rpc.ts#L78)
+[sdk/src/rpc/rpc.ts:78](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/rpc.ts#L78)
 
 ___
 
@@ -149,7 +149,7 @@ Query balances from chain
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:48](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/rpc.ts#L48)
+[sdk/src/rpc/rpc.ts:48](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/rpc.ts#L48)
 
 ___
 
@@ -169,7 +169,7 @@ Object
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:203](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/rpc.ts#L203)
+[sdk/src/rpc/rpc.ts:203](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/rpc.ts#L203)
 
 ___
 
@@ -195,7 +195,7 @@ Promise resolving to delegators votes
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:102](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/rpc.ts#L102)
+[sdk/src/rpc/rpc.ts:102](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/rpc.ts#L102)
 
 ___
 
@@ -215,7 +215,7 @@ Query gas costs
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:194](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/rpc.ts#L194)
+[sdk/src/rpc/rpc.ts:194](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/rpc.ts#L194)
 
 ___
 
@@ -235,7 +235,7 @@ Address of native token
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:57](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/rpc.ts#L57)
+[sdk/src/rpc/rpc.ts:57](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/rpc.ts#L57)
 
 ___
 
@@ -262,7 +262,7 @@ String of public key if found
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:68](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/rpc.ts#L68)
+[sdk/src/rpc/rpc.ts:68](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/rpc.ts#L68)
 
 ___
 
@@ -288,7 +288,7 @@ Promise resolving to pending ethereum transfers
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:185](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/rpc.ts#L185)
+[sdk/src/rpc/rpc.ts:185](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/rpc.ts#L185)
 
 ___
 
@@ -314,7 +314,7 @@ Promise resolving to staking positions
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:139](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/rpc.ts#L139)
+[sdk/src/rpc/rpc.ts:139](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/rpc.ts#L139)
 
 ___
 
@@ -340,7 +340,7 @@ Promise resolving to staking totals
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:112](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/rpc.ts#L112)
+[sdk/src/rpc/rpc.ts:112](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/rpc.ts#L112)
 
 ___
 
@@ -364,7 +364,7 @@ Total bonds amount
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:175](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/rpc.ts#L175)
+[sdk/src/rpc/rpc.ts:175](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/rpc.ts#L175)
 
 ___
 
@@ -391,7 +391,7 @@ Promise resolving to total delegations
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:89](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/rpc.ts#L89)
+[sdk/src/rpc/rpc.ts:89](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/rpc.ts#L89)
 
 ___
 
@@ -415,4 +415,4 @@ Sync the shielded context
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:241](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/rpc.ts#L241)
+[sdk/src/rpc/rpc.ts:241](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/rpc.ts#L241)

--- a/packages/sdk/docs/classes/Sdk.md
+++ b/packages/sdk/docs/classes/Sdk.md
@@ -62,7 +62,7 @@ API for interacting with Namada SDK
 
 #### Defined in
 
-[sdk/src/sdk.ts:23](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/sdk.ts#L23)
+[sdk/src/sdk.ts:23](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/sdk.ts#L23)
 
 ## Properties
 
@@ -74,7 +74,7 @@ Memory accessor for crypto lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:26](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/sdk.ts#L26)
+[sdk/src/sdk.ts:26](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/sdk.ts#L26)
 
 ___
 
@@ -86,7 +86,7 @@ Address of chain's native token
 
 #### Defined in
 
-[sdk/src/sdk.ts:28](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/sdk.ts#L28)
+[sdk/src/sdk.ts:28](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/sdk.ts#L28)
 
 ___
 
@@ -98,7 +98,7 @@ Instance of Query struct from wasm lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:25](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/sdk.ts#L25)
+[sdk/src/sdk.ts:25](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/sdk.ts#L25)
 
 ___
 
@@ -110,7 +110,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:24](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/sdk.ts#L24)
+[sdk/src/sdk.ts:24](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/sdk.ts#L24)
 
 ___
 
@@ -122,7 +122,7 @@ RPC url
 
 #### Defined in
 
-[sdk/src/sdk.ts:27](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/sdk.ts#L27)
+[sdk/src/sdk.ts:27](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/sdk.ts#L27)
 
 ## Accessors
 
@@ -140,7 +140,7 @@ Utilities for encrypting and decrypting data
 
 #### Defined in
 
-[sdk/src/sdk.ts:166](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/sdk.ts#L166)
+[sdk/src/sdk.ts:166](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/sdk.ts#L166)
 
 ___
 
@@ -158,7 +158,7 @@ key-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:142](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/sdk.ts#L142)
+[sdk/src/sdk.ts:142](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/sdk.ts#L142)
 
 ___
 
@@ -176,7 +176,7 @@ Masp utilities for handling params
 
 #### Defined in
 
-[sdk/src/sdk.ts:158](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/sdk.ts#L158)
+[sdk/src/sdk.ts:158](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/sdk.ts#L158)
 
 ___
 
@@ -194,7 +194,7 @@ mnemonic-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:134](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/sdk.ts#L134)
+[sdk/src/sdk.ts:134](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/sdk.ts#L134)
 
 ___
 
@@ -212,7 +212,7 @@ rpc client
 
 #### Defined in
 
-[sdk/src/sdk.ts:118](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/sdk.ts#L118)
+[sdk/src/sdk.ts:118](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/sdk.ts#L118)
 
 ___
 
@@ -230,7 +230,7 @@ Non-Tx signing functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:150](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/sdk.ts#L150)
+[sdk/src/sdk.ts:150](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/sdk.ts#L150)
 
 ___
 
@@ -248,7 +248,7 @@ tx-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:126](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/sdk.ts#L126)
+[sdk/src/sdk.ts:126](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/sdk.ts#L126)
 
 ## Methods
 
@@ -266,7 +266,7 @@ Utilities for encrypting and decrypting data
 
 #### Defined in
 
-[sdk/src/sdk.ts:100](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/sdk.ts#L100)
+[sdk/src/sdk.ts:100](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/sdk.ts#L100)
 
 ___
 
@@ -284,7 +284,7 @@ key-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:76](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/sdk.ts#L76)
+[sdk/src/sdk.ts:76](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/sdk.ts#L76)
 
 ___
 
@@ -302,7 +302,7 @@ Masp utilities for handling params
 
 #### Defined in
 
-[sdk/src/sdk.ts:92](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/sdk.ts#L92)
+[sdk/src/sdk.ts:92](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/sdk.ts#L92)
 
 ___
 
@@ -320,7 +320,7 @@ mnemonic-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:68](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/sdk.ts#L68)
+[sdk/src/sdk.ts:68](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/sdk.ts#L68)
 
 ___
 
@@ -338,7 +338,7 @@ Namada RPC client
 
 #### Defined in
 
-[sdk/src/sdk.ts:52](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/sdk.ts#L52)
+[sdk/src/sdk.ts:52](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/sdk.ts#L52)
 
 ___
 
@@ -356,7 +356,7 @@ Non-Tx signing functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:84](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/sdk.ts#L84)
+[sdk/src/sdk.ts:84](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/sdk.ts#L84)
 
 ___
 
@@ -374,7 +374,7 @@ Tx-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:60](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/sdk.ts#L60)
+[sdk/src/sdk.ts:60](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/sdk.ts#L60)
 
 ___
 
@@ -400,7 +400,7 @@ Class for interacting with NamadaApp for Ledger Hardware Wallets
 
 #### Defined in
 
-[sdk/src/sdk.ts:110](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/sdk.ts#L110)
+[sdk/src/sdk.ts:110](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/sdk.ts#L110)
 
 ___
 
@@ -425,4 +425,4 @@ this instance of Sdk
 
 #### Defined in
 
-[sdk/src/sdk.ts:37](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/sdk.ts#L37)
+[sdk/src/sdk.ts:37](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/sdk.ts#L37)

--- a/packages/sdk/docs/classes/Signing.md
+++ b/packages/sdk/docs/classes/Signing.md
@@ -40,7 +40,7 @@ Signing constructor
 
 #### Defined in
 
-[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/signing.ts#L14)
+[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/signing.ts#L14)
 
 ## Properties
 
@@ -52,7 +52,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/signing.ts#L14)
+[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/signing.ts#L14)
 
 ## Methods
 
@@ -78,7 +78,7 @@ signed tx bytes - Promise resolving to Uint8Array
 
 #### Defined in
 
-[sdk/src/signing.ts:23](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/signing.ts#L23)
+[sdk/src/signing.ts:23](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/signing.ts#L23)
 
 ___
 
@@ -103,7 +103,7 @@ hash and signature
 
 #### Defined in
 
-[sdk/src/signing.ts:41](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/signing.ts#L41)
+[sdk/src/signing.ts:41](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/signing.ts#L41)
 
 ___
 
@@ -129,4 +129,4 @@ void
 
 #### Defined in
 
-[sdk/src/signing.ts:52](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/signing.ts#L52)
+[sdk/src/signing.ts:52](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/signing.ts#L52)

--- a/packages/sdk/docs/classes/Tx.md
+++ b/packages/sdk/docs/classes/Tx.md
@@ -24,12 +24,16 @@ SDK functionality related to transactions
 - [buildIbcTransfer](Tx.md#buildibctransfer)
 - [buildRedelegate](Tx.md#buildredelegate)
 - [buildRevealPk](Tx.md#buildrevealpk)
+- [buildShieldedTransfer](Tx.md#buildshieldedtransfer)
+- [buildShieldingTransfer](Tx.md#buildshieldingtransfer)
 - [buildTransparentTransfer](Tx.md#buildtransparenttransfer)
 - [buildUnbond](Tx.md#buildunbond)
+- [buildUnshieldingTransfer](Tx.md#buildunshieldingtransfer)
 - [buildVoteProposal](Tx.md#buildvoteproposal)
 - [buildWithdraw](Tx.md#buildwithdraw)
 - [deserialize](Tx.md#deserialize)
 - [encodeTxArgs](Tx.md#encodetxargs)
+- [getInnerTxHashes](Tx.md#getinnertxhashes)
 
 ## Constructors
 
@@ -49,7 +53,7 @@ SDK functionality related to transactions
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:44](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/tx/tx.ts#L44)
+[sdk/src/tx/tx.ts:55](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/tx/tx.ts#L55)
 
 ## Properties
 
@@ -61,7 +65,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:44](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/tx/tx.ts#L44)
+[sdk/src/tx/tx.ts:55](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/tx/tx.ts#L55)
 
 ## Methods
 
@@ -86,7 +90,7 @@ Append signature for transactions signed by Ledger Hardware Wallet
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:285](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/tx/tx.ts#L285)
+[sdk/src/tx/tx.ts:371](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/tx/tx.ts#L371)
 
 ___
 
@@ -110,7 +114,7 @@ a serialized TxMsgValue type
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:268](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/tx/tx.ts#L268)
+[sdk/src/tx/tx.ts:354](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/tx/tx.ts#L354)
 
 ___
 
@@ -137,7 +141,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:90](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/tx/tx.ts#L90)
+[sdk/src/tx/tx.ts:176](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/tx/tx.ts#L176)
 
 ___
 
@@ -164,7 +168,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:247](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/tx/tx.ts#L247)
+[sdk/src/tx/tx.ts:333](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/tx/tx.ts#L333)
 
 ___
 
@@ -191,7 +195,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:200](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/tx/tx.ts#L200)
+[sdk/src/tx/tx.ts:286](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/tx/tx.ts#L286)
 
 ___
 
@@ -218,7 +222,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:177](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/tx/tx.ts#L177)
+[sdk/src/tx/tx.ts:263](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/tx/tx.ts#L263)
 
 ___
 
@@ -245,7 +249,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:154](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/tx/tx.ts#L154)
+[sdk/src/tx/tx.ts:240](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/tx/tx.ts#L240)
 
 ___
 
@@ -271,7 +275,61 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:77](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/tx/tx.ts#L77)
+[sdk/src/tx/tx.ts:163](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/tx/tx.ts#L163)
+
+___
+
+### buildShieldedTransfer
+
+▸ **buildShieldedTransfer**(`wrapperTxProps`, `shieldedTransferProps`): `Promise`\<`TxMsgValue`\>
+
+Build Shielded Transfer Tx
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `wrapperTxProps` | `WrapperTxMsgValue` | properties of the transaction |
+| `shieldedTransferProps` | `ShieldedTransferMsgValue` | properties of the shielded transfer |
+
+#### Returns
+
+`Promise`\<`TxMsgValue`\>
+
+promise that resolves to an TxMsgValue
+
+**`Async`**
+
+#### Defined in
+
+[sdk/src/tx/tx.ts:89](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/tx/tx.ts#L89)
+
+___
+
+### buildShieldingTransfer
+
+▸ **buildShieldingTransfer**(`wrapperTxProps`, `shieldingTransferProps`): `Promise`\<`TxMsgValue`\>
+
+Build Shielding Transfer Tx
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `wrapperTxProps` | `WrapperTxMsgValue` | properties of the transaction |
+| `shieldingTransferProps` | `ShieldingTransferMsgValue` | properties of the shielding transfer |
+
+#### Returns
+
+`Promise`\<`TxMsgValue`\>
+
+promise that resolves to an TxMsgValue
+
+**`Async`**
+
+#### Defined in
+
+[sdk/src/tx/tx.ts:114](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/tx/tx.ts#L114)
 
 ___
 
@@ -279,7 +337,7 @@ ___
 
 ▸ **buildTransparentTransfer**(`wrapperTxProps`, `transferProps`): `Promise`\<`TxMsgValue`\>
 
-Build Transfer Tx
+Build Transparent Transfer Tx
 
 #### Parameters
 
@@ -298,7 +356,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:53](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/tx/tx.ts#L53)
+[sdk/src/tx/tx.ts:64](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/tx/tx.ts#L64)
 
 ___
 
@@ -325,7 +383,34 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:111](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/tx/tx.ts#L111)
+[sdk/src/tx/tx.ts:197](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/tx/tx.ts#L197)
+
+___
+
+### buildUnshieldingTransfer
+
+▸ **buildUnshieldingTransfer**(`wrapperTxProps`, `unshieldingTransferProps`): `Promise`\<`TxMsgValue`\>
+
+Build Unshielding Transfer Tx
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `wrapperTxProps` | `WrapperTxMsgValue` | properties of the transaction |
+| `unshieldingTransferProps` | `UnshieldingTransferMsgValue` | properties of the unshielding transfer |
+
+#### Returns
+
+`Promise`\<`TxMsgValue`\>
+
+promise that resolves to an TxMsgValue
+
+**`Async`**
+
+#### Defined in
+
+[sdk/src/tx/tx.ts:139](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/tx/tx.ts#L139)
 
 ___
 
@@ -352,7 +437,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:223](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/tx/tx.ts#L223)
+[sdk/src/tx/tx.ts:309](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/tx/tx.ts#L309)
 
 ___
 
@@ -379,7 +464,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:133](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/tx/tx.ts#L133)
+[sdk/src/tx/tx.ts:219](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/tx/tx.ts#L219)
 
 ___
 
@@ -404,7 +489,7 @@ a TxDetails object
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:338](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/tx/tx.ts#L338)
+[sdk/src/tx/tx.ts:424](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/tx/tx.ts#L424)
 
 ___
 
@@ -428,4 +513,28 @@ Serialized WrapperTxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:326](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/tx/tx.ts#L326)
+[sdk/src/tx/tx.ts:412](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/tx/tx.ts#L412)
+
+___
+
+### getInnerTxHashes
+
+▸ **getInnerTxHashes**(`bytes`): `string`[]
+
+Return the inner tx hashes from the provided tx bytes
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `bytes` | `Uint8Array` | Uint8Array |
+
+#### Returns
+
+`string`[]
+
+array of inner Tx hashes
+
+#### Defined in
+
+[sdk/src/tx/tx.ts:480](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/tx/tx.ts#L480)

--- a/packages/sdk/docs/enums/KdfType.md
+++ b/packages/sdk/docs/enums/KdfType.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:38](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/crypto/types.ts#L38)
+[sdk/src/crypto/types.ts:38](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/crypto/types.ts#L38)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:39](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/crypto/types.ts#L39)
+[sdk/src/crypto/types.ts:39](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/crypto/types.ts#L39)

--- a/packages/sdk/docs/enums/TxType.md
+++ b/packages/sdk/docs/enums/TxType.md
@@ -26,7 +26,7 @@
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:32
+shared/src/shared/shared.d.ts:37
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:23
+shared/src/shared/shared.d.ts:28
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:33
+shared/src/shared/shared.d.ts:38
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:28
+shared/src/shared/shared.d.ts:33
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:27
+shared/src/shared/shared.d.ts:32
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:31
+shared/src/shared/shared.d.ts:36
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:29
+shared/src/shared/shared.d.ts:34
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:26
+shared/src/shared/shared.d.ts:31
 
 ___
 
@@ -106,7 +106,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:24
+shared/src/shared/shared.d.ts:29
 
 ___
 
@@ -116,7 +116,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:30
+shared/src/shared/shared.d.ts:35
 
 ___
 
@@ -126,4 +126,4 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:25
+shared/src/shared/shared.d.ts:30

--- a/packages/sdk/docs/modules.md
+++ b/packages/sdk/docs/modules.md
@@ -69,7 +69,7 @@ Address and public key type
 
 #### Defined in
 
-[sdk/src/keys/types.ts:4](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/keys/types.ts#L4)
+[sdk/src/keys/types.ts:4](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/keys/types.ts#L4)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:16](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/ledger.ts#L16)
+[sdk/src/ledger.ts:16](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/ledger.ts#L16)
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:23](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/crypto/types.ts#L23)
+[sdk/src/crypto/types.ts:23](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/crypto/types.ts#L23)
 
 ___
 
@@ -109,7 +109,7 @@ Balance
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:69](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/types.ts#L69)
+[sdk/src/rpc/types.ts:69](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/types.ts#L69)
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:27](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/types.ts#L27)
+[sdk/src/rpc/types.ts:27](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/types.ts#L27)
 
 ___
 
@@ -156,7 +156,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:42](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/crypto/types.ts#L42)
+[sdk/src/crypto/types.ts:42](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/crypto/types.ts#L42)
 
 ___
 
@@ -169,7 +169,7 @@ Record<address, totalDelegations>
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:51](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/types.ts#L51)
+[sdk/src/rpc/types.ts:51](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/types.ts#L51)
 
 ___
 
@@ -182,7 +182,7 @@ Record<address, boolean>
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:57](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/types.ts#L57)
+[sdk/src/rpc/types.ts:57](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/types.ts#L57)
 
 ___
 
@@ -201,7 +201,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:30](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/crypto/types.ts#L30)
+[sdk/src/crypto/types.ts:30](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/crypto/types.ts#L30)
 
 ___
 
@@ -218,7 +218,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:17](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/ledger.ts#L17)
+[sdk/src/ledger.ts:17](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/ledger.ts#L17)
 
 ___
 
@@ -238,7 +238,7 @@ Shielded keys and address
 
 #### Defined in
 
-[sdk/src/keys/types.ts:19](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/keys/types.ts#L19)
+[sdk/src/keys/types.ts:19](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/keys/types.ts#L19)
 
 ___
 
@@ -255,7 +255,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:42](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/types.ts#L42)
+[sdk/src/rpc/types.ts:42](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/types.ts#L42)
 
 ___
 
@@ -275,7 +275,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:19](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/types.ts#L19)
+[sdk/src/rpc/types.ts:19](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/types.ts#L19)
 
 ___
 
@@ -285,7 +285,7 @@ ___
 
 #### Defined in
 
-[shared/src/types.ts:3](https://github.com/anoma/namada-interface/blob/48e796bf/packages/shared/src/types.ts#L3)
+[shared/src/types.ts:3](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/shared/src/types.ts#L3)
 
 ___
 
@@ -297,7 +297,7 @@ Public and private keypair with address
 
 #### Defined in
 
-[sdk/src/keys/types.ts:12](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/keys/types.ts#L12)
+[sdk/src/keys/types.ts:12](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/keys/types.ts#L12)
 
 ___
 
@@ -317,7 +317,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:34](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/rpc/types.ts#L34)
+[sdk/src/rpc/types.ts:34](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/rpc/types.ts#L34)
 
 ## Variables
 
@@ -335,7 +335,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:3](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/crypto/types.ts#L3)
+[sdk/src/crypto/types.ts:3](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/crypto/types.ts#L3)
 
 ___
 
@@ -345,7 +345,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:40](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/ledger.ts#L40)
+[sdk/src/ledger.ts:40](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/ledger.ts#L40)
 
 ___
 
@@ -355,7 +355,7 @@ ___
 
 #### Defined in
 
-[shared/src/types.ts:28](https://github.com/anoma/namada-interface/blob/48e796bf/packages/shared/src/types.ts#L28)
+[shared/src/types.ts:28](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/shared/src/types.ts#L28)
 
 ## Functions
 
@@ -375,7 +375,7 @@ Transport object
 
 #### Defined in
 
-[sdk/src/ledger.ts:36](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/ledger.ts#L36)
+[sdk/src/ledger.ts:36](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/ledger.ts#L36)
 
 ___
 
@@ -395,7 +395,7 @@ Transport object
 
 #### Defined in
 
-[sdk/src/ledger.ts:27](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/ledger.ts#L27)
+[sdk/src/ledger.ts:27](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/ledger.ts#L27)
 
 ___
 
@@ -415,4 +415,4 @@ ___
 
 #### Defined in
 
-[sdk/src/keys/keys.ts:173](https://github.com/anoma/namada-interface/blob/48e796bf/packages/sdk/src/keys/keys.ts#L173)
+[sdk/src/keys/keys.ts:173](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/sdk/src/keys/keys.ts#L173)

--- a/packages/sdk/src/tx/tx.ts
+++ b/packages/sdk/src/tx/tx.ts
@@ -18,6 +18,10 @@ import {
   RedelegateMsgValue,
   RedelegateProps,
   RevealPkMsgValue,
+  ShieldedTransferMsgValue,
+  ShieldedTransferProps,
+  ShieldingTransferMsgValue,
+  ShieldingTransferProps,
   SignatureMsgValue,
   SupportedTxProps,
   TransferMsgValue,
@@ -29,6 +33,8 @@ import {
   TxProps,
   UnbondMsgValue,
   UnbondProps,
+  UnshieldingTransferMsgValue,
+  UnshieldingTransferProps,
   VoteProposalMsgValue,
   VoteProposalProps,
   WithdrawMsgValue,
@@ -49,7 +55,7 @@ export class Tx {
   constructor(protected readonly sdk: SdkWasm) {}
 
   /**
-   * Build Transfer Tx
+   * Build Transparent Transfer Tx
    * @async
    * @param wrapperTxProps - properties of the transaction
    * @param transferProps -  properties of the transfer
@@ -67,6 +73,81 @@ export class Tx {
     );
 
     const serializedTx = await this.sdk.build_transparent_transfer(
+      encodedTransfer,
+      encodedWrapperArgs
+    );
+    return deserialize(Buffer.from(serializedTx), TxMsgValue);
+  }
+
+  /**
+   * Build Shielded Transfer Tx
+   * @async
+   * @param wrapperTxProps - properties of the transaction
+   * @param shieldedTransferProps -  properties of the shielded transfer
+   * @returns promise that resolves to an TxMsgValue
+   */
+  async buildShieldedTransfer(
+    wrapperTxProps: WrapperTxProps,
+    shieldedTransferProps: ShieldedTransferProps
+  ): Promise<TxMsgValue> {
+    const shieldedTransferMsg = new Message<ShieldedTransferMsgValue>();
+
+    const encodedWrapperArgs = this.encodeTxArgs(wrapperTxProps);
+    const encodedTransfer = shieldedTransferMsg.encode(
+      new ShieldedTransferMsgValue(shieldedTransferProps)
+    );
+
+    const serializedTx = await this.sdk.build_shielded_transfer(
+      encodedTransfer,
+      encodedWrapperArgs
+    );
+    return deserialize(Buffer.from(serializedTx), TxMsgValue);
+  }
+
+  /**
+   * Build Shielding Transfer Tx
+   * @async
+   * @param wrapperTxProps - properties of the transaction
+   * @param shieldingTransferProps -  properties of the shielding transfer
+   * @returns promise that resolves to an TxMsgValue
+   */
+  async buildShieldingTransfer(
+    wrapperTxProps: WrapperTxProps,
+    shieldingTransferProps: ShieldingTransferProps
+  ): Promise<TxMsgValue> {
+    const shieldingTransferMsg = new Message<ShieldingTransferMsgValue>();
+
+    const encodedWrapperArgs = this.encodeTxArgs(wrapperTxProps);
+    const encodedTransfer = shieldingTransferMsg.encode(
+      new ShieldingTransferMsgValue(shieldingTransferProps)
+    );
+
+    const serializedTx = await this.sdk.build_shielding_transfer(
+      encodedTransfer,
+      encodedWrapperArgs
+    );
+    return deserialize(Buffer.from(serializedTx), TxMsgValue);
+  }
+
+  /**
+   * Build Unshielding Transfer Tx
+   * @async
+   * @param wrapperTxProps - properties of the transaction
+   * @param unshieldingTransferProps -  properties of the unshielding transfer
+   * @returns promise that resolves to an TxMsgValue
+   */
+  async buildUnshieldingTransfer(
+    wrapperTxProps: WrapperTxProps,
+    unshieldingTransferProps: UnshieldingTransferProps
+  ): Promise<TxMsgValue> {
+    const shieldingTransferMsg = new Message<UnshieldingTransferMsgValue>();
+
+    const encodedWrapperArgs = this.encodeTxArgs(wrapperTxProps);
+    const encodedTransfer = shieldingTransferMsg.encode(
+      new UnshieldingTransferMsgValue(unshieldingTransferProps)
+    );
+
+    const serializedTx = await this.sdk.build_unshielding_transfer(
       encodedTransfer,
       encodedWrapperArgs
     );

--- a/packages/shared/lib/src/sdk/mod.rs
+++ b/packages/shared/lib/src/sdk/mod.rs
@@ -24,7 +24,8 @@ use namada_sdk::signing::SigningTxData;
 use namada_sdk::string_encoding::Format;
 use namada_sdk::tx::{
     build_batch, build_bond, build_claim_rewards, build_ibc_transfer, build_redelegation,
-    build_reveal_pk, build_transparent_transfer, build_unbond, build_vote_proposal, build_withdraw,
+    build_reveal_pk, build_shielded_transfer, build_shielding_transfer, build_transparent_transfer,
+    build_unbond, build_unshielding_transfer, build_vote_proposal, build_withdraw,
     data::compute_inner_tx_hash, either::Either, process_tx, ProcessTxResponse, Tx,
 };
 use namada_sdk::wallet::{Store, Wallet};
@@ -324,6 +325,38 @@ impl Sdk {
     ) -> Result<JsValue, JsError> {
         let mut args = args::transparent_transfer_tx_args(transfer_msg, wrapper_tx_msg)?;
         let (tx, signing_data) = build_transparent_transfer(&self.namada, &mut args).await?;
+        self.serialize_tx_result(tx, wrapper_tx_msg, signing_data)
+    }
+
+    pub async fn build_shielded_transfer(
+        &self,
+        shielded_transfer_msg: &[u8],
+        wrapper_tx_msg: &[u8],
+    ) -> Result<JsValue, JsError> {
+        let mut args = args::shielded_transfer_tx_args(shielded_transfer_msg, wrapper_tx_msg)?;
+        let (tx, signing_data) = build_shielded_transfer(&self.namada, &mut args).await?;
+        self.serialize_tx_result(tx, wrapper_tx_msg, signing_data)
+    }
+
+    pub async fn build_unshielding_transfer(
+        &self,
+        unshielding_transfer_msg: &[u8],
+        wrapper_tx_msg: &[u8],
+    ) -> Result<JsValue, JsError> {
+        let mut args =
+            args::unshielding_transfer_tx_args(unshielding_transfer_msg, wrapper_tx_msg)?;
+        let (tx, signing_data) = build_unshielding_transfer(&self.namada, &mut args).await?;
+        self.serialize_tx_result(tx, wrapper_tx_msg, signing_data)
+    }
+
+    pub async fn build_shielding_transfer(
+        &self,
+        shielding_transfer_msg: &[u8],
+        wrapper_tx_msg: &[u8],
+    ) -> Result<JsValue, JsError> {
+        let mut args = args::shielding_transfer_tx_args(shielding_transfer_msg, wrapper_tx_msg)?;
+        let (tx, signing_data, _masp_epoch) =
+            build_shielding_transfer(&self.namada, &mut args).await?;
         self.serialize_tx_result(tx, wrapper_tx_msg, signing_data)
     }
 

--- a/packages/shared/lib/src/sdk/transaction.rs
+++ b/packages/shared/lib/src/sdk/transaction.rs
@@ -1,3 +1,4 @@
+use namada_sdk::borsh::BorshSerializeExt;
 use namada_sdk::token::Transfer;
 use serde::Serialize;
 
@@ -136,9 +137,17 @@ impl TransactionKind {
                 let Transfer {
                     sources,
                     targets,
-                    // TODO: Implement
-                    shielded_section_hash: _,
+                    shielded_section_hash,
                 } = transfer;
+
+                let ssh = match shielded_section_hash {
+                    Some(masp_tx_id) => {
+                        // Serialize and return bytes
+                        let bytes = masp_tx_id.serialize_to_vec();
+                        Some(bytes)
+                    }
+                    None => None,
+                };
 
                 let mut sources_data: Vec<TransferDataMsg> = vec![];
                 let mut targets_data: Vec<TransferDataMsg> = vec![];
@@ -157,7 +166,7 @@ impl TransactionKind {
                     targets_data.push(TransferDataMsg::new(owner, token, amount))
                 }
 
-                borsh::to_vec(&TransferMsg::new(sources_data, targets_data, None))?
+                borsh::to_vec(&TransferMsg::new(sources_data, targets_data, ssh))?
             }
             TransactionKind::ProposalVote(vote_proposal) => {
                 let VoteProposalData { id, vote, voter } = vote_proposal;

--- a/packages/types/docs/classes/BatchTxResultMsgValue.md
+++ b/packages/types/docs/classes/BatchTxResultMsgValue.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[tx/schema/batchTxResult.ts:12](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/batchTxResult.ts#L12)
+[tx/schema/batchTxResult.ts:12](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/batchTxResult.ts#L12)
 
 ## Properties
 
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[tx/schema/batchTxResult.ts:7](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/batchTxResult.ts#L7)
+[tx/schema/batchTxResult.ts:7](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/batchTxResult.ts#L7)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[tx/schema/batchTxResult.ts:10](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/batchTxResult.ts#L10)
+[tx/schema/batchTxResult.ts:10](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/batchTxResult.ts#L10)

--- a/packages/types/docs/classes/BondMsgValue.md
+++ b/packages/types/docs/classes/BondMsgValue.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[tx/schema/bond.ts:17](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/bond.ts#L17)
+[tx/schema/bond.ts:17](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/bond.ts#L17)
 
 ## Properties
 
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[tx/schema/bond.ts:15](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/bond.ts#L15)
+[tx/schema/bond.ts:15](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/bond.ts#L15)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[tx/schema/bond.ts:9](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/bond.ts#L9)
+[tx/schema/bond.ts:9](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/bond.ts#L9)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[tx/schema/bond.ts:12](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/bond.ts#L12)
+[tx/schema/bond.ts:12](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/bond.ts#L12)

--- a/packages/types/docs/classes/ClaimRewardsMsgValue.md
+++ b/packages/types/docs/classes/ClaimRewardsMsgValue.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[tx/schema/claimRewards.ts:12](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/claimRewards.ts#L12)
+[tx/schema/claimRewards.ts:12](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/claimRewards.ts#L12)
 
 ## Properties
 
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[tx/schema/claimRewards.ts:10](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/claimRewards.ts#L10)
+[tx/schema/claimRewards.ts:10](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/claimRewards.ts#L10)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[tx/schema/claimRewards.ts:7](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/claimRewards.ts#L7)
+[tx/schema/claimRewards.ts:7](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/claimRewards.ts#L7)

--- a/packages/types/docs/classes/CommitmentMsgValue.md
+++ b/packages/types/docs/classes/CommitmentMsgValue.md
@@ -34,7 +34,7 @@
 
 #### Defined in
 
-[tx/schema/txDetails.ts:19](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/txDetails.ts#L19)
+[tx/schema/txDetails.ts:19](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/txDetails.ts#L19)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:10](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/txDetails.ts#L10)
+[tx/schema/txDetails.ts:10](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/txDetails.ts#L10)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:16](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/txDetails.ts#L16)
+[tx/schema/txDetails.ts:16](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/txDetails.ts#L16)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:13](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/txDetails.ts#L13)
+[tx/schema/txDetails.ts:13](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/txDetails.ts#L13)
 
 ___
 
@@ -74,4 +74,4 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:7](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/txDetails.ts#L7)
+[tx/schema/txDetails.ts:7](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/txDetails.ts#L7)

--- a/packages/types/docs/classes/EthBridgeTransferMsgValue.md
+++ b/packages/types/docs/classes/EthBridgeTransferMsgValue.md
@@ -37,7 +37,7 @@
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:32](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/ethBridgeTransfer.ts#L32)
+[tx/schema/ethBridgeTransfer.ts:32](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/ethBridgeTransfer.ts#L32)
 
 ## Properties
 
@@ -47,7 +47,7 @@
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:21](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/ethBridgeTransfer.ts#L21)
+[tx/schema/ethBridgeTransfer.ts:21](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/ethBridgeTransfer.ts#L21)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:12](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/ethBridgeTransfer.ts#L12)
+[tx/schema/ethBridgeTransfer.ts:12](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/ethBridgeTransfer.ts#L12)
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:24](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/ethBridgeTransfer.ts#L24)
+[tx/schema/ethBridgeTransfer.ts:24](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/ethBridgeTransfer.ts#L24)
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:27](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/ethBridgeTransfer.ts#L27)
+[tx/schema/ethBridgeTransfer.ts:27](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/ethBridgeTransfer.ts#L27)
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:30](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/ethBridgeTransfer.ts#L30)
+[tx/schema/ethBridgeTransfer.ts:30](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/ethBridgeTransfer.ts#L30)
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:9](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/ethBridgeTransfer.ts#L9)
+[tx/schema/ethBridgeTransfer.ts:9](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/ethBridgeTransfer.ts#L9)
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:15](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/ethBridgeTransfer.ts#L15)
+[tx/schema/ethBridgeTransfer.ts:15](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/ethBridgeTransfer.ts#L15)
 
 ___
 
@@ -117,4 +117,4 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:18](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/ethBridgeTransfer.ts#L18)
+[tx/schema/ethBridgeTransfer.ts:18](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/ethBridgeTransfer.ts#L18)

--- a/packages/types/docs/classes/IbcTransferMsgValue.md
+++ b/packages/types/docs/classes/IbcTransferMsgValue.md
@@ -39,7 +39,7 @@
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:38](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/ibcTransfer.ts#L38)
+[tx/schema/ibcTransfer.ts:38](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/ibcTransfer.ts#L38)
 
 ## Properties
 
@@ -49,7 +49,7 @@
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:18](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/ibcTransfer.ts#L18)
+[tx/schema/ibcTransfer.ts:18](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/ibcTransfer.ts#L18)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:24](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/ibcTransfer.ts#L24)
+[tx/schema/ibcTransfer.ts:24](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/ibcTransfer.ts#L24)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:33](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/ibcTransfer.ts#L33)
+[tx/schema/ibcTransfer.ts:33](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/ibcTransfer.ts#L33)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:21](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/ibcTransfer.ts#L21)
+[tx/schema/ibcTransfer.ts:21](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/ibcTransfer.ts#L21)
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:12](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/ibcTransfer.ts#L12)
+[tx/schema/ibcTransfer.ts:12](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/ibcTransfer.ts#L12)
 
 ___
 
@@ -99,7 +99,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:36](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/ibcTransfer.ts#L36)
+[tx/schema/ibcTransfer.ts:36](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/ibcTransfer.ts#L36)
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:9](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/ibcTransfer.ts#L9)
+[tx/schema/ibcTransfer.ts:9](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/ibcTransfer.ts#L9)
 
 ___
 
@@ -119,7 +119,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:27](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/ibcTransfer.ts#L27)
+[tx/schema/ibcTransfer.ts:27](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/ibcTransfer.ts#L27)
 
 ___
 
@@ -129,7 +129,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:30](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/ibcTransfer.ts#L30)
+[tx/schema/ibcTransfer.ts:30](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/ibcTransfer.ts#L30)
 
 ___
 
@@ -139,4 +139,4 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:15](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/ibcTransfer.ts#L15)
+[tx/schema/ibcTransfer.ts:15](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/ibcTransfer.ts#L15)

--- a/packages/types/docs/classes/Message.md
+++ b/packages/types/docs/classes/Message.md
@@ -61,7 +61,7 @@
 
 #### Defined in
 
-[tx/messages/index.ts:9](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/messages/index.ts#L9)
+[tx/messages/index.ts:9](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/messages/index.ts#L9)
 
 ___
 
@@ -88,4 +88,4 @@ ___
 
 #### Defined in
 
-[tx/messages/index.ts:17](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/messages/index.ts#L17)
+[tx/messages/index.ts:17](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/messages/index.ts#L17)

--- a/packages/types/docs/classes/RedelegateMsgValue.md
+++ b/packages/types/docs/classes/RedelegateMsgValue.md
@@ -33,7 +33,7 @@
 
 #### Defined in
 
-[tx/schema/redelegate.ts:19](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/redelegate.ts#L19)
+[tx/schema/redelegate.ts:19](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/redelegate.ts#L19)
 
 ## Properties
 
@@ -43,7 +43,7 @@
 
 #### Defined in
 
-[tx/schema/redelegate.ts:17](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/redelegate.ts#L17)
+[tx/schema/redelegate.ts:17](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/redelegate.ts#L17)
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 #### Defined in
 
-[tx/schema/redelegate.ts:14](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/redelegate.ts#L14)
+[tx/schema/redelegate.ts:14](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/redelegate.ts#L14)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[tx/schema/redelegate.ts:8](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/redelegate.ts#L8)
+[tx/schema/redelegate.ts:8](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/redelegate.ts#L8)
 
 ___
 
@@ -73,4 +73,4 @@ ___
 
 #### Defined in
 
-[tx/schema/redelegate.ts:11](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/redelegate.ts#L11)
+[tx/schema/redelegate.ts:11](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/redelegate.ts#L11)

--- a/packages/types/docs/classes/RevealPkMsgValue.md
+++ b/packages/types/docs/classes/RevealPkMsgValue.md
@@ -30,7 +30,7 @@
 
 #### Defined in
 
-[tx/schema/revealPk.ts:8](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/revealPk.ts#L8)
+[tx/schema/revealPk.ts:8](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/revealPk.ts#L8)
 
 ## Properties
 
@@ -40,4 +40,4 @@
 
 #### Defined in
 
-[tx/schema/revealPk.ts:6](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/revealPk.ts#L6)
+[tx/schema/revealPk.ts:6](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/revealPk.ts#L6)

--- a/packages/types/docs/classes/ShieldedTransferDataMsgValue.md
+++ b/packages/types/docs/classes/ShieldedTransferDataMsgValue.md
@@ -1,0 +1,78 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / ShieldedTransferDataMsgValue
+
+# Class: ShieldedTransferDataMsgValue
+
+Shielded Transfer schemas
+
+## Table of contents
+
+### Constructors
+
+- [constructor](ShieldedTransferDataMsgValue.md#constructor)
+
+### Properties
+
+- [amount](ShieldedTransferDataMsgValue.md#amount)
+- [source](ShieldedTransferDataMsgValue.md#source)
+- [target](ShieldedTransferDataMsgValue.md#target)
+- [token](ShieldedTransferDataMsgValue.md#token)
+
+## Constructors
+
+### constructor
+
+• **new ShieldedTransferDataMsgValue**(`data`): [`ShieldedTransferDataMsgValue`](ShieldedTransferDataMsgValue.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | [`ShieldedTransferDataMsgValue`](ShieldedTransferDataMsgValue.md) |
+
+#### Returns
+
+[`ShieldedTransferDataMsgValue`](ShieldedTransferDataMsgValue.md)
+
+#### Defined in
+
+[tx/schema/transfer.ts:66](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L66)
+
+## Properties
+
+### amount
+
+• **amount**: `BigNumber`
+
+#### Defined in
+
+[tx/schema/transfer.ts:64](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L64)
+
+___
+
+### source
+
+• **source**: `string`
+
+#### Defined in
+
+[tx/schema/transfer.ts:55](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L55)
+
+___
+
+### target
+
+• **target**: `string`
+
+#### Defined in
+
+[tx/schema/transfer.ts:58](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L58)
+
+___
+
+### token
+
+• **token**: `string`
+
+#### Defined in
+
+[tx/schema/transfer.ts:61](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L61)

--- a/packages/types/docs/classes/ShieldedTransferMsgValue.md
+++ b/packages/types/docs/classes/ShieldedTransferMsgValue.md
@@ -1,0 +1,54 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / ShieldedTransferMsgValue
+
+# Class: ShieldedTransferMsgValue
+
+## Table of contents
+
+### Constructors
+
+- [constructor](ShieldedTransferMsgValue.md#constructor)
+
+### Properties
+
+- [data](ShieldedTransferMsgValue.md#data)
+- [gasSpendingKeys](ShieldedTransferMsgValue.md#gasspendingkeys)
+
+## Constructors
+
+### constructor
+
+• **new ShieldedTransferMsgValue**(`«destructured»`): [`ShieldedTransferMsgValue`](ShieldedTransferMsgValue.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `«destructured»` | [`ShieldedTransferMsgValue`](ShieldedTransferMsgValue.md) |
+
+#### Returns
+
+[`ShieldedTransferMsgValue`](ShieldedTransferMsgValue.md)
+
+#### Defined in
+
+[tx/schema/transfer.ts:78](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L78)
+
+## Properties
+
+### data
+
+• **data**: [`ShieldedTransferDataMsgValue`](ShieldedTransferDataMsgValue.md)[]
+
+#### Defined in
+
+[tx/schema/transfer.ts:73](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L73)
+
+___
+
+### gasSpendingKeys
+
+• **gasSpendingKeys**: `string`[]
+
+#### Defined in
+
+[tx/schema/transfer.ts:76](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L76)

--- a/packages/types/docs/classes/ShieldingTransferDataMsgValue.md
+++ b/packages/types/docs/classes/ShieldingTransferDataMsgValue.md
@@ -1,0 +1,67 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / ShieldingTransferDataMsgValue
+
+# Class: ShieldingTransferDataMsgValue
+
+Shielding Transfer schemas
+
+## Table of contents
+
+### Constructors
+
+- [constructor](ShieldingTransferDataMsgValue.md#constructor)
+
+### Properties
+
+- [amount](ShieldingTransferDataMsgValue.md#amount)
+- [source](ShieldingTransferDataMsgValue.md#source)
+- [token](ShieldingTransferDataMsgValue.md#token)
+
+## Constructors
+
+### constructor
+
+• **new ShieldingTransferDataMsgValue**(`data`): [`ShieldingTransferDataMsgValue`](ShieldingTransferDataMsgValue.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | [`ShieldingTransferDataMsgValue`](ShieldingTransferDataMsgValue.md) |
+
+#### Returns
+
+[`ShieldingTransferDataMsgValue`](ShieldingTransferDataMsgValue.md)
+
+#### Defined in
+
+[tx/schema/transfer.ts:102](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L102)
+
+## Properties
+
+### amount
+
+• **amount**: `BigNumber`
+
+#### Defined in
+
+[tx/schema/transfer.ts:100](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L100)
+
+___
+
+### source
+
+• **source**: `string`
+
+#### Defined in
+
+[tx/schema/transfer.ts:94](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L94)
+
+___
+
+### token
+
+• **token**: `string`
+
+#### Defined in
+
+[tx/schema/transfer.ts:97](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L97)

--- a/packages/types/docs/classes/ShieldingTransferMsgValue.md
+++ b/packages/types/docs/classes/ShieldingTransferMsgValue.md
@@ -1,0 +1,43 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / ShieldingTransferMsgValue
+
+# Class: ShieldingTransferMsgValue
+
+## Table of contents
+
+### Constructors
+
+- [constructor](ShieldingTransferMsgValue.md#constructor)
+
+### Properties
+
+- [data](ShieldingTransferMsgValue.md#data)
+
+## Constructors
+
+### constructor
+
+• **new ShieldingTransferMsgValue**(`«destructured»`): [`ShieldingTransferMsgValue`](ShieldingTransferMsgValue.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `«destructured»` | [`ShieldingTransferMsgValue`](ShieldingTransferMsgValue.md) |
+
+#### Returns
+
+[`ShieldingTransferMsgValue`](ShieldingTransferMsgValue.md)
+
+#### Defined in
+
+[tx/schema/transfer.ts:111](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L111)
+
+## Properties
+
+### data
+
+• **data**: [`ShieldingTransferDataMsgValue`](ShieldingTransferDataMsgValue.md)[]
+
+#### Defined in
+
+[tx/schema/transfer.ts:109](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L109)

--- a/packages/types/docs/classes/SignatureMsgValue.md
+++ b/packages/types/docs/classes/SignatureMsgValue.md
@@ -34,7 +34,7 @@
 
 #### Defined in
 
-[tx/schema/signature.ts:21](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/signature.ts#L21)
+[tx/schema/signature.ts:21](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/signature.ts#L21)
 
 ## Properties
 
@@ -44,7 +44,7 @@
 
 #### Defined in
 
-[tx/schema/signature.ts:7](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/signature.ts#L7)
+[tx/schema/signature.ts:7](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/signature.ts#L7)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[tx/schema/signature.ts:10](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/signature.ts#L10)
+[tx/schema/signature.ts:10](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/signature.ts#L10)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[tx/schema/signature.ts:13](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/signature.ts#L13)
+[tx/schema/signature.ts:13](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/signature.ts#L13)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[tx/schema/signature.ts:16](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/signature.ts#L16)
+[tx/schema/signature.ts:16](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/signature.ts#L16)
 
 ___
 
@@ -84,4 +84,4 @@ ___
 
 #### Defined in
 
-[tx/schema/signature.ts:19](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/signature.ts#L19)
+[tx/schema/signature.ts:19](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/signature.ts#L19)

--- a/packages/types/docs/classes/SigningDataMsgValue.md
+++ b/packages/types/docs/classes/SigningDataMsgValue.md
@@ -34,7 +34,7 @@
 
 #### Defined in
 
-[tx/schema/tx.ts:26](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/tx.ts#L26)
+[tx/schema/tx.ts:26](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/tx.ts#L26)
 
 ## Properties
 
@@ -44,7 +44,7 @@
 
 #### Defined in
 
-[tx/schema/tx.ts:21](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/tx.ts#L21)
+[tx/schema/tx.ts:21](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/tx.ts#L21)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[tx/schema/tx.ts:24](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/tx.ts#L24)
+[tx/schema/tx.ts:24](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/tx.ts#L24)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[tx/schema/tx.ts:8](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/tx.ts#L8)
+[tx/schema/tx.ts:8](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/tx.ts#L8)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[tx/schema/tx.ts:11](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/tx.ts#L11)
+[tx/schema/tx.ts:11](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/tx.ts#L11)
 
 ___
 
@@ -84,4 +84,4 @@ ___
 
 #### Defined in
 
-[tx/schema/tx.ts:14](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/tx.ts#L14)
+[tx/schema/tx.ts:14](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/tx.ts#L14)

--- a/packages/types/docs/classes/TransferDataMsgValue.md
+++ b/packages/types/docs/classes/TransferDataMsgValue.md
@@ -2,6 +2,8 @@
 
 # Class: TransferDataMsgValue
 
+General Transfer schema used for displaying details
+
 ## Table of contents
 
 ### Constructors
@@ -32,7 +34,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:49](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/transfer.ts#L49)
+[tx/schema/transfer.ts:172](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L172)
 
 ___
 
@@ -42,7 +44,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:43](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/transfer.ts#L43)
+[tx/schema/transfer.ts:166](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L166)
 
 ___
 
@@ -52,4 +54,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:46](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/transfer.ts#L46)
+[tx/schema/transfer.ts:169](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L169)

--- a/packages/types/docs/classes/TransferMsgValue.md
+++ b/packages/types/docs/classes/TransferMsgValue.md
@@ -28,11 +28,11 @@
 
 ### shieldedSectionHash
 
-• `Optional` **shieldedSectionHash**: `string`
+• `Optional` **shieldedSectionHash**: `Uint8Array`
 
 #### Defined in
 
-[tx/schema/transfer.ts:60](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/transfer.ts#L60)
+[tx/schema/transfer.ts:183](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L183)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:54](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/transfer.ts#L54)
+[tx/schema/transfer.ts:177](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L177)
 
 ___
 
@@ -52,4 +52,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:57](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/transfer.ts#L57)
+[tx/schema/transfer.ts:180](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L180)

--- a/packages/types/docs/classes/TransparentTransferDataMsgValue.md
+++ b/packages/types/docs/classes/TransparentTransferDataMsgValue.md
@@ -2,6 +2,8 @@
 
 # Class: TransparentTransferDataMsgValue
 
+Transparent Transfer schemas
+
 ## Table of contents
 
 ### Constructors
@@ -33,7 +35,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:23](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/transfer.ts#L23)
+[tx/schema/transfer.ts:32](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L32)
 
 ## Properties
 
@@ -43,7 +45,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:21](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/transfer.ts#L21)
+[tx/schema/transfer.ts:30](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L30)
 
 ___
 
@@ -53,7 +55,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:12](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/transfer.ts#L12)
+[tx/schema/transfer.ts:21](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L21)
 
 ___
 
@@ -63,7 +65,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:15](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/transfer.ts#L15)
+[tx/schema/transfer.ts:24](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L24)
 
 ___
 
@@ -73,4 +75,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:18](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/transfer.ts#L18)
+[tx/schema/transfer.ts:27](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L27)

--- a/packages/types/docs/classes/TransparentTransferMsgValue.md
+++ b/packages/types/docs/classes/TransparentTransferMsgValue.md
@@ -30,7 +30,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:32](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/transfer.ts#L32)
+[tx/schema/transfer.ts:41](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L41)
 
 ## Properties
 
@@ -40,4 +40,4 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:30](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/transfer.ts#L30)
+[tx/schema/transfer.ts:39](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L39)

--- a/packages/types/docs/classes/TxDetailsMsgValue.md
+++ b/packages/types/docs/classes/TxDetailsMsgValue.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[tx/schema/txDetails.ts:27](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/txDetails.ts#L27)
+[tx/schema/txDetails.ts:27](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/txDetails.ts#L27)
 
 ___
 
@@ -41,4 +41,4 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:24](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/txDetails.ts#L24)
+[tx/schema/txDetails.ts:24](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/txDetails.ts#L24)

--- a/packages/types/docs/classes/TxMsgValue.md
+++ b/packages/types/docs/classes/TxMsgValue.md
@@ -33,7 +33,7 @@
 
 #### Defined in
 
-[tx/schema/tx.ts:44](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/tx.ts#L44)
+[tx/schema/tx.ts:44](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/tx.ts#L44)
 
 ## Properties
 
@@ -43,7 +43,7 @@
 
 #### Defined in
 
-[tx/schema/tx.ts:33](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/tx.ts#L33)
+[tx/schema/tx.ts:33](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/tx.ts#L33)
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 #### Defined in
 
-[tx/schema/tx.ts:39](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/tx.ts#L39)
+[tx/schema/tx.ts:39](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/tx.ts#L39)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[tx/schema/tx.ts:36](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/tx.ts#L36)
+[tx/schema/tx.ts:36](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/tx.ts#L36)
 
 ___
 
@@ -73,4 +73,4 @@ ___
 
 #### Defined in
 
-[tx/schema/tx.ts:42](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/tx.ts#L42)
+[tx/schema/tx.ts:42](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/tx.ts#L42)

--- a/packages/types/docs/classes/TxResponseMsgValue.md
+++ b/packages/types/docs/classes/TxResponseMsgValue.md
@@ -36,7 +36,7 @@
 
 #### Defined in
 
-[tx/schema/txResponse.ts:28](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/txResponse.ts#L28)
+[tx/schema/txResponse.ts:28](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/txResponse.ts#L28)
 
 ## Properties
 
@@ -46,7 +46,7 @@
 
 #### Defined in
 
-[tx/schema/txResponse.ts:8](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/txResponse.ts#L8)
+[tx/schema/txResponse.ts:8](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/txResponse.ts#L8)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:11](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/txResponse.ts#L11)
+[tx/schema/txResponse.ts:11](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/txResponse.ts#L11)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:14](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/txResponse.ts#L14)
+[tx/schema/txResponse.ts:14](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/txResponse.ts#L14)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:17](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/txResponse.ts#L17)
+[tx/schema/txResponse.ts:17](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/txResponse.ts#L17)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:20](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/txResponse.ts#L20)
+[tx/schema/txResponse.ts:20](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/txResponse.ts#L20)
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:23](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/txResponse.ts#L23)
+[tx/schema/txResponse.ts:23](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/txResponse.ts#L23)
 
 ___
 
@@ -106,4 +106,4 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:26](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/txResponse.ts#L26)
+[tx/schema/txResponse.ts:26](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/txResponse.ts#L26)

--- a/packages/types/docs/classes/UnbondMsgValue.md
+++ b/packages/types/docs/classes/UnbondMsgValue.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[tx/schema/unbond.ts:17](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/unbond.ts#L17)
+[tx/schema/unbond.ts:17](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/unbond.ts#L17)
 
 ## Properties
 
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[tx/schema/unbond.ts:15](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/unbond.ts#L15)
+[tx/schema/unbond.ts:15](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/unbond.ts#L15)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[tx/schema/unbond.ts:9](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/unbond.ts#L9)
+[tx/schema/unbond.ts:9](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/unbond.ts#L9)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[tx/schema/unbond.ts:12](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/unbond.ts#L12)
+[tx/schema/unbond.ts:12](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/unbond.ts#L12)

--- a/packages/types/docs/classes/UnshieldingTransferDataMsgValue.md
+++ b/packages/types/docs/classes/UnshieldingTransferDataMsgValue.md
@@ -1,0 +1,67 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / UnshieldingTransferDataMsgValue
+
+# Class: UnshieldingTransferDataMsgValue
+
+Unshielding Transfer schemas
+
+## Table of contents
+
+### Constructors
+
+- [constructor](UnshieldingTransferDataMsgValue.md#constructor)
+
+### Properties
+
+- [amount](UnshieldingTransferDataMsgValue.md#amount)
+- [target](UnshieldingTransferDataMsgValue.md#target)
+- [token](UnshieldingTransferDataMsgValue.md#token)
+
+## Constructors
+
+### constructor
+
+• **new UnshieldingTransferDataMsgValue**(`data`): [`UnshieldingTransferDataMsgValue`](UnshieldingTransferDataMsgValue.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `data` | [`UnshieldingTransferDataMsgValue`](UnshieldingTransferDataMsgValue.md) |
+
+#### Returns
+
+[`UnshieldingTransferDataMsgValue`](UnshieldingTransferDataMsgValue.md)
+
+#### Defined in
+
+[tx/schema/transfer.ts:134](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L134)
+
+## Properties
+
+### amount
+
+• **amount**: `BigNumber`
+
+#### Defined in
+
+[tx/schema/transfer.ts:132](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L132)
+
+___
+
+### target
+
+• **target**: `string`
+
+#### Defined in
+
+[tx/schema/transfer.ts:126](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L126)
+
+___
+
+### token
+
+• **token**: `string`
+
+#### Defined in
+
+[tx/schema/transfer.ts:129](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L129)

--- a/packages/types/docs/classes/UnshieldingTransferMsgValue.md
+++ b/packages/types/docs/classes/UnshieldingTransferMsgValue.md
@@ -1,0 +1,65 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / UnshieldingTransferMsgValue
+
+# Class: UnshieldingTransferMsgValue
+
+## Table of contents
+
+### Constructors
+
+- [constructor](UnshieldingTransferMsgValue.md#constructor)
+
+### Properties
+
+- [data](UnshieldingTransferMsgValue.md#data)
+- [gasSpendingKeys](UnshieldingTransferMsgValue.md#gasspendingkeys)
+- [source](UnshieldingTransferMsgValue.md#source)
+
+## Constructors
+
+### constructor
+
+• **new UnshieldingTransferMsgValue**(`«destructured»`): [`UnshieldingTransferMsgValue`](UnshieldingTransferMsgValue.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `«destructured»` | [`UnshieldingTransferMsgValue`](UnshieldingTransferMsgValue.md) |
+
+#### Returns
+
+[`UnshieldingTransferMsgValue`](UnshieldingTransferMsgValue.md)
+
+#### Defined in
+
+[tx/schema/transfer.ts:149](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L149)
+
+## Properties
+
+### data
+
+• **data**: [`UnshieldingTransferDataMsgValue`](UnshieldingTransferDataMsgValue.md)[]
+
+#### Defined in
+
+[tx/schema/transfer.ts:144](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L144)
+
+___
+
+### gasSpendingKeys
+
+• **gasSpendingKeys**: `string`[]
+
+#### Defined in
+
+[tx/schema/transfer.ts:147](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L147)
+
+___
+
+### source
+
+• **source**: `string`
+
+#### Defined in
+
+[tx/schema/transfer.ts:141](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/transfer.ts#L141)

--- a/packages/types/docs/classes/VoteProposalMsgValue.md
+++ b/packages/types/docs/classes/VoteProposalMsgValue.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[tx/schema/voteProposal.ts:15](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/voteProposal.ts#L15)
+[tx/schema/voteProposal.ts:15](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/voteProposal.ts#L15)
 
 ## Properties
 
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[tx/schema/voteProposal.ts:10](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/voteProposal.ts#L10)
+[tx/schema/voteProposal.ts:10](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/voteProposal.ts#L10)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[tx/schema/voteProposal.ts:7](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/voteProposal.ts#L7)
+[tx/schema/voteProposal.ts:7](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/voteProposal.ts#L7)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[tx/schema/voteProposal.ts:13](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/voteProposal.ts#L13)
+[tx/schema/voteProposal.ts:13](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/voteProposal.ts#L13)

--- a/packages/types/docs/classes/WithdrawMsgValue.md
+++ b/packages/types/docs/classes/WithdrawMsgValue.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[tx/schema/withdraw.ts:12](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/withdraw.ts#L12)
+[tx/schema/withdraw.ts:12](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/withdraw.ts#L12)
 
 ## Properties
 
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[tx/schema/withdraw.ts:7](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/withdraw.ts#L7)
+[tx/schema/withdraw.ts:7](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/withdraw.ts#L7)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[tx/schema/withdraw.ts:10](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/withdraw.ts#L10)
+[tx/schema/withdraw.ts:10](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/withdraw.ts#L10)

--- a/packages/types/docs/classes/WrapperTxMsgValue.md
+++ b/packages/types/docs/classes/WrapperTxMsgValue.md
@@ -35,7 +35,7 @@
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:26](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/wrapperTx.ts#L26)
+[tx/schema/wrapperTx.ts:26](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/wrapperTx.ts#L26)
 
 ## Properties
 
@@ -45,7 +45,7 @@
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:18](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/wrapperTx.ts#L18)
+[tx/schema/wrapperTx.ts:18](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/wrapperTx.ts#L18)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:12](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/wrapperTx.ts#L12)
+[tx/schema/wrapperTx.ts:12](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/wrapperTx.ts#L12)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:15](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/wrapperTx.ts#L15)
+[tx/schema/wrapperTx.ts:15](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/wrapperTx.ts#L15)
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:24](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/wrapperTx.ts#L24)
+[tx/schema/wrapperTx.ts:24](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/wrapperTx.ts#L24)
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:21](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/wrapperTx.ts#L21)
+[tx/schema/wrapperTx.ts:21](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/wrapperTx.ts#L21)
 
 ___
 
@@ -95,4 +95,4 @@ ___
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:9](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/wrapperTx.ts#L9)
+[tx/schema/wrapperTx.ts:9](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/wrapperTx.ts#L9)

--- a/packages/types/docs/enums/AccountType.md
+++ b/packages/types/docs/enums/AccountType.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[account.ts:18](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/account.ts#L18)
+[account.ts:18](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/account.ts#L18)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[account.ts:12](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/account.ts#L12)
+[account.ts:12](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/account.ts#L12)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[account.ts:14](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/account.ts#L14)
+[account.ts:14](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/account.ts#L14)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[account.ts:16](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/account.ts#L16)
+[account.ts:16](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/account.ts#L16)

--- a/packages/types/docs/enums/BridgeType.md
+++ b/packages/types/docs/enums/BridgeType.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[chain.ts:14](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/chain.ts#L14)
+[chain.ts:14](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/chain.ts#L14)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[chain.ts:13](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/chain.ts#L13)
+[chain.ts:13](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/chain.ts#L13)

--- a/packages/types/docs/enums/Events.md
+++ b/packages/types/docs/enums/Events.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[events.ts:5](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/events.ts#L5)
+[events.ts:5](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/events.ts#L5)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[events.ts:8](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/events.ts#L8)
+[events.ts:8](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/events.ts#L8)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[events.ts:7](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/events.ts#L7)
+[events.ts:7](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/events.ts#L7)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[events.ts:6](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/events.ts#L6)
+[events.ts:6](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/events.ts#L6)

--- a/packages/types/docs/enums/KeplrEvents.md
+++ b/packages/types/docs/enums/KeplrEvents.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[events.ts:13](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/events.ts#L13)
+[events.ts:13](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/events.ts#L13)

--- a/packages/types/docs/enums/MetamaskEvents.md
+++ b/packages/types/docs/enums/MetamaskEvents.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[events.ts:18](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/events.ts#L18)
+[events.ts:18](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/events.ts#L18)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[events.ts:19](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/events.ts#L19)
+[events.ts:19](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/events.ts#L19)

--- a/packages/types/docs/interfaces/IMessage.md
+++ b/packages/types/docs/interfaces/IMessage.md
@@ -36,4 +36,4 @@
 
 #### Defined in
 
-[tx/messages/index.ts:5](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/messages/index.ts#L5)
+[tx/messages/index.ts:5](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/messages/index.ts#L5)

--- a/packages/types/docs/interfaces/Namada.md
+++ b/packages/types/docs/interfaces/Namada.md
@@ -14,9 +14,11 @@
 - [accounts](Namada.md#accounts)
 - [connect](Namada.md#connect)
 - [defaultAccount](Namada.md#defaultaccount)
+- [disconnect](Namada.md#disconnect)
 - [isConnected](Namada.md#isconnected)
 - [sign](Namada.md#sign)
 - [signArbitrary](Namada.md#signarbitrary)
+- [updateDefaultAccount](Namada.md#updatedefaultaccount)
 - [verify](Namada.md#verify)
 
 ## Properties
@@ -35,7 +37,7 @@
 
 #### Defined in
 
-[namada.ts:38](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/namada.ts#L38)
+[namada.ts:40](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/namada.ts#L40)
 
 ___
 
@@ -53,7 +55,7 @@ ___
 
 #### Defined in
 
-[namada.ts:39](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/namada.ts#L39)
+[namada.ts:41](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/namada.ts#L41)
 
 ## Methods
 
@@ -73,7 +75,7 @@ ___
 
 #### Defined in
 
-[namada.ts:29](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/namada.ts#L29)
+[namada.ts:29](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/namada.ts#L29)
 
 ___
 
@@ -87,7 +89,7 @@ ___
 
 #### Defined in
 
-[namada.ts:30](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/namada.ts#L30)
+[namada.ts:30](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/namada.ts#L30)
 
 ___
 
@@ -107,7 +109,21 @@ ___
 
 #### Defined in
 
-[namada.ts:32](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/namada.ts#L32)
+[namada.ts:33](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/namada.ts#L33)
+
+___
+
+### disconnect
+
+▸ **disconnect**(): `Promise`\<`void`\>
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Defined in
+
+[namada.ts:31](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/namada.ts#L31)
 
 ___
 
@@ -121,7 +137,7 @@ ___
 
 #### Defined in
 
-[namada.ts:31](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/namada.ts#L31)
+[namada.ts:32](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/namada.ts#L32)
 
 ___
 
@@ -141,7 +157,7 @@ ___
 
 #### Defined in
 
-[namada.ts:33](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/namada.ts#L33)
+[namada.ts:35](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/namada.ts#L35)
 
 ___
 
@@ -161,7 +177,27 @@ ___
 
 #### Defined in
 
-[namada.ts:34](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/namada.ts#L34)
+[namada.ts:36](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/namada.ts#L36)
+
+___
+
+### updateDefaultAccount
+
+▸ **updateDefaultAccount**(`address`): `Promise`\<`void`\>
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `address` | `string` |
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Defined in
+
+[namada.ts:34](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/namada.ts#L34)
 
 ___
 
@@ -181,4 +217,4 @@ ___
 
 #### Defined in
 
-[namada.ts:37](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/namada.ts#L37)
+[namada.ts:39](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/namada.ts#L39)

--- a/packages/types/docs/interfaces/Signer.md
+++ b/packages/types/docs/interfaces/Signer.md
@@ -34,7 +34,7 @@
 
 #### Defined in
 
-[signer.ts:10](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/signer.ts#L10)
+[signer.ts:10](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/signer.ts#L10)
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 #### Defined in
 
-[signer.ts:11](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/signer.ts#L11)
+[signer.ts:11](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/signer.ts#L11)
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 #### Defined in
 
-[signer.ts:12](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/signer.ts#L12)
+[signer.ts:12](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/signer.ts#L12)
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 #### Defined in
 
-[signer.ts:17](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/signer.ts#L17)
+[signer.ts:17](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/signer.ts#L17)
 
 ___
 
@@ -135,4 +135,4 @@ ___
 
 #### Defined in
 
-[signer.ts:21](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/signer.ts#L21)
+[signer.ts:21](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/signer.ts#L21)

--- a/packages/types/docs/modules.md
+++ b/packages/types/docs/modules.md
@@ -23,6 +23,10 @@
 - [Message](classes/Message.md)
 - [RedelegateMsgValue](classes/RedelegateMsgValue.md)
 - [RevealPkMsgValue](classes/RevealPkMsgValue.md)
+- [ShieldedTransferDataMsgValue](classes/ShieldedTransferDataMsgValue.md)
+- [ShieldedTransferMsgValue](classes/ShieldedTransferMsgValue.md)
+- [ShieldingTransferDataMsgValue](classes/ShieldingTransferDataMsgValue.md)
+- [ShieldingTransferMsgValue](classes/ShieldingTransferMsgValue.md)
 - [SignatureMsgValue](classes/SignatureMsgValue.md)
 - [SigningDataMsgValue](classes/SigningDataMsgValue.md)
 - [TransferDataMsgValue](classes/TransferDataMsgValue.md)
@@ -33,6 +37,8 @@
 - [TxMsgValue](classes/TxMsgValue.md)
 - [TxResponseMsgValue](classes/TxResponseMsgValue.md)
 - [UnbondMsgValue](classes/UnbondMsgValue.md)
+- [UnshieldingTransferDataMsgValue](classes/UnshieldingTransferDataMsgValue.md)
+- [UnshieldingTransferMsgValue](classes/UnshieldingTransferMsgValue.md)
 - [VoteProposalMsgValue](classes/VoteProposalMsgValue.md)
 - [WithdrawMsgValue](classes/WithdrawMsgValue.md)
 - [WrapperTxMsgValue](classes/WrapperTxMsgValue.md)
@@ -79,6 +85,10 @@
 - [RedelegateProps](modules.md#redelegateprops)
 - [RevealPkProps](modules.md#revealpkprops)
 - [Schema](modules.md#schema)
+- [ShieldedTransferDataProps](modules.md#shieldedtransferdataprops)
+- [ShieldedTransferProps](modules.md#shieldedtransferprops)
+- [ShieldingTransferDataProps](modules.md#shieldingtransferdataprops)
+- [ShieldingTransferProps](modules.md#shieldingtransferprops)
 - [SignArbitraryProps](modules.md#signarbitraryprops)
 - [SignArbitraryResponse](modules.md#signarbitraryresponse)
 - [SignProps](modules.md#signprops)
@@ -96,6 +106,8 @@
 - [TxProps](modules.md#txprops)
 - [TxResponseProps](modules.md#txresponseprops)
 - [UnbondProps](modules.md#unbondprops)
+- [UnshieldingTransferDataProps](modules.md#unshieldingtransferdataprops)
+- [UnshieldingTransferProps](modules.md#unshieldingtransferprops)
 - [ValidatorVote](modules.md#validatorvote)
 - [VerifyArbitraryProps](modules.md#verifyarbitraryprops)
 - [Vote](modules.md#vote)
@@ -136,7 +148,7 @@
 
 #### Defined in
 
-[account.ts:32](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/account.ts#L32)
+[account.ts:32](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/account.ts#L32)
 
 ___
 
@@ -153,7 +165,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:34](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L34)
+[proposals.ts:34](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L34)
 
 ___
 
@@ -170,7 +182,7 @@ ___
 
 #### Defined in
 
-[namada.ts:23](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/namada.ts#L23)
+[namada.ts:23](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/namada.ts#L23)
 
 ___
 
@@ -180,7 +192,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:22](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/types.ts#L22)
+[tx/types.ts:28](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L28)
 
 ___
 
@@ -198,7 +210,7 @@ ___
 
 #### Defined in
 
-[account.ts:3](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/account.ts#L3)
+[account.ts:3](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/account.ts#L3)
 
 ___
 
@@ -208,7 +220,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:23](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/types.ts#L23)
+[tx/types.ts:29](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L29)
 
 ___
 
@@ -235,7 +247,7 @@ ___
 
 #### Defined in
 
-[chain.ts:49](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/chain.ts#L49)
+[chain.ts:49](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/chain.ts#L49)
 
 ___
 
@@ -245,7 +257,7 @@ ___
 
 #### Defined in
 
-[chain.ts:21](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/chain.ts#L21)
+[chain.ts:21](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/chain.ts#L21)
 
 ___
 
@@ -255,7 +267,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:36](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/types.ts#L36)
+[tx/types.ts:48](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L48)
 
 ___
 
@@ -265,7 +277,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:53](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/types.ts#L53)
+[tx/types.ts:65](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L65)
 
 ___
 
@@ -275,7 +287,7 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:13](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tokens/Cosmos.ts#L13)
+[tokens/Cosmos.ts:13](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tokens/Cosmos.ts#L13)
 
 ___
 
@@ -285,7 +297,7 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:6](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tokens/Cosmos.ts#L6)
+[tokens/Cosmos.ts:6](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tokens/Cosmos.ts#L6)
 
 ___
 
@@ -307,7 +319,7 @@ ___
 
 #### Defined in
 
-[chain.ts:1](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/chain.ts#L1)
+[chain.ts:1](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/chain.ts#L1)
 
 ___
 
@@ -323,7 +335,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:55](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L55)
+[proposals.ts:55](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L55)
 
 ___
 
@@ -340,7 +352,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:56](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L56)
+[proposals.ts:56](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L56)
 
 ___
 
@@ -350,7 +362,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:84](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L84)
+[proposals.ts:84](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L84)
 
 ___
 
@@ -373,7 +385,7 @@ ___
 
 #### Defined in
 
-[account.ts:21](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/account.ts#L21)
+[account.ts:21](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/account.ts#L21)
 
 ___
 
@@ -383,7 +395,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:24](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/types.ts#L24)
+[tx/types.ts:30](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L30)
 
 ___
 
@@ -401,7 +413,7 @@ ___
 
 #### Defined in
 
-[chain.ts:23](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/chain.ts#L23)
+[chain.ts:23](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/chain.ts#L23)
 
 ___
 
@@ -411,7 +423,7 @@ ___
 
 #### Defined in
 
-[chain.ts:18](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/chain.ts#L18)
+[chain.ts:18](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/chain.ts#L18)
 
 ___
 
@@ -421,7 +433,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:25](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/types.ts#L25)
+[tx/types.ts:31](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L31)
 
 ___
 
@@ -431,7 +443,7 @@ ___
 
 #### Defined in
 
-[utils.ts:1](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/utils.ts#L1)
+[utils.ts:1](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/utils.ts#L1)
 
 ___
 
@@ -445,7 +457,7 @@ ___
 
 #### Defined in
 
-[utils.ts:2](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/utils.ts#L2)
+[utils.ts:2](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/utils.ts#L2)
 
 ___
 
@@ -464,7 +476,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:47](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L47)
+[proposals.ts:47](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L47)
 
 ___
 
@@ -481,7 +493,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:58](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L58)
+[proposals.ts:58](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L58)
 
 ___
 
@@ -498,7 +510,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:57](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L57)
+[proposals.ts:57](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L57)
 
 ___
 
@@ -516,7 +528,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:40](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L40)
+[proposals.ts:40](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L40)
 
 ___
 
@@ -526,7 +538,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:15](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L15)
+[proposals.ts:15](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L15)
 
 ___
 
@@ -536,7 +548,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:10](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L10)
+[proposals.ts:10](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L10)
 
 ___
 
@@ -546,7 +558,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:59](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L59)
+[proposals.ts:59](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L59)
 
 ___
 
@@ -556,7 +568,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:61](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L61)
+[proposals.ts:61](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L61)
 
 ___
 
@@ -566,7 +578,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:26](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/types.ts#L26)
+[tx/types.ts:32](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L32)
 
 ___
 
@@ -576,17 +588,57 @@ ___
 
 #### Defined in
 
-[tx/types.ts:39](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/types.ts#L39)
+[tx/types.ts:51](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L51)
 
 ___
 
 ### Schema
 
-Ƭ **Schema**: [`BatchTxResultMsgValue`](classes/BatchTxResultMsgValue.md) \| [`EthBridgeTransferMsgValue`](classes/EthBridgeTransferMsgValue.md) \| [`IbcTransferMsgValue`](classes/IbcTransferMsgValue.md) \| [`SignatureMsgValue`](classes/SignatureMsgValue.md) \| [`BondMsgValue`](classes/BondMsgValue.md) \| [`UnbondMsgValue`](classes/UnbondMsgValue.md) \| [`VoteProposalMsgValue`](classes/VoteProposalMsgValue.md) \| [`ClaimRewardsMsgValue`](classes/ClaimRewardsMsgValue.md) \| [`WithdrawMsgValue`](classes/WithdrawMsgValue.md) \| [`SigningDataMsgValue`](classes/SigningDataMsgValue.md) \| [`TransferMsgValue`](classes/TransferMsgValue.md) \| [`TransferDataMsgValue`](classes/TransferDataMsgValue.md) \| [`TransparentTransferMsgValue`](classes/TransparentTransferMsgValue.md) \| [`TransparentTransferDataMsgValue`](classes/TransparentTransferDataMsgValue.md) \| [`TxMsgValue`](classes/TxMsgValue.md) \| [`TxResponseMsgValue`](classes/TxResponseMsgValue.md) \| [`WrapperTxMsgValue`](classes/WrapperTxMsgValue.md) \| [`RedelegateMsgValue`](classes/RedelegateMsgValue.md) \| [`CommitmentMsgValue`](classes/CommitmentMsgValue.md) \| [`TxDetailsMsgValue`](classes/TxDetailsMsgValue.md) \| [`RevealPkMsgValue`](classes/RevealPkMsgValue.md)
+Ƭ **Schema**: [`BatchTxResultMsgValue`](classes/BatchTxResultMsgValue.md) \| [`EthBridgeTransferMsgValue`](classes/EthBridgeTransferMsgValue.md) \| [`IbcTransferMsgValue`](classes/IbcTransferMsgValue.md) \| [`SignatureMsgValue`](classes/SignatureMsgValue.md) \| [`BondMsgValue`](classes/BondMsgValue.md) \| [`UnbondMsgValue`](classes/UnbondMsgValue.md) \| [`VoteProposalMsgValue`](classes/VoteProposalMsgValue.md) \| [`ClaimRewardsMsgValue`](classes/ClaimRewardsMsgValue.md) \| [`WithdrawMsgValue`](classes/WithdrawMsgValue.md) \| [`ShieldedTransferMsgValue`](classes/ShieldedTransferMsgValue.md) \| [`ShieldedTransferDataMsgValue`](classes/ShieldedTransferDataMsgValue.md) \| [`ShieldingTransferMsgValue`](classes/ShieldingTransferMsgValue.md) \| [`ShieldingTransferDataMsgValue`](classes/ShieldingTransferDataMsgValue.md) \| [`SigningDataMsgValue`](classes/SigningDataMsgValue.md) \| [`TransferMsgValue`](classes/TransferMsgValue.md) \| [`TransferDataMsgValue`](classes/TransferDataMsgValue.md) \| [`TransparentTransferMsgValue`](classes/TransparentTransferMsgValue.md) \| [`TransparentTransferDataMsgValue`](classes/TransparentTransferDataMsgValue.md) \| [`TxMsgValue`](classes/TxMsgValue.md) \| [`TxResponseMsgValue`](classes/TxResponseMsgValue.md) \| [`UnshieldingTransferDataMsgValue`](classes/UnshieldingTransferDataMsgValue.md) \| [`UnshieldingTransferMsgValue`](classes/UnshieldingTransferMsgValue.md) \| [`WrapperTxMsgValue`](classes/WrapperTxMsgValue.md) \| [`RedelegateMsgValue`](classes/RedelegateMsgValue.md) \| [`CommitmentMsgValue`](classes/CommitmentMsgValue.md) \| [`TxDetailsMsgValue`](classes/TxDetailsMsgValue.md) \| [`RevealPkMsgValue`](classes/RevealPkMsgValue.md)
 
 #### Defined in
 
-[tx/schema/index.ts:41](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/index.ts#L41)
+[tx/schema/index.ts:47](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/index.ts#L47)
+
+___
+
+### ShieldedTransferDataProps
+
+Ƭ **ShieldedTransferDataProps**: [`ShieldedTransferDataMsgValue`](classes/ShieldedTransferDataMsgValue.md)
+
+#### Defined in
+
+[tx/types.ts:35](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L35)
+
+___
+
+### ShieldedTransferProps
+
+Ƭ **ShieldedTransferProps**: [`ShieldedTransferMsgValue`](classes/ShieldedTransferMsgValue.md)
+
+#### Defined in
+
+[tx/types.ts:34](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L34)
+
+___
+
+### ShieldingTransferDataProps
+
+Ƭ **ShieldingTransferDataProps**: [`ShieldingTransferDataMsgValue`](classes/ShieldingTransferDataMsgValue.md)
+
+#### Defined in
+
+[tx/types.ts:37](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L37)
+
+___
+
+### ShieldingTransferProps
+
+Ƭ **ShieldingTransferProps**: [`ShieldingTransferMsgValue`](classes/ShieldingTransferMsgValue.md)
+
+#### Defined in
+
+[tx/types.ts:36](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L36)
 
 ___
 
@@ -603,7 +655,7 @@ ___
 
 #### Defined in
 
-[namada.ts:6](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/namada.ts#L6)
+[namada.ts:6](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/namada.ts#L6)
 
 ___
 
@@ -620,7 +672,7 @@ ___
 
 #### Defined in
 
-[signer.ts:4](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/signer.ts#L4)
+[signer.ts:4](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/signer.ts#L4)
 
 ___
 
@@ -638,7 +690,7 @@ ___
 
 #### Defined in
 
-[namada.ts:11](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/namada.ts#L11)
+[namada.ts:11](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/namada.ts#L11)
 
 ___
 
@@ -648,7 +700,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:27](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/types.ts#L27)
+[tx/types.ts:33](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L33)
 
 ___
 
@@ -658,7 +710,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:33](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/types.ts#L33)
+[tx/types.ts:45](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L45)
 
 ___
 
@@ -668,7 +720,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:41](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/types.ts#L41)
+[tx/types.ts:53](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L53)
 
 ___
 
@@ -678,7 +730,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:100](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L100)
+[proposals.ts:100](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L100)
 
 ___
 
@@ -694,7 +746,7 @@ ___
 
 #### Defined in
 
-[tokens/types.ts:19](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tokens/types.ts#L19)
+[tokens/types.ts:19](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tokens/types.ts#L19)
 
 ___
 
@@ -726,7 +778,7 @@ ___
 
 #### Defined in
 
-[tokens/types.ts:5](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tokens/types.ts#L5)
+[tokens/types.ts:5](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tokens/types.ts#L5)
 
 ___
 
@@ -736,7 +788,7 @@ ___
 
 #### Defined in
 
-[tokens/Namada.ts:21](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tokens/Namada.ts#L21)
+[tokens/Namada.ts:21](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tokens/Namada.ts#L21)
 
 ___
 
@@ -746,7 +798,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:28](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/types.ts#L28)
+[tx/types.ts:40](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L40)
 
 ___
 
@@ -756,7 +808,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:30](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/types.ts#L30)
+[tx/types.ts:42](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L42)
 
 ___
 
@@ -766,7 +818,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:29](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/types.ts#L29)
+[tx/types.ts:41](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L41)
 
 ___
 
@@ -776,7 +828,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:59](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/types.ts#L59)
+[tx/types.ts:71](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L71)
 
 ___
 
@@ -786,7 +838,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:31](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/types.ts#L31)
+[tx/types.ts:43](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L43)
 
 ___
 
@@ -796,7 +848,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:32](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/types.ts#L32)
+[tx/types.ts:44](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L44)
 
 ___
 
@@ -806,7 +858,27 @@ ___
 
 #### Defined in
 
-[tx/types.ts:34](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/types.ts#L34)
+[tx/types.ts:46](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L46)
+
+___
+
+### UnshieldingTransferDataProps
+
+Ƭ **UnshieldingTransferDataProps**: [`UnshieldingTransferDataMsgValue`](classes/UnshieldingTransferDataMsgValue.md)
+
+#### Defined in
+
+[tx/types.ts:38](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L38)
+
+___
+
+### UnshieldingTransferProps
+
+Ƭ **UnshieldingTransferProps**: [`UnshieldingTransferMsgValue`](classes/UnshieldingTransferMsgValue.md)
+
+#### Defined in
+
+[tx/types.ts:39](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L39)
 
 ___
 
@@ -816,7 +888,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:76](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L76)
+[proposals.ts:76](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L76)
 
 ___
 
@@ -834,7 +906,7 @@ ___
 
 #### Defined in
 
-[namada.ts:17](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/namada.ts#L17)
+[namada.ts:17](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/namada.ts#L17)
 
 ___
 
@@ -844,7 +916,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:92](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L92)
+[proposals.ts:92](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L92)
 
 ___
 
@@ -854,7 +926,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:35](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/types.ts#L35)
+[tx/types.ts:47](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L47)
 
 ___
 
@@ -864,7 +936,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:64](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L64)
+[proposals.ts:64](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L64)
 
 ___
 
@@ -874,7 +946,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:69](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L69)
+[proposals.ts:69](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L69)
 
 ___
 
@@ -884,7 +956,7 @@ ___
 
 #### Defined in
 
-[namada.ts:42](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/namada.ts#L42)
+[namada.ts:44](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/namada.ts#L44)
 
 ___
 
@@ -894,7 +966,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:37](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/types.ts#L37)
+[tx/types.ts:49](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L49)
 
 ___
 
@@ -904,7 +976,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:38](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/types.ts#L38)
+[tx/types.ts:50](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/types.ts#L50)
 
 ## Variables
 
@@ -921,7 +993,7 @@ ___
 
 #### Defined in
 
-[tx/schema/utils.ts:4](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tx/schema/utils.ts#L4)
+[tx/schema/utils.ts:4](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tx/schema/utils.ts#L4)
 
 ___
 
@@ -931,7 +1003,7 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:5](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tokens/Cosmos.ts#L5)
+[tokens/Cosmos.ts:5](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tokens/Cosmos.ts#L5)
 
 ___
 
@@ -941,7 +1013,7 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:22](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tokens/Cosmos.ts#L22)
+[tokens/Cosmos.ts:22](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tokens/Cosmos.ts#L22)
 
 ___
 
@@ -968,7 +1040,7 @@ ___
 
 #### Defined in
 
-[chain.ts:30](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/chain.ts#L30)
+[chain.ts:30](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/chain.ts#L30)
 
 ___
 
@@ -978,7 +1050,7 @@ ___
 
 #### Defined in
 
-[tokens/Namada.ts:11](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tokens/Namada.ts#L11)
+[tokens/Namada.ts:11](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tokens/Namada.ts#L11)
 
 ___
 
@@ -988,7 +1060,7 @@ ___
 
 #### Defined in
 
-[tokens/Namada.ts:23](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tokens/Namada.ts#L23)
+[tokens/Namada.ts:23](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tokens/Namada.ts#L23)
 
 ___
 
@@ -998,7 +1070,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:3](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L3)
+[proposals.ts:3](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L3)
 
 ___
 
@@ -1008,7 +1080,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:94](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L94)
+[proposals.ts:94](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L94)
 
 ___
 
@@ -1018,7 +1090,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:63](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L63)
+[proposals.ts:63](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L63)
 
 ## Functions
 
@@ -1038,7 +1110,7 @@ vote is DelegatorVote
 
 #### Defined in
 
-[proposals.ts:89](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L89)
+[proposals.ts:89](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L89)
 
 ___
 
@@ -1058,7 +1130,7 @@ str is "pending" \| "ongoing" \| "passed" \| "rejected"
 
 #### Defined in
 
-[proposals.ts:12](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L12)
+[proposals.ts:12](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L12)
 
 ___
 
@@ -1078,7 +1150,7 @@ tallyType is "two-thirds" \| "one-half-over-one-third" \| "less-one-half-over-on
 
 #### Defined in
 
-[proposals.ts:102](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L102)
+[proposals.ts:102](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L102)
 
 ___
 
@@ -1098,7 +1170,7 @@ vote is ValidatorVote
 
 #### Defined in
 
-[proposals.ts:81](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L81)
+[proposals.ts:81](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L81)
 
 ___
 
@@ -1118,7 +1190,7 @@ str is "yay" \| "nay" \| "abstain"
 
 #### Defined in
 
-[proposals.ts:66](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/proposals.ts#L66)
+[proposals.ts:66](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/proposals.ts#L66)
 
 ___
 
@@ -1138,7 +1210,7 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:66](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tokens/Cosmos.ts#L66)
+[tokens/Cosmos.ts:66](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tokens/Cosmos.ts#L66)
 
 ___
 
@@ -1158,4 +1230,4 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:48](https://github.com/anoma/namada-interface/blob/48e796bf/packages/types/src/tokens/Cosmos.ts#L48)
+[tokens/Cosmos.ts:48](https://github.com/anoma/namada-interface/blob/fed376fb8f8e78431a4124d1835f659952e931ac/packages/types/src/tokens/Cosmos.ts#L48)

--- a/packages/types/src/tx/schema/index.ts
+++ b/packages/types/src/tx/schema/index.ts
@@ -25,10 +25,16 @@ import { RedelegateMsgValue } from "./redelegate";
 import { RevealPkMsgValue } from "./revealPk";
 import { SignatureMsgValue } from "./signature";
 import {
+  ShieldedTransferDataMsgValue,
+  ShieldedTransferMsgValue,
+  ShieldingTransferDataMsgValue,
+  ShieldingTransferMsgValue,
   TransferDataMsgValue,
   TransferMsgValue,
   TransparentTransferDataMsgValue,
   TransparentTransferMsgValue,
+  UnshieldingTransferDataMsgValue,
+  UnshieldingTransferMsgValue,
 } from "./transfer";
 import { SigningDataMsgValue, TxMsgValue } from "./tx";
 import { CommitmentMsgValue, TxDetailsMsgValue } from "./txDetails";
@@ -48,6 +54,10 @@ export type Schema =
   | VoteProposalMsgValue
   | ClaimRewardsMsgValue
   | WithdrawMsgValue
+  | ShieldedTransferMsgValue
+  | ShieldedTransferDataMsgValue
+  | ShieldingTransferMsgValue
+  | ShieldingTransferDataMsgValue
   | SigningDataMsgValue
   | TransferMsgValue
   | TransferDataMsgValue
@@ -55,6 +65,8 @@ export type Schema =
   | TransparentTransferDataMsgValue
   | TxMsgValue
   | TxResponseMsgValue
+  | UnshieldingTransferDataMsgValue
+  | UnshieldingTransferMsgValue
   | WrapperTxMsgValue
   | RedelegateMsgValue
   | CommitmentMsgValue

--- a/packages/types/src/tx/schema/transfer.ts
+++ b/packages/types/src/tx/schema/transfer.ts
@@ -2,11 +2,20 @@
 import { field, option, vec } from "@dao-xyz/borsh";
 import BigNumber from "bignumber.js";
 import {
+  ShieldedTransferDataProps,
+  ShieldedTransferProps,
+  ShieldingTransferDataProps,
+  ShieldingTransferProps,
   TransparentTransferDataProps,
   TransparentTransferProps,
+  UnshieldingTransferDataProps,
+  UnshieldingTransferProps,
 } from "../types";
 import { BigNumberSerializer } from "./utils";
 
+/**
+ * Transparent Transfer schemas
+ */
 export class TransparentTransferDataMsgValue {
   @field({ type: "string" })
   source!: string;
@@ -38,6 +47,117 @@ export class TransparentTransferMsgValue {
   }
 }
 
+/**
+ * Shielded Transfer schemas
+ */
+export class ShieldedTransferDataMsgValue {
+  @field({ type: "string" })
+  source!: string;
+
+  @field({ type: "string" })
+  target!: string;
+
+  @field({ type: "string" })
+  token!: string;
+
+  @field(BigNumberSerializer)
+  amount!: BigNumber;
+
+  constructor(data: ShieldedTransferDataProps) {
+    Object.assign(this, data);
+  }
+}
+
+export class ShieldedTransferMsgValue {
+  @field({ type: vec(ShieldedTransferDataMsgValue) })
+  data!: ShieldedTransferDataMsgValue[];
+
+  @field({ type: vec("string") })
+  gasSpendingKeys!: string[];
+
+  constructor({ data }: ShieldedTransferProps) {
+    Object.assign(this, {
+      data: data.map(
+        (shieldedTransferProps) =>
+          new ShieldedTransferDataMsgValue(shieldedTransferProps)
+      ),
+    });
+  }
+}
+
+/**
+ * Shielding Transfer schemas
+ */
+export class ShieldingTransferDataMsgValue {
+  @field({ type: "string" })
+  source!: string;
+
+  @field({ type: "string" })
+  token!: string;
+
+  @field(BigNumberSerializer)
+  amount!: BigNumber;
+
+  constructor(data: ShieldingTransferDataProps) {
+    Object.assign(this, data);
+  }
+}
+
+export class ShieldingTransferMsgValue {
+  @field({ type: vec(ShieldingTransferDataMsgValue) })
+  data!: ShieldingTransferDataMsgValue[];
+
+  constructor({ data }: ShieldingTransferProps) {
+    Object.assign(this, {
+      data: data.map(
+        (shieldingTransferProps) =>
+          new ShieldingTransferDataMsgValue(shieldingTransferProps)
+      ),
+    });
+  }
+}
+
+/**
+ * Unshielding Transfer schemas
+ */
+export class UnshieldingTransferDataMsgValue {
+  @field({ type: "string" })
+  target!: string;
+
+  @field({ type: "string" })
+  token!: string;
+
+  @field(BigNumberSerializer)
+  amount!: BigNumber;
+
+  constructor(data: UnshieldingTransferDataProps) {
+    Object.assign(this, data);
+  }
+}
+
+export class UnshieldingTransferMsgValue {
+  @field({ type: "string" })
+  source!: string;
+
+  @field({ type: vec(UnshieldingTransferDataMsgValue) })
+  data!: UnshieldingTransferDataMsgValue[];
+
+  @field({ type: vec("string") })
+  gasSpendingKeys!: string[];
+
+  constructor({ data }: UnshieldingTransferProps) {
+    Object.assign(this, {
+      data: data.map(
+        (unshieldingTransferProps) =>
+          new UnshieldingTransferDataMsgValue(unshieldingTransferProps)
+      ),
+    });
+  }
+}
+
+/**
+ * General Transfer schema used for displaying details
+ */
 export class TransferDataMsgValue {
   @field({ type: "string" })
   owner!: string;
@@ -56,6 +176,6 @@ export class TransferMsgValue {
   @field({ type: vec(TransferDataMsgValue) })
   targets!: TransferDataMsgValue[];
 
-  @field({ type: option("string") })
-  shieldedSectionHash?: string;
+  @field({ type: option(vec("u8")) })
+  shieldedSectionHash?: Uint8Array;
 }

--- a/packages/types/src/tx/schema/transfer.ts
+++ b/packages/types/src/tx/schema/transfer.ts
@@ -75,12 +75,13 @@ export class ShieldedTransferMsgValue {
   @field({ type: vec("string") })
   gasSpendingKeys!: string[];
 
-  constructor({ data }: ShieldedTransferProps) {
+  constructor({ data, gasSpendingKeys }: ShieldedTransferProps) {
     Object.assign(this, {
       data: data.map(
-        (shieldedTransferProps) =>
-          new ShieldedTransferDataMsgValue(shieldedTransferProps)
+        (shieldedTransferDataProps) =>
+          new ShieldedTransferDataMsgValue(shieldedTransferDataProps)
       ),
+      gasSpendingKeys,
     });
   }
 }
@@ -110,8 +111,8 @@ export class ShieldingTransferMsgValue {
   constructor({ data }: ShieldingTransferProps) {
     Object.assign(this, {
       data: data.map(
-        (shieldingTransferProps) =>
-          new ShieldingTransferDataMsgValue(shieldingTransferProps)
+        (shieldingTransferDataProps) =>
+          new ShieldingTransferDataMsgValue(shieldingTransferDataProps)
       ),
     });
   }
@@ -145,12 +146,14 @@ export class UnshieldingTransferMsgValue {
   @field({ type: vec("string") })
   gasSpendingKeys!: string[];
 
-  constructor({ data }: UnshieldingTransferProps) {
+  constructor({ source, data, gasSpendingKeys }: UnshieldingTransferProps) {
     Object.assign(this, {
+      source,
       data: data.map(
-        (unshieldingTransferProps) =>
-          new UnshieldingTransferDataMsgValue(unshieldingTransferProps)
+        (unshieldingTransferDataProps) =>
+          new UnshieldingTransferDataMsgValue(unshieldingTransferDataProps)
       ),
+      gasSpendingKeys,
     });
   }
 }

--- a/packages/types/src/tx/types.ts
+++ b/packages/types/src/tx/types.ts
@@ -5,6 +5,10 @@ import {
   EthBridgeTransferMsgValue,
   IbcTransferMsgValue,
   RedelegateMsgValue,
+  ShieldedTransferDataMsgValue,
+  ShieldedTransferMsgValue,
+  ShieldingTransferDataMsgValue,
+  ShieldingTransferMsgValue,
   SignatureMsgValue,
   SigningDataMsgValue,
   TransferMsgValue,
@@ -13,6 +17,8 @@ import {
   TxMsgValue,
   TxResponseMsgValue,
   UnbondMsgValue,
+  UnshieldingTransferDataMsgValue,
+  UnshieldingTransferMsgValue,
   VoteProposalMsgValue,
   WithdrawMsgValue,
   WrapperTxMsgValue,
@@ -25,6 +31,12 @@ export type EthBridgeTransferProps = EthBridgeTransferMsgValue;
 export type IbcTransferProps = IbcTransferMsgValue;
 export type RedelegateProps = RedelegateMsgValue;
 export type SignatureProps = SignatureMsgValue;
+export type ShieldedTransferProps = ShieldedTransferMsgValue;
+export type ShieldedTransferDataProps = ShieldedTransferDataMsgValue;
+export type ShieldingTransferProps = ShieldingTransferMsgValue;
+export type ShieldingTransferDataProps = ShieldingTransferDataMsgValue;
+export type UnshieldingTransferDataProps = UnshieldingTransferDataMsgValue;
+export type UnshieldingTransferProps = UnshieldingTransferMsgValue;
 export type TransferProps = TransferMsgValue;
 export type TransparentTransferProps = TransparentTransferMsgValue;
 export type TransparentTransferDataProps = TransparentTransferDataMsgValue;


### PR DESCRIPTION
Resolves #1098

Mainly we want to add support to MASP to the SDK & the Interface. Short of implementing the Transfer UI, we should have the following:

Need args and Borsh schema for:
- [x] Shielded Transfer (Shielded<->Shielded)
- [x] Shielding Transfer (Transparent->Shielded)
- [x] Unshielding Transfer (Shielding->Shielded)

Need SDK (`@heliax/namada-sdk`) functions for:

- [x] `build_shielded_transfer`
- [x] `build_shielding_transfer`
- [x] `build_unshielding_transfer`

Docs:
- [x] Regenerate docs for `@namada/types` `@heliax/namada-sdk`

TODO:
- [ ] Load MASP Params into SDK wasm (fetch & store, provide to SDK)