### PR TITLE
feat/1098: Namadillo: Fetch, Store, and Load MASP params in SDK

### DIFF
--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -45,7 +45,7 @@
     "dev": "vite",
     "preview": "vite preview",
     "dev:local": "NODE_ENV=development NAMADA_INTERFACE_LOCAL=\"true\" yarn dev",
-    "dev:proxy": "NAMADA_INTERFACE_PROXY=true && ./scripts/start-proxies.sh && yarn dev:local",
+    "dev:proxy": "VITE_PROXY=true && ./scripts/start-proxies.sh && yarn dev:local",
     "build": "NODE_ENV=production && yarn wasm:build && vite build",
     "build:only": "NODE_ENV=production &&  vite build",
     "lint": "eslint src --ext .ts,.tsx",

--- a/apps/namadillo/scripts/proxies.json
+++ b/apps/namadillo/scripts/proxies.json
@@ -1,0 +1,7 @@
+[
+  {
+    "alias": "MASP Params",
+    "url": "https://github.com/anoma/masp-mpc/releases/download/namada-trusted-setup/",
+    "proxyPort": 8010
+  }
+]

--- a/apps/namadillo/scripts/startProxies.js
+++ b/apps/namadillo/scripts/startProxies.js
@@ -1,47 +1,16 @@
 const { exec } = require("child_process");
-require("dotenv").config();
 
-const {
-  NAMADA_INTERFACE_NAMADA_ALIAS = "Namada",
-  NAMADA_INTERFACE_NAMADA_URL,
-  NAMADA_INTERFACE_COSMOS_ALIAS = "Cosmos",
-  NAMADA_INTERFACE_COSMOS_URL,
-  NAMADA_INTERFACE_ETH_ALIAS = "Ethereum",
-  NAMADA_INTERFACE_ETH_URL,
-} = process.env;
+const proxiesJson = require("./proxies.json");
 
