### PR TITLE
IBC: Fix "Not enough balance" bugs + use display denom for amounts

### DIFF
--- a/apps/namadillo/src/App/Ibc/IbcTransfer.tsx
+++ b/apps/namadillo/src/App/Ibc/IbcTransfer.tsx
@@ -132,7 +132,7 @@ export const IbcTransfer: React.FC = () => {
             sourceAddress,
             destinationAddress,
             amount,
-            token: selectedAsset.base,
+            asset: selectedAsset,
             transactionFee,
             sourceChannelId: ibcOptions.sourceChannel,
             ...(shielded ?

--- a/apps/namadillo/src/App/Ibc/IbcWithdraw.tsx
+++ b/apps/namadillo/src/App/Ibc/IbcWithdraw.tsx
@@ -32,21 +32,15 @@ export const IbcWithdraw: React.FC = () => {
 
   const [selectedAsset, setSelectedAsset] = useState<Asset>();
 
-  const namBalance = useAtomValue(accountBalanceAtom).data;
-
   // TODO: remove hardcoding and display assets other than NAM
+  const availableAmount = useAtomValue(accountBalanceAtom).data;
   const availableAssets = [namadaAsset];
-  // TODO: TransferModule expects amounts in namnam, but Namada SDK expects
-  // amounts in NAM. We should figure out how to deal with this properly.
-  const availableAmount = namBalance?.shiftedBy(6);
 
   const GAS_PRICE = BigNumber(0.000001); // 0.000001 NAM
   const GAS_LIMIT = BigNumber(1_000_000);
   const transactionFee = {
     token: namadaAsset,
-    // TODO: TransferModule expects amounts in namnam, but Namada SDK expects
-    // amounts in NAM. We should figure out how to deal with this properly.
-    amount: GAS_PRICE.multipliedBy(GAS_LIMIT).shiftedBy(6),
+    amount: GAS_PRICE.multipliedBy(GAS_LIMIT),
   };
 
   const {
@@ -60,15 +54,11 @@ export const IbcWithdraw: React.FC = () => {
   };
 
   const submitIbcTransfer = async ({
-    amount: namnamAmount,
+    amount,
     destinationAddress,
     ibcOptions,
     memo,
   }: OnSubmitTransferParams): Promise<void> => {
-    // TODO: TransferModule expects amounts in namnam, but Namada SDK expects
-    // amounts in NAM. We should figure out how to deal with this properly.
-    const amount = namnamAmount.shiftedBy(-6);
-
     const wrapperTxProps = {
       token: namadaChain.data!.nativeTokenAddress,
       feeAmount: GAS_PRICE,

--- a/apps/namadillo/src/App/Ibc/ShieldAllAssetList.tsx
+++ b/apps/namadillo/src/App/Ibc/ShieldAllAssetList.tsx
@@ -5,7 +5,6 @@ import BigNumber from "bignumber.js";
 import clsx from "clsx";
 import { getAssetImageUrl } from "integrations/utils";
 import { AssetWithBalanceAndIbcInfo } from "types";
-import { toDisplayAmount } from "utils";
 
 export type SelectableAssetWithBalanceAndIbcInfo =
   AssetWithBalanceAndIbcInfo & {
@@ -56,10 +55,7 @@ export const ShieldAllAssetList = ({
                 <TokenCurrency
                   currencySymbolClassName="hidden"
                   asset={assetWithBalance.asset}
-                  amount={toDisplayAmount(
-                    assetWithBalance.asset,
-                    assetWithBalance.balance || new BigNumber(0)
-                  )}
+                  amount={assetWithBalance.balance || new BigNumber(0)}
                 />
               </span>
             </li>

--- a/apps/namadillo/src/App/Transfer/TransferModule.tsx
+++ b/apps/namadillo/src/App/Transfer/TransferModule.tsx
@@ -4,7 +4,6 @@ import { InlineError } from "App/Common/InlineError";
 import BigNumber from "bignumber.js";
 import { useMemo, useState } from "react";
 import { WalletProvider } from "types";
-import { toBaseAmount, toDisplayAmount } from "utils";
 import { parseChainInfo } from "./common";
 import { IbcChannels } from "./IbcChannels";
 import { SelectAssetModal } from "./SelectAssetModal";
@@ -108,12 +107,9 @@ export const TransferModule = ({
       return undefined;
     }
 
-    const availableAmountMinusFees =
-      transactionFee && selectedAsset.base === transactionFee.token.base ?
+    return transactionFee && selectedAsset.base === transactionFee.token.base ?
         availableAmount.minus(transactionFee.amount)
       : availableAmount;
-
-    return toDisplayAmount(selectedAsset, availableAmountMinusFees);
   }, [source.selectedAsset, source.availableAmount, transactionFee]);
 
   const validationResult = useMemo((): ValidationResult => {
@@ -157,7 +153,7 @@ export const TransferModule = ({
     }
 
     const params: OnSubmitTransferParams = {
-      amount: toBaseAmount(source.selectedAsset, amount),
+      amount,
       destinationAddress: address.trim(),
       memo,
     };

--- a/apps/namadillo/src/App/Transfer/TransferTransactionFee.tsx
+++ b/apps/namadillo/src/App/Transfer/TransferTransactionFee.tsx
@@ -1,7 +1,6 @@
 import { TokenCurrency } from "App/Common/TokenCurrency";
 import clsx from "clsx";
 import { twMerge } from "tailwind-merge";
-import { toDisplayAmount } from "utils";
 import { TransactionFee } from "./TransferModule";
 import ibcTransferImageBlack from "./assets/ibc-transfer-black.png";
 import ibcTransferImageWhite from "./assets/ibc-transfer-white.png";
@@ -34,7 +33,7 @@ export const TransferTransactionFee = ({
         </span>
       )}
       <TokenCurrency
-        amount={toDisplayAmount(transactionFee.token, transactionFee.amount)}
+        amount={transactionFee.amount}
         asset={transactionFee.token}
       />
     </footer>

--- a/apps/namadillo/src/App/Transfer/__tests__/TransferDestination.test.tsx
+++ b/apps/namadillo/src/App/Transfer/__tests__/TransferDestination.test.tsx
@@ -97,7 +97,7 @@ describe("TransferDestination", () => {
   });
 
   it("should display the transaction fee if provided", () => {
-    const fee = BigNumber(1);
+    const fee = BigNumber(0.000001);
     render(
       <TransferDestination
         transactionFee={{ amount: fee, token: namadaAsset }}

--- a/apps/namadillo/src/atoms/integrations/services.ts
+++ b/apps/namadillo/src/atoms/integrations/services.ts
@@ -1,4 +1,4 @@
-import { Chain } from "@chain-registry/types";
+import { Asset, Chain } from "@chain-registry/types";
 import { Coin, OfflineSigner } from "@cosmjs/launchpad";
 import { coin, coins } from "@cosmjs/proto-signing";
 import {
@@ -9,6 +9,7 @@ import {
 import { TransactionFee } from "App/Transfer/TransferModule";
 import BigNumber from "bignumber.js";
 import { getDefaultStore } from "jotai";
+import { toBaseAmount } from "utils";
 import { getSdkInstance } from "utils/sdk";
 import { workingRpcsAtom } from "./atoms";
 import { getRpcByIndex } from "./functions";
@@ -18,7 +19,7 @@ type CommonParams = {
   sourceAddress: string;
   destinationAddress: string;
   amount: BigNumber;
-  token: string;
+  asset: Asset;
   sourceChannelId: string;
   transactionFee: TransactionFee;
 };
@@ -69,8 +70,8 @@ export const submitIbcTransfer =
       signer,
       sourceAddress,
       destinationAddress,
-      amount,
-      token,
+      amount: displayAmount,
+      asset,
       sourceChannelId,
       isShielded,
       transactionFee,
@@ -81,23 +82,26 @@ export const submitIbcTransfer =
       broadcastTimeoutMs: 8_000,
     });
 
+    // cosmjs expects amounts to be represented in the base denom, so convert
+    const baseAmount = toBaseAmount(asset, displayAmount);
+    const baseFee = toBaseAmount(transactionFee.token, transactionFee.amount);
+
     const fee = {
-      amount: coins(
-        transactionFee.amount.toString(),
-        transactionFee.token.base
-      ),
+      amount: coins(baseFee.toString(), transactionFee.token.base),
       gas: "222000", // TODO: what should this be?
     };
 
     const timeoutTimestampNanoseconds =
       BigInt(Math.floor(Date.now() / 1000) + 60) * BigInt(1_000_000_000);
 
+    const token = asset.base;
+
     const { receiver, memo }: { receiver: string; memo?: string } =
       isShielded ?
         await getShieldedArgs(
           destinationAddress,
           token,
-          amount,
+          baseAmount,
           transferParams.destinationChannelId
         )
       : { receiver: destinationAddress };
@@ -109,7 +113,7 @@ export const submitIbcTransfer =
         sourceChannel: sourceChannelId,
         sender: sourceAddress,
         receiver,
-        token: coin(amount.toString(), token),
+        token: coin(baseAmount.toString(), token),
         timeoutHeight: undefined,
         timeoutTimestamp: timeoutTimestampNanoseconds,
         memo,

--- a/apps/namadillo/src/integrations/utils.ts
+++ b/apps/namadillo/src/integrations/utils.ts
@@ -43,7 +43,7 @@ export const getTransactionFee = (
 
     if (typeof asset !== "undefined") {
       return {
-        amount: BigNumber(3000), // TODO: remove hardcoding
+        amount: BigNumber(0.003), // TODO: remove hardcoding
         token: asset,
       };
     }


### PR DESCRIPTION
This PR fixes two bugs that were causing the TransferModule to incorrectly detect that there is not enough balance when the user is performing an IBC transaction. It also changes all amounts in Namadillo to be represented in the display denom (which is what we normally do for non-IBC things), converting to/from the base denom only when we receive or send amounts in the base denom (e.g. when submitting an IBC transfer to cosmjs).

The commits are fairly separate so it might be easier to review commit by commit.

Closes #1211.

---

### Changed
- Represent all amount values in display denom
  - This changes all amounts to be represented in their display denom throughout Namadilllo, converting at the edges when we receive or send amounts represented in the base denom
  - Fixes the first of two bugs causing IBC transfer to incorrectly detect that there is not enough balance
- Make TransferModule validation more DRY

### Fixed
- Stop deducting fees twice in available amount
  - Fixes the second of two bugs causing IBC transfer to incorrectly detect that there is not enough balance
- Display 0 if available amount minus fees is less than 0