### PR TITLE
MASP indexer integration

### DIFF
--- a/apps/extension/src/background/sdk/service.ts
+++ b/apps/extension/src/background/sdk/service.ts
@@ -8,6 +8,9 @@ const {
     defaultTokenAddress = "tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e",
 } = process.env;
 
+// Extension does not care about the MASP indexer - this will map to None in Rust
+const MASP_INDEXER_URL = "";
+
 export class SdkService {
   private constructor(
     private rpc: string,
@@ -27,6 +30,12 @@ export class SdkService {
   }
 
   getSdk(): Sdk {
-    return getSdk(this.cryptoMemory, this.rpc, "NOT USED DB NAME", this.token);
+    return getSdk(
+      this.cryptoMemory,
+      this.rpc,
+      MASP_INDEXER_URL,
+      "NOT USED DB NAME",
+      this.token
+    );
   }
 }

--- a/apps/namadillo/src/App/Settings/Advanced.tsx
+++ b/apps/namadillo/src/App/Settings/Advanced.tsx
@@ -2,8 +2,10 @@ import { ActionButton, Input, Stack } from "@namada/components";
 import { chainParametersAtom } from "atoms/chain";
 import {
   indexerUrlAtom,
+  maspIndexerUrlAtom,
   rpcUrlAtom,
   updateIndexerUrlAtom,
+  updateMaspIndexerUrlAtom,
   updateRpcUrlAtom,
 } from "atoms/settings";
 import { useAtom, useAtomValue } from "jotai";
@@ -16,11 +18,14 @@ export const Advanced = (): JSX.Element => {
   const [currentRpc] = useAtom(rpcUrlAtom);
   const [rpcMutation] = useAtom(updateRpcUrlAtom);
   const [currentIndexer] = useAtom(indexerUrlAtom);
+  const [currentMaspIndexer] = useAtom(maspIndexerUrlAtom);
   const [indexerMutation] = useAtom(updateIndexerUrlAtom);
+  const [maspIndexerMutation] = useAtom(updateMaspIndexerUrlAtom);
   const { data: chainParameters } = useAtomValue(chainParametersAtom);
 
   const [rpc, setRpc] = useState(currentRpc);
   const [indexer, setIndexer] = useState(currentIndexer);
+  const [maspIndexer, setMaspIndexer] = useState(currentMaspIndexer);
 
   const onSubmit = async (e: React.FormEvent): Promise<void> => {
     e.preventDefault();
@@ -28,13 +33,17 @@ export const Advanced = (): JSX.Element => {
       await Promise.all([
         rpcMutation.mutateAsync(rpc),
         indexerMutation.mutateAsync(indexer),
+        maspIndexerMutation.mutateAsync(maspIndexer),
       ]);
       document.location.href =
         location.state.backgroundLocation.pathname ?? location.pathname;
     } catch {}
   };
 
-  const isPending = rpcMutation.isPending || indexerMutation.isPending;
+  const isPending =
+    rpcMutation.isPending ||
+    indexerMutation.isPending ||
+    maspIndexerMutation.isPending;
 
   return (
     <form
@@ -70,6 +79,21 @@ export const Advanced = (): JSX.Element => {
             rpcMutation.reset();
           }}
           required
+        />
+        <Input
+          type="text"
+          placeholder="Optional"
+          value={maspIndexer}
+          error={
+            maspIndexerMutation.error instanceof Error &&
+            maspIndexerMutation.error.message
+          }
+          label="MASP Indexer URL"
+          className="[&_input]:border-neutral-300"
+          onChange={(e) => {
+            setMaspIndexer(e.currentTarget.value);
+            maspIndexerMutation.reset();
+          }}
         />
         <Input
           type="text"

--- a/apps/namadillo/src/atoms/settings/services.ts
+++ b/apps/namadillo/src/atoms/settings/services.ts
@@ -17,6 +17,18 @@ export const isIndexerAlive = async (url: string): Promise<boolean> => {
   }
 };
 
+export const isMaspIndexerAlive = async (url: string): Promise<boolean> => {
+  if (!isUrlValid(url)) {
+    return false;
+  }
+  try {
+    const response = await fetch(`${url}/health`);
+    return response.ok && response.status === 200;
+  } catch {
+    return false;
+  }
+};
+
 export const isRpcAlive = async (url: string): Promise<boolean> => {
   if (!isUrlValid(url)) {
     return false;

--- a/apps/namadillo/src/hooks/useSdk.tsx
+++ b/apps/namadillo/src/hooks/useSdk.tsx
@@ -1,7 +1,7 @@
 import initSdk from "@heliax/namada-sdk/inline-init";
 import { getSdk, Sdk } from "@heliax/namada-sdk/web";
 import { nativeTokenAddressAtom } from "atoms/chain";
-import { rpcUrlAtom } from "atoms/settings";
+import { maspIndexerUrlAtom, rpcUrlAtom } from "atoms/settings";
 import { getDefaultStore, useAtomValue } from "jotai";
 import {
   createContext,
@@ -24,13 +24,20 @@ const initializeSdk = async (): Promise<Sdk> => {
   const { cryptoMemory } = await initSdk();
   const store = getDefaultStore();
   const rpcUrl = store.get(rpcUrlAtom);
+  const maspIndexerUrl = store.get(maspIndexerUrlAtom);
   const nativeToken = store.get(nativeTokenAddressAtom);
 
   if (!nativeToken.isSuccess) {
     throw "Native token not loaded";
   }
 
-  const sdk = getSdk(cryptoMemory, rpcUrl, "", nativeToken.data);
+  const sdk = getSdk(
+    cryptoMemory,
+    rpcUrl,
+    maspIndexerUrl,
+    "",
+    nativeToken.data
+  );
   return sdk;
 };
 

--- a/apps/namadillo/src/types.d.ts
+++ b/apps/namadillo/src/types.d.ts
@@ -45,6 +45,7 @@ export type ChainSettings = {
 
 export type SettingsTomlOptions = {
   indexer_url?: string;
+  masp_indexer_url?: string;
   rpc_url?: string;
 };
 
@@ -61,6 +62,7 @@ export type SettingsStorage = {
   fiat: CurrencyType;
   rpcUrl?: string;
   indexerUrl: string;
+  maspIndexerUrl?: string;
   signArbitraryEnabled: boolean;
 };
 

--- a/packages/crypto/lib/Cargo.lock
+++ b/packages/crypto/lib/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aead"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c192eb8f11fc081b0fe4259ba5af04217d4e0faddd02417310a927911abd7c8"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
  "generic-array",
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.8.1"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe0133578c0986e1fe3dfcd4af1cc5b2dd6c3dbf534d69916ce16a2701d40ba"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -25,9 +25,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
  "aes",
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "argon2"
@@ -56,21 +56,21 @@ dependencies = [
 
 [[package]]
 name = "arrayref"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.2"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "base16ct"
@@ -80,9 +80,9 @@ checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64ct"
@@ -99,7 +99,7 @@ dependencies = [
  "hmac",
  "pbkdf2 0.10.1",
  "rand 0.8.5",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "unicode-normalization",
  "zeroize",
 ]
@@ -117,7 +117,7 @@ dependencies = [
  "pbkdf2 0.11.0",
  "rand_core 0.6.4",
  "ripemd",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "subtle",
  "zeroize",
 ]
@@ -136,18 +136,18 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.10.4"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9cf849ee05b2ee5fba5e36f97ff8ec2533916700fc0758d40d92136a42f3388"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.7",
 ]
 
 [[package]]
 name = "blake2b_simd"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72936ee4afc7f8f736d1c38383b56480b5497b4617b4a77bdbf1d2ababc76127"
+checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -156,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "blake2s_simd"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db539cc2b5f6003621f1cd9ef92d7ded8ea5232c7de0f9faa2de251cd98730d4"
+checksum = "94230421e395b9920d23df13ea5d77a20e1725331f90fbbf6df6040b33f756ae"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.2.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9897ef0f1bd2362169de6d7e436ea2237dc1085d7d1e4db75f4be34d86f309d1"
+checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -208,15 +208,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.2.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478b41ff04256c5c8330f3dfdaaae2a5cc976a8e75088bafa4625b0d0208de8c"
+checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn",
  "syn_derive",
 ]
 
@@ -239,15 +239,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cbc"
@@ -259,6 +259,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bcde016d64c21da4be18b655631e5ab6d3107607e71a73a9f53eb48aae23fb"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -266,9 +275,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -317,21 +326,21 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.0"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.1.5"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -346,7 +355,7 @@ dependencies = [
  "bip32",
  "borsh",
  "borsh-ext",
- "getrandom 0.2.7",
+ "getrandom 0.2.15",
  "gloo-utils",
  "hex",
  "js-sys",
@@ -365,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2b443d17d49dad5ef0ede301c3179cc923b8822f3393b4d2c28c269dd4a122"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -388,9 +397,9 @@ dependencies = [
 
 [[package]]
 name = "ct-codecs"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df"
+checksum = "026ac6ceace6298d2c557ef5ed798894962296469ec7842288ea64674201a2d1"
 
 [[package]]
 name = "ctr"
@@ -403,9 +412,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
 ]
@@ -421,11 +430,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.5"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.3",
+ "block-buffer 0.10.4",
  "crypto-common",
  "subtle",
 ]
@@ -451,10 +460,10 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
- "digest 0.10.5",
- "ff 0.12.0",
+ "digest 0.10.7",
+ "ff 0.12.1",
  "generic-array",
- "group 0.12.0",
+ "group 0.12.1",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -469,9 +478,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "ff"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df689201f395c6b90dfe87127685f8dbfc083a5e779e613575d8bd7314300c3e"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -510,9 +519,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -533,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.7"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -546,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -556,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "gloo-utils"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40913a05c8297adca04392f707b1e73b12ba7b8eab7244a4961580b1fd34063c"
+checksum = "037fcb07216cb3a30f7292bd0176b050b7b9a052ba830ef7d5d65f6dc64ba58e"
 dependencies = [
  "js-sys",
  "serde",
@@ -569,11 +578,11 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7391856def869c1c81063a03457c676fbcd419709c3dfb33d8d319de484b154d"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff 0.12.0",
+ "ff 0.12.1",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -592,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hex"
@@ -608,7 +617,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -628,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -647,15 +656,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -683,42 +692,42 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "sha3",
 ]
 
 [[package]]
 name = "keccak"
-version = "0.1.2"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
+]
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libm"
-version = "0.2.5"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "masp_note_encryption"
@@ -759,22 +768,32 @@ dependencies = [
  "num-traits",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "subtle",
  "zcash_encoding",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memuse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2145869435ace5ea6ea3d35f59be559317ec9a0d04e1812d5f185a87b6d36f1a"
+
+[[package]]
+name = "minicov"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c71e683cd655513b99affab7d317deb690528255a0d5f717f1024093c12b169"
+dependencies = [
+ "cc",
+ "walkdir",
+]
 
 [[package]]
 name = "nonempty"
@@ -784,45 +803,43 @@ checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
 
 [[package]]
 name = "num-bigint"
-version = "0.4.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "orion"
@@ -831,7 +848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6624905ddd92e460ff0685567539ed1ac985b2dee4c92c7edcd64fce905b00c"
 dependencies = [
  "ct-codecs",
- "getrandom 0.2.7",
+ "getrandom 0.2.15",
  "subtle",
  "zeroize",
 ]
@@ -873,7 +890,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.7",
  "password-hash 0.3.2",
 ]
 
@@ -883,7 +900,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -899,9 +916,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -911,17 +928,19 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.16"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97dc5fea232fc28d2f597b37c4876b348a40e33f3b02cc975c8d006d78d94b1a"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_datetime",
  "toml_edit",
 ]
 
