### PR TITLE
feat: sdk version bump 0.10.0, CHANGELOG

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,0 +1,24 @@
+
+
+## 0.10.0 (2024-10-11)
+
+
+### Features
+
+* allow Sdk to update itself, regen docs ([#861](https://github.com/anoma/namada-interface/issues/861)) ([ce1562b](https://github.com/anoma/namada-interface/commit/ce1562bf9ca61fe8a7372a74963ea616bc0ce129))
+* bump to 0.39.0, specify transparent transfer in types ([#858](https://github.com/anoma/namada-interface/issues/858)) ([3ad6200](https://github.com/anoma/namada-interface/commit/3ad620045a6c2c51dda7be0ccc1a2e88b54a959e))
+* fetch and load masp params ([#1136](https://github.com/anoma/namada-interface/issues/1136)) ([5df8577](https://github.com/anoma/namada-interface/commit/5df8577cf0627247a7aeb5fa4de5e3970049b024))
+* hook up interface to SDK package, extension signing ([1e2ad8e](https://github.com/anoma/namada-interface/commit/1e2ad8e4ff3c64451e94d36ef9559180fbcd27c5))
+* hook up tx hash to build Tx, add to SDK ([#753](https://github.com/anoma/namada-interface/issues/753)) ([35909e7](https://github.com/anoma/namada-interface/commit/35909e7a2cdba35fea0f0af46b8628de240d420e))
+* **interface:** fixing namadillo dev serve ([c66af51](https://github.com/anoma/namada-interface/commit/c66af51f59c6b4d611e0c69911e73e6605678191))
+* sdk api improvements ([#695](https://github.com/anoma/namada-interface/issues/695)) ([6eee06c](https://github.com/anoma/namada-interface/commit/6eee06cb2b40eac8bd2eebc399fc87698654aaa1))
+* sdk js publish ([#665](https://github.com/anoma/namada-interface/issues/665)) ([ec3dec8](https://github.com/anoma/namada-interface/commit/ec3dec8070219f29ccf95e8a50c880da3f032566))
+* support claim rewards tx in SDK ([#932](https://github.com/anoma/namada-interface/issues/932)) ([59d0ea9](https://github.com/anoma/namada-interface/commit/59d0ea9659658c23c804324d46594783ed695a2e)), closes [#679](https://github.com/anoma/namada-interface/issues/679)
+* update unbonding period calculation ([#1034](https://github.com/anoma/namada-interface/issues/1034)) ([2e65ae8](https://github.com/anoma/namada-interface/commit/2e65ae8ae3d2430b6268603785c30016d2df77a6))
+* update zip32 path ([#621](https://github.com/anoma/namada-interface/issues/621)) ([c4e5413](https://github.com/anoma/namada-interface/commit/c4e54131064b1d7df3704a0f815cd041dc551740))
+
+
+### Bug Fixes
+
+* fix tests ([d49bd66](https://github.com/anoma/namada-interface/commit/d49bd66a00556205374fe19a092a36717d7ba75a))
+* linting and TypeScript errors ([82eb87e](https://github.com/anoma/namada-interface/commit/82eb87eeb8f96100f239c7ff1a6cc2e953fbfdac))

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heliaxdev/namada-sdk",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Namada SDK package",
   "exports": {
     "./web": {


### PR DESCRIPTION
With the initial release of the SDK, the version has been bump, and the first `CHANGELOG` added.