### PR TITLE
fix: trim long strings on extension list items

### DIFF
--- a/apps/extension/src/App/Settings/ConnectedSites.tsx
+++ b/apps/extension/src/App/Settings/ConnectedSites.tsx
@@ -84,7 +84,9 @@ export const ConnectedSites: React.FC = ({}) => {
                 "items-center text-base py-4 px-6"
               )}
             >
-              <span>{site}</span>
+              <span className="text-ellipsis overflow-hidden" title={site}>
+                {site}
+              </span>
               <span
                 className="p-2 cursor-pointer hover:text-yellow -mr-2"
                 onClick={() => handleRevokeConnection(site)}

--- a/packages/components/src/KeyListItem.tsx
+++ b/packages/components/src/KeyListItem.tsx
@@ -53,7 +53,9 @@ export const KeyListItem = ({
           checked={isMainKey}
         />
       </div>
-      <label>{alias}</label>
+      <label className="text-ellipsis overflow-hidden" title={alias}>
+        {alias}
+      </label>
       <DropdownMenu
         id={alias}
         align="right"


### PR DESCRIPTION
Trim long strings on extension list items and add the `title` attribute for it as a last user resource

![Screenshot 2024-09-13 at 10 54 27](https://github.com/user-attachments/assets/e845c22e-e211-4e7d-811c-3cbc32cf7ca4)

![Screenshot 2024-09-13 at 10 59 33](https://github.com/user-attachments/assets/d8d1f608-45c1-41b5-ad35-27e50366904f)