@@ -950,18 +969,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.57"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ec6d5fe0b140acb27c9a0444118cf55bfbb4e0b259739429abb4521dd67c16"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -1031,7 +1050,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -1045,9 +1064,9 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c86280f057430a52f4861551b092a01b419b8eacefc7c995eacb9dc132fe32"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint",
  "hmac",
@@ -1060,7 +1079,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1071,15 +1090,24 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scoped-tls"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "sec1"
@@ -1096,31 +1124,32 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.101",
+ "syn",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -1140,32 +1169,38 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.5",
+ "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.5"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2904bea16a1ae962b483322a1c7b81d976029203aea1f461e51cd7705db7ba9"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.7",
  "keccak",
 ]
 
 [[package]]
-name = "signature"
-version = "1.6.3"
+name = "shlex"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb766570a2825fa972bceff0d195727876a9cdf2460ab2e52d455dc2de47fd9"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -1186,20 +1221,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.101"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1215,19 +1239,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.101",
- "unicode-xid",
+ "syn",
 ]
 
 [[package]]
@@ -1238,22 +1250,22 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.101",
+ "syn",
 ]
 
 [[package]]
@@ -1267,7 +1279,7 @@ dependencies = [
  "pbkdf2 0.11.0",
  "rand 0.8.5",
  "rustc-hash",
- "sha2 0.10.6",
+ "sha2 0.10.8",
  "thiserror",
  "unicode-normalization",
  "wasm-bindgen",
@@ -1276,30 +1288,30 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.20.2"
+version = "0.22.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1308,36 +1320,30 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.4"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
 name = "universal-hash"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
  "crypto-common",
  "subtle",
@@ -1345,9 +1351,19 @@ dependencies = [
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -1363,34 +1379,35 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1400,9 +1417,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1410,31 +1427,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.33"
+version = "0.3.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d2fff962180c3fadf677438054b1db62bee4aa32af26a45388af07d1287e1d"
+checksum = "68497a05fb21143a08a7d24fc81763384a3072ee43c44e86aad1744d6adef9d9"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
+ "minicov",
  "scoped-tls",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1443,29 +1461,112 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.33"
+version = "0.3.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4683da3dfc016f704c9f82cf401520c4f1cb3ee440f7f52b3d6ac29506a49ca7"
+checksum = "4b8220be1fa9e4c889b30fd207d4906657e7e90b12e0e6b0c8b8d8709f5de021"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "winnow"
-version = "0.5.17"
+name = "winapi-util"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b801d0e0a6726477cc207f60162da452f3a95adb368399bef20a946e06f65c"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
 ]
@@ -1489,22 +1590,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "zeroize"
-version = "1.6.0"
+name = "zerocopy"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.2"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.101",
- "synstructure",
+ "syn",
 ]

--- a/packages/crypto/lib/rust-toolchain.toml
+++ b/packages/crypto/lib/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.70.0"
+channel = "nightly-2024-09-08"
 components = ["rustc", "cargo", "rust-std", "rust-docs", "rls", "rust-src", "rust-analysis"]
 targets = ['wasm32-unknown-unknown']

--- a/packages/crypto/lib/src/crypto/bip39.rs
+++ b/packages/crypto/lib/src/crypto/bip39.rs
@@ -70,9 +70,8 @@ impl Mnemonic {
         let words: Vec<String> = self
             .mnemonic
             .phrase()
-            .clone()
             .split(' ')
-            .map(|word| String::from(word))
+            .map(String::from)
             .collect();
         Ok(new_vec_string_pointer(words))
     }

--- a/packages/crypto/lib/src/crypto/zip32.rs
+++ b/packages/crypto/lib/src/crypto/zip32.rs
@@ -124,11 +124,11 @@ mod tests {
             .expect("Deriving from ExtendedKeys should not fail");
 
         let payment_address: PaymentAddress =
-            borsh::BorshDeserialize::try_from_slice(&payment_address)
+            borsh::BorshDeserialize::try_from_slice(payment_address)
                 .expect("Should be able to deserialize payment address!");
-        let xsk: ExtendedSpendingKey = borsh::BorshDeserialize::try_from_slice(&xsk)
+        let xsk: ExtendedSpendingKey = borsh::BorshDeserialize::try_from_slice(xsk)
             .expect("Should be able to deserialize extended spending key!");
-        let xfvk: ExtendedFullViewingKey = borsh::BorshDeserialize::try_from_slice(&xfvk)
+        let xfvk: ExtendedFullViewingKey = borsh::BorshDeserialize::try_from_slice(xfvk)
             .expect("Should be able to deserialize full viewing key!");
 
         assert_eq!(payment_address.to_bytes().len(), 43);

--- a/packages/sdk/src/indexWeb.ts
+++ b/packages/sdk/src/indexWeb.ts
@@ -8,6 +8,7 @@ export * from "./utils";
  * @async
  * @param cryptoMemory - WebAssembly.Memory of crypto package
  * @param url - URL of the node
+ * @param maspIndexerUrl - optional URL of the MASP indexer
  * @param dbName - Name of the database for the serialized wallet
  * @param [token] - Native token of the chain
  * @throws {Error} - Unable to Query native token
@@ -16,11 +17,15 @@ export * from "./utils";
 export function getSdk(
   cryptoMemory: WebAssembly.Memory,
   url: string,
+  maspIndexerUrl: string,
   dbName: string,
   token: string
 ): Sdk {
+  // We change empty string to undefined so it "maps" to the Option<String> in Rust
+  const maspIndexerUrlOpt =
+    maspIndexerUrl.length === 0 ? undefined : maspIndexerUrl;
   // Instantiate QueryWasm
-  const query = new QueryWasm(url);
+  const query = new QueryWasm(url, maspIndexerUrlOpt);
 
   // Instantiate SdkWasm
   const sdk = new SdkWasm(url, token, dbName);

--- a/packages/sdk/src/tests/signing.test.ts
+++ b/packages/sdk/src/tests/signing.test.ts
@@ -27,7 +27,7 @@ describe("Signing", () => {
       validSignature.signature
     );
 
-    expect(result).toBe(null);
+    expect(result).toBeUndefined();
   });
 
   it("should throw error when validating an invalid signature", () => {
@@ -40,6 +40,6 @@ describe("Signing", () => {
         invalidSignature.signature
       );
 
-    expect(verify).toThrowError();
+    expect(verify).toThrow();
   });
 });

