### PR TITLE
Namadillo: removing unused .env injection on Vite config

### DIFF
--- a/apps/namadillo/vite.config.mjs
+++ b/apps/namadillo/vite.config.mjs
@@ -1,22 +1,11 @@
 /* eslint-disable */
 import react from "@vitejs/plugin-react";
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig } from "vite";
 import checker from "vite-plugin-checker";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 import tsconfigPaths from "vite-tsconfig-paths";
 
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), "");
-  const filteredEnv = Object.keys(env).reduce((acc, current) => {
-    if (current.startsWith("NAMADA_INTERFACE_")) {
-      return {
-        ...acc,
-        [current]: env[current],
-      };
-    }
-    return acc;
-  }, {});
-
+export default defineConfig(() => {
   return {
     plugins: [
       react(),
@@ -30,9 +19,6 @@ export default defineConfig(({ mode }) => {
         overlay: { initialIsOpen: false },
       }),
     ],
-    define: {
-      "process.env": filteredEnv,
-    },
     optimizeDeps: {
       esbuildOptions: {
         // Node.js global to browser globalThis


### PR DESCRIPTION
Environment variables are not used anymore in Namadillo. Recently, due to some package updates we've introduced a very unlikely error entitled as `Uncaught TypeError: process.version is undefined` . This PR removes this unused configuration and also fixes this error. 