### PR TITLE
feat: expand ActionButton to use react-router Link for internal navigation

### DIFF
--- a/apps/namadillo/src/App/AccountOverview/NavigationFooter.tsx
+++ b/apps/namadillo/src/App/AccountOverview/NavigationFooter.tsx
@@ -1,10 +1,8 @@
 import { ActionButton, Heading, Stack } from "@namada/components";
 import GovernanceRoutes from "App/Governance/routes";
 import StakingRoutes from "App/Staking/routes";
-import { useNavigate } from "react-router-dom";
 
 export const NavigationFooter = (): JSX.Element => {
-  const navigate = useNavigate();
   return (
     <footer className="text-center">
       <Heading level="h3" className="uppercase text-4xl text-yellow mb-2">
@@ -13,7 +11,7 @@ export const NavigationFooter = (): JSX.Element => {
       <Stack gap={3} direction="horizontal">
         <ActionButton
           className="border uppercase"
-          onClick={() => navigate(StakingRoutes.overview().url)}
+          href={StakingRoutes.overview().url}
           size="sm"
           backgroundColor="cyan"
           outlineColor="cyan"
@@ -25,7 +23,7 @@ export const NavigationFooter = (): JSX.Element => {
         </ActionButton>
         <ActionButton
           size="sm"
-          onClick={() => navigate(GovernanceRoutes.index())}
+          href={GovernanceRoutes.index()}
           outlineColor="yellow"
           className="uppercase"
           backgroundColor="transparent"

--- a/apps/namadillo/src/App/Governance/ProposalHeader.tsx
+++ b/apps/namadillo/src/App/Governance/ProposalHeader.tsx
@@ -120,14 +120,12 @@ const TypeLabel: React.FC<{
 const JsonButton: React.FC<{
   proposalId: bigint;
 }> = ({ proposalId }) => {
-  const navigate = useNavigate();
-
   return (
     <ActionButton
       className="px-3 py-2"
       size="xs"
       outlineColor="white"
-      onClick={() => navigate(GovernanceRoutes.viewJson(proposalId).url)}
+      href={GovernanceRoutes.viewJson(proposalId).url}
     >
       <span className="flex text-xs justify-between gap-2">
         <VscJson />

--- a/apps/namadillo/src/App/Staking/AllValidatorsTable.tsx
+++ b/apps/namadillo/src/App/Staking/AllValidatorsTable.tsx
@@ -14,7 +14,6 @@ import { useValidatorFilter } from "hooks/useValidatorFilter";
 import { useValidatorTableSorting } from "hooks/useValidatorTableSorting";
 import { useAtomValue } from "jotai";
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
 import { Validator } from "types";
 import { ValidatorAlias } from "./ValidatorAlias";
 import { ValidatorThumb } from "./ValidatorThumb";
@@ -32,7 +31,6 @@ export const AllValidatorsTable = ({
 }: AllValidatorsProps): JSX.Element => {
   const validators = useAtomValue(allValidatorsAtom);
   const isConnected = useAtomValue(namadaExtensionConnectedAtom);
-  const navigate = useNavigate();
   const [searchTerm, setSearchTerm] = useState("");
   const hasAccount = useUserHasAccount();
 
@@ -123,7 +121,7 @@ export const AllValidatorsTable = ({
             <ActionButton
               size="sm"
               backgroundColor="cyan"
-              onClick={() => navigate(StakingRoutes.incrementBonding().url)}
+              href={StakingRoutes.incrementBonding().url}
             >
               Stake
             </ActionButton>

--- a/apps/namadillo/src/App/Staking/MyValidatorsTable.tsx
+++ b/apps/namadillo/src/App/Staking/MyValidatorsTable.tsx
@@ -7,14 +7,12 @@ import { myValidatorsAtom } from "atoms/validators";
 import BigNumber from "bignumber.js";
 import { useValidatorTableSorting } from "hooks/useValidatorTableSorting";
 import { useAtomValue } from "jotai";
-import { useNavigate } from "react-router-dom";
 import { Address, MyValidator, Validator } from "types";
 import { ValidatorCard } from "./ValidatorCard";
 import { ValidatorsTable } from "./ValidatorsTable";
 import StakingRoutes from "./routes";
 
 export const MyValidatorsTable = (): JSX.Element => {
-  const navigate = useNavigate();
   const myValidators = useAtomValue(myValidatorsAtom);
 
   const validators =
@@ -110,7 +108,7 @@ export const MyValidatorsTable = (): JSX.Element => {
           className="basis-[content] py-1"
           backgroundColor="cyan"
           size="md"
-          onClick={() => navigate(StakingRoutes.incrementBonding().url)}
+          href={StakingRoutes.incrementBonding().url}
         >
           Stake
         </ActionButton>
@@ -118,7 +116,7 @@ export const MyValidatorsTable = (): JSX.Element => {
           className="basis-[content] py-1"
           backgroundColor="white"
           size="md"
-          onClick={() => navigate(StakingRoutes.redelegateBonding().url)}
+          href={StakingRoutes.redelegateBonding().url}
         >
           Redelegate
         </ActionButton>
@@ -130,7 +128,7 @@ export const MyValidatorsTable = (): JSX.Element => {
           textHoverColor="white"
           backgroundHoverColor="pink"
           size="md"
-          onClick={() => navigate(StakingRoutes.unstake().url)}
+          href={StakingRoutes.unstake().url}
         >
           Unstake
         </ActionButton>

--- a/apps/namadillo/src/App/Staking/ReDelegate.tsx
+++ b/apps/namadillo/src/App/Staking/ReDelegate.tsx
@@ -169,7 +169,7 @@ export const ReDelegate = (): JSX.Element => {
                 backgroundColor="white"
                 backgroundHoverColor="pink"
                 size="sm"
-                onClick={() => navigate(StakingRoutes.unstake().url)}
+                href={StakingRoutes.unstake().url}
               >
                 Unstake
               </ActionButton>

--- a/apps/namadillo/src/App/Staking/StakingSummary.tsx
+++ b/apps/namadillo/src/App/Staking/StakingSummary.tsx
@@ -8,12 +8,10 @@ import { AtomErrorBoundary } from "App/Common/AtomErrorBoundary";
 import { BalanceChart } from "App/Common/BalanceChart";
 import { NamCurrency } from "App/Common/NamCurrency";
 import { useBalances } from "hooks/useBalances";
-import { useNavigate } from "react-router-dom";
 import StakingRoutes from "./routes";
 import { StakingRewardsPanel } from "./StakingRewardsPanel";
 
 export const StakingSummary = (): JSX.Element => {
-  const navigate = useNavigate();
   const {
     balanceQuery,
     stakeQuery,
@@ -74,7 +72,7 @@ export const StakingSummary = (): JSX.Element => {
                 className="px-8"
                 size="xs"
                 backgroundColor="cyan"
-                onClick={() => navigate(StakingRoutes.incrementBonding().url)}
+                href={StakingRoutes.incrementBonding().url}
               >
                 Stake
               </ActionButton>

--- a/packages/components/src/ActionButton.tsx
+++ b/packages/components/src/ActionButton.tsx
@@ -2,6 +2,7 @@ import { Color } from "@namada/components/types";
 import { getDefaultColorString } from "@namada/components/utils";
 import clsx from "clsx";
 import { createElement, CSSProperties } from "react";
+import { Link } from "react-router-dom";
 import { twMerge } from "tailwind-merge";
 import { tv, type VariantProps } from "tailwind-variants";
 
@@ -80,7 +81,7 @@ export type ActionButtonProps<HtmlTag extends keyof React.ReactHTML> = {
 } & React.ComponentPropsWithoutRef<HtmlTag> &
   Omit<ButtonTailwindVariantsProps, "noHover" | "outlined">;
 
-export const ActionButton = ({
+export const Button = ({
   icon,
   children,
   className,
@@ -92,7 +93,7 @@ export const ActionButton = ({
   backgroundColor: backgroundColorProp,
   backgroundHoverColor: backgroundHoverColorProp,
   textHoverColor: textHoverColorProp,
-  as,
+  as = "button",
   ...domProps
 }: ActionButtonProps<keyof React.ReactHTML>): JSX.Element => {
   const textColor = textColorProp || outlineColor || "black";
@@ -112,7 +113,7 @@ export const ActionButton = ({
     outlined ? getDefaultColorString(outlineColor) : undefined;
 
   return createElement(
-    as ?? ("href" in domProps ? "a" : "button"),
+    as,
     {
       className: twMerge(
         actionButtonShape({
@@ -148,4 +149,24 @@ export const ActionButton = ({
       />
     </>
   );
+};
+
+export const ActionButton = <HtmlTag extends keyof React.ReactHTML>(
+  props: ActionButtonProps<HtmlTag>
+): JSX.Element => {
+  if ("href" in props) {
+    const { href, ...otherProps } = props;
+    if (href) {
+      if (href.startsWith("http")) {
+        return <Button as="a" {...props} />;
+      }
+      return (
+        <Link to={href}>
+          <Button as="div" {...otherProps} />
+        </Link>
+      );
+    }
+  }
+
+  return <Button {...props} />;
 };

--- a/packages/components/src/ActionButton.tsx
+++ b/packages/components/src/ActionButton.tsx
@@ -81,7 +81,7 @@ export type ActionButtonProps<HtmlTag extends keyof React.ReactHTML> = {
 } & React.ComponentPropsWithoutRef<HtmlTag> &
   Omit<ButtonTailwindVariantsProps, "noHover" | "outlined">;
 
-export const Button = ({
+const Button = ({
   icon,
   children,
   className,


### PR DESCRIPTION
Expand `ActionButton` to use react-router `Link` for internal navigation

This improves accessibility transforming the `<button onClick={() => navigate(...)}>` into `<a href={...}>` but not breaking the SPA

To test, you can navigate on any button, like the ones on TopNavigation and observe they are regular `<a>` that don't break the SPA