### PR TITLE
Firefox - 0.3.3 updates

### DIFF
--- a/apps/extension/FIREFOX_README.md
+++ b/apps/extension/FIREFOX_README.md
@@ -37,11 +37,13 @@ nvm install v20.9.0
 These instructions should work for the default reviewer build environment.
 
 ```bash
-sudo apt install protobuf-compiler build-essential
+sudo apt install protobuf-compiler build-essential curl pkg-config libssl-dev binaryen
 curl https://sh.rustup.rs -sSf | sh
 
+# Proceed with standard installation when prompted
+
 # Make sure to pull cargo into your current environment:
-source ~/.bashrc
+. "$HOME/.cargo/env"
 
 npm install -g yarn
 export PUPPETEER_SKIP_DOWNLOAD=true

--- a/apps/extension/FIREFOX_README.md
+++ b/apps/extension/FIREFOX_README.md
@@ -21,11 +21,28 @@ several local packages; their sources are in:
 
 ## Build instructions
 
+If you don't already have Node v20 LTS and NPM v10, install now via `nvm`:
+
+```bash
+wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+
+# Enable nvm in current shell
+export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+# Install v20 LTS
+nvm install v20.9.0
+```
+
 These instructions should work for the default reviewer build environment.
 
 ```bash
 sudo apt install protobuf-compiler build-essential
 curl https://sh.rustup.rs -sSf | sh
+
+# Make sure to pull cargo into your current environment:
+source ~/.bashrc
+
 npm install -g yarn
 export PUPPETEER_SKIP_DOWNLOAD=true
 yarn

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@namada/extension",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Namada Browser Extension",
   "repository": "https://github.com/anoma/namada-interface/",
   "author": "Heliax Dev <info@heliax.dev>",


### PR DESCRIPTION
### How I tested this

According to the results of our Firefox submission, the testers were using an `arm64` version of Ubuntu Desktop 22. As such:

- In macos (arm64) I installed the Ubuntu 22.04.5 LTS (Jammy Jellyfish) Daily build from https://cdimage.ubuntu.com/jammy/daily-live/current/ into VirtualBox
- Ran through testing instructions in `apps/extension/FIREFOX_README.md`, and added any commands that were needed along the way to get `yarn wasm:build` and `yarn build:firefox` to work

See the `Default Reviewer Build Environment` info at https://extensionworkshop.com/documentation/publish/source-code-submission/