-const proxyConfigs = [
-  {
-    alias: NAMADA_INTERFACE_NAMADA_ALIAS,
-    url: NAMADA_INTERFACE_NAMADA_URL,
-    proxyPort: 8010,
-  },
-  {
-    alias: NAMADA_INTERFACE_COSMOS_ALIAS,
-    url: NAMADA_INTERFACE_COSMOS_URL,
-    proxyPort: 8011,
-  },
-  {
-    alias: NAMADA_INTERFACE_ETH_ALIAS,
-    url: NAMADA_INTERFACE_ETH_URL,
-    proxyPort: 8012,
-  },
-];
+proxiesJson.forEach(({ alias, url, proxyPort }) => {
+  console.log(`Starting local-cors-proxy for ${alias}`);
+  console.log(`-> ${url} proxied to http://localhost:${proxyPort}/proxy\n`);
 
-proxyConfigs.forEach(({ alias, url, proxyPort }) => {
-  if (url) {
-    console.log(`Starting local-cors-proxy for ${alias}`);
-    console.log(`-> ${url} proxied to http://localhost:${proxyPort}/proxy\n`);
-
-    exec(
-      `lcp --proxyUrl ${url} --port ${proxyPort}`,
-      (error, stdout, stderr) => {
-        console.log(stdout);
-        console.log(stderr);
-        if (error !== null) {
-          console.log(`exec error: ${error}`);
-        }
-      }
-    );
-  }
+  exec(`lcp --proxyUrl ${url} --port ${proxyPort}`, (error, stdout, stderr) => {
+    console.log(stdout);
+    console.log(stderr);
+    if (error !== null) {
+      console.log(`exec error: ${error}`);
+    }
+  });
 });

--- a/packages/sdk/src/masp.ts
+++ b/packages/sdk/src/masp.ts
@@ -21,10 +21,11 @@ export class Masp {
   /**
    * Fetch MASP parameters and store them in SDK
    * @async
+   * @param [url] - optional URL to override the default
    * @returns void
    */
-  async fetchAndStoreMaspParams(): Promise<void> {
-    return await SdkWasm.fetch_and_store_masp_params();
+  async fetchAndStoreMaspParams(url?: string): Promise<void> {
+    return await SdkWasm.fetch_and_store_masp_params(url);
   }
 
   /**

--- a/packages/shared/lib/src/sdk/mod.rs
+++ b/packages/shared/lib/src/sdk/mod.rs
@@ -71,8 +71,8 @@ impl Sdk {
         Ok(js_sys::Boolean::from(has.as_bool().unwrap()).into())
     }
 
-    pub async fn fetch_and_store_masp_params() -> Result<(), JsValue> {
-        fetch_and_store_masp_params().await?;
+    pub async fn fetch_and_store_masp_params(url: Option<String>) -> Result<(), JsValue> {
+        fetch_and_store_masp_params(url).await?;
         Ok(())
     }
 
@@ -495,5 +495,5 @@ extern "C" {
     #[wasm_bindgen(catch, js_name = "hasMaspParams")]
     async fn has_masp_params() -> Result<JsValue, JsValue>;
     #[wasm_bindgen(catch, js_name = "fetchAndStoreMaspParams")]
-    async fn fetch_and_store_masp_params() -> Result<JsValue, JsValue>;
+    async fn fetch_and_store_masp_params(url: Option<String>) -> Result<JsValue, JsValue>;
 }

--- a/packages/shared/lib/src/sdk/mod.ts
+++ b/packages/shared/lib/src/sdk/mod.ts
@@ -8,11 +8,13 @@ export async function hasMaspParams(): Promise<boolean> {
   );
 }
 
-export async function fetchAndStoreMaspParams(): Promise<[void, void, void]> {
+export async function fetchAndStoreMaspParams(
+  url?: string
+): Promise<[void, void, void]> {
   return Promise.all([
-    fetchAndStore("masp-spend.params"),
-    fetchAndStore("masp-output.params"),
-    fetchAndStore("masp-convert.params"),
+    fetchAndStore("masp-spend.params", url),
+    fetchAndStore("masp-output.params", url),
+    fetchAndStore("masp-convert.params", url),
   ]);
 }
 
@@ -24,17 +26,19 @@ export async function getMaspParams(): Promise<[unknown, unknown, unknown]> {
   ]);
 }
 
-export async function fetchAndStore(params: string): Promise<void> {
-  const data = await fetchParams(params);
+export async function fetchAndStore(
+  params: string,
+  url?: string
+): Promise<void> {
+  const data = await fetchParams(params, url);
   await set(params, data);
 }
 
-export async function fetchParams(params: string): Promise<Uint8Array> {
-  const path =
-    process.env.NAMADA_INTERFACE_MASP_PARAMS_PATH ||
-    "https://github.com/anoma/masp-mpc/releases/download/namada-trusted-setup/";
-
-  return fetch(`${path}${params}`)
+export async function fetchParams(
+  params: string,
+  url: string = "https://github.com/anoma/masp-mpc/releases/download/namada-trusted-setup/"
+): Promise<Uint8Array> {
+  return fetch(`${url}${params}`)
     .then((response) => response.arrayBuffer())
     .then((ab) => new Uint8Array(ab));
 }


### PR DESCRIPTION
Relates to #1098 (for building shielded Tx)

- [x] Update proxy script to proxy the MASP Params URL (to get around the CORS errors on local dev)
- [x] Update SDK to accept an alternate URL (proxied URL) to fetch MASP params
- [x] Issue check for masp params: If we don't have them, fetch and store params. Once stored, load them into SDK

### Testing

- In Namadillo: `yarn dev:proxy`
  - **NOTE** In local dev mode, you only need to run the proxy once when to fetch the params. Once it's downloaded, the `masp.hasMaspParams()` check should always return true, as it is now persisted in IndexedDB!
- You'll probably need to just monitor the network requests the first time you load it, ensure the MASP param requests runs the first time, then on future runs it should not request anything. I didn't want to leave any `console.log` :D 