### PR TITLE
PoC: Adding offscreen & web worker to the extension

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.20.11",
     "@svgr/webpack": "^6.3.1",
-    "@types/chrome": "^0.0.237",
+    "@types/chrome": "^0.0.277",
     "@types/dompurify": "^3.0.5",
     "@types/firefox-webext-browser": "^94.0.1",
     "@types/jest": "^29.5.12",

--- a/apps/extension/src/background/keyring/handler.ts
+++ b/apps/extension/src/background/keyring/handler.ts
@@ -7,9 +7,11 @@ import {
 import { Env, Handler, InternalHandler, Message } from "router";
 import {
   AddLedgerAccountMsg,
+  CloseOffscreenDocumentMsg,
   DeleteAccountMsg,
   DeriveAccountMsg,
   GenerateMnemonicMsg,
+  GenerateProofCompletedEvent,
   GetActiveAccountMsg,
   QueryAccountDetailsMsg,
   QueryParentAccountsMsg,
@@ -88,6 +90,16 @@ export const getHandler: (service: KeyRingService) => Handler = (service) => {
         return handleQueryAccountDetails(service)(
           env,
           msg as QueryAccountDetailsMsg
+        );
+      case CloseOffscreenDocumentMsg:
+        return handleCloseOffscreenDocumentMsg(service)(
+          env,
+          msg as CloseOffscreenDocumentMsg
+        );
+      case GenerateProofCompletedEvent:
+        return handleGenerateProofCompletedEvent(service)(
+          env,
+          msg as GenerateProofCompletedEvent
         );
       default:
         throw new Error("Unknown msg type");
@@ -235,5 +247,22 @@ const handleQueryAccountDetails: (
 ) => InternalHandler<QueryAccountDetailsMsg> = (service) => {
   return async (_, { address }) => {
     return await service.queryAccountDetails(address);
+  };
+};
+
+const handleCloseOffscreenDocumentMsg: (
+  service: KeyRingService
+) => InternalHandler<CloseOffscreenDocumentMsg> = (service) => {
+  return async () => {
+    return await service.closeOffscreenDocument();
+  };
+};
+
+const handleGenerateProofCompletedEvent: (
+  service: KeyRingService
+) => InternalHandler<GenerateProofCompletedEvent> = (service) => {
+  return async (_, msg) => {
+    const { msgId, success, payload } = msg;
+    return await service.handleGenerateProofCompleted(msgId, success, payload);
   };
 };

--- a/apps/extension/src/background/keyring/init.ts
+++ b/apps/extension/src/background/keyring/init.ts
@@ -9,9 +9,11 @@ import { ROUTE } from "./constants";
 import { getHandler } from "./handler";
 import {
   AddLedgerAccountMsg,
+  CloseOffscreenDocumentMsg,
   DeleteAccountMsg,
   DeriveAccountMsg,
   GenerateMnemonicMsg,
+  GenerateProofCompletedEvent,
   GetActiveAccountMsg,
   QueryAccountDetailsMsg,
   QueryParentAccountsMsg,
@@ -40,6 +42,8 @@ export function init(router: Router, service: KeyRingService): void {
   router.registerMessage(RevealAccountMnemonicMsg);
   router.registerMessage(RenameAccountMsg);
   router.registerMessage(VerifyArbitraryMsg);
+  router.registerMessage(CloseOffscreenDocumentMsg);
+  router.registerMessage(GenerateProofCompletedEvent);
 
   router.addHandler(ROUTE, getHandler(service));
 }

--- a/apps/extension/src/background/keyring/messages.ts
+++ b/apps/extension/src/background/keyring/messages.ts
@@ -28,6 +28,8 @@ enum MessageType {
   RenameAccount = "rename-account",
   QueryAccountDetails = "query-account-details",
   AppendLedgerSignature = "append-ledger-signature",
+  CloseOffscreenDocument = "close-offscreen-document",
+  GenerateProofCompletedEvent = "generate-proof-completed-event",
 }
 
 export class GenerateMnemonicMsg extends Message<string[]> {
@@ -408,5 +410,55 @@ export class AppendLedgerSignatureMsg extends Message<Uint8Array> {
 
   type(): string {
     return AppendLedgerSignatureMsg.type();
+  }
+}
+
+export class CloseOffscreenDocumentMsg extends Message<void> {
+  public static type(): MessageType {
+    return MessageType.CloseOffscreenDocument;
+  }
+
+  constructor() {
+    super();
+  }
+
+  validate(): void {
+    return;
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return CloseOffscreenDocumentMsg.type();
+  }
+}
+
+export class GenerateProofCompletedEvent extends Message<void> {
+  public static type(): MessageType {
+    return MessageType.GenerateProofCompletedEvent;
+  }
+
+  constructor(
+    public readonly success: boolean,
+    public readonly msgId: string,
+    public readonly payload?: string
+  ) {
+    super();
+  }
+
+  validate(): void {
+    if (this.success === undefined) {
+      throw new Error("Success is undefined");
+    }
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return GenerateProofCompletedEvent.type();
   }
 }

--- a/apps/extension/src/background/offscreen/index.ts
+++ b/apps/extension/src/background/offscreen/index.ts
@@ -1,0 +1,1 @@
+export * from "./utils";

--- a/apps/extension/src/background/offscreen/offscreen.html
+++ b/apps/extension/src/background/offscreen/offscreen.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<script src="offscreen.namada.js"></script>

--- a/apps/extension/src/background/offscreen/offscreen.ts
+++ b/apps/extension/src/background/offscreen/offscreen.ts
@@ -1,0 +1,81 @@
+import {
+  CloseOffscreenDocumentMsg,
+  GenerateProofCompletedEvent,
+} from "background/keyring";
+import { init as initGenerateProofWorker } from "background/web-workers";
+import { GenerateProofMessage } from "background/web-workers/types";
+import { ExtensionMessenger, ExtensionRequester } from "extension";
+import { Ports } from "router";
+import { GENERATE_PROOF_MSG_TYPE, OFFSCREEN_TARGET } from "./utils";
+
+const SW_TTL = 20000;
+
+void (async function init() {
+  let ww_count = 0;
+  chrome.runtime.onMessage.addListener(handleMessages);
+
+  const pingSw = setInterval(() => {
+    // We do not have to "await" as this is fire and forget
+    void chrome.runtime.sendMessage({ keepAlive: true });
+  }, SW_TTL);
+
+  // Return value of true indicates response will be asynchronously
+  // sent using sendResponse; false otherwise.
+  function handleMessages(
+    generateProofMessage: GenerateProofMessage,
+    _sender: unknown,
+    sendResponse: (response?: unknown) => void
+  ): boolean {
+    const { data, type, routerId, target } = generateProofMessage;
+
+    if (target !== OFFSCREEN_TARGET) {
+      return false;
+    }
+
+    const messenger = new ExtensionMessenger();
+    const requester = new ExtensionRequester(messenger, routerId);
+
+    const generateProofCompletedHandler = async (
+      msgId: string,
+      success: boolean,
+      payload?: string
+    ): Promise<void> => {
+      // We are sending the message to the background script
+      await requester.sendMessage(
+        Ports.Background,
+        new GenerateProofCompletedEvent(success, msgId, payload)
+      );
+
+      // Reducing a number of tracked web workers
+      ww_count--;
+
+      // If number of trached web workers is 0, we are
+      // closing the offscreen document and stopping the
+      // service worker ping.
+      if (ww_count === 0) {
+        // We do not have to wait for the response
+        void requester.sendMessage<CloseOffscreenDocumentMsg>(
+          Ports.Background,
+          new CloseOffscreenDocumentMsg()
+        );
+        clearInterval(pingSw);
+        // send blank response since returning true requires we send a response
+        sendResponse();
+      }
+    };
+
+    if (type == GENERATE_PROOF_MSG_TYPE) {
+      initGenerateProofWorker(
+        data,
+        generateProofCompletedHandler,
+        sendResponse
+      );
+      ww_count++;
+    } else {
+      console.warn(`Unexpected message type received: '${type}'.`);
+      return false;
+    }
+
+    return true;
+  }
+})();

--- a/apps/extension/src/background/offscreen/utils.ts
+++ b/apps/extension/src/background/offscreen/utils.ts
@@ -1,0 +1,29 @@
+declare let self: ServiceWorkerGlobalScope;
+
+export const hasOffscreenDocument = async (path: string): Promise<boolean> => {
+  const offscreenUrl = chrome.runtime.getURL(path);
+  const matchedClients = await self.clients.matchAll();
+  for (const client of matchedClients) {
+    if (client.url === offscreenUrl) {
+      return true;
+    }
+  }
+  return false;
+};
+
+export const createOffscreenWithProofWorker = async (
+  offscreenDocumentPath: string
+): Promise<void> => {
+  await chrome.offscreen.createDocument({
+    url: chrome.runtime.getURL(offscreenDocumentPath),
+    reasons: [
+      chrome.offscreen.Reason.WORKERS ||
+        chrome.offscreen.Reason.IFRAME_SCRIPTING,
+    ],
+    justification:
+      "We need to spawn WebWorkers to generate ZK proofs in a non-blocking way.",
+  });
+};
+
+export const GENERATE_PROOF_MSG_TYPE = "generate-proof-offscreen";
+export const OFFSCREEN_TARGET = "offscreen.namada-keychain";

--- a/apps/extension/src/background/web-workers/generate-proof-web-worker.ts
+++ b/apps/extension/src/background/web-workers/generate-proof-web-worker.ts
@@ -1,0 +1,51 @@
+import { fromBase64 } from "@cosmjs/encoding";
+import { deserialize, serialize } from "@dao-xyz/borsh";
+import { getSdk } from "@heliax/namada-sdk/web";
+import { initMulticore } from "@heliax/namada-sdk/web-init";
+import { TxMsgValue } from "@namada/types";
+import {
+  GENERATE_PROOF_FAILED_MSG,
+  GENERATE_PROOF_SUCCESSFUL_MSG,
+  GenerateProofMessageData,
+  INIT_MSG,
+  WEB_WORKER_ERROR_MSG,
+} from "./types";
+
+(async function init() {
+  const { cryptoMemory } = await initMulticore();
+
+  addEventListener(
+    "message",
+    async ({ data }: { data: GenerateProofMessageData }) => {
+      try {
+        const { spendingKey, nativeToken } = data;
+        let txMsg = fromBase64(data.txMsg);
+
+        const { masp } = getSdk(cryptoMemory, "", "", "", nativeToken);
+        await masp.loadMaspParams("");
+        await masp.addSpendingKey(spendingKey, "alias");
+
+        const deserializedTxMsg = deserialize(Buffer.from(txMsg), TxMsgValue);
+        txMsg = serialize(deserializedTxMsg);
+
+        // TODO: Do Proof-Generating stuff
+        postMessage({ msgName: GENERATE_PROOF_SUCCESSFUL_MSG });
+      } catch (error) {
+        console.error(error);
+        postMessage({
+          msgName: GENERATE_PROOF_FAILED_MSG,
+          payload: error instanceof Error ? error.message : error,
+        });
+      }
+    },
+    false
+  );
+
+  postMessage({ msgName: INIT_MSG });
+})().catch((error) => {
+  const { message, stack } = error;
+  postMessage({
+    msgName: WEB_WORKER_ERROR_MSG,
+    payload: { message, stack },
+  });
+});

--- a/apps/extension/src/background/web-workers/index.ts
+++ b/apps/extension/src/background/web-workers/index.ts
@@ -1,0 +1,39 @@
+import {
+  GENERATE_PROOF_FAILED_MSG,
+  GENERATE_PROOF_SUCCESSFUL_MSG,
+  GenerateProofMessageData,
+  INIT_MSG,
+  Msg,
+  WEB_WORKER_ERROR_MSG,
+} from "./types";
+
+export const init = (
+  data: GenerateProofMessageData,
+  proofGenerateCompletedHandler: (
+    msgId: string,
+    success: boolean,
+    payload?: string
+  ) => Promise<void>,
+  sendResponse?: (response?: unknown) => void
+): void => {
+  const w = new Worker("generate-proof-web-worker.namada.js");
+
+  w.onmessage = (e: MessageEvent<Msg>) => {
+    const { msgName, payload } = e.data;
+    if (msgName === INIT_MSG) {
+      w.postMessage(data);
+    } else if (msgName === GENERATE_PROOF_SUCCESSFUL_MSG) {
+      proofGenerateCompletedHandler(data.msgId, true, payload)
+        .then(() => w.terminate())
+        .catch((e) => console.error(e));
+    } else if (msgName === GENERATE_PROOF_FAILED_MSG) {
+      proofGenerateCompletedHandler(data.msgId, false, payload)
+        .then(() => w.terminate())
+        .catch((e) => console.error(e));
+    } else if (msgName === WEB_WORKER_ERROR_MSG) {
+      sendResponse?.({ error: payload });
+    } else {
+      console.warn("Not supported msg type.");
+    }
+  };
+};

--- a/apps/extension/src/background/web-workers/types.ts
+++ b/apps/extension/src/background/web-workers/types.ts
@@ -1,0 +1,29 @@
+export type SpendingKey = string;
+
+export type GenerateProofMessage = {
+  type: string;
+  target: string;
+  routerId: number;
+  data: GenerateProofMessageData;
+};
+
+export type GenerateProofMessageData = {
+  transferMsg: string;
+  txMsg: string;
+  msgId: string;
+  spendingKey: SpendingKey;
+  rpc: string;
+  nativeToken: string;
+};
+
+export const INIT_MSG = "init";
+export const GENERATE_PROOF_SUCCESSFUL_MSG = "generate-proof-successful";
+export const GENERATE_PROOF_FAILED_MSG = "generate-proof-failed";
+export const WEB_WORKER_ERROR_MSG = "web-worker-error";
+export type MsgName =
+  | typeof INIT_MSG
+  | typeof GENERATE_PROOF_FAILED_MSG
+  | typeof GENERATE_PROOF_SUCCESSFUL_MSG
+  | typeof WEB_WORKER_ERROR_MSG;
+
+export type Msg = { msgName: MsgName; payload?: string };

--- a/apps/extension/src/manifest/v3/_base.json
+++ b/apps/extension/src/manifest/v3/_base.json
@@ -13,7 +13,7 @@
   "action": {
     "default_popup": "popup.html"
   },
-  "permissions": ["storage"],
+  "permissions": ["storage", "offscreen"],
   "content_security_policy": {
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
   },

--- a/apps/extension/webpack.config.js
+++ b/apps/extension/webpack.config.js
@@ -64,6 +64,10 @@ const copyPatterns = [
     from: "./src/public/images/*",
     to: "./assets/images/[name][ext]",
   },
+  {
+    from: "./src/background/offscreen/offscreen.html",
+    to: "./offscreen.html",
+  },
   // browser-polyfill expects a source-map
   {
     from: "../../node_modules/webextension-polyfill/dist/browser-polyfill.js.map",
@@ -148,6 +152,9 @@ module.exports = {
     setup: "./src/Setup",
     approvals: "./src/Approvals",
     injected: "./src/content/injected.ts",
+    offscreen: "./src/background/offscreen/offscreen.ts",
+    ["generate-proof-web-worker"]:
+      "./src/background/web-workers/generate-proof-web-worker.ts",
   },
   output: {
     publicPath: "",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3485,7 +3485,7 @@ __metadata:
     "@ledgerhq/hw-transport-webhid": "npm:^6.28.0"
     "@ledgerhq/hw-transport-webusb": "npm:^6.28.0"
     "@svgr/webpack": "npm:^6.3.1"
-    "@types/chrome": "npm:^0.0.237"
+    "@types/chrome": "npm:^0.0.277"
     "@types/dompurify": "npm:^3.0.5"
     "@types/firefox-webext-browser": "npm:^94.0.1"
     "@types/jest": "npm:^29.5.12"
@@ -4895,13 +4895,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/chrome@npm:^0.0.237":
-  version: 0.0.237
-  resolution: "@types/chrome@npm:0.0.237"
+"@types/chrome@npm:^0.0.277":
+  version: 0.0.277
+  resolution: "@types/chrome@npm:0.0.277"
   dependencies:
     "@types/filesystem": "npm:*"
     "@types/har-format": "npm:*"
-  checksum: 1e28700c935d019c31bd556986a10384b855ee0b02fb3520966d49945ce223fcca6cf9c1b93ae21cb624c8c6fbc54ea0e78e07a6e52d33aaf84d987008825bdf
+  checksum: 2874eba7da827fbb18f60e2103cb20d7ebeea6ca44bee8f9853db3cdb3c2abb59798b5ab348bfd247339ec9c3e330b314694ec726c693e51a1cee6518f07c1da
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Restoring offscreen/web-workers as of: https://github.com/anoma/namada-interface/tree/5eaf361df780a660dd73b2c462a03c057c47b241

- Updated naming for generating proofs (instead of Transfers)
- Use new version of SDK package
- Updated `@types/chrome` to add `chrome.offscreen.Reason.WORKERS` to support newer browsers

I think we can pass the Tx hash of the shielded Tx as the `msgId` to link it up in the interface, but if we need to change anything in the msg, we can do that. This PR is mainly to get the pieces in place