### PR TITLE
feat: re-enable IBC withdrawals for NAM

### DIFF
--- a/apps/namadillo/src/App/Ibc/IbcTransfer.tsx
+++ b/apps/namadillo/src/App/Ibc/IbcTransfer.tsx
@@ -44,7 +44,7 @@ export const IbcTransfer: React.FC = () => {
   } = useWalletManager(keplr);
 
   const {
-    balance: totalAvailableAmount,
+    balance: availableAmount,
     availableAssets,
     isLoading: isLoadingBalances,
   } = useAssetAmount({
@@ -177,22 +177,6 @@ export const IbcTransfer: React.FC = () => {
     connectToChainId(chain.chain_id);
   };
 
-  const availableAmountMinusFees = useMemo(() => {
-    if (
-      typeof totalAvailableAmount === "undefined" ||
-      typeof transactionFee === "undefined" ||
-      typeof selectedAsset === "undefined"
-    ) {
-      return undefined;
-    }
-
-    if (selectedAsset.base === transactionFee.token.base) {
-      return totalAvailableAmount.minus(transactionFee.amount);
-    } else {
-      return totalAvailableAmount;
-    }
-  }, [totalAvailableAmount, selectedAsset, transactionFee]);
-
   return (
     <>
       <header className="flex flex-col items-center text-center mb-3 gap-6">
@@ -211,7 +195,7 @@ export const IbcTransfer: React.FC = () => {
                 isLoadingAssets: isLoadingBalances,
                 availableAssets,
                 selectedAsset,
-                availableAmount: availableAmountMinusFees,
+                availableAmount,
                 availableChains,
                 onChangeChain,
                 chain: mapUndefined((id) => chainRegistry[id].chain, chainId),

--- a/apps/namadillo/src/App/Transfer/__tests__/TransferDestination.test.tsx
+++ b/apps/namadillo/src/App/Transfer/__tests__/TransferDestination.test.tsx
@@ -1,6 +1,6 @@
 jest.mock("../assets/ibc-transfer.png", () => "ibc-transfer.png");
 
-import { Asset, Chain } from "@chain-registry/types";
+import { Chain } from "@chain-registry/types";
 import { fireEvent, render, screen } from "@testing-library/react";
 import {
   namadaChainMock,
@@ -8,26 +8,9 @@ import {
 } from "App/Transfer/__mocks__/chains";
 import { TransferDestination } from "App/Transfer/TransferDestination";
 import BigNumber from "bignumber.js";
+import { namadaAsset } from "registry/namadaAsset";
 import { walletMock } from "../__mocks__/providers";
 import { parseChainInfo } from "../common";
-
-// TODO: we probably want to put this somewhere else for IBC withdraws
-const namAsset: Asset = {
-  name: "Namada",
-  base: "namnam",
-  display: "nam",
-  symbol: "NAM",
-  denom_units: [
-    {
-      denom: "namnam",
-      exponent: 0,
-    },
-    {
-      denom: "nam",
-      exponent: 6,
-    },
-  ],
-};
 
 describe("TransferDestination", () => {
   it("should render the component with the default props", () => {
@@ -115,7 +98,9 @@ describe("TransferDestination", () => {
   it("should display the transaction fee if provided", () => {
     const fee = BigNumber(1);
     render(
-      <TransferDestination transactionFee={{ amount: fee, token: namAsset }} />
+      <TransferDestination
+        transactionFee={{ amount: fee, token: namadaAsset }}
+      />
     );
     const transactionFee = screen.getByText("Transaction Fee");
     expect(transactionFee).toBeInTheDocument();

--- a/apps/namadillo/src/registry/namadaAsset.ts
+++ b/apps/namadillo/src/registry/namadaAsset.ts
@@ -3,12 +3,18 @@ import namadaShieldedSvg from "./assets/namada-shielded.svg";
 
 export const namadaAsset: Asset = {
   name: "Namada",
-  base: "unam",
+  base: "namnam",
   display: "nam",
   symbol: "NAM",
   denom_units: [
-    { denom: "unam", exponent: 0 },
-    { denom: "nam", exponent: 6 },
+    {
+      denom: "namnam",
+      exponent: 0,
+    },
+    {
+      denom: "nam",
+      exponent: 6,
+    },
   ],
   logo_URIs: { svg: namadaShieldedSvg },
 };


### PR DESCRIPTION
This PR re-enables IBC withdrawals for NAM (other tokens will follow later).

We have a problem where the TransferModule and cosmjs expect amounts to be in the base denom (e.g. namnam), but the Namada SDK expects amounts to be in the display denom (e.g. NAM). This has resulted in some temporary hacky code in this PR to convert between namnam and NAM which I'll remove this once I understand how to handle this properly, but for now the hacky code is enough to switch back on IBC withdrawals for NAM. Related: #1211.

---

### Changed
- Move available amount fee deduction calculation to TransferModule
- Return `undefined` instead of `0` from available balance calculation when initial balance is undefined.

### Added
- Re-enable IBC withdrawals for NAM

### Fixed
- Rename "unam" to "namnam" in Namada asset