### PR TITLE
feat: add disconnect account approval step

### DIFF
--- a/apps/extension/src/Approvals/Approvals.tsx
+++ b/apps/extension/src/Approvals/Approvals.tsx
@@ -7,7 +7,7 @@ import { AccountType, TxDetails } from "@namada/types";
 import { AppHeader } from "App/Common/AppHeader";
 import { TopLevelRoute } from "Approvals/types";
 import { ApproveConnection } from "./ApproveConnection";
-import { ApproveDisconnect } from "./ApproveDisconnect";
+import { ApproveDisconnection } from "./ApproveDisconnection";
 import { ApproveSignArbitrary } from "./ApproveSignArbitrary";
 import { ApproveSignTx } from "./ApproveSignTx";
 import { ConfirmSignature } from "./ConfirmSignArbitrary";
@@ -67,8 +67,8 @@ export const Approvals: React.FC = () => {
           element={<ApproveConnection />}
         />
         <Route
-          path={TopLevelRoute.ApproveDisconnect}
-          element={<ApproveDisconnect />}
+          path={TopLevelRoute.ApproveDisconnection}
+          element={<ApproveDisconnection />}
         />
         <Route
           path={`${TopLevelRoute.ApproveSignArbitrary}/:signer`}

--- a/apps/extension/src/Approvals/Approvals.tsx
+++ b/apps/extension/src/Approvals/Approvals.tsx
@@ -7,6 +7,7 @@ import { AccountType, TxDetails } from "@namada/types";
 import { AppHeader } from "App/Common/AppHeader";
 import { TopLevelRoute } from "Approvals/types";
 import { ApproveConnection } from "./ApproveConnection";
+import { ApproveDisconnect } from "./ApproveDisconnect";
 import { ApproveSignArbitrary } from "./ApproveSignArbitrary";
 import { ApproveSignTx } from "./ApproveSignTx";
 import { ConfirmSignature } from "./ConfirmSignArbitrary";
@@ -64,6 +65,10 @@ export const Approvals: React.FC = () => {
         <Route
           path={TopLevelRoute.ApproveConnection}
           element={<ApproveConnection />}
+        />
+        <Route
+          path={TopLevelRoute.ApproveDisconnect}
+          element={<ApproveDisconnect />}
         />
         <Route
           path={`${TopLevelRoute.ApproveSignArbitrary}/:signer`}

--- a/apps/extension/src/Approvals/ApproveConnection.tsx
+++ b/apps/extension/src/Approvals/ApproveConnection.tsx
@@ -10,17 +10,12 @@ export const ApproveConnection: React.FC = () => {
   const requester = useRequester();
   const params = useQuery();
   const interfaceOrigin = params.get("interfaceOrigin");
-  const interfaceTabId = params.get("interfaceTabId");
 
   const handleResponse = async (allowConnection: boolean): Promise<void> => {
-    if (interfaceTabId && interfaceOrigin) {
+    if (interfaceOrigin) {
       await requester.sendMessage(
         Ports.Background,
-        new ConnectInterfaceResponseMsg(
-          parseInt(interfaceTabId),
-          interfaceOrigin,
-          allowConnection
-        )
+        new ConnectInterfaceResponseMsg(interfaceOrigin, allowConnection)
       );
       await closeCurrentTab();
     }

--- a/apps/extension/src/Approvals/ApproveDisconnect.tsx
+++ b/apps/extension/src/Approvals/ApproveDisconnect.tsx
@@ -1,0 +1,45 @@
+import { ActionButton, Alert, GapPatterns, Stack } from "@namada/components";
+import { PageHeader } from "App/Common";
+import { RevokeConnectionMsg } from "background/approvals";
+import { useQuery } from "hooks";
+import { useRequester } from "hooks/useRequester";
+import { Ports } from "router";
+import { closeCurrentTab } from "utils";
+
+export const ApproveDisconnect: React.FC = () => {
+  const requester = useRequester();
+  const params = useQuery();
+  const interfaceOrigin = params.get("interfaceOrigin");
+
+  const handleResponse = async (revokeConnection: boolean): Promise<void> => {
+    if (revokeConnection && interfaceOrigin) {
+      await requester.sendMessage(
+        Ports.Background,
+        new RevokeConnectionMsg(interfaceOrigin)
+      );
+    }
+    await closeCurrentTab();
+  };
+
+  return (
+    <Stack full gap={GapPatterns.TitleContent} className="pt-4 pb-8">
+      <PageHeader title="Approve Request" />
+      <Stack full className="justify-between" gap={12}>
+        <Alert type="warning">
+          Approve disconnect for <strong>{interfaceOrigin}</strong>?
+        </Alert>
+        <Stack gap={2}>
+          <ActionButton onClick={() => handleResponse(true)}>
+            Approve
+          </ActionButton>
+          <ActionButton
+            outlineColor="yellow"
+            onClick={() => handleResponse(false)}
+          >
+            Reject
+          </ActionButton>
+        </Stack>
+      </Stack>
+    </Stack>
+  );
+};

--- a/apps/extension/src/Approvals/ApproveDisconnect.tsx
+++ b/apps/extension/src/Approvals/ApproveDisconnect.tsx
@@ -10,17 +10,12 @@ export const ApproveDisconnect: React.FC = () => {
   const requester = useRequester();
   const params = useQuery();
   const interfaceOrigin = params.get("interfaceOrigin");
-  const interfaceTabId = params.get("interfaceTabId");
 
   const handleResponse = async (revokeConnection: boolean): Promise<void> => {
-    if (interfaceTabId && interfaceOrigin) {
+    if (interfaceOrigin) {
       await requester.sendMessage(
         Ports.Background,
-        new DisconnectInterfaceResponseMsg(
-          parseInt(interfaceTabId),
-          interfaceOrigin,
-          revokeConnection
-        )
+        new DisconnectInterfaceResponseMsg(interfaceOrigin, revokeConnection)
       );
       await closeCurrentTab();
     }

--- a/apps/extension/src/Approvals/ApproveDisconnect.tsx
+++ b/apps/extension/src/Approvals/ApproveDisconnect.tsx
@@ -1,6 +1,6 @@
 import { ActionButton, Alert, GapPatterns, Stack } from "@namada/components";
 import { PageHeader } from "App/Common";
-import { RevokeConnectionMsg } from "background/approvals";
+import { DisconnectInterfaceResponseMsg } from "background/approvals";
 import { useQuery } from "hooks";
 import { useRequester } from "hooks/useRequester";
 import { Ports } from "router";
@@ -10,15 +10,20 @@ export const ApproveDisconnect: React.FC = () => {
   const requester = useRequester();
   const params = useQuery();
   const interfaceOrigin = params.get("interfaceOrigin");
+  const interfaceTabId = params.get("interfaceTabId");
 
   const handleResponse = async (revokeConnection: boolean): Promise<void> => {
-    if (revokeConnection && interfaceOrigin) {
+    if (interfaceTabId && interfaceOrigin) {
       await requester.sendMessage(
         Ports.Background,
-        new RevokeConnectionMsg(interfaceOrigin)
+        new DisconnectInterfaceResponseMsg(
+          parseInt(interfaceTabId),
+          interfaceOrigin,
+          revokeConnection
+        )
       );
+      await closeCurrentTab();
     }
-    await closeCurrentTab();
   };
 
   return (

--- a/apps/extension/src/Approvals/ApproveDisconnection.tsx
+++ b/apps/extension/src/Approvals/ApproveDisconnection.tsx
@@ -6,7 +6,7 @@ import { useRequester } from "hooks/useRequester";
 import { Ports } from "router";
 import { closeCurrentTab } from "utils";
 
-export const ApproveDisconnect: React.FC = () => {
+export const ApproveDisconnection: React.FC = () => {
   const requester = useRequester();
   const params = useQuery();
   const interfaceOrigin = params.get("interfaceOrigin");

--- a/apps/extension/src/Approvals/types.ts
+++ b/apps/extension/src/Approvals/types.ts
@@ -5,6 +5,7 @@ export enum TopLevelRoute {
 
   // Connection approval
   ApproveConnection = "/approve-connection",
+  ApproveDisconnect = "/approve-disconnect",
 
   // Sign Tx approval
   ApproveSignTx = "/approve-sign-tx",

--- a/apps/extension/src/Approvals/types.ts
+++ b/apps/extension/src/Approvals/types.ts
@@ -5,7 +5,7 @@ export enum TopLevelRoute {
 
   // Connection approval
   ApproveConnection = "/approve-connection",
-  ApproveDisconnect = "/approve-disconnect",
+  ApproveDisconnection = "/approve-disconnection",
 
   // Sign Tx approval
   ApproveSignTx = "/approve-sign-tx",

--- a/apps/extension/src/background/approvals/handler.test.ts
+++ b/apps/extension/src/background/approvals/handler.test.ts
@@ -80,7 +80,6 @@ describe("approvals handler", () => {
     expect(service.approveConnection).toBeCalled();
 
     const connectInterfaceResponseMsg = new ConnectInterfaceResponseMsg(
-      0,
       "",
       true
     );

--- a/apps/extension/src/background/approvals/handler.test.ts
+++ b/apps/extension/src/background/approvals/handler.test.ts
@@ -12,6 +12,7 @@ import { Message } from "router";
 import { getHandler } from "./handler";
 import {
   ConnectInterfaceResponseMsg,
+  DisconnectInterfaceResponseMsg,
   RejectSignArbitraryMsg,
   RejectSignTxMsg,
   RevokeConnectionMsg,
@@ -85,6 +86,13 @@ describe("approvals handler", () => {
     );
     handler(env, connectInterfaceResponseMsg);
     expect(service.approveConnectionResponse).toBeCalled();
+
+    const disconnectInterfaceResponseMsg = new DisconnectInterfaceResponseMsg(
+      "",
+      true
+    );
+    handler(env, disconnectInterfaceResponseMsg);
+    expect(service.approveDisconnectionResponse).toBeCalled();
 
     const revokeConnectionMsg = new RevokeConnectionMsg("");
     handler(env, revokeConnectionMsg);

--- a/apps/extension/src/background/approvals/handler.ts
+++ b/apps/extension/src/background/approvals/handler.ts
@@ -113,8 +113,8 @@ const handleIsConnectionApprovedMsg: (
 const handleApproveConnectInterfaceMsg: (
   service: ApprovalsService
 ) => InternalHandler<ApproveConnectInterfaceMsg> = (service) => {
-  return async ({ senderTabId: interfaceTabId }, { origin }) => {
-    return await service.approveConnection(interfaceTabId, origin);
+  return async (_, { origin }) => {
+    return await service.approveConnection(origin);
   };
 };
 
@@ -123,13 +123,12 @@ const handleConnectInterfaceResponseMsg: (
 ) => InternalHandler<ConnectInterfaceResponseMsg> = (service) => {
   return async (
     { senderTabId: popupTabId },
-    { interfaceTabId, interfaceOrigin, allowConnection }
+    { interfaceOrigin, allowConnection }
   ) => {
     return await service.approveConnectionResponse(
-      interfaceTabId,
+      popupTabId,
       interfaceOrigin,
-      allowConnection,
-      popupTabId
+      allowConnection
     );
   };
 };
@@ -137,8 +136,8 @@ const handleConnectInterfaceResponseMsg: (
 const handleApproveDisconnectInterfaceMsg: (
   service: ApprovalsService
 ) => InternalHandler<ApproveDisconnectInterfaceMsg> = (service) => {
-  return async ({ senderTabId: interfaceTabId }, { origin }) => {
-    return await service.approveDisconnect(interfaceTabId, origin);
+  return async (_, { origin }) => {
+    return await service.approveDisconnect(origin);
   };
 };
 
@@ -147,13 +146,12 @@ const handleDisconnectInterfaceResponseMsg: (
 ) => InternalHandler<DisconnectInterfaceResponseMsg> = (service) => {
   return async (
     { senderTabId: popupTabId },
-    { interfaceTabId, interfaceOrigin, revokeConnection }
+    { interfaceOrigin, revokeConnection }
   ) => {
     return await service.approveDisconnectionResponse(
-      interfaceTabId,
+      popupTabId,
       interfaceOrigin,
-      revokeConnection,
-      popupTabId
+      revokeConnection
     );
   };
 };

--- a/apps/extension/src/background/approvals/handler.ts
+++ b/apps/extension/src/background/approvals/handler.ts
@@ -8,6 +8,7 @@ import {
 import { Env, Handler, InternalHandler, Message } from "router";
 import {
   ConnectInterfaceResponseMsg,
+  DisconnectInterfaceResponseMsg,
   QueryPendingTxBytesMsg,
   QuerySignArbitraryDataMsg,
   QueryTxDetailsMsg,
@@ -42,6 +43,11 @@ export const getHandler: (service: ApprovalsService) => Handler = (service) => {
         return handleApproveDisconnectInterfaceMsg(service)(
           env,
           msg as ApproveDisconnectInterfaceMsg
+        );
+      case DisconnectInterfaceResponseMsg:
+        return handleDisconnectInterfaceResponseMsg(service)(
+          env,
+          msg as DisconnectInterfaceResponseMsg
         );
       case RevokeConnectionMsg:
         return handleRevokeConnectionMsg(service)(
@@ -131,8 +137,24 @@ const handleConnectInterfaceResponseMsg: (
 const handleApproveDisconnectInterfaceMsg: (
   service: ApprovalsService
 ) => InternalHandler<ApproveDisconnectInterfaceMsg> = (service) => {
-  return async (_, { origin }) => {
-    return await service.approveDisconnect(origin);
+  return async ({ senderTabId: interfaceTabId }, { origin }) => {
+    return await service.approveDisconnect(interfaceTabId, origin);
+  };
+};
+
+const handleDisconnectInterfaceResponseMsg: (
+  service: ApprovalsService
+) => InternalHandler<DisconnectInterfaceResponseMsg> = (service) => {
+  return async (
+    { senderTabId: popupTabId },
+    { interfaceTabId, interfaceOrigin, revokeConnection }
+  ) => {
+    return await service.approveDisconnectionResponse(
+      interfaceTabId,
+      interfaceOrigin,
+      revokeConnection,
+      popupTabId
+    );
   };
 };
 

--- a/apps/extension/src/background/approvals/handler.ts
+++ b/apps/extension/src/background/approvals/handler.ts
@@ -137,7 +137,7 @@ const handleApproveDisconnectInterfaceMsg: (
   service: ApprovalsService
 ) => InternalHandler<ApproveDisconnectInterfaceMsg> = (service) => {
   return async (_, { origin }) => {
-    return await service.approveDisconnect(origin);
+    return await service.approveDisconnection(origin);
   };
 };
 

--- a/apps/extension/src/background/approvals/handler.ts
+++ b/apps/extension/src/background/approvals/handler.ts
@@ -1,5 +1,6 @@
 import {
   ApproveConnectInterfaceMsg,
+  ApproveDisconnectInterfaceMsg,
   ApproveSignArbitraryMsg,
   ApproveSignTxMsg,
   IsConnectionApprovedMsg,
@@ -36,6 +37,11 @@ export const getHandler: (service: ApprovalsService) => Handler = (service) => {
         return handleConnectInterfaceResponseMsg(service)(
           env,
           msg as ConnectInterfaceResponseMsg
+        );
+      case ApproveDisconnectInterfaceMsg:
+        return handleApproveDisconnectInterfaceMsg(service)(
+          env,
+          msg as ApproveDisconnectInterfaceMsg
         );
       case RevokeConnectionMsg:
         return handleRevokeConnectionMsg(service)(
@@ -119,6 +125,14 @@ const handleConnectInterfaceResponseMsg: (
       allowConnection,
       popupTabId
     );
+  };
+};
+
+const handleApproveDisconnectInterfaceMsg: (
+  service: ApprovalsService
+) => InternalHandler<ApproveDisconnectInterfaceMsg> = (service) => {
+  return async (_, { origin }) => {
+    return await service.approveDisconnect(origin);
   };
 };
 

--- a/apps/extension/src/background/approvals/init.ts
+++ b/apps/extension/src/background/approvals/init.ts
@@ -8,6 +8,7 @@ import {
 import { Router } from "router";
 import {
   ConnectInterfaceResponseMsg,
+  DisconnectInterfaceResponseMsg,
   QueryPendingTxBytesMsg,
   QuerySignArbitraryDataMsg,
   QueryTxDetailsMsg,
@@ -35,6 +36,7 @@ export function init(router: Router, service: ApprovalsService): void {
   router.registerMessage(ApproveConnectInterfaceMsg);
   router.registerMessage(ApproveDisconnectInterfaceMsg);
   router.registerMessage(ConnectInterfaceResponseMsg);
+  router.registerMessage(DisconnectInterfaceResponseMsg);
   router.registerMessage(RevokeConnectionMsg);
   router.registerMessage(QueryTxDetailsMsg);
   router.registerMessage(QuerySignArbitraryDataMsg);

--- a/apps/extension/src/background/approvals/init.ts
+++ b/apps/extension/src/background/approvals/init.ts
@@ -34,8 +34,8 @@ export function init(router: Router, service: ApprovalsService): void {
   router.registerMessage(SubmitApprovedSignLedgerTxMsg);
   router.registerMessage(IsConnectionApprovedMsg);
   router.registerMessage(ApproveConnectInterfaceMsg);
-  router.registerMessage(ApproveDisconnectInterfaceMsg);
   router.registerMessage(ConnectInterfaceResponseMsg);
+  router.registerMessage(ApproveDisconnectInterfaceMsg);
   router.registerMessage(DisconnectInterfaceResponseMsg);
   router.registerMessage(RevokeConnectionMsg);
   router.registerMessage(QueryTxDetailsMsg);

--- a/apps/extension/src/background/approvals/init.ts
+++ b/apps/extension/src/background/approvals/init.ts
@@ -1,5 +1,6 @@
 import {
   ApproveConnectInterfaceMsg,
+  ApproveDisconnectInterfaceMsg,
   ApproveSignArbitraryMsg,
   ApproveSignTxMsg,
   IsConnectionApprovedMsg,
@@ -32,6 +33,7 @@ export function init(router: Router, service: ApprovalsService): void {
   router.registerMessage(SubmitApprovedSignLedgerTxMsg);
   router.registerMessage(IsConnectionApprovedMsg);
   router.registerMessage(ApproveConnectInterfaceMsg);
+  router.registerMessage(ApproveDisconnectInterfaceMsg);
   router.registerMessage(ConnectInterfaceResponseMsg);
   router.registerMessage(RevokeConnectionMsg);
   router.registerMessage(QueryTxDetailsMsg);

--- a/apps/extension/src/background/approvals/messages.test.ts
+++ b/apps/extension/src/background/approvals/messages.test.ts
@@ -63,7 +63,7 @@ describe("approvals messages", () => {
   });
 
   test("valid ConnectInterfaceResponseMsg", () => {
-    const msg = new ConnectInterfaceResponseMsg(0, "interface", true);
+    const msg = new ConnectInterfaceResponseMsg("interface", true);
 
     expect(msg.type()).toBe(MessageType.ConnectInterfaceResponse);
     expect(msg.route()).toBe(ROUTE);
@@ -71,21 +71,15 @@ describe("approvals messages", () => {
   });
 
   test("invalid ConnectInterfaceResponseMsg", () => {
-    const msg = new ConnectInterfaceResponseMsg(0, "interface", true);
-
-    (msg as any).interfaceTabId = undefined;
+    const msg = new ConnectInterfaceResponseMsg("interface", true);
+    (msg as any).interfaceOrigin = undefined;
 
     expect(() => msg.validate()).toThrow();
 
-    const msg2 = new ConnectInterfaceResponseMsg(0, "interface", true);
-    (msg2 as any).interfaceOrigin = undefined;
+    const msg2 = new ConnectInterfaceResponseMsg("interface", true);
+    (msg2 as any).allowConnection = undefined;
 
     expect(() => msg2.validate()).toThrow();
-
-    const msg3 = new ConnectInterfaceResponseMsg(0, "interface", true);
-    (msg3 as any).allowConnection = undefined;
-
-    expect(() => msg3.validate()).toThrow();
   });
 
   test("valid RevokeConnectionMsg", () => {

--- a/apps/extension/src/background/approvals/messages.ts
+++ b/apps/extension/src/background/approvals/messages.ts
@@ -12,6 +12,7 @@ export enum MessageType {
   SubmitApprovedSignLedgerTx = "submit-approved-sign-ledger-tx",
   RejectSignArbitrary = "reject-sign-arbitrary",
   ConnectInterfaceResponse = "connect-interface-response",
+  DisconnectInterfaceResponse = "disconnect-interface-response",
   RevokeConnection = "revoke-connection",
   QueryTxDetails = "query-tx-details",
   QuerySignArbitraryData = "query-sign-arbitrary-data",
@@ -165,6 +166,36 @@ export class ConnectInterfaceResponseMsg extends Message<void> {
 
   type(): string {
     return ConnectInterfaceResponseMsg.type();
+  }
+}
+
+export class DisconnectInterfaceResponseMsg extends Message<void> {
+  public static type(): MessageType {
+    return MessageType.DisconnectInterfaceResponse;
+  }
+
+  constructor(
+    public readonly interfaceTabId: number,
+    public readonly interfaceOrigin: string,
+    public readonly revokeConnection: boolean
+  ) {
+    super();
+  }
+
+  validate(): void {
+    validateProps(this, [
+      "interfaceTabId",
+      "interfaceOrigin",
+      "revokeConnection",
+    ]);
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return DisconnectInterfaceResponseMsg.type();
   }
 }
 

--- a/apps/extension/src/background/approvals/messages.ts
+++ b/apps/extension/src/background/approvals/messages.ts
@@ -145,7 +145,6 @@ export class ConnectInterfaceResponseMsg extends Message<void> {
   }
 
   constructor(
-    public readonly interfaceTabId: number,
     public readonly interfaceOrigin: string,
     public readonly allowConnection: boolean
   ) {
@@ -153,11 +152,7 @@ export class ConnectInterfaceResponseMsg extends Message<void> {
   }
 
   validate(): void {
-    validateProps(this, [
-      "interfaceTabId",
-      "interfaceOrigin",
-      "allowConnection",
-    ]);
+    validateProps(this, ["interfaceOrigin", "allowConnection"]);
   }
 
   route(): string {
@@ -175,7 +170,6 @@ export class DisconnectInterfaceResponseMsg extends Message<void> {
   }
 
   constructor(
-    public readonly interfaceTabId: number,
     public readonly interfaceOrigin: string,
     public readonly revokeConnection: boolean
   ) {
@@ -183,11 +177,7 @@ export class DisconnectInterfaceResponseMsg extends Message<void> {
   }
 
   validate(): void {
-    validateProps(this, [
-      "interfaceTabId",
-      "interfaceOrigin",
-      "revokeConnection",
-    ]);
+    validateProps(this, ["interfaceOrigin", "revokeConnection"]);
   }
 
   route(): string {

--- a/apps/extension/src/background/approvals/service.test.ts
+++ b/apps/extension/src/background/approvals/service.test.ts
@@ -267,7 +267,7 @@ describe("approvals service", () => {
       const tabId = 1;
 
       jest.spyOn(service, "isConnectionApproved").mockResolvedValue(false);
-      jest.spyOn(service as any, "launchApprovalWindow");
+      jest.spyOn(service as any, "launchApprovalPopup");
       service["resolverMap"] = {};
 
       const promise = service.approveConnection(interfaceOrigin);
@@ -278,7 +278,7 @@ describe("approvals service", () => {
       );
       service["resolverMap"][tabId]?.resolve(true);
 
-      expect((service as any).launchApprovalWindow).toHaveBeenCalledWith(
+      expect((service as any).launchApprovalPopup).toHaveBeenCalledWith(
         "/approve-connection",
         { interfaceOrigin }
       );
@@ -357,7 +357,7 @@ describe("approvals service", () => {
       const tabId = 1;
 
       jest.spyOn(service, "isConnectionApproved").mockResolvedValue(true);
-      jest.spyOn(service as any, "launchApprovalWindow");
+      jest.spyOn(service as any, "launchApprovalPopup");
       service["resolverMap"] = {};
 
       const promise = service.approveDisconnection(interfaceOrigin);
@@ -368,7 +368,7 @@ describe("approvals service", () => {
       );
       service["resolverMap"][tabId]?.resolve(true);
 
-      expect((service as any).launchApprovalWindow).toHaveBeenCalledWith(
+      expect((service as any).launchApprovalPopup).toHaveBeenCalledWith(
         "/approve-disconnection",
         { interfaceOrigin }
       );
@@ -443,13 +443,13 @@ describe("approvals service", () => {
     });
   });
 
-  describe("openPopup", () => {
+  describe("createPopup", () => {
     it("should create and return a new window", async () => {
       const url = "url";
       const window = { tabs: [{ id: 1 }] };
       (webextensionPolyfill.windows.create as any).mockResolvedValue(window);
 
-      await expect((service as any).openPopup(url)).resolves.toBe(window);
+      await expect((service as any).createPopup(url)).resolves.toBe(window);
       expect(webextensionPolyfill.windows.create).toHaveBeenCalledWith(
         expect.objectContaining({ url })
       );
@@ -475,7 +475,7 @@ describe("approvals service", () => {
     });
   });
 
-  describe("launchApprovalWindow", () => {
+  describe("launchApprovalPopup", () => {
     it("should create a window with the given route and params saving the resolver on the resolverMap", async () => {
       const route = "route";
       const params = { foo: "bar" };
@@ -483,10 +483,10 @@ describe("approvals service", () => {
       const window = { tabs: [{ id: popupTabId }] };
 
       jest
-        .spyOn<any, any>(service, "openPopup")
+        .spyOn<any, any>(service, "createPopup")
         .mockImplementationOnce(() => window);
 
-      (service as any).launchApprovalWindow(route, params);
+      (service as any).launchApprovalPopup(route, params);
 
       expect(await (service as any).openPopup).toHaveBeenCalledWith(
         `url#${route}?foo=bar`

--- a/apps/extension/src/background/approvals/service.test.ts
+++ b/apps/extension/src/background/approvals/service.test.ts
@@ -473,6 +473,19 @@ describe("approvals service", () => {
 
       expect(() => (service as any).getPopupTabId(window)).toThrow();
     });
+
+    it("should throw an error if the tab already exists on the resolverMap", async () => {
+      const popupTabId = 1;
+      const window = { tabs: [{ id: popupTabId }] };
+      service["resolverMap"] = {
+        [popupTabId]: {
+          resolve: jest.fn(),
+          reject: jest.fn(),
+        },
+      };
+
+      expect(() => (service as any).getPopupTabId(window)).toThrow();
+    });
   });
 
   describe("launchApprovalPopup", () => {
@@ -488,7 +501,7 @@ describe("approvals service", () => {
 
       (service as any).launchApprovalPopup(route, params);
 
-      expect(await (service as any).openPopup).toHaveBeenCalledWith(
+      expect(await (service as any).createPopup).toHaveBeenCalledWith(
         `url#${route}?foo=bar`
       );
       expect((service as any).resolverMap[popupTabId]).toBeDefined();

--- a/apps/extension/src/background/approvals/service.test.ts
+++ b/apps/extension/src/background/approvals/service.test.ts
@@ -278,7 +278,7 @@ describe("approvals service", () => {
       );
       service["resolverMap"][tabId]?.resolve(true);
 
-      expect((service as any).launchApprovalPopup).toHaveBeenCalledWith(
+      expect(service["launchApprovalPopup"]).toHaveBeenCalledWith(
         "/approve-connection",
         { interfaceOrigin }
       );

--- a/apps/extension/src/background/approvals/service.test.ts
+++ b/apps/extension/src/background/approvals/service.test.ts
@@ -261,7 +261,6 @@ describe("approvals service", () => {
   describe("approveConnection", () => {
     it("should approve connection if it's not already approved", async () => {
       const url = "url-with-params";
-      const interfaceTabId = 999;
       const interfaceOrigin = "origin";
       const tabId = 1;
 
@@ -272,10 +271,7 @@ describe("approvals service", () => {
       });
       service["resolverMap"] = {};
 
-      const promise = service.approveConnection(
-        interfaceTabId,
-        interfaceOrigin
-      );
+      const promise = service.approveConnection(interfaceOrigin);
       await new Promise<void>((r) =>
         setTimeout(() => {
           r();
@@ -284,7 +280,6 @@ describe("approvals service", () => {
       service["resolverMap"][tabId]?.resolve(true);
 
       expect(paramsToUrl).toHaveBeenCalledWith("url#/approve-connection", {
-        interfaceTabId: interfaceTabId.toString(),
         interfaceOrigin,
       });
       expect(service.isConnectionApproved).toHaveBeenCalledWith(
@@ -296,19 +291,17 @@ describe("approvals service", () => {
 
     it("should not approve connection if it was already approved", async () => {
       const url = "url-with-params";
-      const interfaceTabId = 999;
       const interfaceOrigin = "origin";
       (paramsToUrl as any).mockImplementation(() => url);
       jest.spyOn(service, "isConnectionApproved").mockResolvedValue(true);
 
       await expect(
-        service.approveConnection(interfaceTabId, interfaceOrigin)
+        service.approveConnection(interfaceOrigin)
       ).resolves.toBeUndefined();
     });
 
     it("should throw an error when popupTabId is not found", async () => {
       const url = "url-with-params";
-      const interfaceTabId = 999;
       const interfaceOrigin = "origin";
 
       (paramsToUrl as any).mockImplementation(() => url);
@@ -318,13 +311,12 @@ describe("approvals service", () => {
       });
 
       await expect(
-        service.approveConnection(interfaceTabId, interfaceOrigin)
+        service.approveConnection(interfaceOrigin)
       ).rejects.toBeDefined();
     });
 
     it("should throw an error when popupTabId is found in resolverMap", async () => {
       const url = "url-with-params";
-      const interfaceTabId = 999;
       const interfaceOrigin = "origin";
       const approvedOrigins = ["other-origin"];
       const tabId = 1;
@@ -345,14 +337,13 @@ describe("approvals service", () => {
       });
 
       await expect(
-        service.approveConnection(interfaceTabId, interfaceOrigin)
+        service.approveConnection(interfaceOrigin)
       ).rejects.toBeDefined();
     });
   });
 
   describe("approveConnectionResponse", () => {
     it("should approve connection response", async () => {
-      const interfaceTabId = 999;
       const interfaceOrigin = "origin";
       const popupTabId = 1;
       service["resolverMap"] = {
@@ -364,10 +355,9 @@ describe("approvals service", () => {
       jest.spyOn(localStorage, "addApprovedOrigin").mockResolvedValue();
 
       await service.approveConnectionResponse(
-        interfaceTabId,
+        popupTabId,
         interfaceOrigin,
-        true,
-        popupTabId
+        true
       );
 
       expect(service["resolverMap"][popupTabId].resolve).toHaveBeenCalled();
@@ -377,22 +367,15 @@ describe("approvals service", () => {
     });
 
     it("should throw an error if resolvers are not found", async () => {
-      const interfaceTabId = 999;
       const interfaceOrigin = "origin";
       const popupTabId = 1;
 
       await expect(
-        service.approveConnectionResponse(
-          interfaceTabId,
-          interfaceOrigin,
-          true,
-          popupTabId
-        )
+        service.approveConnectionResponse(popupTabId, interfaceOrigin, true)
       ).rejects.toBeDefined();
     });
 
     it("should reject the connection if allowConnection is set to false", async () => {
-      const interfaceTabId = 999;
       const interfaceOrigin = "origin";
       const popupTabId = 1;
       service["resolverMap"] = {
@@ -403,10 +386,9 @@ describe("approvals service", () => {
       };
 
       await service.approveConnectionResponse(
-        interfaceTabId,
+        popupTabId,
         interfaceOrigin,
-        false,
-        popupTabId
+        false
       );
 
       expect(service["resolverMap"][popupTabId].reject).toHaveBeenCalled();

--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -225,10 +225,10 @@ export class ApprovalsService {
     }
   }
 
-  async approveDisconnect(interfaceOrigin: string): Promise<void> {
+  async approveDisconnection(interfaceOrigin: string): Promise<void> {
     const baseUrl = `${browser.runtime.getURL(
       "approvals.html"
-    )}#${TopLevelRoute.ApproveDisconnect}`;
+    )}#${TopLevelRoute.ApproveDisconnection}`;
 
     const url = paramsToUrl(baseUrl, {
       interfaceOrigin,
@@ -339,7 +339,7 @@ export class ApprovalsService {
     const window = await this.openPopup(url);
     const popupTabId = this.getPopupTabId(window);
 
-    return await new Promise<T>((resolve, reject) => {
+    return new Promise<T>((resolve, reject) => {
       this.resolverMap[popupTabId] = {
         resolve: (args: T) => {
           delete this.resolverMap[popupTabId];

--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -7,6 +7,7 @@ import { SignArbitraryResponse, TxDetails } from "@namada/types";
 import { paramsToUrl } from "@namada/utils";
 
 import { ResponseSign } from "@zondax/ledger-namada";
+import { TopLevelRoute } from "Approvals/types";
 import { ChainsService } from "background/chains";
 import { KeyRingService } from "background/keyring";
 import { SdkService } from "background/sdk";
@@ -279,6 +280,30 @@ export class ApprovalsService {
     } else {
       resolvers.reject();
     }
+  }
+
+  async approveDisconnect(interfaceOrigin: string): Promise<void> {
+    const baseUrl = `${browser.runtime.getURL(
+      "approvals.html"
+    )}#${TopLevelRoute.ApproveDisconnect}`;
+
+    const url = paramsToUrl(baseUrl, {
+      interfaceOrigin,
+    });
+
+    const popupTabId = await this.getPopupTabId(url);
+
+    if (!popupTabId) {
+      throw new Error("no popup tab ID");
+    }
+
+    if (popupTabId in this.resolverMap) {
+      throw new Error(`tab ID ${popupTabId} already exists in promise map`);
+    }
+
+    return new Promise((resolve, reject) => {
+      this.resolverMap[popupTabId] = { resolve, reject };
+    });
   }
 
   async revokeConnection(originToRevoke: string): Promise<void> {

--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -63,7 +63,7 @@ export class ApprovalsService {
 
     await this.txStore.set(msgId, pendingTx);
 
-    return this.launchApprovalWindow(
+    return this.launchApprovalPopup(
       `${TopLevelRoute.ApproveSignTx}/${msgId}/${details.type}/${signer}`
     );
   }
@@ -76,7 +76,7 @@ export class ApprovalsService {
 
     await this.dataStore.set(msgId, data);
 
-    return this.launchApprovalWindow(
+    return this.launchApprovalPopup(
       `${TopLevelRoute.ApproveSignArbitrary}/${signer}`,
       { msgId }
     );
@@ -186,7 +186,7 @@ export class ApprovalsService {
     const alreadyApproved = await this.isConnectionApproved(interfaceOrigin);
 
     if (!alreadyApproved) {
-      return this.launchApprovalWindow(TopLevelRoute.ApproveConnection, {
+      return this.launchApprovalPopup(TopLevelRoute.ApproveConnection, {
         interfaceOrigin,
       });
     }
@@ -218,7 +218,7 @@ export class ApprovalsService {
     const isConnected = await this.isConnectionApproved(interfaceOrigin);
 
     if (isConnected) {
-      return this.launchApprovalWindow(TopLevelRoute.ApproveDisconnection, {
+      return this.launchApprovalPopup(TopLevelRoute.ApproveDisconnection, {
         interfaceOrigin,
       });
     }
@@ -294,7 +294,7 @@ export class ApprovalsService {
     return await this.dataStore.set(msgId, null);
   }
 
-  private openPopup = (url: string): Promise<Windows.Window> => {
+  private createPopup = (url: string): Promise<Windows.Window> => {
     return browser.windows.create({
       url,
       width: 396,
@@ -318,14 +318,14 @@ export class ApprovalsService {
     return popupTabId;
   };
 
-  private launchApprovalWindow = async <T>(
+  private launchApprovalPopup = async <T>(
     route: string,
     params?: Record<string, string>
   ): Promise<T> => {
     const baseUrl = `${browser.runtime.getURL("approvals.html")}#${route}`;
     const url = params ? paramsToUrl(baseUrl, params) : baseUrl;
 
-    const window = await this.openPopup(url);
+    const window = await this.createPopup(url);
     const popupTabId = this.getPopupTabId(window);
 
     return new Promise<T>((resolve, reject) => {

--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -39,7 +39,11 @@ export class ApprovalsService {
     protected readonly broadcaster: ExtensionBroadcaster
   ) {
     browser.tabs.onRemoved.addListener((tabId) => {
-      this.removeResolver(tabId);
+      const resolver = this.getResolver(tabId);
+      if (resolver) {
+        resolver.reject(new Error("Window closed"));
+        this.removeResolver(tabId);
+      }
     });
   }
 

--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -39,7 +39,7 @@ export class ApprovalsService {
     protected readonly broadcaster: ExtensionBroadcaster
   ) {
     browser.tabs.onRemoved.addListener((tabId) => {
-      delete this.resolverMap[tabId];
+      this.removeResolver(tabId);
     });
   }
 
@@ -331,11 +331,11 @@ export class ApprovalsService {
     return new Promise<T>((resolve, reject) => {
       this.resolverMap[popupTabId] = {
         resolve: (args: T) => {
-          delete this.resolverMap[popupTabId];
+          this.removeResolver(popupTabId);
           return resolve(args);
         },
         reject: (args: unknown) => {
-          delete this.resolverMap[popupTabId];
+          this.removeResolver(popupTabId);
           return reject(args);
         },
       };
@@ -348,5 +348,9 @@ export class ApprovalsService {
       throw new Error(`no resolvers found for tab ID ${popupTabId}`);
     }
     return resolvers;
+  };
+
+  private removeResolver = (popupTabId: number): void => {
+    delete this.resolverMap[popupTabId];
   };
 }

--- a/apps/extension/src/provider/Namada.test.ts
+++ b/apps/extension/src/provider/Namada.test.ts
@@ -21,6 +21,14 @@ jest.mock(
     )
 );
 
+jest.mock("webextension-polyfill", () => ({
+  tabs: {
+    onRemoved: {
+      addListener: jest.fn(),
+    },
+  },
+}));
+
 describe("Namada", () => {
   let namada: Namada;
   let vaultStorage: VaultStorage;

--- a/apps/extension/src/provider/Namada.ts
+++ b/apps/extension/src/provider/Namada.ts
@@ -9,10 +9,10 @@ import {
 } from "@namada/types";
 import { MessageRequester, Ports } from "router";
 
-import { RevokeConnectionMsg } from "background/approvals";
 import { toEncodedTx } from "utils";
 import {
   ApproveConnectInterfaceMsg,
+  ApproveDisconnectInterfaceMsg,
   ApproveSignArbitraryMsg,
   ApproveSignTxMsg,
   CheckDurabilityMsg,
@@ -40,7 +40,7 @@ export class Namada implements INamada {
   public async disconnect(): Promise<void> {
     return await this.requester?.sendMessage(
       Ports.Background,
-      new RevokeConnectionMsg(location.origin)
+      new ApproveDisconnectInterfaceMsg(location.origin)
     );
   }
 

--- a/apps/extension/src/provider/messages.ts
+++ b/apps/extension/src/provider/messages.ts
@@ -20,6 +20,7 @@ enum MessageType {
   ApproveSignArbitrary = "approve-sign-arbitrary",
   IsConnectionApproved = "is-connection-approved",
   ApproveConnectInterface = "approve-connect-interface",
+  ApproveDisconnectInterface = "approve-disconnect-interface",
   QueryAccounts = "query-accounts",
   QueryDefaultAccount = "query-default-account",
   UpdateDefaultAccount = "update-default-account",
@@ -131,6 +132,28 @@ export class ApproveConnectInterfaceMsg extends Message<void> {
 
   type(): string {
     return ApproveConnectInterfaceMsg.type();
+  }
+}
+
+export class ApproveDisconnectInterfaceMsg extends Message<void> {
+  public static type(): MessageType {
+    return MessageType.ApproveDisconnectInterface;
+  }
+
+  constructor(public readonly originToRevoke: string) {
+    super();
+  }
+
+  validate(): void {
+    validateProps(this, ["originToRevoke"]);
+  }
+
+  route(): string {
+    return Route.Approvals;
+  }
+
+  type(): string {
+    return ApproveDisconnectInterfaceMsg.type();
   }
 }
 

--- a/apps/namadillo/src/App/AppRoutes.tsx
+++ b/apps/namadillo/src/App/AppRoutes.tsx
@@ -13,7 +13,7 @@ import { RouteErrorBoundary } from "./Common/RouteErrorBoundary";
 import { Governance } from "./Governance";
 import { SettingsPanel } from "./Settings/SettingsPanel";
 import { Staking } from "./Staking";
-import { SwitchAccountModal } from "./SwitchAccount/SwitchAccountModal";
+import { SwitchAccountPanel } from "./SwitchAccount/SwitchAccountPanel";
 
 import GovernanceRoutes from "./Governance/routes";
 import SettingsRoutes from "./Settings/routes";
@@ -52,7 +52,7 @@ export const MainRoutes = (): JSX.Element => {
         />
         <Route
           path={`${SwitchAccountRoutes.index()}/*`}
-          element={<SwitchAccountModal />}
+          element={<SwitchAccountPanel />}
           errorElement={<RouteErrorBoundary />}
         />
         <Route

--- a/apps/namadillo/src/App/SwitchAccount/SwitchAccountPanel.tsx
+++ b/apps/namadillo/src/App/SwitchAccount/SwitchAccountPanel.tsx
@@ -11,7 +11,7 @@ import { useAtomValue } from "jotai";
 import { IoClose } from "react-icons/io5";
 import { twMerge } from "tailwind-merge";
 
-export const SwitchAccountModal = (): JSX.Element => {
+export const SwitchAccountPanel = (): JSX.Element => {
   const { onCloseModal } = useModalCloseEvent();
   const { data: defaultAccount } = useAtomValue(defaultAccountAtom);
   const { data } = useAtomValue(accountsAtom);

--- a/apps/namadillo/src/App/SwitchAccount/SwitchAccountPanel.tsx
+++ b/apps/namadillo/src/App/SwitchAccount/SwitchAccountPanel.tsx
@@ -18,7 +18,13 @@ export const SwitchAccountPanel = (): JSX.Element => {
   const { mutateAsync: updateAccount } = useAtomValue(updateDefaultAccountAtom);
 
   return (
-    <Modal onClose={onCloseModal}>
+    <Modal
+      onClose={onCloseModal}
+      className={clsx(
+        "w-full left-auto right-0 top-0 translate-x-0 translate-y-0",
+        "translate-y-0 pointer-events-none"
+      )}
+    >
       <ModalTransition className="custom-container sm:p-5">
         <div
           className={clsx(


### PR DESCRIPTION
Add the disconnection account approval step

This PR also combine e create some methods for the Approvals service to manage the popup easier, the main one is `launchApprovalPopup` which takes a typed route and custom params. And it'll remove the popup resolver from the map once they are resolved or rejected, or when the popup is removed/closed by the user

![Screenshot 2024-09-12 at 19 38 04](https://github.com/user-attachments/assets/36e91165-6ed8-49fb-bbdf-2b8a102f933b)

https://github.com/user-attachments/assets/285a3a6f-aef3-4e8a-8c08-ea47e1cdc988

