### PR TITLE
feat: display IBC tokens in IBC asset list

### DIFF
--- a/apps/namadillo/src/App/Ibc/IbcTransfer.tsx
+++ b/apps/namadillo/src/App/Ibc/IbcTransfer.tsx
@@ -67,7 +67,7 @@ export const IbcTransfer: React.FC = () => {
 
         if (typeof asset !== "undefined") {
           return {
-            amount: BigNumber(1), // TODO: remove hardcoding
+            amount: BigNumber(3000), // TODO: remove hardcoding
             token: asset,
           };
         }

--- a/apps/namadillo/src/atoms/integrations/atoms.ts
+++ b/apps/namadillo/src/atoms/integrations/atoms.ts
@@ -58,13 +58,10 @@ export const assetBalanceAtomFamily = atomFamily(
     return atomWithQuery(() => ({
       queryKey: ["assets", walletAddress, chain?.chain_id, assets],
       ...queryDependentFn(async () => {
-        const assetsBalances = await queryAndStoreRpc(
-          chain!,
-          async (rpc: string) => {
-            return await queryAssetBalances(walletAddress!, rpc);
-          }
-        );
-        return mapCoinsToAssets(assetsBalances, assets!);
+        return await queryAndStoreRpc(chain!, async (rpc: string) => {
+          const assetsBalances = await queryAssetBalances(walletAddress!, rpc);
+          return await mapCoinsToAssets(assetsBalances, assets!, rpc);
+        });
       }, [!!walletAddress, !!chain]),
     }));
   },


### PR DESCRIPTION
This PR adds IBC assets to the asset list even when there is not a registry entry, and stores the hash for IBC tokens. Both of these things will be needed later for Shield All.

There are some UI problems with the IBC assets obscuring the amount input on the IBC transfer page, so for testing I suggest selecting "Cosmos" as the asset, entering the amount, and then switching to the asset you actually want to transfer. We can fix the UI in a later PR.

---

### Changed
- Store IBC tokens by IBC hash (needed later for sending IBC tokens)
- Display full path for IBC tokens (i.e. including "transfer/channel-0/")
- Increase hardcoded transfer fee to stop transactions failing

### Added
- Show IBC tokens in asset list even when there isn't a registry entry