### PR TITLE
packages: Additional tests around shielded keys

### DIFF
--- a/packages/crypto/lib/src/crypto/bip39.rs
+++ b/packages/crypto/lib/src/crypto/bip39.rs
@@ -115,6 +115,24 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
+    fn can_restore_seed_from_phrase() {
+        let phrase = "caught pig embody hip goose like become worry face oval manual flame \
+                      pizza steel viable proud eternal speed chapter sunny boat because view bullet";
+        let seed_bytes = vec![
+            178, 64, 160, 168, 33, 68, 84, 63, 0, 137, 121, 29, 66, 47, 123, 36, 64, 38, 160, 236,
+            93, 38, 53, 157, 169, 119, 42, 153, 188, 80, 209, 149, 51, 92, 251, 168, 150, 220, 70,
+            78, 230, 16, 152, 160, 85, 248, 115, 82, 183, 126, 96, 112, 58, 238, 230, 63, 89, 239,
+            0, 250, 163, 169, 166, 174,
+        ];
+        let mnemonic = Mnemonic::from_phrase(phrase.into()).unwrap();
+        let seed = mnemonic
+            .to_seed(None)
+            .expect("Should return seed from mnemonic phrase");
+
+        assert_eq!(seed.vec, seed_bytes);
+    }
+
+    #[wasm_bindgen_test]
     fn invalid_phrase_should_panic() {
         let bad_phrase = "caught pig embody hip goose like become";
         let res = Mnemonic::from_phrase(bad_phrase.into());

--- a/packages/sdk/src/tests/data.ts
+++ b/packages/sdk/src/tests/data.ts
@@ -7,6 +7,9 @@ export const CHAIN_ID = "localnet.a905b497170d585eb67fd";
 export const MNEMONIC_1 =
   "liar bird install win wool venue observe maid flock clap bullet myth illness trip bread fresh polar smart use lunar tired embody come deer";
 
+export const MNEMONIC_2 =
+  "resist mystery settle ask saddle great kite tragic leaf improve ticket admit analyst tomorrow tobacco aim desk melt wheel despair patch ketchup calm winner";
+
 export const ACCOUNT_1 = {
   address: "tnam1qz4sdx5jlh909j44uz46pf29ty0ztftfzc98s8dx",
   publicKey:
@@ -21,13 +24,22 @@ export const ACCOUNT_2 = {
     "tpknam1qrxzmeyka3v43jnrhep9stnj3jhtgzq96ku3u6lk8hy8xqmjqgjtw8qu274",
 };
 
-export const SHIELDED_ACCOUNT = {
+export const SHIELDED_ACCOUNT_1 = {
   paymentAddress:
     "znam1t5y7e7n6l9n3wfdq8j973lu9n8s086et6snmcmvu3lues59d5qlg085u25grflkr87ktwuhvd4y",
   spendingKey:
     "zsknam1qdjyja2zqqqqpqpxsekqx3tg8qz727cyqqhujj7c74xglmzk5lk0e2gej2s2e6c4vthhegtlxuulu4g4d3dqfc08fg0xunw4q22xdhac46t7empalaeq3czx7nfx456w7dqdm3tldwu83jjcc9dees3cefpkv23jnra5c3cwsy092ahrtpm7zv34sj8dy72zwpzwjja69pw6lacdd655j0zaxdjk6ej387njquecyqm2hzv3kps76wrv2y5xk634kkcc05tdrvwyhhq9p5gcy",
   viewingKey:
     "zvknam1qdjyja2zqqqqpqpxsekqx3tg8qz727cyqqhujj7c74xglmzk5lk0e2gej2s2e6c4vgxlamnryqz6ytms0wflzthg264m4qxucgsxf8en6unm9l33sc3qs9duecssuxah0hw267uu7nr9qym763v8qup2t3upxungmc0cqggvsy092ahrtpm7zv34sj8dy72zwpzwjja69pw6lacdd655j0zaxdjk6ej387njquecyqm2hzv3kps76wrv2y5xk634kkcc05tdrvwyhhqukwe9z",
+};
+
+export const SHIELDED_ACCOUNT_2 = {
+  paymentAddress:
+    "znam1u5nehkhgys5hdxzx6un9j2lfyx2e9fpzluaq7pedhkzxn9dm2wtfs8kywh45wc96yh63grkpw54",
+  spendingKey:
+    "zsknam1q0yp502jqqqqpqpf0vcvm20gadwfl2xt4gaqc5nwrdvl2ky3upvwja6uryucvmw5r7jxu2tuujuapqa5ud9cvuh9x4lkgy7sn7xlzm2kapqjl6y8zq4qwkl3vaye5z5gwe4yrmy5nh0a5zrlj8we947n2c4kmqm0t47gldgz8r58w2kwuee0edafdqmvvgtalpqyvanhzcvmglcufmu6g3jhr3kjayfhdfjefnsr8yhd3ah6xwpslgzy5s3xnhehzrsr2lqq0wfzacgrptw09",
+  viewingKey:
+    "zvknam1q0yp502jqqqqpqpf0vcvm20gadwfl2xt4gaqc5nwrdvl2ky3upvwja6uryucvmw5r7p9ddjvw86ma4qy57vzcqqqwa5efmvj2cnhgqgnktuffgz7zscd3fx776pul3f4df5ve3tef0htzwm7wv702t432m6fv9q2kepazvf78r58w2kwuee0edafdqmvvgtalpqyvanhzcvmglcufmu6g3jhr3kjayfhdfjefnsr8yhd3ah6xwpslgzy5s3xnhehzrsr2lqq0wfzacgx2s96s",
 };
 
 export const SIG_VALID = {

--- a/packages/sdk/src/tests/keys.test.ts
+++ b/packages/sdk/src/tests/keys.test.ts
@@ -1,7 +1,9 @@
 import {
   ACCOUNT_1 as account1,
   MNEMONIC_1 as mnemonic1,
-  SHIELDED_ACCOUNT as shieldedAccount,
+  MNEMONIC_2 as mnemonic2,
+  SHIELDED_ACCOUNT_1 as shieldedAccount1,
+  SHIELDED_ACCOUNT_2 as shieldedAccount2,
 } from "./data";
 import { initSdk } from "./initSdk";
 
@@ -20,13 +22,24 @@ describe("Keys", () => {
   it("should derive shielded keys from seed", () => {
     const { keys, mnemonic } = initSdk();
     const seed = mnemonic.toSeed(mnemonic1);
+    const seed2 = mnemonic.toSeed(mnemonic2);
 
     const { address, viewingKey, spendingKey } =
       keys.deriveShieldedFromSeed(seed);
 
-    expect(address).toBe(shieldedAccount.paymentAddress);
-    expect(viewingKey).toBe(shieldedAccount.viewingKey);
-    expect(spendingKey).toBe(shieldedAccount.spendingKey);
+    expect(address).toBe(shieldedAccount1.paymentAddress);
+    expect(viewingKey).toBe(shieldedAccount1.viewingKey);
+    expect(spendingKey).toBe(shieldedAccount1.spendingKey);
+
+    const {
+      address: address2,
+      viewingKey: viewingKey2,
+      spendingKey: spendingKey2,
+    } = keys.deriveShieldedFromSeed(seed2);
+
+    expect(address2).toBe(shieldedAccount2.paymentAddress);
+    expect(viewingKey2).toBe(shieldedAccount2.viewingKey);
+    expect(spendingKey2).toBe(shieldedAccount2.spendingKey);
   });
 
   it("should derive keys from seed", () => {

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -31,8 +31,7 @@ export const makeBip44Path = (
 /**
  * Return a properly formatted Sapling path
  * @param coinType - SLIP-044 Coin designation
- * @param account - numbered from index 
- in sequentially increasing manner. Defined as in BIP 44
+ * @param account - numbered from index in sequentially increasing manner. Defined as in BIP 44
  * @returns Sapling path
  */
 export const makeSaplingPath = (coinType: number, account: number): string => {
@@ -42,8 +41,7 @@ export const makeSaplingPath = (coinType: number, account: number): string => {
 /**
  * Return a properly formatted Sapling path array
  * @param coinType - SLIP-044 Coin designation
- * @param account - numbered from index 
- in sequentially increasing manner. Defined as in BIP 44
+ * @param account - numbered from index in sequentially increasing manner. Defined as in BIP 44
  * @returns Sapling path array
  */
 export const makeSaplingPathArray = (


### PR DESCRIPTION
Someone on Discord has reported that when testing import of the same mnemonic in the extension, sometimes their Payment Address is different. I'm not sure how this could be possible, and we have existing tests that ensure that the keys must match for any given mnemonic.

So, I propose:
- Add additional tests to the `@namada/crypto` lib (Rust & Jest)
  - Imported mnemonic generates the same seed
  - Payment Address & Viewing Key match expected when deriving from seed
- Add additional tests to `@heliax/namada-sdk` package (we currently have one test mnemonic, will add more)
- Ensure these tests are being run in CI each time

### Testing

- `packages/crypto`
  - `yarn test-wasm:ci`
  - `yarn test`
- `packages/sdk`
  - `yarn test`
