### PR TITLE
fix: Ethers dependency should be listed for integrations only

### DIFF
--- a/apps/faucet/package.json
+++ b/apps/faucet/package.json
@@ -19,7 +19,6 @@
     "@cosmjs/encoding": "^0.29.0",
     "buffer": "^6.0.3",
     "dompurify": "^3.0.5",
-    "ethers": "6.7.1",
     "framer-motion": "^11.5.4",
     "node-forge": "^1.3.1",
     "react": "^18.3.0",

--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -16,7 +16,6 @@
     "bignumber.js": "^9.1.1",
     "clsx": "^2.1.1",
     "crypto-browserify": "^3.12.0",
-    "ethers": "^6.7.1",
     "fp-ts": "^2.16.1",
     "framer-motion": "^11.3.28",
     "idb-keyval": "^6.2.1",

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -45,7 +45,8 @@
     "@cosmjs/stargate": "^0.29.5",
     "@cosmjs/tendermint-rpc": "~0.29.5",
     "@keplr-wallet/types": "^0.10.19",
-    "@metamask/providers": "^10.2.1"
+    "@metamask/providers": "^10.2.1",
+    "ethers": "^6.7.1"
   },
   "files": [
     "dist"

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,13 +26,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@adraffy/ens-normalize@npm:1.9.2":
-  version: 1.9.2
-  resolution: "@adraffy/ens-normalize@npm:1.9.2"
-  checksum: 70aca9af28c8d707f6194d3a717582ce8b87087e9c395013f409b2e97b6918a177287bc3dd55c38955f2aa1d6ca604f94e66bfe9aa5651d8aa9979c0896786ee
-  languageName: node
-  linkType: hard
-
 "@alloc/quick-lru@npm:^5.2.0":
   version: 5.2.0
   resolution: "@alloc/quick-lru@npm:5.2.0"
@@ -3565,7 +3558,6 @@ __metadata:
     eslint-plugin-import: "npm:^2.30.0"
     eslint-plugin-react: "npm:^7.35.2"
     eslint-plugin-react-hooks: "npm:^4.6.0"
-    ethers: "npm:6.7.1"
     file-loader: "npm:^6.2.0"
     framer-motion: "npm:^11.5.4"
     html-webpack-plugin: "npm:^5.6.0"
@@ -3634,6 +3626,7 @@ __metadata:
     eslint-plugin-import: "npm:^2.30.0"
     eslint-plugin-react: "npm:^7.35.2"
     eslint-plugin-react-hooks: "npm:^4.6.0"
+    ethers: "npm:^6.7.1"
     jest: "npm:^29.7.0"
     jest-create-mock-instance: "npm:^2.0.0"
     jest-mock-extended: "npm:^3.0.3"
@@ -3683,7 +3676,6 @@ __metadata:
     eslint-plugin-import: "npm:^2.30.0"
     eslint-plugin-react: "npm:^7.35.2"
     eslint-plugin-react-hooks: "npm:^4.6.0"
-    ethers: "npm:^6.7.1"
     fp-ts: "npm:^2.16.1"
     framer-motion: "npm:^11.3.28"
     globals: "npm:^15.9.0"
@@ -3835,13 +3827,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.1.2":
-  version: 1.1.2
-  resolution: "@noble/hashes@npm:1.1.2"
-  checksum: 452a197522dabd163cf5297fe7b768fabba73072a198752074da6fce7c1438c7f614b27891391e9f6b118842656a4da4c0fc04e464ba1e15f306291d05dd106a
-  languageName: node
-  linkType: hard
-
 "@noble/hashes@npm:1.3.2":
   version: 1.3.2
   resolution: "@noble/hashes@npm:1.3.2"
@@ -3853,13 +3838,6 @@ __metadata:
   version: 1.5.0
   resolution: "@noble/hashes@npm:1.5.0"
   checksum: 1b46539695fbfe4477c0822d90c881a04d4fa2921c08c552375b444a48cac9930cb1ee68de0a3c7859e676554d0f3771999716606dc4d8f826e414c11692cdd9
-  languageName: node
-  linkType: hard
-
-"@noble/secp256k1@npm:1.7.1":
-  version: 1.7.1
-  resolution: "@noble/secp256k1@npm:1.7.1"
-  checksum: 48091801d39daba75520012027d0ff0b1719338d96033890cfe0d287ad75af00d82769c0194a06e7e4fbd816ae3f204f4a59c9e26f0ad16b429f7e9b5403ccd5
   languageName: node
   linkType: hard
 
@@ -10510,21 +10488,6 @@ __metadata:
   dependencies:
     fast-safe-stringify: "npm:^2.0.6"
   checksum: 332cbc5a957b62bb66ea01da2a467da65026df47e6516a286a969cad74d6002f2b481335510c93f12ca29c46ebc8354e39e2240769d86184f9b4c30832cf5466
-  languageName: node
-  linkType: hard
-
-"ethers@npm:6.7.1":
-  version: 6.7.1
-  resolution: "ethers@npm:6.7.1"
-  dependencies:
-    "@adraffy/ens-normalize": "npm:1.9.2"
-    "@noble/hashes": "npm:1.1.2"
-    "@noble/secp256k1": "npm:1.7.1"
-    "@types/node": "npm:18.15.13"
-    aes-js: "npm:4.0.0-beta.5"
-    tslib: "npm:2.4.0"
-    ws: "npm:8.5.0"
-  checksum: 1f5a4a024f865637bbc2c6d3383558ff9b62bf87a30d3159e3cc96d7b91e39e42483875edeff4ff0e30f3bea50d286598e2587d1652a0fcec0f8a8ad054a6d7f
   languageName: node
   linkType: hard
 
@@ -22798,21 +22761,6 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: f4a49064afae4500be772abdc2211c8518f39e1c959640457dcee15d4488628620625c783902a52af2dd02f68558da2868fd06e6fd0e67ebcd09e6881b1b5bfe
-  languageName: node
-  linkType: hard
-
-"ws@npm:8.5.0":
-  version: 8.5.0
-  resolution: "ws@npm:8.5.0"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ^5.0.2
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 0baeee03e97865accda8fad51e8e5fa17d19b8e264529efdf662bbba2acc1c7f1de8316287e6df5cb639231a96009e6d5234b57e6ff36ee2d04e49a0995fec2f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Moved dependency to `packages/integrations`, re-ran `yarn`. This was breaking Namadillo in dev mode


### TESTING

- Confirm that all apps should run in dev mode! Previously we were getting a runtime error in Namadillo
- Confirm that all apps build (production mode)
- Docker actions in CI are successful