### PR TITLE
feat/592: Validate length and checksum of fetched masp param

### DIFF
--- a/apps/namadillo/src/hooks/useSdk.tsx
+++ b/apps/namadillo/src/hooks/useSdk.tsx
@@ -63,7 +63,7 @@ export const SdkProvider: FunctionComponent<PropsWithChildren> = ({
           masp
             .fetchAndStoreMaspParams(paramsUrl)
             .then(() => masp.loadMaspParams(""))
-            .catch((e) => console.error(`${e}`));
+            .catch((e) => console.error(`Error downloading MASP params ${e}`));
         });
       });
     }

--- a/packages/shared/lib/src/sdk/mod.ts
+++ b/packages/shared/lib/src/sdk/mod.ts
@@ -20,6 +20,32 @@ type MaspParamBytes = {
   bytes: Uint8Array;
 };
 
+/**
+ * The following sha256 digests where produced by downloading the following:
+ * https://github.com/anoma/masp-mpc/releases/download/namada-trusted-setup/masp-convert.params
+ * https://github.com/anoma/masp-mpc/releases/download/namada-trusted-setup/masp-spend.params
+ * https://github.com/anoma/masp-mpc/releases/download/namada-trusted-setup/masp-output.params
+ *
+ * And running "sha256sum" against each file:
+ *
+ * > sha256sum masp-convert.params
+ * 8e049c905e0e46f27662c7577a4e3480c0047ee1171f7f6d9c5b0de757bf71f1  masp-convert.params
+ *
+ * > sha256sum masp-spend.params
+ * 62b3c60ca54bd99eb390198e949660624612f7db7942db84595fa9f1b4a29fd8  masp-spend.params
+ *
+ * > sha256sum masp-output.params
+ * ed8b5d354017d808cfaf7b31eca5c511936e65ef6d276770251f5234ec5328b8  masp-output.params
+ *
+ * Length is specified in bytes, and can be retrieved with:
+ *
+ * > wc -c < masp-convert.params
+ * 22570940
+ * > wc -c < masp-spend.params
+ * 49848572
+ * > wc -c < masp-output.params
+ * 16398620
+ */
 const MASP_PARAM_ATTR: Record<
   MaspParam,
   { length: number; sha256sum: string }
@@ -102,7 +128,7 @@ export async function fetchAndStore(
   return await fetchParams(param, url)
     .then((data) => set(param, data))
     .catch((e) => {
-      console.warn(`Encountered errors fetching ${param}: ${e}`);
+      return Promise.reject(`Encountered errors fetching ${param}: ${e}`);
     });
 }
 


### PR DESCRIPTION
Resolves #592 

This PR validates the fetched MASP param before storing it. This will reject the promise and prevent an invalid param from being stored should length or checksum not match.

## TESTING

- In `packages/shared/lib/src/sdk/mod.ts` https://github.com/anoma/namada-interface/blob/e160a31a23a259e9e7a4ed205b7d15fcbfa596e9/packages/shared/lib/src/sdk/mod.ts#L21-L40 modify these values to invalidate them (either length or hash, length is checked first!)
- Rebuild the shared package: `yarn wasm:build` (Even though these changes are 100% TS, they are a part of `shared` lib and will not auto-reload in dev mode)
- Start Namadillo with `yarn dev:proxy` (bypasses CORS issue with localhost)
- If you have already successfully downloaded MASP params, just comment out the lines below in `useSdk` to force a download on next refresh: https://github.com/anoma/namada-interface/blob/e160a31a23a259e9e7a4ed205b7d15fcbfa596e9/apps/namadillo/src/hooks/useSdk.tsx#L60-L62
- You should see errors for each param that has issues. Currently if any one of these fails, `hasMaspParams()` will return false, so it will retry all of them on next refresh.
- Also, you can run `yarn dev` locally (without the proxy) which will trigger the `retry` behavior, it is currently configured to retry a total of 3 times with 3 second intervals in between before failing

## TODO

- How should we respond to a MASP param validation failure? One option would be to simply prompt the user to try again, perhaps we could have a warning modal with a `Retry` button that invokes the download again.

## NOTES

- What could cause an invalid MASP param download?
  - If a download is interrupted due to connectivity issues, the promise will likely just hang
  - If the user is running this locally and overrides the trusted setup params URL, they could be loading invalid params
    - If the length is valid, it will then check the checksum, which must match our constants
  - This feature is for piece of mind, so that the user can be sure they are using the trusted params. Only the trusted params will successfully be stored in IndexedDB