--- a/packages/shared/lib/Cargo.lock
+++ b/packages/shared/lib/Cargo.lock
@@ -2886,7 +2886,6 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "namada_account"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2898,7 +2897,6 @@ dependencies = [
 [[package]]
 name = "namada_controller"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "namada_core",
  "smooth-operator",
@@ -2908,7 +2906,6 @@ dependencies = [
 [[package]]
 name = "namada_core"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "bech32 0.8.1",
  "borsh",
@@ -2958,7 +2955,6 @@ dependencies = [
 [[package]]
 name = "namada_ethereum_bridge"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "ethers",
@@ -2986,7 +2982,6 @@ dependencies = [
 [[package]]
 name = "namada_events"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3000,7 +2995,6 @@ dependencies = [
 [[package]]
 name = "namada_gas"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3013,7 +3007,6 @@ dependencies = [
 [[package]]
 name = "namada_governance"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3036,7 +3029,6 @@ dependencies = [
 [[package]]
 name = "namada_ibc"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "data-encoding",
@@ -3066,7 +3058,6 @@ dependencies = [
 [[package]]
 name = "namada_io"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "async-trait",
  "kdam",
@@ -3079,7 +3070,6 @@ dependencies = [
 [[package]]
 name = "namada_macros"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "data-encoding",
  "proc-macro2",
@@ -3091,7 +3081,6 @@ dependencies = [
 [[package]]
 name = "namada_merkle_tree"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "eyre",
@@ -3106,7 +3095,6 @@ dependencies = [
 [[package]]
 name = "namada_parameters"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "namada_core",
  "namada_macros",
@@ -3121,7 +3109,6 @@ dependencies = [
 [[package]]
 name = "namada_proof_of_stake"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3145,7 +3132,6 @@ dependencies = [
 [[package]]
 name = "namada_replay_protection"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "namada_core",
 ]
@@ -3153,7 +3139,6 @@ dependencies = [
 [[package]]
 name = "namada_sdk"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "async-trait",
  "bimap",
@@ -3215,6 +3200,7 @@ dependencies = [
  "tokio",
  "toml 0.5.11",
  "tracing",
+ "web-sys",
  "xorf",
  "zeroize",
 ]
@@ -3222,7 +3208,6 @@ dependencies = [
 [[package]]
 name = "namada_shielded_token"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3257,13 +3242,13 @@ dependencies = [
  "thiserror",
  "tracing",
  "typed-builder",
+ "web-sys",
  "xorf",
 ]
 
 [[package]]
 name = "namada_state"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "clru",
@@ -3286,7 +3271,6 @@ dependencies = [
 [[package]]
 name = "namada_storage"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3305,7 +3289,6 @@ dependencies = [
 [[package]]
 name = "namada_systems"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -3315,7 +3298,6 @@ dependencies = [
 [[package]]
 name = "namada_token"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3330,7 +3312,6 @@ dependencies = [
 [[package]]
 name = "namada_trans_token"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "konst",
  "namada_core",
@@ -3346,7 +3327,6 @@ dependencies = [
 [[package]]
 name = "namada_tx"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "ark-bls12-381",
  "bitflags 2.5.0",
@@ -3375,7 +3355,6 @@ dependencies = [
 [[package]]
 name = "namada_vm"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "clru",
@@ -3397,7 +3376,6 @@ dependencies = [
 [[package]]
 name = "namada_vote_ext"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3409,7 +3387,6 @@ dependencies = [
 [[package]]
 name = "namada_vp"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -3425,7 +3402,6 @@ dependencies = [
 [[package]]
 name = "namada_vp_env"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "derivative",
  "masp_primitives",
@@ -3440,7 +3416,6 @@ dependencies = [
 [[package]]
 name = "namada_wallet"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "bimap",
  "borsh",

--- a/packages/shared/lib/Cargo.lock
+++ b/packages/shared/lib/Cargo.lock
@@ -2886,6 +2886,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "namada_account"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2897,6 +2898,7 @@ dependencies = [
 [[package]]
 name = "namada_controller"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "namada_core",
  "smooth-operator",
@@ -2906,6 +2908,7 @@ dependencies = [
 [[package]]
 name = "namada_core"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "bech32 0.8.1",
  "borsh",
@@ -2955,6 +2958,7 @@ dependencies = [
 [[package]]
 name = "namada_ethereum_bridge"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "ethers",
@@ -2982,6 +2986,7 @@ dependencies = [
 [[package]]
 name = "namada_events"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2995,6 +3000,7 @@ dependencies = [
 [[package]]
 name = "namada_gas"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3007,6 +3013,7 @@ dependencies = [
 [[package]]
 name = "namada_governance"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3029,6 +3036,7 @@ dependencies = [
 [[package]]
 name = "namada_ibc"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "data-encoding",
@@ -3058,6 +3066,7 @@ dependencies = [
 [[package]]
 name = "namada_io"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "async-trait",
  "kdam",
@@ -3070,6 +3079,7 @@ dependencies = [
 [[package]]
 name = "namada_macros"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "data-encoding",
  "proc-macro2",
@@ -3081,6 +3091,7 @@ dependencies = [
 [[package]]
 name = "namada_merkle_tree"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "eyre",
@@ -3095,6 +3106,7 @@ dependencies = [
 [[package]]
 name = "namada_parameters"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "namada_core",
  "namada_macros",
@@ -3109,6 +3121,7 @@ dependencies = [
 [[package]]
 name = "namada_proof_of_stake"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3132,6 +3145,7 @@ dependencies = [
 [[package]]
 name = "namada_replay_protection"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "namada_core",
 ]
@@ -3139,6 +3153,7 @@ dependencies = [
 [[package]]
 name = "namada_sdk"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "async-trait",
  "bimap",
@@ -3200,7 +3215,6 @@ dependencies = [
  "tokio",
  "toml 0.5.11",
  "tracing",
- "web-sys",
  "xorf",
  "zeroize",
 ]
@@ -3208,6 +3222,7 @@ dependencies = [
 [[package]]
 name = "namada_shielded_token"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3242,13 +3257,13 @@ dependencies = [
  "thiserror",
  "tracing",
  "typed-builder",
- "web-sys",
  "xorf",
 ]
 
 [[package]]
 name = "namada_state"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "clru",
@@ -3271,6 +3286,7 @@ dependencies = [
 [[package]]
 name = "namada_storage"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3289,6 +3305,7 @@ dependencies = [
 [[package]]
 name = "namada_systems"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -3298,6 +3315,7 @@ dependencies = [
 [[package]]
 name = "namada_token"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3312,6 +3330,7 @@ dependencies = [
 [[package]]
 name = "namada_trans_token"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "konst",
  "namada_core",
@@ -3327,6 +3346,7 @@ dependencies = [
 [[package]]
 name = "namada_tx"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "ark-bls12-381",
  "bitflags 2.5.0",
@@ -3355,6 +3375,7 @@ dependencies = [
 [[package]]
 name = "namada_vm"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "clru",
@@ -3376,6 +3397,7 @@ dependencies = [
 [[package]]
 name = "namada_vote_ext"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3387,6 +3409,7 @@ dependencies = [
 [[package]]
 name = "namada_vp"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -3402,6 +3425,7 @@ dependencies = [
 [[package]]
 name = "namada_vp_env"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "derivative",
  "masp_primitives",
@@ -3416,6 +3440,7 @@ dependencies = [
 [[package]]
 name = "namada_wallet"
 version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "bimap",
  "borsh",

--- a/packages/shared/lib/Cargo.lock
+++ b/packages/shared/lib/Cargo.lock
@@ -1936,8 +1936,8 @@ dependencies = [
 
 [[package]]
 name = "ibc"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "ibc-apps",
  "ibc-clients",
@@ -1949,8 +1949,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-nft-transfer"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "ibc-app-nft-transfer-types",
  "ibc-core",
@@ -1959,8 +1959,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-nft-transfer-types"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -1980,8 +1980,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-transfer"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "ibc-app-transfer-types",
  "ibc-core",
@@ -1990,8 +1990,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-app-transfer-types"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2008,8 +2008,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-apps"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "ibc-app-nft-transfer",
  "ibc-app-transfer",
@@ -2017,8 +2017,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-client-tendermint"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "derive_more",
  "ibc-client-tendermint-types",
@@ -2028,14 +2028,14 @@ dependencies = [
  "ibc-core-host",
  "ibc-primitives",
  "serde",
- "tendermint 0.37.0",
+ "tendermint 0.38.1",
  "tendermint-light-client-verifier",
 ]
 
 [[package]]
 name = "ibc-client-tendermint-types"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "displaydoc",
  "ibc-core-client-types",
@@ -2044,15 +2044,15 @@ dependencies = [
  "ibc-primitives",
  "ibc-proto",
  "serde",
- "tendermint 0.37.0",
+ "tendermint 0.38.1",
  "tendermint-light-client-verifier",
- "tendermint-proto 0.37.0",
+ "tendermint-proto 0.38.1",
 ]
 
 [[package]]
 name = "ibc-client-wasm-types"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "base64 0.22.1",
  "displaydoc",
@@ -2065,8 +2065,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-clients"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "ibc-client-tendermint",
  "ibc-client-wasm-types",
@@ -2074,8 +2074,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2090,8 +2090,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-channel"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "ibc-core-channel-types",
  "ibc-core-client",
@@ -2105,8 +2105,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-channel-types"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2123,13 +2123,13 @@ dependencies = [
  "serde",
  "sha2 0.10.8",
  "subtle-encoding",
- "tendermint 0.37.0",
+ "tendermint 0.38.1",
 ]
 
 [[package]]
 name = "ibc-core-client"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "ibc-core-client-context",
  "ibc-core-client-types",
@@ -2141,8 +2141,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-client-context"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2152,13 +2152,13 @@ dependencies = [
  "ibc-core-host-types",
  "ibc-primitives",
  "subtle-encoding",
- "tendermint 0.37.0",
+ "tendermint 0.38.1",
 ]
 
 [[package]]
 name = "ibc-core-client-types"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2172,13 +2172,13 @@ dependencies = [
  "schemars",
  "serde",
  "subtle-encoding",
- "tendermint 0.37.0",
+ "tendermint 0.38.1",
 ]
 
 [[package]]
 name = "ibc-core-commitment-types"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2196,8 +2196,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-connection"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "ibc-client-wasm-types",
  "ibc-core-client",
@@ -2205,13 +2205,13 @@ dependencies = [
  "ibc-core-handler-types",
  "ibc-core-host",
  "ibc-primitives",
- "prost",
+ "prost 0.13.2",
 ]
 
 [[package]]
 name = "ibc-core-connection-types"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2226,13 +2226,13 @@ dependencies = [
  "schemars",
  "serde",
  "subtle-encoding",
- "tendermint 0.37.0",
+ "tendermint 0.38.1",
 ]
 
 [[package]]
 name = "ibc-core-handler"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "ibc-core-channel",
  "ibc-core-client",
@@ -2246,8 +2246,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-handler-types"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2265,13 +2265,13 @@ dependencies = [
  "schemars",
  "serde",
  "subtle-encoding",
- "tendermint 0.37.0",
+ "tendermint 0.38.1",
 ]
 
 [[package]]
 name = "ibc-core-host"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2288,8 +2288,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-host-cosmos"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2306,13 +2306,13 @@ dependencies = [
  "serde",
  "sha2 0.10.8",
  "subtle-encoding",
- "tendermint 0.37.0",
+ "tendermint 0.38.1",
 ]
 
 [[package]]
 name = "ibc-core-host-types"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2326,8 +2326,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-router"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "derive_more",
  "displaydoc",
@@ -2340,8 +2340,8 @@ dependencies = [
 
 [[package]]
 name = "ibc-core-router-types"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "borsh",
  "derive_more",
@@ -2354,13 +2354,13 @@ dependencies = [
  "schemars",
  "serde",
  "subtle-encoding",
- "tendermint 0.37.0",
+ "tendermint 0.38.1",
 ]
 
 [[package]]
 name = "ibc-derive"
-version = "0.7.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.8.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2369,27 +2369,27 @@ dependencies = [
 
 [[package]]
 name = "ibc-primitives"
-version = "0.53.0"
-source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=0c3b3c0ab598e1e627089d06941efe0e39b61cd7#0c3b3c0ab598e1e627089d06941efe0e39b61cd7"
+version = "0.54.0"
+source = "git+https://github.com/heliaxdev/cosmos-ibc-rs?rev=38bd2a32f35117d4d9165a3c68c64ccd87ad56dd#38bd2a32f35117d4d9165a3c68c64ccd87ad56dd"
 dependencies = [
  "borsh",
  "derive_more",
  "displaydoc",
  "ibc-proto",
  "parity-scale-codec",
- "prost",
+ "prost 0.13.2",
  "scale-info",
  "schemars",
  "serde",
- "tendermint 0.37.0",
+ "tendermint 0.38.1",
  "time",
 ]
 
 [[package]]
 name = "ibc-proto"
-version = "0.46.0"
+version = "0.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb09e0b52b8a16e98ce98845e7c15b018440f3c56defa12fa44782cd66bab65"
+checksum = "c852d22b782d2d793f4a646f968de419be635e02bc8798d5d74a6e44eef27733"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -2398,19 +2398,19 @@ dependencies = [
  "ics23",
  "informalsystems-pbjson",
  "parity-scale-codec",
- "prost",
+ "prost 0.13.2",
  "scale-info",
  "schemars",
  "serde",
  "subtle-encoding",
- "tendermint-proto 0.37.0",
+ "tendermint-proto 0.38.1",
 ]
 
 [[package]]
 name = "ics23"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3b8be84e7285c73b88effdc3294b552277d6b0ec728ee016c861b7b9a2c19c"
+checksum = "73b17f1a5bd7d12ad30a21445cfa5f52fd7651cb3243ba866f9916b1ec112f12"
 dependencies = [
  "anyhow",
  "blake2",
@@ -2418,7 +2418,7 @@ dependencies = [
  "bytes",
  "hex",
  "informalsystems-pbjson",
- "prost",
+ "prost 0.13.2",
  "ripemd",
  "serde",
  "sha2 0.10.8",
@@ -2886,7 +2886,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "namada_account"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2898,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "namada_controller"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "namada_core",
  "smooth-operator",
@@ -2908,7 +2908,7 @@ dependencies = [
 [[package]]
 name = "namada_core"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "bech32 0.8.1",
  "borsh",
@@ -2919,7 +2919,6 @@ dependencies = [
  "ethabi",
  "ethbridge-structs",
  "eyre",
- "futures",
  "ibc",
  "ics23",
  "impl-num-traits",
@@ -2935,17 +2934,18 @@ dependencies = [
  "num256",
  "num_enum",
  "primitive-types",
- "prost-types",
+ "prost-types 0.13.2",
  "rand 0.8.5",
  "rand_core 0.6.4",
+ "rayon",
  "ripemd",
  "serde",
  "serde_json",
  "sha2 0.9.9",
  "smooth-operator",
  "sparse-merkle-tree",
- "tendermint 0.37.0",
- "tendermint-proto 0.37.0",
+ "tendermint 0.38.1",
+ "tendermint-proto 0.38.1",
  "thiserror",
  "tiny-keccak",
  "tokio",
@@ -2958,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "namada_ethereum_bridge"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "ethers",
@@ -2976,7 +2976,7 @@ dependencies = [
  "namada_trans_token",
  "namada_tx",
  "namada_vote_ext",
- "namada_vp",
+ "namada_vp_env",
  "serde",
  "smooth-operator",
  "thiserror",
@@ -2986,7 +2986,7 @@ dependencies = [
 [[package]]
 name = "namada_events"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3000,7 +3000,7 @@ dependencies = [
 [[package]]
 name = "namada_gas"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3013,7 +3013,7 @@ dependencies = [
 [[package]]
 name = "namada_governance"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3025,7 +3025,7 @@ dependencies = [
  "namada_state",
  "namada_systems",
  "namada_tx",
- "namada_vp",
+ "namada_vp_env",
  "serde",
  "serde_json",
  "smooth-operator",
@@ -3036,7 +3036,7 @@ dependencies = [
 [[package]]
 name = "namada_ibc"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "data-encoding",
@@ -3050,12 +3050,11 @@ dependencies = [
  "namada_gas",
  "namada_macros",
  "namada_state",
- "namada_storage",
  "namada_systems",
  "namada_tx",
  "namada_vp",
  "primitive-types",
- "prost",
+ "prost 0.13.2",
  "serde",
  "serde_json",
  "sha2 0.9.9",
@@ -3065,9 +3064,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "namada_io"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
+dependencies = [
+ "async-trait",
+ "kdam",
+ "namada_core",
+ "tendermint-rpc",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "namada_macros"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "data-encoding",
  "proc-macro2",
@@ -3079,14 +3091,14 @@ dependencies = [
 [[package]]
 name = "namada_merkle_tree"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "eyre",
  "ics23",
  "namada_core",
  "namada_macros",
- "prost",
+ "prost 0.13.2",
  "sparse-merkle-tree",
  "thiserror",
 ]
@@ -3094,15 +3106,14 @@ dependencies = [
 [[package]]
 name = "namada_parameters"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "namada_core",
  "namada_macros",
  "namada_state",
- "namada_storage",
  "namada_systems",
  "namada_tx",
- "namada_vp",
+ "namada_vp_env",
  "smooth-operator",
  "thiserror",
 ]
@@ -3110,7 +3121,7 @@ dependencies = [
 [[package]]
 name = "namada_proof_of_stake"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3121,10 +3132,9 @@ dependencies = [
  "namada_events",
  "namada_macros",
  "namada_state",
- "namada_storage",
  "namada_systems",
  "namada_tx",
- "namada_vp",
+ "namada_vp_env",
  "once_cell",
  "serde",
  "smooth-operator",
@@ -3135,7 +3145,7 @@ dependencies = [
 [[package]]
 name = "namada_replay_protection"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "namada_core",
 ]
@@ -3143,7 +3153,7 @@ dependencies = [
 [[package]]
 name = "namada_sdk"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "async-trait",
  "bimap",
@@ -3152,17 +3162,14 @@ dependencies = [
  "circular-queue",
  "clap",
  "data-encoding",
- "derivation-path",
  "duration-str",
  "either",
  "ethbridge-bridge-contract",
  "ethers",
  "eyre",
- "flume",
  "futures",
  "init-once",
  "itertools 0.12.1",
- "kdam",
  "lazy_static",
  "masp_primitives",
  "masp_proofs",
@@ -3173,6 +3180,7 @@ dependencies = [
  "namada_gas",
  "namada_governance",
  "namada_ibc",
+ "namada_io",
  "namada_macros",
  "namada_parameters",
  "namada_proof_of_stake",
@@ -3183,32 +3191,30 @@ dependencies = [
  "namada_vm",
  "namada_vote_ext",
  "namada_vp",
+ "namada_wallet",
  "num-traits 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "num256",
- "orion",
  "owo-colors",
  "paste",
  "patricia_tree",
- "prost",
+ "prost 0.13.2",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rayon",
  "regex",
  "reqwest",
+ "rustversion",
  "serde",
  "serde_json",
  "sha2 0.9.9",
- "slip10_ed25519",
  "smooth-operator",
  "tempfile",
  "tendermint-rpc",
  "thiserror",
  "tiny-bip39 0.8.2 (git+https://github.com/anoma/tiny-bip39.git?rev=bf0f6d8713589b83af7a917366ec31f5275c0e57)",
- "tiny-hderive",
  "tokio",
  "toml 0.5.11",
  "tracing",
- "typed-builder",
  "xorf",
  "zeroize",
 ]
@@ -3216,35 +3222,48 @@ dependencies = [
 [[package]]
 name = "namada_shielded_token"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
+ "async-trait",
  "borsh",
+ "eyre",
+ "flume",
+ "futures",
+ "itertools 0.12.1",
  "lazy_static",
  "masp_primitives",
  "masp_proofs",
  "namada_account",
  "namada_controller",
  "namada_core",
+ "namada_events",
  "namada_gas",
+ "namada_io",
+ "namada_macros",
  "namada_state",
- "namada_storage",
  "namada_systems",
  "namada_tx",
- "namada_vp",
+ "namada_vp_env",
+ "namada_wallet",
+ "rand 0.8.5",
  "rand_core 0.6.4",
  "rayon",
  "ripemd",
  "serde",
+ "serde_json",
  "sha2 0.9.9",
  "smooth-operator",
+ "tempfile",
  "thiserror",
  "tracing",
+ "typed-builder",
+ "xorf",
 ]
 
 [[package]]
 name = "namada_state"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "clru",
@@ -3267,11 +3286,12 @@ dependencies = [
 [[package]]
 name = "namada_storage"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
  "namada_core",
+ "namada_gas",
  "namada_macros",
  "namada_merkle_tree",
  "namada_replay_protection",
@@ -3285,23 +3305,23 @@ dependencies = [
 [[package]]
 name = "namada_systems"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "namada_core",
+ "namada_events",
  "namada_storage",
 ]
 
 [[package]]
 name = "namada_token"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "namada_core",
  "namada_events",
  "namada_macros",
  "namada_shielded_token",
- "namada_storage",
  "namada_systems",
  "namada_trans_token",
  "serde",
@@ -3310,16 +3330,15 @@ dependencies = [
 [[package]]
 name = "namada_trans_token"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "konst",
  "namada_core",
  "namada_events",
  "namada_state",
- "namada_storage",
  "namada_systems",
  "namada_tx",
- "namada_vp",
+ "namada_vp_env",
  "thiserror",
  "tracing",
 ]
@@ -3327,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "namada_tx"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "ark-bls12-381",
  "bitflags 2.5.0",
@@ -3336,14 +3355,15 @@ dependencies = [
  "either",
  "konst",
  "masp_primitives",
+ "namada_account",
  "namada_core",
  "namada_events",
  "namada_gas",
  "namada_macros",
  "num-derive 0.4.2",
  "num-traits 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost",
- "prost-types",
+ "prost 0.13.2",
+ "prost-types 0.13.2",
  "rand_core 0.6.4",
  "serde",
  "serde_json",
@@ -3355,10 +3375,11 @@ dependencies = [
 [[package]]
 name = "namada_vm"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "clru",
+ "namada_account",
  "namada_core",
  "namada_events",
  "namada_gas",
@@ -3376,7 +3397,7 @@ dependencies = [
 [[package]]
 name = "namada_vote_ext"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3388,7 +3409,7 @@ dependencies = [
 [[package]]
 name = "namada_vp"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -3404,15 +3425,44 @@ dependencies = [
 [[package]]
 name = "namada_vp_env"
 version = "0.43.0"
-source = "git+https://github.com/anoma/namada#dbafe50c158b65e9e8095e9ec838cf27a1a214f9"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
 dependencies = [
  "derivative",
  "masp_primitives",
  "namada_core",
  "namada_events",
+ "namada_gas",
  "namada_storage",
  "namada_tx",
  "smooth-operator",
+]
+
+[[package]]
+name = "namada_wallet"
+version = "0.43.0"
+source = "git+https://github.com/anoma/namada?rev=8c4e722fd93d2b1294b5f70504785937e8bce032#8c4e722fd93d2b1294b5f70504785937e8bce032"
+dependencies = [
+ "bimap",
+ "borsh",
+ "borsh-ext",
+ "data-encoding",
+ "derivation-path",
+ "itertools 0.12.1",
+ "masp_primitives",
+ "namada_core",
+ "namada_ibc",
+ "namada_macros",
+ "orion",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "serde",
+ "slip10_ed25519",
+ "smooth-operator",
+ "thiserror",
+ "tiny-bip39 0.8.2 (git+https://github.com/anoma/tiny-bip39.git?rev=bf0f6d8713589b83af7a917366ec31f5275c0e57)",
+ "tiny-hderive",
+ "toml 0.5.11",
+ "zeroize",
 ]
 
 [[package]]
@@ -4075,7 +4125,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2ecbe40f08db5c006b5764a2645f7f3f141ce756412ac9e1dd6087e6d32995"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.2",
 ]
 
 [[package]]
@@ -4092,8 +4152,8 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "regex",
  "syn 2.0.65",
  "tempfile",
@@ -4113,12 +4173,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
+dependencies = [
+ "anyhow",
+ "itertools 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.65",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
- "prost",
+ "prost 0.12.6",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60caa6738c7369b940c3d49246a8d1749323674c65cb13010134f5c9bad5b519"
+dependencies = [
+ "prost 0.13.2",
 ]
 
 [[package]]
@@ -4937,7 +5019,7 @@ dependencies = [
 [[package]]
 name = "sparse-merkle-tree"
 version = "0.3.1-pre"
-source = "git+https://github.com/heliaxdev/sparse-merkle-tree?rev=bab8cb96872db22cc9a139b2d3dfc4e00521d097#bab8cb96872db22cc9a139b2d3dfc4e00521d097"
+source = "git+https://github.com/heliaxdev/sparse-merkle-tree?rev=a93c55ccd47840ee0967eee237e47d9245478594#a93c55ccd47840ee0967eee237e47d9245478594"
 dependencies = [
  "borsh",
  "cfg-if",
@@ -5113,8 +5195,8 @@ dependencies = [
  "futures",
  "num-traits 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell",
- "prost",
- "prost-types",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -5130,9 +5212,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954496fbc9716eb4446cdd6d00c071a3e2f22578d62aa03b40c7e5b4fda3ed42"
+checksum = "505d9d6ffeb83b1de47c307c6e0d2dff56c6256989299010ad03cd80a8491e97"
 dependencies = [
  "bytes",
  "digest 0.10.7",
@@ -5143,8 +5225,8 @@ dependencies = [
  "k256",
  "num-traits 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell",
- "prost",
- "prost-types",
+ "prost 0.13.2",
+ "prost-types 0.13.2",
  "ripemd",
  "serde",
  "serde_bytes",
@@ -5154,7 +5236,7 @@ dependencies = [
  "signature",
  "subtle",
  "subtle-encoding",
- "tendermint-proto 0.37.0",
+ "tendermint-proto 0.38.1",
  "time",
  "zeroize",
 ]
@@ -5175,28 +5257,28 @@ dependencies = [
 
 [[package]]
 name = "tendermint-config"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84b11b57d20ee4492a1452faff85f5c520adc36ca9fe5e701066935255bb89f"
+checksum = "9de111ea653b2adaef627ac2452b463c77aa615c256eaaddf279ec5a1cf9775f"
 dependencies = [
  "flex-error",
  "serde",
  "serde_json",
- "tendermint 0.37.0",
+ "tendermint 0.38.1",
  "toml 0.8.13",
  "url",
 ]
 
 [[package]]
 name = "tendermint-light-client-verifier"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3848090df4502a09ee27cb1a00f1835e1111c8993b22c5e1e41ffb7f6f09d57e"
+checksum = "7a2674adbf0dc51aa0c8eaf8462c7d6692ec79502713e50ed5432a442002be90"
 dependencies = [
  "derive_more",
  "flex-error",
  "serde",
- "tendermint 0.37.0",
+ "tendermint 0.38.1",
  "time",
 ]
 
@@ -5210,8 +5292,8 @@ dependencies = [
  "flex-error",
  "num-derive 0.3.3",
  "num-traits 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost",
- "prost-types",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "serde",
  "serde_bytes",
  "subtle-encoding",
@@ -5220,14 +5302,14 @@ dependencies = [
 
 [[package]]
 name = "tendermint-proto"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc87024548c7f3da479885201e3da20ef29e85a3b13d04606b380ac4c7120d87"
+checksum = "8ed14abe3b0502a3afe21ca74ca5cdd6c7e8d326d982c26f98a394445eb31d6e"
 dependencies = [
  "bytes",
  "flex-error",
- "prost",
- "prost-types",
+ "prost 0.13.2",
+ "prost-types 0.13.2",
  "serde",
  "serde_bytes",
  "subtle-encoding",
@@ -5236,9 +5318,9 @@ dependencies = [
 
 [[package]]
 name = "tendermint-rpc"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfdc2281e271277fda184d96d874a6fe59f569b130b634289257baacfc95aa85"
+checksum = "02f96a2b8a0d3d0b59e4024b1a6bdc1589efc6af4709d08a480a20cc4ba90f63"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5253,9 +5335,9 @@ dependencies = [
  "serde_json",
  "subtle",
  "subtle-encoding",
- "tendermint 0.37.0",
- "tendermint-config 0.37.0",
- "tendermint-proto 0.37.0",
+ "tendermint 0.38.1",
+ "tendermint-config 0.38.1",
+ "tendermint-proto 0.38.1",
  "thiserror",
  "time",
  "url",

--- a/packages/shared/lib/Cargo.lock
+++ b/packages/shared/lib/Cargo.lock
@@ -2886,7 +2886,7 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "namada_account"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2898,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "namada_controller"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "namada_core",
  "smooth-operator",
@@ -2908,7 +2908,7 @@ dependencies = [
 [[package]]
 name = "namada_core"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "bech32 0.8.1",
  "borsh",
@@ -2958,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "namada_ethereum_bridge"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "borsh",
  "ethers",
@@ -2986,7 +2986,7 @@ dependencies = [
 [[package]]
 name = "namada_events"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3000,7 +3000,7 @@ dependencies = [
 [[package]]
 name = "namada_gas"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3013,7 +3013,7 @@ dependencies = [
 [[package]]
 name = "namada_governance"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3036,7 +3036,7 @@ dependencies = [
 [[package]]
 name = "namada_ibc"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "borsh",
  "data-encoding",
@@ -3066,7 +3066,7 @@ dependencies = [
 [[package]]
 name = "namada_io"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "async-trait",
  "kdam",
@@ -3079,7 +3079,7 @@ dependencies = [
 [[package]]
 name = "namada_macros"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "data-encoding",
  "proc-macro2",
@@ -3091,7 +3091,7 @@ dependencies = [
 [[package]]
 name = "namada_merkle_tree"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "borsh",
  "eyre",
@@ -3106,7 +3106,7 @@ dependencies = [
 [[package]]
 name = "namada_parameters"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "namada_core",
  "namada_macros",
@@ -3121,7 +3121,7 @@ dependencies = [
 [[package]]
 name = "namada_proof_of_stake"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3145,7 +3145,7 @@ dependencies = [
 [[package]]
 name = "namada_replay_protection"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "namada_core",
 ]
@@ -3153,7 +3153,7 @@ dependencies = [
 [[package]]
 name = "namada_sdk"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "async-trait",
  "bimap",
@@ -3222,7 +3222,7 @@ dependencies = [
 [[package]]
 name = "namada_shielded_token"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3263,7 +3263,7 @@ dependencies = [
 [[package]]
 name = "namada_state"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "borsh",
  "clru",
@@ -3286,7 +3286,7 @@ dependencies = [
 [[package]]
 name = "namada_storage"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3305,7 +3305,7 @@ dependencies = [
 [[package]]
 name = "namada_systems"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -3315,7 +3315,7 @@ dependencies = [
 [[package]]
 name = "namada_token"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3333,7 +3333,7 @@ dependencies = [
 [[package]]
 name = "namada_trans_token"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "konst",
  "namada_core",
@@ -3350,7 +3350,7 @@ dependencies = [
 [[package]]
 name = "namada_tx"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "ark-bls12-381",
  "bitflags 2.5.0",
@@ -3379,7 +3379,7 @@ dependencies = [
 [[package]]
 name = "namada_tx_env"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -3389,7 +3389,7 @@ dependencies = [
 [[package]]
 name = "namada_vm"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "borsh",
  "clru",
@@ -3411,7 +3411,7 @@ dependencies = [
 [[package]]
 name = "namada_vote_ext"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3423,7 +3423,7 @@ dependencies = [
 [[package]]
 name = "namada_vp"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -3439,7 +3439,7 @@ dependencies = [
 [[package]]
 name = "namada_vp_env"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "derivative",
  "masp_primitives",
@@ -3454,7 +3454,7 @@ dependencies = [
 [[package]]
 name = "namada_wallet"
 version = "0.44.0"
-source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+source = "git+https://github.com/anoma/namada?rev=4093f0bb98e1fdb72ae0552f371807749f986937#4093f0bb98e1fdb72ae0552f371807749f986937"
 dependencies = [
  "bimap",
  "borsh",

--- a/packages/shared/lib/Cargo.lock
+++ b/packages/shared/lib/Cargo.lock
@@ -2885,8 +2885,8 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "namada_account"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2897,8 +2897,8 @@ dependencies = [
 
 [[package]]
 name = "namada_controller"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "namada_core",
  "smooth-operator",
@@ -2907,8 +2907,8 @@ dependencies = [
 
 [[package]]
 name = "namada_core"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "bech32 0.8.1",
  "borsh",
@@ -2957,8 +2957,8 @@ dependencies = [
 
 [[package]]
 name = "namada_ethereum_bridge"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "borsh",
  "ethers",
@@ -2985,8 +2985,8 @@ dependencies = [
 
 [[package]]
 name = "namada_events"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2999,8 +2999,8 @@ dependencies = [
 
 [[package]]
 name = "namada_gas"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3012,8 +3012,8 @@ dependencies = [
 
 [[package]]
 name = "namada_governance"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3035,8 +3035,8 @@ dependencies = [
 
 [[package]]
 name = "namada_ibc"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "borsh",
  "data-encoding",
@@ -3065,8 +3065,8 @@ dependencies = [
 
 [[package]]
 name = "namada_io"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "async-trait",
  "kdam",
@@ -3078,8 +3078,8 @@ dependencies = [
 
 [[package]]
 name = "namada_macros"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "data-encoding",
  "proc-macro2",
@@ -3090,8 +3090,8 @@ dependencies = [
 
 [[package]]
 name = "namada_merkle_tree"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "borsh",
  "eyre",
@@ -3105,8 +3105,8 @@ dependencies = [
 
 [[package]]
 name = "namada_parameters"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "namada_core",
  "namada_macros",
@@ -3120,8 +3120,8 @@ dependencies = [
 
 [[package]]
 name = "namada_proof_of_stake"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3144,16 +3144,16 @@ dependencies = [
 
 [[package]]
 name = "namada_replay_protection"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "namada_core",
 ]
 
 [[package]]
 name = "namada_sdk"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "async-trait",
  "bimap",
@@ -3221,8 +3221,8 @@ dependencies = [
 
 [[package]]
 name = "namada_shielded_token"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3262,8 +3262,8 @@ dependencies = [
 
 [[package]]
 name = "namada_state"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "borsh",
  "clru",
@@ -3285,8 +3285,8 @@ dependencies = [
 
 [[package]]
 name = "namada_storage"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3304,8 +3304,8 @@ dependencies = [
 
 [[package]]
 name = "namada_systems"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -3314,23 +3314,26 @@ dependencies = [
 
 [[package]]
 name = "namada_token"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "borsh",
  "namada_core",
  "namada_events",
  "namada_macros",
  "namada_shielded_token",
+ "namada_storage",
  "namada_systems",
  "namada_trans_token",
+ "namada_tx",
+ "namada_tx_env",
  "serde",
 ]
 
 [[package]]
 name = "namada_trans_token"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "konst",
  "namada_core",
@@ -3338,6 +3341,7 @@ dependencies = [
  "namada_state",
  "namada_systems",
  "namada_tx",
+ "namada_tx_env",
  "namada_vp_env",
  "thiserror",
  "tracing",
@@ -3345,8 +3349,8 @@ dependencies = [
 
 [[package]]
 name = "namada_tx"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "ark-bls12-381",
  "bitflags 2.5.0",
@@ -3373,9 +3377,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "namada_tx_env"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
+dependencies = [
+ "namada_core",
+ "namada_events",
+ "namada_storage",
+]
+
+[[package]]
 name = "namada_vm"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "borsh",
  "clru",
@@ -3396,8 +3410,8 @@ dependencies = [
 
 [[package]]
 name = "namada_vote_ext"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3408,8 +3422,8 @@ dependencies = [
 
 [[package]]
 name = "namada_vp"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -3424,8 +3438,8 @@ dependencies = [
 
 [[package]]
 name = "namada_vp_env"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "derivative",
  "masp_primitives",
@@ -3439,8 +3453,8 @@ dependencies = [
 
 [[package]]
 name = "namada_wallet"
-version = "0.43.0"
-source = "git+https://github.com/anoma/namada?rev=8c4e722fd93#8c4e722fd93d2b1294b5f70504785937e8bce032"
+version = "0.44.0"
+source = "git+https://github.com/anoma/namada#4110d8fbec81d39a683c5d299260aa0fd1174d37"
 dependencies = [
  "bimap",
  "borsh",

--- a/packages/shared/lib/Cargo.toml
+++ b/packages/shared/lib/Cargo.toml
@@ -24,7 +24,7 @@ chrono = "0.4.22"
 getrandom = { version = "0.2.7", features = ["js"] }
 gloo-utils = { version = "0.1.5", features = ["serde"] }
 js-sys = "0.3.60"
-namada_sdk = { git = "https://github.com/anoma/namada", version = "0.43.0", default-features = false }
+namada_sdk = { git = "https://github.com/anoma/namada", rev = "8c4e722fd93d2b1294b5f70504785937e8bce032", default-features = false }
 rand = "0.8.5"
 rexie = "0.5"
 serde = "^1.0.181"

--- a/packages/shared/lib/Cargo.toml
+++ b/packages/shared/lib/Cargo.toml
@@ -24,7 +24,7 @@ chrono = "0.4.22"
 getrandom = { version = "0.2.7", features = ["js"] }
 gloo-utils = { version = "0.1.5", features = ["serde"] }
 js-sys = "0.3.60"
-namada_sdk = { git = "https://github.com/anoma/namada", rev = "8c4e722fd93d2b1294b5f70504785937e8bce032", default-features = false }
+namada_sdk = { git = "https://github.com/anoma/namada", rev = "8c4e722fd93", default-features = false }
 rand = "0.8.5"
 rexie = "0.5"
 serde = "^1.0.181"

--- a/packages/shared/lib/Cargo.toml
+++ b/packages/shared/lib/Cargo.toml
@@ -24,7 +24,7 @@ chrono = "0.4.22"
 getrandom = { version = "0.2.7", features = ["js"] }
 gloo-utils = { version = "0.1.5", features = ["serde"] }
 js-sys = "0.3.60"
-namada_sdk = { git = "https://github.com/anoma/namada", rev = "8c4e722fd93", default-features = false }
+namada_sdk = { git = "https://github.com/anoma/namada", version = "0.44.0", default-features = false }
 rand = "0.8.5"
 rexie = "0.5"
 serde = "^1.0.181"

--- a/packages/shared/lib/Cargo.toml
+++ b/packages/shared/lib/Cargo.toml
@@ -24,7 +24,7 @@ chrono = "0.4.22"
 getrandom = { version = "0.2.7", features = ["js"] }
 gloo-utils = { version = "0.1.5", features = ["serde"] }
 js-sys = "0.3.60"
-namada_sdk = { git = "https://github.com/anoma/namada", version = "0.44.0", default-features = false }
+namada_sdk = { git = "https://github.com/anoma/namada", rev = "4093f0bb98e1fdb72ae0552f371807749f986937", default-features = false }
 rand = "0.8.5"
 rexie = "0.5"
 serde = "^1.0.181"

--- a/packages/shared/lib/rust-toolchain.toml
+++ b/packages/shared/lib/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-02-09"
+channel = "nightly-2024-09-08"
 components = ["rustc", "cargo", "rust-std", "rust-docs", "rls", "rust-src", "rust-analysis"]
 targets = ['wasm32-unknown-unknown']

--- a/packages/shared/lib/src/query.rs
+++ b/packages/shared/lib/src/query.rs
@@ -359,13 +359,7 @@ impl Query {
         let mut shielded_context: ShieldedContext<JSShieldedUtils> = ShieldedContext::default();
 
         shielded_context
-            .sync(
-                env,
-                config,
-                None,
-                &[],
-                dated_keypairs.as_slice(),
-            )
+            .sync(env, config, None, &[], dated_keypairs.as_slice())
             .await
             .map_err(|e| JsError::new(&format!("{:?}", e)))?;
 

--- a/packages/shared/lib/src/rpc_client.rs
+++ b/packages/shared/lib/src/rpc_client.rs
@@ -8,7 +8,8 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::Response;
 
-use namada_sdk::queries::{Client, EncodedResponseQuery};
+use namada_sdk::io::Client;
+use namada_sdk::queries::EncodedResponseQuery;
 use namada_sdk::tendermint::{self, abci::Code};
 use namada_sdk::tendermint_rpc::{
     error::Error as TendermintRpcError, Response as RpcResponse, SimpleRequest,

--- a/packages/shared/lib/src/rpc_client.rs
+++ b/packages/shared/lib/src/rpc_client.rs
@@ -54,6 +54,7 @@ impl From<namada_sdk::tendermint_rpc::Error> for RpcError {
     }
 }
 
+#[derive(Clone)]
 pub struct HttpClient {
     url: String,
 }

--- a/packages/shared/lib/src/sdk/args.rs
+++ b/packages/shared/lib/src/sdk/args.rs
@@ -3,7 +3,6 @@ use std::{path::PathBuf, str::FromStr};
 use namada_sdk::borsh::{BorshDeserialize, BorshSerialize};
 use namada_sdk::ibc::core::host::types::identifiers::{ChannelId, PortId};
 use namada_sdk::ibc::IbcShieldingData;
-use namada_sdk::masp::{ExtendedSpendingKey, PaymentAddress};
 use namada_sdk::tendermint_rpc;
 use namada_sdk::tx::data::GasLimit;
 use namada_sdk::{
@@ -12,9 +11,10 @@ use namada_sdk::{
     chain::ChainId,
     ethereum_events::EthAddress,
     key::common::PublicKey,
-    masp::TransferSource,
     token::{Amount, DenominatedAmount, NATIVE_MAX_DECIMAL_PLACES},
+    TransferSource,
 };
+use namada_sdk::{ExtendedSpendingKey, PaymentAddress};
 use wasm_bindgen::JsError;
 
 #[derive(BorshSerialize, BorshDeserialize, Debug)]
@@ -548,6 +548,8 @@ pub fn shielded_transfer_tx_args(
         data: shielded_transfer_data,
         tx,
         tx_code_path: PathBuf::from("tx_transfer.wasm"),
+        // TODO: false for now
+        disposable_signing_key: false,
         gas_spending_keys: gsk,
     };
 
@@ -685,6 +687,8 @@ pub fn unshielding_transfer_tx_args(
         source,
         tx,
         gas_spending_keys: gsk,
+        // TODO: false for now
+        disposable_signing_key: false,
         tx_code_path: PathBuf::from("tx_transfer.wasm"),
     };
 
@@ -761,6 +765,8 @@ pub fn ibc_transfer_tx_args(
         channel_id,
         timeout_height,
         timeout_sec_offset,
+        // TODO: false for now
+        disposable_signing_key: false,
         tx_code_path: PathBuf::from("tx_ibc.wasm"),
         refund_target: None,
         // TODO: Implement?
@@ -869,7 +875,6 @@ fn tx_msg_into_args(tx_msg: &[u8]) -> Result<args::Tx, JsError> {
         _ => None,
     };
 
-    let disposable_signing_key = false;
     let signing_keys: Vec<PublicKey> = match public_key {
         Some(v) => vec![v.clone()],
         _ => vec![],
@@ -884,7 +889,6 @@ fn tx_msg_into_args(tx_msg: &[u8]) -> Result<args::Tx, JsError> {
     let args = args::Tx {
         dry_run: false,
         dry_run_wrapper: false,
-        disposable_signing_key,
         dump_tx: false,
         force: false,
         broadcast_only: false,

--- a/packages/shared/lib/src/sdk/masp/mod.rs
+++ b/packages/shared/lib/src/sdk/masp/mod.rs
@@ -9,3 +9,5 @@ mod masp_node;
 
 #[cfg(feature = "nodejs")]
 pub use masp_node::NodeShieldedUtils as JSShieldedUtils;
+
+pub mod sync;

--- a/packages/shared/lib/src/sdk/masp/sync.rs
+++ b/packages/shared/lib/src/sdk/masp/sync.rs
@@ -1,0 +1,67 @@
+use js_sys::Function;
+use namada_sdk::control_flow::ShutdownSignal;
+use namada_sdk::task_env::{TaskEnvironment, TaskSpawner};
+use wasm_bindgen::prelude::Closure;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::window;
+
+pub struct TaskSpawnerWeb {}
+
+impl TaskSpawner for TaskSpawnerWeb {
+    fn spawn_async<F>(&self, fut: F)
+    where
+        F: std::future::Future<Output = ()> + 'static,
+    {
+        // In browsers we use `spawn_local` which runs the future in the WebAssembly context.
+        spawn_local(fut);
+    }
+
+    fn spawn_sync<F>(&self, job: F)
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        // To synchronize in the browser environment, we use `setTimeout`.
+        let job_box = Box::new(job) as Box<dyn FnOnce()>;
+
+        // We create a `Closure` that will be called by `setTimeout`.
+        let closure = Closure::once_into_js(move || {
+            job_box();
+        });
+
+        // We call `setTimeout` with a timeout of 0ms, which will run the closure as soon as possible.
+        // TODO: this might not work outside of the browser application(in web/service worker)
+        window()
+            .expect("no global `window` exists")
+            .set_timeout_with_callback_and_timeout_and_arguments_0(
+                closure.as_ref().unchecked_ref::<Function>(),
+                0,
+            )
+            .expect("setTimeout failed");
+    }
+}
+
+pub struct TaskEnvWeb {}
+
+impl TaskEnvironment for TaskEnvWeb {
+    type Spawner = TaskSpawnerWeb;
+
+    async fn run<M, F, R>(self, main: M) -> R
+    where
+        M: FnOnce(Self::Spawner) -> F,
+        F: std::future::Future<Output = R>,
+    {
+        main(TaskSpawnerWeb {}).await
+    }
+}
+
+// We can't use the real shutdown signal in the browser, so we just use a dummy one.
+pub struct ShutdownSignalWeb {}
+
+impl ShutdownSignal for ShutdownSignalWeb {
+    async fn wait_for_shutdown(&mut self) {}
+
+    fn received(&mut self) -> bool {
+        false
+    }
+}

--- a/packages/shared/lib/src/sdk/masp/sync.rs
+++ b/packages/shared/lib/src/sdk/masp/sync.rs
@@ -1,5 +1,6 @@
 use js_sys::Function;
 use namada_sdk::control_flow::ShutdownSignal;
+use namada_sdk::io::ProgressBar;
 use namada_sdk::task_env::{TaskEnvironment, TaskSpawner};
 use wasm_bindgen::prelude::Closure;
 use wasm_bindgen::JsCast;
@@ -63,5 +64,33 @@ impl ShutdownSignal for ShutdownSignalWeb {
 
     fn received(&mut self) -> bool {
         false
+    }
+}
+
+pub struct ProgressBarWeb {
+    pub total: usize,
+    pub current: usize,
+}
+
+impl ProgressBar for ProgressBarWeb {
+    fn upper_limit(&self) -> u64 {
+        self.total as u64
+    }
+
+    fn set_upper_limit(&mut self, limit: u64) {
+        self.total = limit as usize;
+    }
+
+    fn increment_by(&mut self, amount: u64) {
+        self.current += amount as usize;
+        web_sys::console::log_1(&format!("Progress: {}/{}", self.current, self.total).into());
+    }
+
+    fn message(&mut self, message: String) {
+        web_sys::console::log_1(&message.into());
+    }
+
+    fn finish(&mut self) {
+        web_sys::console::log_1(&"Finished".into());
     }
 }

--- a/packages/shared/lib/src/sdk/masp/sync.rs
+++ b/packages/shared/lib/src/sdk/masp/sync.rs
@@ -1,11 +1,7 @@
-use js_sys::Function;
 use namada_sdk::control_flow::ShutdownSignal;
 use namada_sdk::io::ProgressBar;
 use namada_sdk::task_env::{TaskEnvironment, TaskSpawner};
-use wasm_bindgen::prelude::Closure;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
-use web_sys::window;
 
 pub struct TaskSpawnerWeb {}
 
@@ -22,23 +18,7 @@ impl TaskSpawner for TaskSpawnerWeb {
     where
         F: FnOnce() + Send + 'static,
     {
-        // To synchronize in the browser environment, we use `setTimeout`.
-        let job_box = Box::new(job) as Box<dyn FnOnce()>;
-
-        // We create a `Closure` that will be called by `setTimeout`.
-        let closure = Closure::once_into_js(move || {
-            job_box();
-        });
-
-        // We call `setTimeout` with a timeout of 0ms, which will run the closure as soon as possible.
-        // TODO: this might not work outside of the browser application(in web/service worker)
-        window()
-            .expect("no global `window` exists")
-            .set_timeout_with_callback_and_timeout_and_arguments_0(
-                closure.as_ref().unchecked_ref::<Function>(),
-                0,
-            )
-            .expect("setTimeout failed");
+        job();
     }
 }
 

--- a/packages/shared/lib/src/sdk/mod.rs
+++ b/packages/shared/lib/src/sdk/mod.rs
@@ -102,7 +102,7 @@ impl Sdk {
         let context_dir = context_dir.as_string().unwrap();
 
         let mut shielded = self.namada.shielded_mut().await;
-        *shielded = masp::JSShieldedUtils::new(&context_dir).await;
+        *shielded = ShieldedContext::new(masp::JSShieldedUtils::new(&context_dir).await);
 
         Ok(())
     }

--- a/packages/shared/lib/src/sdk/wallet/mod.rs
+++ b/packages/shared/lib/src/sdk/wallet/mod.rs
@@ -1,8 +1,8 @@
 use namada_sdk::{
     key::common::SecretKey,
-    masp::{ExtendedSpendingKey, ExtendedViewingKey, PaymentAddress},
     masp_primitives::zip32::ExtendedFullViewingKey,
     wallet::{alias::Alias, Wallet, WalletIo},
+    ExtendedSpendingKey, ExtendedViewingKey, PaymentAddress,
 };
 use std::str::FromStr;
 use zeroize::Zeroizing;

--- a/packages/shared/lib/src/types/masp.rs
+++ b/packages/shared/lib/src/types/masp.rs
@@ -1,7 +1,7 @@
 //! PaymentAddress - Provide wasm_bindgen bindings for shielded addresses
 //! See @namada/crypto for zip32 HD wallet functionality.
 use namada_sdk::borsh::BorshDeserialize;
-use namada_sdk::masp;
+use namada_sdk::{ExtendedViewingKey as NamadaExtendedViewingKey, ExtendedSpendingKey as NamadaExtendedSpendingKey, PaymentAddress as NamadaPaymentAddress};
 use namada_sdk::masp_primitives::{sapling, zip32};
 use thiserror::Error;
 use wasm_bindgen::prelude::*;
@@ -14,9 +14,9 @@ pub enum MaspError {
     BorshDeserialize,
 }
 
-/// Wrap masp::ExtendedViewingKey
+/// Wrap ExtendedViewingKey
 #[wasm_bindgen]
-pub struct ExtendedViewingKey(pub(crate) masp::ExtendedViewingKey);
+pub struct ExtendedViewingKey(pub(crate) NamadaExtendedViewingKey);
 
 /// wasm_bindgen bindings for ExtendedViewingKey
 #[wasm_bindgen]
@@ -27,7 +27,7 @@ impl ExtendedViewingKey {
         let xfvk: zip32::ExtendedFullViewingKey = BorshDeserialize::try_from_slice(key)
             .map_err(|err| format!("{}: {:?}", MaspError::BorshDeserialize, err))?;
 
-        let vk = masp::ExtendedViewingKey::from(xfvk);
+        let vk = NamadaExtendedViewingKey::from(xfvk);
 
         Ok(ExtendedViewingKey(vk))
     }
@@ -38,9 +38,9 @@ impl ExtendedViewingKey {
     }
 }
 
-/// Wrap masp::ExtendedSpendingKey
+/// Wrap ExtendedSpendingKey
 #[wasm_bindgen]
-pub struct ExtendedSpendingKey(pub(crate) masp::ExtendedSpendingKey);
+pub struct ExtendedSpendingKey(pub(crate) NamadaExtendedSpendingKey);
 
 /// wasm_bindgen bindings for ExtendedViewingKey
 #[wasm_bindgen]
@@ -51,7 +51,7 @@ impl ExtendedSpendingKey {
         let xsk: zip32::ExtendedSpendingKey = BorshDeserialize::try_from_slice(key)
             .map_err(|err| format!("{}: {:?}", MaspError::BorshDeserialize, err))?;
 
-        let xsk = masp::ExtendedSpendingKey::from(xsk);
+        let xsk = NamadaExtendedSpendingKey::from(xsk);
 
         Ok(ExtendedSpendingKey(xsk))
     }
@@ -62,9 +62,9 @@ impl ExtendedSpendingKey {
     }
 }
 
-/// Wrap masp::PaymentAddress
+/// Wrap PaymentAddress
 #[wasm_bindgen]
-pub struct PaymentAddress(pub(crate) masp::PaymentAddress);
+pub struct PaymentAddress(pub(crate) NamadaPaymentAddress);
 
 /// wasm_bindgen bindings for PaymentAddress
 #[wasm_bindgen]
@@ -74,7 +74,7 @@ impl PaymentAddress {
     pub fn new(address: &[u8]) -> Result<PaymentAddress, String> {
         let payment_address: sapling::PaymentAddress = BorshDeserialize::try_from_slice(address)
             .map_err(|err| format!("{}: {:?}", MaspError::BorshDeserialize, err))?;
-        let payment_address = masp::PaymentAddress::from(payment_address);
+        let payment_address = NamadaPaymentAddress::from(payment_address);
         Ok(PaymentAddress(payment_address))
     }
 


### PR DESCRIPTION
I don't think there is an easy way to test this for now :/ But I think as long as this does not break other features we can merge it.

Okay!
**Make sure you test against 0.44.0**
So to test shielded sync w/o masp indexer you can:
- shield some nam using CLI(localnet example)
```sh
target/debug/namada wallet gen --shielded --alias albert-shielded --base-dir .namada/validator-0
target/debug/namada wallet gen-payment-addr --alias albert-pa1 --key albert-shielded --base-dir .namada/validator-0
target/debug/namada client shield --source albert --target albert-pa1 --token nam --amount 1000  --base-dir .namada/validator-0
# To get the viewing key
target/debug/namada wallet find --alias albert-shielded --base-dir .namada/validator-0
```

- Add this to `App.tsx` in namadillo(with missing imports)
```ts
  useEffect(() => {
    const shieldedSync = async (): Promise<void> => {
      const vk =
        "YOUR_VK";
      const sdk = await getSdkInstance();
      await sdk.rpc.shieldedSync([vk]);
    };

    // eslint-disable-next-line @typescript-eslint/no-explicit-any
    (window as any).shieldedSync = shieldedSync;
  });
```
- run `await window.shieldedSync()` in namadillo console, you should see progress logged
- :eyes: 

![image](https://github.com/user-attachments/assets/3cb43258-46d5-44b1-bbee-389d66909903)

To test with masp indexer you can do the same setup but also run masp_indexer locally.
- running [instructions ](https://github.com/anoma/namada-masp-indexer?tab=readme-ov-file#how-to-run)
- if you want to run masp indexer alongsinde indexer(it's a bit of a headache for now) you need to change ports :/ I will change ports in regular indexer soon so there are no conflicts during development
```yml
    command: ["postgres", "-c", "listen_addresses=0.0.0.0", "-c", "max_connections=200", "-p", "5433"]
    expose:
      - "5433" # Publishes 5432 to other containers but NOT to host machine
    ports:
      - "5433:5433"
# AND
    ports:
      - 5000:5001
 # AND ALL
      DATABASE_URL: postgres://postgres:password@postgres:5433/masp_indexer_local
```
- paste MASP indexer url
![image](https://github.com/user-attachments/assets/e3f89e86-542e-49be-b7ad-5d30944613f9)
- wait for commitment tree to get indexed
- retest


❗**CLEAR CONTEXT MANUALLY BETWEEN TESTS, JUST REMOVE IT FROM IDB** ❗
ALSO currently I;m getting this :(
```
Caused by:
    Could not deserialize the notes map JSON response at height 3017: error decoding response body: missing field `batch_index` at line 1 column 89
```