### PR TITLE
Namadillo: Optimistically updating staking rewards balance

### DIFF
--- a/apps/namadillo/src/atoms/staking/atoms.ts
+++ b/apps/namadillo/src/atoms/staking/atoms.ts
@@ -96,21 +96,6 @@ export const createWithdrawTxAtomFamily = atomFamily((id: string) => {
   });
 });
 
-export const claimRewardsAtom = atomWithMutation((get) => {
-  const chain = get(chainAtom);
-  return {
-    mutationKey: ["create-claim-tx"],
-    enabled: chain.isSuccess,
-    mutationFn: async ({
-      params,
-      gasConfig,
-      account,
-    }: BuildTxAtomParams<ClaimRewardsMsgValue>) => {
-      return createClaimTx(chain.data!, account, params, gasConfig);
-    },
-  };
-});
-
 export const claimableRewardsAtom = atomWithQuery<AddressBalance>((get) => {
   const account = get(defaultAccountAtom);
   const chainParameters = get(chainParametersAtom);
@@ -131,6 +116,21 @@ export const claimableRewardsAtom = atomWithQuery<AddressBalance>((get) => {
         {}
       );
     }, [account, chainParameters]),
+  };
+});
+
+export const claimRewardsAtom = atomWithMutation((get) => {
+  const chain = get(chainAtom);
+  return {
+    mutationKey: ["create-claim-tx"],
+    enabled: chain.isSuccess,
+    mutationFn: async ({
+      params,
+      gasConfig,
+      account,
+    }: BuildTxAtomParams<ClaimRewardsMsgValue>) => {
+      return createClaimTx(chain.data!, account, params, gasConfig);
+    },
   };
 });
 

--- a/apps/namadillo/src/atoms/staking/services.ts
+++ b/apps/namadillo/src/atoms/staking/services.ts
@@ -12,6 +12,7 @@ import {
   WithdrawProps,
   WrapperTxProps,
 } from "@namada/types";
+import { queryClient } from "App/Common/QueryProvider";
 import { getSdkInstance } from "hooks";
 import { TransactionPair, buildTxPair } from "lib/query";
 import { Address, AddressBalance, ChainSettings, GasConfig } from "types";
@@ -158,4 +159,8 @@ export const createClaimAndStakeTx = async (
     buildClaimRewardsAndStake,
     account.address
   );
+};
+
+export const clearClaimRewards = (accountAddress: string): void => {
+  queryClient.setQueryData(["claim-rewards", accountAddress], () => ({}));
 };

--- a/apps/namadillo/src/hooks/useTransactionCallbacks.tsx
+++ b/apps/namadillo/src/hooks/useTransactionCallbacks.tsx
@@ -1,29 +1,36 @@
-import { accountBalanceAtom } from "atoms/accounts";
+import { accountBalanceAtom, defaultAccountAtom } from "atoms/accounts";
 import { shouldUpdateBalanceAtom, shouldUpdateProposalAtom } from "atoms/etc";
-import { claimableRewardsAtom } from "atoms/staking";
+import { claimableRewardsAtom, clearClaimRewards } from "atoms/staking";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useTransactionEventListener } from "utils";
 
 export const useTransactionCallback = (): void => {
   const { refetch: refetchBalances } = useAtomValue(accountBalanceAtom);
   const { refetch: refetchRewards } = useAtomValue(claimableRewardsAtom);
+  const { data: account } = useAtomValue(defaultAccountAtom);
   const shouldUpdateBalance = useSetAtom(shouldUpdateBalanceAtom);
 
   const onBalanceUpdate = (): void => {
     // TODO: refactor this after event subscription is enabled on indexer
     shouldUpdateBalance(true);
     refetchBalances();
-    refetchRewards();
 
     const timePolling = 6 * 1000;
     setTimeout(() => shouldUpdateBalance(false), timePolling);
+
+    if (account?.address) {
+      clearClaimRewards(account.address);
+      setTimeout(() => refetchRewards(), timePolling);
+    }
   };
 
   useTransactionEventListener("Bond.Success", onBalanceUpdate);
   useTransactionEventListener("Unbond.Success", onBalanceUpdate);
   useTransactionEventListener("Withdraw.Success", onBalanceUpdate);
   useTransactionEventListener("Redelegate.Success", onBalanceUpdate);
-  useTransactionEventListener("ClaimRewards.Success", onBalanceUpdate);
+  useTransactionEventListener("ClaimRewards.Success", onBalanceUpdate, [
+    account,
+  ]);
 
   const shouldUpdateProposal = useSetAtom(shouldUpdateProposalAtom);
 

--- a/apps/namadillo/src/utils/index.ts
+++ b/apps/namadillo/src/utils/index.ts
@@ -36,14 +36,15 @@ export const proposalIdToString = (proposalId: bigint): string =>
 
 export const useTransactionEventListener = <T extends keyof WindowEventMap>(
   event: T,
-  handler: (this: Window, ev: WindowEventMap[T]) => void
+  handler: (this: Window, ev: WindowEventMap[T]) => void,
+  deps: React.DependencyList = []
 ): void => {
   useEffect(() => {
     window.addEventListener(event, handler);
     return () => {
       window.removeEventListener(event, handler);
     };
-  }, []);
+  }, deps);
 };
 
 const secondsToDateTime = (seconds: bigint): DateTime =>


### PR DESCRIPTION
When you claim rewards, the indexer will need to wait for the next block to sync the new amount. This process might take a few seconds, depending on network configuration. This PR sets the available rewards balance to zero as soon as the claim rewards success event gets fired.