### PR TITLE
feat: add support for IBC deposits to shielded

### DIFF
--- a/apps/namadillo/src/App/Ibc/IbcTransfer.tsx
+++ b/apps/namadillo/src/App/Ibc/IbcTransfer.tsx
@@ -23,9 +23,6 @@ import { basicConvertToKeplrChain } from "utils/integration";
 
 const keplr = (window as KeplrWindow).keplr!;
 
-//TODO: we need to find a good way to manage IBC channels
-const namadaChannelId = "channel-4353";
-
 export const IbcTransfer: React.FC = () => {
   const knownChains = useAtomValue(knownChainsAtom);
   const [chainId, setChainId] = useAtom(selectedIBCChainAtom);
@@ -33,6 +30,8 @@ export const IbcTransfer: React.FC = () => {
   const [sourceAddress, setSourceAddress] = useState<string | undefined>();
   const [shielded, setShielded] = useState<boolean>(true);
   const [selectedAsset, setSelectedAsset] = useState<Asset>();
+  const [sourceChannelId, setSourceChannelId] = useState<string>("");
+  const [destinationChannelId, setDestinationChannelId] = useState<string>("");
   const performIbcTransfer = useAtomValue(ibcTransferAtom);
   const defaultAccounts = useAtomValue(allDefaultAccountsAtom);
 
@@ -140,7 +139,15 @@ export const IbcTransfer: React.FC = () => {
         destinationAddress,
         amount,
         token: selectedAsset.base,
-        channelId: namadaChannelId,
+        sourceChannelId,
+        ...(shielded ?
+          {
+            isShielded: true,
+            destinationChannelId,
+          }
+        : {
+            isShielded: false,
+          }),
       },
     });
   };
@@ -161,6 +168,23 @@ export const IbcTransfer: React.FC = () => {
       <header className="text-center mb-4">
         <h2>IBC Transfer to Namada</h2>
       </header>
+      <div className="flex flex-col gap-2">
+        <input
+          className="text-black"
+          type="text"
+          placeholder="source channel id"
+          value={sourceChannelId}
+          onChange={(e) => setSourceChannelId(e.target.value)}
+        />
+
+        <input
+          className="text-black"
+          type="text"
+          placeholder="destination channel id"
+          value={destinationChannelId}
+          onChange={(e) => setDestinationChannelId(e.target.value)}
+        />
+      </div>
       <TransferModule
         source={{
           isLoadingAssets: isLoadingBalances,

--- a/apps/namadillo/src/atoms/integrations/atoms.ts
+++ b/apps/namadillo/src/atoms/integrations/atoms.ts
@@ -7,14 +7,14 @@ import { atomWithMutation, atomWithQuery } from "jotai-tanstack-query";
 import { atomFamily, atomWithStorage } from "jotai/utils";
 import { getKnownChains, mapCoinsToAssets } from "./functions";
 import {
-  IBCTransferParams,
+  IbcTransferParams,
   queryAndStoreRpc,
   queryAssetBalances,
   submitIbcTransfer,
 } from "./services";
 
 type IBCTransferAtomParams = {
-  transferParams: IBCTransferParams;
+  transferParams: IbcTransferParams;
   chain: Chain;
 };
 

--- a/packages/sdk/src/masp.ts
+++ b/packages/sdk/src/masp.ts
@@ -70,4 +70,13 @@ export class Masp {
   async addDefaultPaymentAddress(xvk: string, alias: string): Promise<void> {
     return await this.sdk.add_default_payment_address(xvk, alias);
   }
+
+  /**
+   * Returns the MASP address used as the receiving address in IBC transfers to
+   * shielded accounts
+   * @returns the MASP address
+   */
+  maspAddress(): string {
+    return this.sdk.masp_address();
+  }
 }

--- a/packages/sdk/src/tx/tx.ts
+++ b/packages/sdk/src/tx/tx.ts
@@ -43,6 +43,7 @@ import {
   WrapperTxProps,
 } from "@namada/types";
 import { ResponseSign } from "@zondax/ledger-namada";
+import BigNumber from "bignumber.js";
 import { WasmHash } from "../rpc";
 
 /**
@@ -471,6 +472,30 @@ export class Tx {
         })
       ),
     };
+  }
+
+  /**
+   * Generate the memo needed for performing an IBC transfer to a Namada shielded
+   * address.
+   * @async
+   * @param target - the Namada shielded address to send tokens to
+   * @param token - the token to transfer
+   * @param amount - the amount to transfer
+   * @param channelId - the IBC channel ID on the Namada side
+   * @returns promise that resolves to the shielding memo
+   */
+  generateIbcShieldingMemo(
+    target: string,
+    token: string,
+    amount: BigNumber,
+    channelId: string
+  ): Promise<string> {
+    return this.sdk.generate_ibc_shielding_memo(
+      target,
+      token,
+      amount.toString(),
+      channelId
+    );
   }
 
   /**


### PR DESCRIPTION
This PR adds support for IBC deposits to shielded Namada addresses.

Testing instructions are the same as #1162 but running `namadac shielded-sync` is necessary before checking that balance was received.

---

### Changed
- Re-add source channel input element (since I think we will need to change channels relatively frequently before mainnet)
- Rename `IBCTransferParams` to `IbcTransferParams`

### Added
- Support IBC deposits to Namada shielded addresses
- Add SDK methods to get MASP address and to generate IBC shielding memo

### Fixed
- Fix Long value being passed instead of BigInt in `timeoutTimestampNanoseconds`
  - I don't think this is what was causing the timeouts over IBC but I'm not 100% sure
<!--

Make sure you have read CONTRIBUTING.md before submitting a pull request!

-->
