### PR TITLE
chore: Move SDK package into @namada org

### DIFF
--- a/apps/extension/src/App/Accounts/ViewAccount.tsx
+++ b/apps/extension/src/App/Accounts/ViewAccount.tsx
@@ -1,6 +1,6 @@
-import { makeBip44Path, makeSaplingPath } from "@heliaxdev/namada-sdk/web";
 import { chains } from "@namada/chains";
 import { ActionButton, GapPatterns, Stack, ViewKeys } from "@namada/components";
+import { makeBip44Path, makeSaplingPath } from "@namada/sdk/web";
 import { AccountType, DerivedAccount } from "@namada/types";
 import { PageHeader } from "App/Common";
 import routes from "App/routes";

--- a/apps/extension/src/Approvals/ApproveSignTx.tsx
+++ b/apps/extension/src/Approvals/ApproveSignTx.tsx
@@ -1,6 +1,6 @@
-import { TxType, TxTypeLabel } from "@heliaxdev/namada-sdk/web";
 import { ActionButton, GapPatterns, Stack } from "@namada/components";
 import { useSanitizedParams } from "@namada/hooks";
+import { TxType, TxTypeLabel } from "@namada/sdk/web";
 import { AccountType } from "@namada/types";
 import { shortenAddress } from "@namada/utils";
 import { PageHeader } from "App/Common/PageHeader";

--- a/apps/extension/src/Approvals/Commitment.tsx
+++ b/apps/extension/src/Approvals/Commitment.tsx
@@ -1,4 +1,4 @@
-import { TxType } from "@heliaxdev/namada-sdk/web";
+import { TxType } from "@namada/sdk/web";
 import {
   BondProps,
   ClaimRewardsProps,

--- a/apps/extension/src/Approvals/ConfirmSignLedgerTx.tsx
+++ b/apps/extension/src/Approvals/ConfirmSignLedgerTx.tsx
@@ -1,8 +1,8 @@
 import clsx from "clsx";
 import { ReactNode, useCallback, useEffect, useState } from "react";
 
-import { Ledger, makeBip44Path } from "@heliaxdev/namada-sdk/web";
 import { ActionButton, Stack } from "@namada/components";
+import { Ledger, makeBip44Path } from "@namada/sdk/web";
 import { LedgerError, ResponseSign } from "@zondax/ledger-namada";
 
 import { fromBase64 } from "@cosmjs/encoding";

--- a/apps/extension/src/Setup/Common/Completion.tsx
+++ b/apps/extension/src/Setup/Common/Completion.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from "react";
 import browser from "webextension-polyfill";
 
-import { makeBip44Path, makeSaplingPath } from "@heliaxdev/namada-sdk/web";
 import { chains } from "@namada/chains";
 import { ActionButton, Alert, Loading, ViewKeys } from "@namada/components";
+import { makeBip44Path, makeSaplingPath } from "@namada/sdk/web";
 import { AccountType, Bip44Path } from "@namada/types";
 import { assertNever } from "@namada/utils";
 import {

--- a/apps/extension/src/Setup/Ledger/LedgerConnect.tsx
+++ b/apps/extension/src/Setup/Ledger/LedgerConnect.tsx
@@ -1,6 +1,6 @@
-import { Ledger as LedgerApp, makeBip44Path } from "@heliaxdev/namada-sdk/web";
 import { chains } from "@namada/chains";
 import { ActionButton, Alert, Image, Stack } from "@namada/components";
+import { Ledger as LedgerApp, makeBip44Path } from "@namada/sdk/web";
 import { Bip44Path } from "@namada/types";
 import { LedgerError } from "@zondax/ledger-namada";
 import { LedgerStep } from "Setup/Common";

--- a/apps/extension/src/background/approvals/service.test.ts
+++ b/apps/extension/src/background/approvals/service.test.ts
@@ -36,11 +36,9 @@ jest.mock("@namada/utils", () => {
 
 // Because we run tests in node environment, we need to mock web-init as node-init
 jest.mock(
-  "@heliaxdev/namada-sdk/web-init",
+  "@namada/sdk/web-init",
   () => () =>
-    Promise.resolve(
-      jest.requireActual("@heliaxdev/namada-sdk/node-init").default()
-    )
+    Promise.resolve(jest.requireActual("@namada/sdk/node-init").default())
 );
 
 describe("approvals service", () => {

--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -1,4 +1,4 @@
-import { PhraseSize } from "@heliaxdev/namada-sdk/web";
+import { PhraseSize } from "@namada/sdk/web";
 import { KVStore } from "@namada/storage";
 import {
   AccountType,

--- a/apps/extension/src/background/keyring/messages.ts
+++ b/apps/extension/src/background/keyring/messages.ts
@@ -1,4 +1,4 @@
-import { PhraseSize } from "@heliaxdev/namada-sdk/web";
+import { PhraseSize } from "@namada/sdk/web";
 import { AccountType, Bip44Path, DerivedAccount } from "@namada/types";
 import { Result } from "@namada/utils";
 import { ResponseSign } from "@zondax/ledger-namada";

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -1,4 +1,4 @@
-import { PhraseSize } from "@heliaxdev/namada-sdk/web";
+import { PhraseSize } from "@namada/sdk/web";
 import { IndexedDBKVStore, KVStore } from "@namada/storage";
 import {
   AccountType,

--- a/apps/extension/src/background/keyring/types.ts
+++ b/apps/extension/src/background/keyring/types.ts
@@ -1,4 +1,4 @@
-import { CryptoRecord } from "@heliaxdev/namada-sdk/web";
+import { CryptoRecord } from "@namada/sdk/web";
 import { StoredRecord } from "@namada/storage";
 import { AccountType, DerivedAccount, Path } from "@namada/types";
 

--- a/apps/extension/src/background/sdk/service.ts
+++ b/apps/extension/src/background/sdk/service.ts
@@ -1,6 +1,6 @@
-import { Sdk, getSdk } from "@heliaxdev/namada-sdk/web";
-import sdkInit from "@heliaxdev/namada-sdk/web-init";
 import { chains } from "@namada/chains";
+import { Sdk, getSdk } from "@namada/sdk/web";
+import sdkInit from "@namada/sdk/web-init";
 import { LocalStorage } from "storage";
 
 const {

--- a/apps/extension/src/background/vault/service.ts
+++ b/apps/extension/src/background/vault/service.ts
@@ -1,4 +1,4 @@
-import { CryptoRecord } from "@heliaxdev/namada-sdk/web";
+import { CryptoRecord } from "@namada/sdk/web";
 import { KVStore } from "@namada/storage";
 import { Result } from "@namada/utils";
 import { SdkService } from "background/sdk";

--- a/apps/extension/src/background/vault/tests/service.test.ts
+++ b/apps/extension/src/background/vault/tests/service.test.ts
@@ -11,11 +11,9 @@ jest.mock("webextension-polyfill", () => ({}));
 
 // Because we run tests in node environment, we need to mock web-init as node-init
 jest.mock(
-  "@heliaxdev/namada-sdk/web-init",
+  "@namada/sdk/web-init",
   () => () =>
-    Promise.resolve(
-      jest.requireActual("@heliaxdev/namada-sdk/node-init").default()
-    )
+    Promise.resolve(jest.requireActual("@namada/sdk/node-init").default())
 );
 
 type VaultPublicObj = { id: string; alias: string };

--- a/apps/extension/src/background/vault/types.ts
+++ b/apps/extension/src/background/vault/types.ts
@@ -1,4 +1,4 @@
-import { CryptoRecord } from "@heliaxdev/namada-sdk/web";
+import { CryptoRecord } from "@namada/sdk/web";
 
 export enum ResetPasswordError {
   BadPassword,

--- a/apps/extension/src/provider/Namada.test.ts
+++ b/apps/extension/src/provider/Namada.test.ts
@@ -14,11 +14,9 @@ jest.mock("webextension-polyfill", () => ({}));
 
 // Because we run tests in node environment, we need to mock web-init as node-init
 jest.mock(
-  "@heliaxdev/namada-sdk/web-init",
+  "@namada/sdk/web-init",
   () => () =>
-    Promise.resolve(
-      jest.requireActual("@heliaxdev/namada-sdk/node-init").default()
-    )
+    Promise.resolve(jest.requireActual("@namada/sdk/node-init").default())
 );
 
 jest.mock("webextension-polyfill", () => ({

--- a/apps/extension/src/provider/data.mock.ts
+++ b/apps/extension/src/provider/data.mock.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { KdfType } from "@heliaxdev/namada-sdk/web";
+import { KdfType } from "@namada/sdk/web";
 import { AccountType, BridgeType, Chain, Extensions } from "@namada/types";
 import { ActiveAccountStore } from "background/keyring";
 import { Vault } from "background/vault";

--- a/apps/extension/src/storage/VaultStorage.test.ts
+++ b/apps/extension/src/storage/VaultStorage.test.ts
@@ -7,11 +7,9 @@ jest.mock("webextension-polyfill", () => ({}));
 
 // Because we run tests in node environment, we need to mock web-init as node-init
 jest.mock(
-  "@heliaxdev/namada-sdk/web-init",
+  "@namada/sdk/web-init",
   () => () =>
-    Promise.resolve(
-      jest.requireActual("@heliaxdev/namada-sdk/node-init").default()
-    )
+    Promise.resolve(jest.requireActual("@namada/sdk/node-init").default())
 );
 
 describe("VaultStorage", () => {

--- a/apps/namadillo/src/App/Masp/ShieldedFungibleTable.tsx
+++ b/apps/namadillo/src/App/Masp/ShieldedFungibleTable.tsx
@@ -1,6 +1,6 @@
 import { Asset } from "@chain-registry/types";
-import { Balance } from "@heliaxdev/namada-sdk/web";
 import { ActionButton, TableRow } from "@namada/components";
+import { Balance } from "@namada/sdk/web";
 import { formatPercentage } from "@namada/utils";
 import { FiatCurrency } from "App/Common/FiatCurrency";
 import { TableWithPaginator } from "App/Common/TableWithPaginator";

--- a/apps/namadillo/src/atoms/masp/atoms.ts
+++ b/apps/namadillo/src/atoms/masp/atoms.ts
@@ -1,4 +1,4 @@
-import { Balance } from "@heliaxdev/namada-sdk/web";
+import { Balance } from "@namada/sdk/web";
 import { accountsAtom, defaultAccountAtom } from "atoms/accounts/atoms";
 import { chainTokensAtom, nativeTokenAddressAtom } from "atoms/chain";
 import { shouldUpdateBalanceAtom } from "atoms/etc";

--- a/apps/namadillo/src/hooks/useSdk.tsx
+++ b/apps/namadillo/src/hooks/useSdk.tsx
@@ -1,4 +1,4 @@
-import { Sdk } from "@heliaxdev/namada-sdk/web";
+import { Sdk } from "@namada/sdk/web";
 import { QueryStatus, useQuery } from "@tanstack/react-query";
 import { nativeTokenAddressAtom } from "atoms/chain";
 import { useAtomValue } from "jotai";

--- a/apps/namadillo/src/lib/query.ts
+++ b/apps/namadillo/src/lib/query.ts
@@ -1,5 +1,5 @@
-import { Sdk } from "@heliaxdev/namada-sdk/web";
 import { getIntegration } from "@namada/integrations/utils";
+import { Sdk } from "@namada/sdk/web";
 import {
   Account,
   AccountType,

--- a/apps/namadillo/src/utils/sdk.ts
+++ b/apps/namadillo/src/utils/sdk.ts
@@ -1,5 +1,5 @@
-import initSdk from "@heliaxdev/namada-sdk/inline-init";
-import { getSdk, Sdk } from "@heliaxdev/namada-sdk/web";
+import initSdk from "@namada/sdk/inline-init";
+import { getSdk, Sdk } from "@namada/sdk/web";
 import { nativeTokenAddressAtom } from "atoms/chain";
 import { maspIndexerUrlAtom, rpcUrlAtom } from "atoms/settings";
 import { getDefaultStore } from "jotai";

--- a/apps/namadillo/src/workers/ShieldWorker.ts
+++ b/apps/namadillo/src/workers/ShieldWorker.ts
@@ -1,6 +1,6 @@
 import { Configuration, DefaultApi } from "@anomaorg/namada-indexer-client";
-import { initMulticore } from "@heliaxdev/namada-sdk/inline-init";
-import { getSdk, Sdk } from "@heliaxdev/namada-sdk/web";
+import { initMulticore } from "@namada/sdk/inline-init";
+import { getSdk, Sdk } from "@namada/sdk/web";
 import { ShieldingTransferMsgValue, TxResponseMsgValue } from "@namada/types";
 import * as Comlink from "comlink";
 import { buildTx, EncodedTxData } from "lib/query";

--- a/apps/namadillo/src/workers/ShieldedSyncWorker.ts
+++ b/apps/namadillo/src/workers/ShieldedSyncWorker.ts
@@ -1,5 +1,5 @@
-import { initMulticore } from "@heliaxdev/namada-sdk/inline-init";
-import { getSdk, Sdk } from "@heliaxdev/namada-sdk/web";
+import { initMulticore } from "@namada/sdk/inline-init";
+import { getSdk, Sdk } from "@namada/sdk/web";
 import * as Comlink from "comlink";
 import { Init, InitDone, Sync, SyncDone } from "./ShieldedSyncMessages";
 

--- a/packages/sdk/docs/README.md
+++ b/packages/sdk/docs/README.md
@@ -1,10 +1,104 @@
-@heliaxdev/namada-sdk / [Exports](modules.md)
+@namada/sdk / [Exports](modules.md)
 
 # sdk
 
-Namada SDK package
+The Namada SDK package
+
+## Usage
+
+### Installation
+
+```bash
+npm install @namada/sdk
+
+# Or, via yarn
+yarn add @namada/sdk
+```
+
+### Initializing the SDK
+
+As this package depends on Wasm compiled from Rust to integrate with Namada, this must be loaded asynchronously when
+developing for the Web. The following is a quick overview of some of the features of the SDK package:
+
+```typescript
+import { Sdk, getSdk } from "@namada/sdk/web";
+import sdkInit from "@namada/sdk/web-init";
+
+// Load Tx props from types package
+import { BondProps, WrapperTxProps } from "@namada/types";
+
+// Amounts are defined as BigNumber
+import BigNumber from "bignumber.js";
+
+// Define the following values:
+const rpcUrl = "https://rpc.example.net";
+const tokenAddress = "tnam1qxgfw7myv4dh0qna4hq0xdg6lx77fzl7dcem8h7e"; // bech32m encoded NAM address
+const chainId = "namada-testnet-1";
+
+const init = async (): Promise<void> => {
+  const { cryptoMemory } = await sdkInit();
+  const sdk = getSdk(rpcUrl, tokenAddress, cryptoMemory);
+
+  // Access various modules of the SDK
+  const { keys, mnemonic, rpc, signing, tx } = sdk; // Alternatively, invoke getters directly, e.g., sdk.getRpc(), etc.
+
+  // Examples:
+
+  // Generate a 24 word mnemonic
+  const mnemonicPhrase = mnemonic.generate(24).join(" ");
+
+  // Mnemonic to seed
+  const seed = mnemonic.toSeed(mnemonicPhrase);
+
+  // Derive a keypair and address
+  const bip44Path = {
+    account: 0,
+    change: 0,
+    index: 0,
+  };
+  const { address, publicKey, privateKey } = keys.deriveFromSeed(
+    seed,
+    bip44Path
+  );
+
+  // Construct a Bond transaction
+  const bondProps: BondProps = {
+    source: address,
+    validator: "tnam1q9vhfdur7gadtwx4r223agpal0fvlqhywylf2mzx",
+    amount: BigNumber(123),
+  };
+
+  // Define Wrapper Tx props
+  const wrapperTxProps: WrapperTxProps = {
+    token: tokenAddress,
+    feeAmount: BigNumber(1),
+    gasLimit: BigNumber(1000),
+    chainId: "",
+    publicKey,
+    memo: "A bond transaction",
+  };
+
+  // Build a Bond transaction
+  const bondTx = await tx.buildBond(bondProps, wrapperTxProps);
+
+  // Sign a Bond transaction with a private key
+  const signedBondTxBytes = await signing.sign(bondTx, privateKey);
+
+  // Broadcast the signed transaction to a node
+  const txResponse = await rpc.broadcastTx(signedBondTxBytes, wrapperTxProps);
+};
+
+init();
+```
+
+### Types
+
+Explore the generated type docs here: [modules.md](./docs/modules.md)
 
 ## Development
+
+In order to compile the required Rust libraries locally (`@namada/crypto` and `@namada/shared`), issue one
+of the following commands, depending on the environment you are targeting:
 
 ```bash
 # Build wasm for single core, release mode
@@ -18,10 +112,7 @@ yarn wasm:build[:node]:dev
 
 # Build wasm with debugging for multicore
 yarn wasm:build[:node]:dev:multicore
+
+# Generate new docs
+yarn build:docs
 ```
-
-## Usage
-
-See [examples](../examples)
-
-For more information, read the [documentation](../docs).

--- a/packages/sdk/docs/classes/Crypto.md
+++ b/packages/sdk/docs/classes/Crypto.md
@@ -1,4 +1,4 @@
-[@heliaxdev/namada-sdk](../README.md) / [Exports](../modules.md) / Crypto
+[@namada/sdk](../README.md) / [Exports](../modules.md) / Crypto
 
 # Class: Crypto
 
@@ -40,7 +40,7 @@ Class Crypto handles AES encryption tasks
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/crypto/crypto.ts#L20)
+[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/crypto/crypto.ts#L20)
 
 ## Properties
 
@@ -52,7 +52,7 @@ WebAssembly Memory for crypto
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/crypto/crypto.ts#L20)
+[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/crypto/crypto.ts#L20)
 
 ## Methods
 
@@ -75,7 +75,7 @@ decrypted text
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:115](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/crypto/crypto.ts#L115)
+[sdk/src/crypto/crypto.ts:115](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/crypto/crypto.ts#L115)
 
 ___
 
@@ -100,7 +100,7 @@ crypto record
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:61](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/crypto/crypto.ts#L61)
+[sdk/src/crypto/crypto.ts:61](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/crypto/crypto.ts#L61)
 
 ___
 
@@ -126,7 +126,7 @@ array of encrypted bytes
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:98](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/crypto/crypto.ts#L98)
+[sdk/src/crypto/crypto.ts:98](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/crypto/crypto.ts#L98)
 
 ___
 
@@ -153,7 +153,7 @@ crypto record used for storage
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:30](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/crypto/crypto.ts#L30)
+[sdk/src/crypto/crypto.ts:30](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/crypto/crypto.ts#L30)
 
 ___
 
@@ -178,4 +178,4 @@ encryption parameters
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:73](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/crypto/crypto.ts#L73)
+[sdk/src/crypto/crypto.ts:73](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/crypto/crypto.ts#L73)

--- a/packages/sdk/docs/classes/Ledger.md
+++ b/packages/sdk/docs/classes/Ledger.md
@@ -1,4 +1,4 @@
-[@heliaxdev/namada-sdk](../README.md) / [Exports](../modules.md) / Ledger
+[@namada/sdk](../README.md) / [Exports](../modules.md) / Ledger
 
 # Class: Ledger
 
@@ -42,7 +42,7 @@ Functionality for interacting with NamadaApp for Ledger Hardware Wallets
 
 #### Defined in
 
-[sdk/src/ledger.ts:53](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/ledger.ts#L53)
+[sdk/src/ledger.ts:53](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/ledger.ts#L53)
 
 ## Properties
 
@@ -54,7 +54,7 @@ Inititalized NamadaApp class from Zondax package
 
 #### Defined in
 
-[sdk/src/ledger.ts:53](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/ledger.ts#L53)
+[sdk/src/ledger.ts:53](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/ledger.ts#L53)
 
 ## Methods
 
@@ -75,7 +75,7 @@ void
 
 #### Defined in
 
-[sdk/src/ledger.ts:174](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/ledger.ts#L174)
+[sdk/src/ledger.ts:174](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/ledger.ts#L174)
 
 ___
 
@@ -102,7 +102,7 @@ Address and public key
 
 #### Defined in
 
-[sdk/src/ledger.ts:96](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/ledger.ts#L96)
+[sdk/src/ledger.ts:96](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/ledger.ts#L96)
 
 ___
 
@@ -123,7 +123,7 @@ Error message if error is found
 
 #### Defined in
 
-[sdk/src/ledger.ts:157](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/ledger.ts#L157)
+[sdk/src/ledger.ts:157](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/ledger.ts#L157)
 
 ___
 
@@ -150,7 +150,7 @@ Address and public key
 
 #### Defined in
 
-[sdk/src/ledger.ts:116](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/ledger.ts#L116)
+[sdk/src/ledger.ts:116](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/ledger.ts#L116)
 
 ___
 
@@ -178,7 +178,7 @@ Response signature
 
 #### Defined in
 
-[sdk/src/ledger.ts:142](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/ledger.ts#L142)
+[sdk/src/ledger.ts:142](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/ledger.ts#L142)
 
 ___
 
@@ -199,7 +199,7 @@ Version and info of NamadaApp
 
 #### Defined in
 
-[sdk/src/ledger.ts:79](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/ledger.ts#L79)
+[sdk/src/ledger.ts:79](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/ledger.ts#L79)
 
 ___
 
@@ -225,4 +225,4 @@ Ledger class instance
 
 #### Defined in
 
-[sdk/src/ledger.ts:61](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/ledger.ts#L61)
+[sdk/src/ledger.ts:61](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/ledger.ts#L61)

--- a/packages/sdk/docs/classes/Masp.md
+++ b/packages/sdk/docs/classes/Masp.md
@@ -1,4 +1,4 @@
-[@heliaxdev/namada-sdk](../README.md) / [Exports](../modules.md) / Masp
+[@namada/sdk](../README.md) / [Exports](../modules.md) / Masp
 
 # Class: Masp
 
@@ -22,6 +22,7 @@ Class representing utilities related to MASP
 - [fetchAndStoreMaspParams](Masp.md#fetchandstoremaspparams)
 - [hasMaspParams](Masp.md#hasmaspparams)
 - [loadMaspParams](Masp.md#loadmaspparams)
+- [maspAddress](Masp.md#maspaddress)
 
 ## Constructors
 
@@ -41,7 +42,7 @@ Class representing utilities related to MASP
 
 #### Defined in
 
-[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/masp.ts#L10)
+[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/masp.ts#L10)
 
 ## Properties
 
@@ -53,7 +54,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/masp.ts#L10)
+[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/masp.ts#L10)
 
 ## Methods
 
@@ -80,7 +81,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:70](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/masp.ts#L70)
+[sdk/src/masp.ts:70](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/masp.ts#L70)
 
 ___
 
@@ -107,7 +108,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:48](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/masp.ts#L48)
+[sdk/src/masp.ts:48](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/masp.ts#L48)
 
 ___
 
@@ -134,7 +135,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:59](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/masp.ts#L59)
+[sdk/src/masp.ts:59](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/masp.ts#L59)
 
 ___
 
@@ -160,7 +161,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:27](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/masp.ts#L27)
+[sdk/src/masp.ts:27](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/masp.ts#L27)
 
 ___
 
@@ -180,7 +181,7 @@ True if MASP parameters are loaded
 
 #### Defined in
 
-[sdk/src/masp.ts:17](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/masp.ts#L17)
+[sdk/src/masp.ts:17](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/masp.ts#L17)
 
 ___
 
@@ -206,4 +207,23 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:37](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/masp.ts#L37)
+[sdk/src/masp.ts:37](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/masp.ts#L37)
+
+___
+
+### maspAddress
+
+▸ **maspAddress**(): `string`
+
+Returns the MASP address used as the receiving address in IBC transfers to
+shielded accounts
+
+#### Returns
+
+`string`
+
+the MASP address
+
+#### Defined in
+
+[sdk/src/masp.ts:79](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/masp.ts#L79)

--- a/packages/sdk/docs/classes/Mnemonic.md
+++ b/packages/sdk/docs/classes/Mnemonic.md
@@ -1,4 +1,4 @@
-[@heliaxdev/namada-sdk](../README.md) / [Exports](../modules.md) / Mnemonic
+[@namada/sdk](../README.md) / [Exports](../modules.md) / Mnemonic
 
 # Class: Mnemonic
 
@@ -38,7 +38,7 @@ Class for accessing mnemonic functionality from wasm
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/mnemonic.ts#L18)
+[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/mnemonic.ts#L18)
 
 ## Properties
 
@@ -50,7 +50,7 @@ Memory accessor for crypto lib
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/mnemonic.ts#L18)
+[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/mnemonic.ts#L18)
 
 ## Methods
 
@@ -74,7 +74,7 @@ An array of words
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:25](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/mnemonic.ts#L25)
+[sdk/src/mnemonic.ts:25](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/mnemonic.ts#L25)
 
 ___
 
@@ -99,7 +99,7 @@ Seed bytes
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:43](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/mnemonic.ts#L43)
+[sdk/src/mnemonic.ts:43](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/mnemonic.ts#L43)
 
 ___
 
@@ -129,4 +129,4 @@ Object with validation result and error message if invalid
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:61](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/mnemonic.ts#L61)
+[sdk/src/mnemonic.ts:61](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/mnemonic.ts#L61)

--- a/packages/sdk/docs/classes/Rpc.md
+++ b/packages/sdk/docs/classes/Rpc.md
@@ -1,4 +1,4 @@
-[@heliaxdev/namada-sdk](../README.md) / [Exports](../modules.md) / Rpc
+[@namada/sdk](../README.md) / [Exports](../modules.md) / Rpc
 
 # Class: Rpc
 
@@ -51,7 +51,7 @@ API for executing RPC requests with Namada
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:36](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/rpc.ts#L36)
+[sdk/src/rpc/rpc.ts:36](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/rpc.ts#L36)
 
 ## Properties
 
@@ -63,7 +63,7 @@ Instance of Query struct from wasm lib
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:38](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/rpc.ts#L38)
+[sdk/src/rpc/rpc.ts:38](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/rpc.ts#L38)
 
 ___
 
@@ -75,7 +75,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:37](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/rpc.ts#L37)
+[sdk/src/rpc/rpc.ts:37](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/rpc.ts#L37)
 
 ## Methods
 
@@ -102,7 +102,7 @@ TxResponseProps object
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:223](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/rpc.ts#L223)
+[sdk/src/rpc/rpc.ts:223](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/rpc.ts#L223)
 
 ___
 
@@ -122,7 +122,7 @@ Array of all validator addresses
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:78](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/rpc.ts#L78)
+[sdk/src/rpc/rpc.ts:78](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/rpc.ts#L78)
 
 ___
 
@@ -149,7 +149,7 @@ Query balances from chain
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:48](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/rpc.ts#L48)
+[sdk/src/rpc/rpc.ts:48](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/rpc.ts#L48)
 
 ___
 
@@ -169,7 +169,7 @@ Object
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:203](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/rpc.ts#L203)
+[sdk/src/rpc/rpc.ts:203](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/rpc.ts#L203)
 
 ___
 
@@ -195,7 +195,7 @@ Promise resolving to delegators votes
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:102](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/rpc.ts#L102)
+[sdk/src/rpc/rpc.ts:102](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/rpc.ts#L102)
 
 ___
 
@@ -215,7 +215,7 @@ Query gas costs
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:194](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/rpc.ts#L194)
+[sdk/src/rpc/rpc.ts:194](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/rpc.ts#L194)
 
 ___
 
@@ -235,7 +235,7 @@ Address of native token
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:57](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/rpc.ts#L57)
+[sdk/src/rpc/rpc.ts:57](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/rpc.ts#L57)
 
 ___
 
@@ -262,7 +262,7 @@ String of public key if found
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:68](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/rpc.ts#L68)
+[sdk/src/rpc/rpc.ts:68](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/rpc.ts#L68)
 
 ___
 
@@ -288,7 +288,7 @@ Promise resolving to pending ethereum transfers
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:185](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/rpc.ts#L185)
+[sdk/src/rpc/rpc.ts:185](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/rpc.ts#L185)
 
 ___
 
@@ -314,7 +314,7 @@ Promise resolving to staking positions
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:139](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/rpc.ts#L139)
+[sdk/src/rpc/rpc.ts:139](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/rpc.ts#L139)
 
 ___
 
@@ -340,7 +340,7 @@ Promise resolving to staking totals
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:112](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/rpc.ts#L112)
+[sdk/src/rpc/rpc.ts:112](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/rpc.ts#L112)
 
 ___
 
@@ -364,7 +364,7 @@ Total bonds amount
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:175](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/rpc.ts#L175)
+[sdk/src/rpc/rpc.ts:175](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/rpc.ts#L175)
 
 ___
 
@@ -391,7 +391,7 @@ Promise resolving to total delegations
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:89](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/rpc.ts#L89)
+[sdk/src/rpc/rpc.ts:89](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/rpc.ts#L89)
 
 ___
 
@@ -415,4 +415,4 @@ Sync the shielded context
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:241](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/rpc.ts#L241)
+[sdk/src/rpc/rpc.ts:241](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/rpc.ts#L241)

--- a/packages/sdk/docs/classes/Sdk.md
+++ b/packages/sdk/docs/classes/Sdk.md
@@ -1,4 +1,4 @@
-[@heliaxdev/namada-sdk](../README.md) / [Exports](../modules.md) / Sdk
+[@namada/sdk](../README.md) / [Exports](../modules.md) / Sdk
 
 # Class: Sdk
 
@@ -64,7 +64,7 @@ API for interacting with Namada SDK
 
 #### Defined in
 
-[sdk/src/sdk.ts:24](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L24)
+[sdk/src/sdk.ts:24](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L24)
 
 ## Properties
 
@@ -76,7 +76,7 @@ Memory accessor for crypto lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:27](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L27)
+[sdk/src/sdk.ts:27](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L27)
 
 ___
 
@@ -88,7 +88,7 @@ Address of chain's native token
 
 #### Defined in
 
-[sdk/src/sdk.ts:29](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L29)
+[sdk/src/sdk.ts:29](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L29)
 
 ___
 
@@ -100,7 +100,7 @@ Instance of Query struct from wasm lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:26](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L26)
+[sdk/src/sdk.ts:26](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L26)
 
 ___
 
@@ -112,7 +112,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:25](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L25)
+[sdk/src/sdk.ts:25](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L25)
 
 ___
 
@@ -124,7 +124,7 @@ RPC url
 
 #### Defined in
 
-[sdk/src/sdk.ts:28](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L28)
+[sdk/src/sdk.ts:28](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L28)
 
 ## Accessors
 
@@ -142,7 +142,7 @@ Utilities for encrypting and decrypting data
 
 #### Defined in
 
-[sdk/src/sdk.ts:174](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L174)
+[sdk/src/sdk.ts:174](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L174)
 
 ___
 
@@ -160,7 +160,7 @@ key-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:150](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L150)
+[sdk/src/sdk.ts:150](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L150)
 
 ___
 
@@ -178,7 +178,7 @@ Masp utilities for handling params
 
 #### Defined in
 
-[sdk/src/sdk.ts:166](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L166)
+[sdk/src/sdk.ts:166](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L166)
 
 ___
 
@@ -196,7 +196,7 @@ mnemonic-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:142](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L142)
+[sdk/src/sdk.ts:142](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L142)
 
 ___
 
@@ -214,7 +214,7 @@ rpc client
 
 #### Defined in
 
-[sdk/src/sdk.ts:126](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L126)
+[sdk/src/sdk.ts:126](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L126)
 
 ___
 
@@ -232,7 +232,7 @@ Non-Tx signing functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:158](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L158)
+[sdk/src/sdk.ts:158](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L158)
 
 ___
 
@@ -250,7 +250,7 @@ tx-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:134](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L134)
+[sdk/src/sdk.ts:134](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L134)
 
 ___
 
@@ -268,7 +268,7 @@ Version from package.json
 
 #### Defined in
 
-[sdk/src/sdk.ts:182](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L182)
+[sdk/src/sdk.ts:182](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L182)
 
 ## Methods
 
@@ -286,7 +286,7 @@ Utilities for encrypting and decrypting data
 
 #### Defined in
 
-[sdk/src/sdk.ts:101](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L101)
+[sdk/src/sdk.ts:101](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L101)
 
 ___
 
@@ -304,7 +304,7 @@ key-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:77](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L77)
+[sdk/src/sdk.ts:77](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L77)
 
 ___
 
@@ -322,7 +322,7 @@ Masp utilities for handling params
 
 #### Defined in
 
-[sdk/src/sdk.ts:93](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L93)
+[sdk/src/sdk.ts:93](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L93)
 
 ___
 
@@ -340,7 +340,7 @@ mnemonic-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:69](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L69)
+[sdk/src/sdk.ts:69](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L69)
 
 ___
 
@@ -358,7 +358,7 @@ Namada RPC client
 
 #### Defined in
 
-[sdk/src/sdk.ts:53](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L53)
+[sdk/src/sdk.ts:53](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L53)
 
 ___
 
@@ -376,7 +376,7 @@ Non-Tx signing functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:85](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L85)
+[sdk/src/sdk.ts:85](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L85)
 
 ___
 
@@ -394,7 +394,7 @@ Tx-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:61](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L61)
+[sdk/src/sdk.ts:61](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L61)
 
 ___
 
@@ -410,7 +410,7 @@ Return SDK Package version
 
 #### Defined in
 
-[sdk/src/sdk.ts:118](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L118)
+[sdk/src/sdk.ts:118](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L118)
 
 ___
 
@@ -436,7 +436,7 @@ Class for interacting with NamadaApp for Ledger Hardware Wallets
 
 #### Defined in
 
-[sdk/src/sdk.ts:111](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L111)
+[sdk/src/sdk.ts:111](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L111)
 
 ___
 
@@ -461,4 +461,4 @@ this instance of Sdk
 
 #### Defined in
 
-[sdk/src/sdk.ts:38](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/sdk.ts#L38)
+[sdk/src/sdk.ts:38](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/sdk.ts#L38)

--- a/packages/sdk/docs/classes/Signing.md
+++ b/packages/sdk/docs/classes/Signing.md
@@ -1,4 +1,4 @@
-[@heliaxdev/namada-sdk](../README.md) / [Exports](../modules.md) / Signing
+[@namada/sdk](../README.md) / [Exports](../modules.md) / Signing
 
 # Class: Signing
 
@@ -40,7 +40,7 @@ Signing constructor
 
 #### Defined in
 
-[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/signing.ts#L14)
+[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/signing.ts#L14)
 
 ## Properties
 
@@ -52,7 +52,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/signing.ts#L14)
+[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/signing.ts#L14)
 
 ## Methods
 
@@ -78,7 +78,7 @@ signed tx bytes - Promise resolving to Uint8Array
 
 #### Defined in
 
-[sdk/src/signing.ts:23](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/signing.ts#L23)
+[sdk/src/signing.ts:23](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/signing.ts#L23)
 
 ___
 
@@ -103,7 +103,7 @@ hash and signature
 
 #### Defined in
 
-[sdk/src/signing.ts:41](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/signing.ts#L41)
+[sdk/src/signing.ts:41](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/signing.ts#L41)
 
 ___
 
@@ -129,4 +129,4 @@ void
 
 #### Defined in
 
-[sdk/src/signing.ts:52](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/signing.ts#L52)
+[sdk/src/signing.ts:52](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/signing.ts#L52)

--- a/packages/sdk/docs/classes/Tx.md
+++ b/packages/sdk/docs/classes/Tx.md
@@ -1,4 +1,4 @@
-[@heliaxdev/namada-sdk](../README.md) / [Exports](../modules.md) / Tx
+[@namada/sdk](../README.md) / [Exports](../modules.md) / Tx
 
 # Class: Tx
 
@@ -33,6 +33,7 @@ SDK functionality related to transactions
 - [buildWithdraw](Tx.md#buildwithdraw)
 - [deserialize](Tx.md#deserialize)
 - [encodeTxArgs](Tx.md#encodetxargs)
+- [generateIbcShieldingMemo](Tx.md#generateibcshieldingmemo)
 - [getInnerTxHashes](Tx.md#getinnertxhashes)
 
 ## Constructors
@@ -53,7 +54,7 @@ SDK functionality related to transactions
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:55](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/tx/tx.ts#L55)
+[sdk/src/tx/tx.ts:56](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/tx/tx.ts#L56)
 
 ## Properties
 
@@ -65,7 +66,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:55](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/tx/tx.ts#L55)
+[sdk/src/tx/tx.ts:56](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/tx/tx.ts#L56)
 
 ## Methods
 
@@ -90,7 +91,7 @@ Append signature for transactions signed by Ledger Hardware Wallet
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:371](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/tx/tx.ts#L371)
+[sdk/src/tx/tx.ts:373](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/tx/tx.ts#L373)
 
 ___
 
@@ -114,7 +115,7 @@ a serialized TxMsgValue type
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:354](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/tx/tx.ts#L354)
+[sdk/src/tx/tx.ts:356](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/tx/tx.ts#L356)
 
 ___
 
@@ -141,7 +142,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:176](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/tx/tx.ts#L176)
+[sdk/src/tx/tx.ts:178](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/tx/tx.ts#L178)
 
 ___
 
@@ -168,7 +169,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:333](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/tx/tx.ts#L333)
+[sdk/src/tx/tx.ts:335](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/tx/tx.ts#L335)
 
 ___
 
@@ -195,7 +196,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:286](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/tx/tx.ts#L286)
+[sdk/src/tx/tx.ts:288](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/tx/tx.ts#L288)
 
 ___
 
@@ -222,7 +223,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:263](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/tx/tx.ts#L263)
+[sdk/src/tx/tx.ts:265](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/tx/tx.ts#L265)
 
 ___
 
@@ -249,7 +250,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:240](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/tx/tx.ts#L240)
+[sdk/src/tx/tx.ts:242](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/tx/tx.ts#L242)
 
 ___
 
@@ -275,7 +276,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:163](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/tx/tx.ts#L163)
+[sdk/src/tx/tx.ts:165](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/tx/tx.ts#L165)
 
 ___
 
@@ -302,7 +303,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:89](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/tx/tx.ts#L89)
+[sdk/src/tx/tx.ts:90](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/tx/tx.ts#L90)
 
 ___
 
@@ -329,7 +330,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:114](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/tx/tx.ts#L114)
+[sdk/src/tx/tx.ts:115](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/tx/tx.ts#L115)
 
 ___
 
@@ -356,7 +357,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:64](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/tx/tx.ts#L64)
+[sdk/src/tx/tx.ts:65](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/tx/tx.ts#L65)
 
 ___
 
@@ -383,7 +384,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:197](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/tx/tx.ts#L197)
+[sdk/src/tx/tx.ts:199](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/tx/tx.ts#L199)
 
 ___
 
@@ -410,7 +411,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:139](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/tx/tx.ts#L139)
+[sdk/src/tx/tx.ts:141](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/tx/tx.ts#L141)
 
 ___
 
@@ -437,7 +438,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:309](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/tx/tx.ts#L309)
+[sdk/src/tx/tx.ts:311](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/tx/tx.ts#L311)
 
 ___
 
@@ -464,7 +465,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:219](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/tx/tx.ts#L219)
+[sdk/src/tx/tx.ts:221](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/tx/tx.ts#L221)
 
 ___
 
@@ -489,7 +490,7 @@ a TxDetails object
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:424](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/tx/tx.ts#L424)
+[sdk/src/tx/tx.ts:426](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/tx/tx.ts#L426)
 
 ___
 
@@ -513,7 +514,37 @@ Serialized WrapperTxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:412](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/tx/tx.ts#L412)
+[sdk/src/tx/tx.ts:414](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/tx/tx.ts#L414)
+
+___
+
+### generateIbcShieldingMemo
+
+▸ **generateIbcShieldingMemo**(`target`, `token`, `amount`, `channelId`): `Promise`\<`string`\>
+
+Generate the memo needed for performing an IBC transfer to a Namada shielded
+address.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `target` | `string` | the Namada shielded address to send tokens to |
+| `token` | `string` | the token to transfer |
+| `amount` | `BigNumber` | the amount to transfer |
+| `channelId` | `string` | the IBC channel ID on the Namada side |
+
+#### Returns
+
+`Promise`\<`string`\>
+
+promise that resolves to the shielding memo
+
+**`Async`**
+
+#### Defined in
+
+[sdk/src/tx/tx.ts:489](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/tx/tx.ts#L489)
 
 ___
 
@@ -537,4 +568,4 @@ array of inner Tx hashes
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:480](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/tx/tx.ts#L480)
+[sdk/src/tx/tx.ts:508](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/tx/tx.ts#L508)

--- a/packages/sdk/docs/enums/KdfType.md
+++ b/packages/sdk/docs/enums/KdfType.md
@@ -1,4 +1,4 @@
-[@heliaxdev/namada-sdk](../README.md) / [Exports](../modules.md) / KdfType
+[@namada/sdk](../README.md) / [Exports](../modules.md) / KdfType
 
 # Enumeration: KdfType
 
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:38](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/crypto/types.ts#L38)
+[sdk/src/crypto/types.ts:38](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/crypto/types.ts#L38)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:39](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/crypto/types.ts#L39)
+[sdk/src/crypto/types.ts:39](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/crypto/types.ts#L39)

--- a/packages/sdk/docs/enums/PhraseSize.md
+++ b/packages/sdk/docs/enums/PhraseSize.md
@@ -1,4 +1,4 @@
-[@heliaxdev/namada-sdk](../README.md) / [Exports](../modules.md) / PhraseSize
+[@namada/sdk](../README.md) / [Exports](../modules.md) / PhraseSize
 
 # Enumeration: PhraseSize
 
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-crypto/src/crypto/crypto.d.ts:13
+crypto/src/crypto/crypto.d.ts:6
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-crypto/src/crypto/crypto.d.ts:14
+crypto/src/crypto/crypto.d.ts:7

--- a/packages/sdk/docs/enums/TxType.md
+++ b/packages/sdk/docs/enums/TxType.md
@@ -1,4 +1,4 @@
-[@heliaxdev/namada-sdk](../README.md) / [Exports](../modules.md) / TxType
+[@namada/sdk](../README.md) / [Exports](../modules.md) / TxType
 
 # Enumeration: TxType
 

--- a/packages/sdk/docs/modules.md
+++ b/packages/sdk/docs/modules.md
@@ -1,6 +1,6 @@
-[@heliaxdev/namada-sdk](README.md) / Exports
+[@namada/sdk](README.md) / Exports
 
-# @heliaxdev/namada-sdk
+# @namada/sdk
 
 ## Table of contents
 
@@ -69,7 +69,7 @@ Address and public key type
 
 #### Defined in
 
-[sdk/src/keys/types.ts:4](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/keys/types.ts#L4)
+[sdk/src/keys/types.ts:4](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/keys/types.ts#L4)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:16](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/ledger.ts#L16)
+[sdk/src/ledger.ts:16](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/ledger.ts#L16)
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:23](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/crypto/types.ts#L23)
+[sdk/src/crypto/types.ts:23](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/crypto/types.ts#L23)
 
 ___
 
@@ -109,7 +109,7 @@ Balance
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:69](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/types.ts#L69)
+[sdk/src/rpc/types.ts:69](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/types.ts#L69)
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:27](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/types.ts#L27)
+[sdk/src/rpc/types.ts:27](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/types.ts#L27)
 
 ___
 
@@ -156,7 +156,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:42](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/crypto/types.ts#L42)
+[sdk/src/crypto/types.ts:42](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/crypto/types.ts#L42)
 
 ___
 
@@ -169,7 +169,7 @@ Record<address, totalDelegations>
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:51](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/types.ts#L51)
+[sdk/src/rpc/types.ts:51](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/types.ts#L51)
 
 ___
 
@@ -182,7 +182,7 @@ Record<address, boolean>
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:57](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/types.ts#L57)
+[sdk/src/rpc/types.ts:57](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/types.ts#L57)
 
 ___
 
@@ -201,7 +201,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:30](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/crypto/types.ts#L30)
+[sdk/src/crypto/types.ts:30](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/crypto/types.ts#L30)
 
 ___
 
@@ -218,7 +218,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:17](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/ledger.ts#L17)
+[sdk/src/ledger.ts:17](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/ledger.ts#L17)
 
 ___
 
@@ -238,7 +238,7 @@ Shielded keys and address
 
 #### Defined in
 
-[sdk/src/keys/types.ts:19](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/keys/types.ts#L19)
+[sdk/src/keys/types.ts:19](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/keys/types.ts#L19)
 
 ___
 
@@ -255,7 +255,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:42](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/types.ts#L42)
+[sdk/src/rpc/types.ts:42](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/types.ts#L42)
 
 ___
 
@@ -275,7 +275,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:19](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/types.ts#L19)
+[sdk/src/rpc/types.ts:19](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/types.ts#L19)
 
 ___
 
@@ -285,7 +285,7 @@ ___
 
 #### Defined in
 
-[shared/src/types.ts:3](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/shared/src/types.ts#L3)
+[shared/src/types.ts:3](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/shared/src/types.ts#L3)
 
 ___
 
@@ -297,7 +297,7 @@ Public and private keypair with address
 
 #### Defined in
 
-[sdk/src/keys/types.ts:12](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/keys/types.ts#L12)
+[sdk/src/keys/types.ts:12](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/keys/types.ts#L12)
 
 ___
 
@@ -317,7 +317,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:34](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/rpc/types.ts#L34)
+[sdk/src/rpc/types.ts:34](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/rpc/types.ts#L34)
 
 ## Variables
 
@@ -335,7 +335,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:3](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/crypto/types.ts#L3)
+[sdk/src/crypto/types.ts:3](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/crypto/types.ts#L3)
 
 ___
 
@@ -345,7 +345,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:40](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/ledger.ts#L40)
+[sdk/src/ledger.ts:40](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/ledger.ts#L40)
 
 ___
 
@@ -355,7 +355,7 @@ ___
 
 #### Defined in
 
-[shared/src/types.ts:28](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/shared/src/types.ts#L28)
+[shared/src/types.ts:28](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/shared/src/types.ts#L28)
 
 ## Functions
 
@@ -375,7 +375,7 @@ Transport object
 
 #### Defined in
 
-[sdk/src/ledger.ts:36](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/ledger.ts#L36)
+[sdk/src/ledger.ts:36](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/ledger.ts#L36)
 
 ___
 
@@ -395,7 +395,7 @@ Transport object
 
 #### Defined in
 
-[sdk/src/ledger.ts:27](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/ledger.ts#L27)
+[sdk/src/ledger.ts:27](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/ledger.ts#L27)
 
 ___
 
@@ -415,4 +415,4 @@ ___
 
 #### Defined in
 
-[sdk/src/keys/keys.ts:173](https://github.com/anoma/namada-interface/blob/fac55d872bf5cdde37f7f3e49eb78636bc327fc0/packages/sdk/src/keys/keys.ts#L173)
+[sdk/src/keys/keys.ts:173](https://github.com/anoma/namada-interface/blob/f4c1ee3fc8f46d98479687b9b4b0b2ae8ecd87bd/packages/sdk/src/keys/keys.ts#L173)

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@heliaxdev/namada-sdk",
+  "name": "@namada/sdk",
   "version": "0.10.0",
   "description": "Namada SDK package",
   "exports": {
@@ -32,7 +32,7 @@
     "wasm:node:cp": "We need to copy wasm to the shared in dist folder, so it can be imported correctly in node"
   },
   "scripts": {
-    "prepublish": "yarn workspaces focus @heliaxdev/namada-sdk && yarn build",
+    "prepublish": "yarn workspaces focus @namada/sdk && yarn build",
     "release": "yarn prepublish && release-it --verbose --ci",
     "release:dry-run": "yarn prepublish && release-it --verbose --dry-run --ci",
     "release:no-npm": "yarn prepublish && release-it --verbose --no-npm.publish --ci",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,18 +31,12 @@
       "@namada/utils": ["../../../packages/utils/src"],
       "@namada/utils/*": ["../../../packages/utils/src/*"],
 
-      "@heliaxdev/namada-sdk/web": ["../../../packages/sdk/src/indexWeb.ts"],
-      "@heliaxdev/namada-sdk/web-init": [
-        "../../../packages/sdk/src/initWeb.ts"
-      ],
-      "@heliaxdev/namada-sdk/inline-init": [
-        "../../../packages/sdk/src/initInline.ts"
-      ],
+      "@namada/sdk/web": ["../../../packages/sdk/src/indexWeb.ts"],
+      "@namada/sdk/web-init": ["../../../packages/sdk/src/initWeb.ts"],
+      "@namada/sdk/inline-init": ["../../../packages/sdk/src/initInline.ts"],
 
-      "@heliaxdev/namada-sdk/node": ["../../../packages/sdk/src/indexNode.ts"],
-      "@heliaxdev/namada-sdk/node-init": [
-        "../../../packages/sdk/src/initNode.ts"
-      ]
+      "@namada/sdk/node": ["../../../packages/sdk/src/indexNode.ts"],
+      "@namada/sdk/node-init": ["../../../packages/sdk/src/initNode.ts"]
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2766,55 +2766,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@heliaxdev/namada-sdk@workspace:packages/sdk":
-  version: 0.0.0-use.local
-  resolution: "@heliaxdev/namada-sdk@workspace:packages/sdk"
-  dependencies:
-    "@babel/cli": "npm:^7.23.9"
-    "@babel/core": "npm:^7.23.9"
-    "@babel/plugin-proposal-class-properties": "npm:^7.18.6"
-    "@babel/plugin-proposal-object-rest-spread": "npm:^7.20.7"
-    "@babel/preset-env": "npm:^7.23.9"
-    "@babel/preset-typescript": "npm:^7.23.3"
-    "@cosmjs/encoding": "npm:^0.29.0"
-    "@dao-xyz/borsh": "npm:^5.1.5"
-    "@ledgerhq/hw-transport": "npm:^6.30.0"
-    "@ledgerhq/hw-transport-webhid": "npm:^6.28.0"
-    "@ledgerhq/hw-transport-webusb": "npm:^6.28.0"
-    "@release-it/conventional-changelog": "npm:^8.0.1"
-    "@types/jest": "npm:^29.5.12"
-    "@types/node": "npm:^20.11.4"
-    "@zondax/ledger-namada": "npm:^0.0.6"
-    babel-jest: "npm:^29.0.3"
-    bignumber.js: "npm:^9.1.1"
-    buffer: "npm:^6.0.3"
-    eslint: "npm:^8.57.0"
-    eslint-config-prettier: "npm:^9.1.0"
-    eslint-import-resolver-typescript: "npm:^3.6.3"
-    eslint-plugin-import: "npm:^2.30.0"
-    eslint-plugin-jsdoc: "npm:^48.2.1"
-    eslint-plugin-react: "npm:^7.35.2"
-    eslint-plugin-react-hooks: "npm:^4.6.0"
-    jest: "npm:^29.7.0"
-    jest-create-mock-instance: "npm:^2.0.0"
-    jest-mock-server: "npm:^0.1.0"
-    jsdoc-babel: "npm:^0.5.0"
-    release-it: "npm:^17.0.1"
-    rimraf: "npm:^5.0.5"
-    slip44: "npm:^3.0.18"
-    ts-jest: "npm:^29.2.5"
-    ts-node: "npm:^10.9.1"
-    ts-patch: "npm:^3.1.2"
-    tsconfig-paths: "npm:^4.2.0"
-    typedoc: "npm:^0.25.12"
-    typedoc-plugin-markdown: "npm:^3.17.1"
-    typescript: "npm:^5.5.4"
-    typescript-transform-paths: "npm:^3.4.7"
-    webpack: "npm:^5.90.3"
-    webpack-cli: "npm:^5.1.4"
-  languageName: unknown
-  linkType: soft
-
 "@humanwhocodes/config-array@npm:^0.11.14":
   version: 0.11.14
   resolution: "@humanwhocodes/config-array@npm:0.11.14"
@@ -3742,6 +3693,55 @@ __metadata:
     vite-tsconfig-paths: "npm:^5.0.1"
     web-vitals: "npm:^2.1.4"
     wonka: "npm:^6.3.4"
+  languageName: unknown
+  linkType: soft
+
+"@namada/sdk@workspace:packages/sdk":
+  version: 0.0.0-use.local
+  resolution: "@namada/sdk@workspace:packages/sdk"
+  dependencies:
+    "@babel/cli": "npm:^7.23.9"
+    "@babel/core": "npm:^7.23.9"
+    "@babel/plugin-proposal-class-properties": "npm:^7.18.6"
+    "@babel/plugin-proposal-object-rest-spread": "npm:^7.20.7"
+    "@babel/preset-env": "npm:^7.23.9"
+    "@babel/preset-typescript": "npm:^7.23.3"
+    "@cosmjs/encoding": "npm:^0.29.0"
+    "@dao-xyz/borsh": "npm:^5.1.5"
+    "@ledgerhq/hw-transport": "npm:^6.30.0"
+    "@ledgerhq/hw-transport-webhid": "npm:^6.28.0"
+    "@ledgerhq/hw-transport-webusb": "npm:^6.28.0"
+    "@release-it/conventional-changelog": "npm:^8.0.1"
+    "@types/jest": "npm:^29.5.12"
+    "@types/node": "npm:^20.11.4"
+    "@zondax/ledger-namada": "npm:^0.0.6"
+    babel-jest: "npm:^29.0.3"
+    bignumber.js: "npm:^9.1.1"
+    buffer: "npm:^6.0.3"
+    eslint: "npm:^8.57.0"
+    eslint-config-prettier: "npm:^9.1.0"
+    eslint-import-resolver-typescript: "npm:^3.6.3"
+    eslint-plugin-import: "npm:^2.30.0"
+    eslint-plugin-jsdoc: "npm:^48.2.1"
+    eslint-plugin-react: "npm:^7.35.2"
+    eslint-plugin-react-hooks: "npm:^4.6.0"
+    jest: "npm:^29.7.0"
+    jest-create-mock-instance: "npm:^2.0.0"
+    jest-mock-server: "npm:^0.1.0"
+    jsdoc-babel: "npm:^0.5.0"
+    release-it: "npm:^17.0.1"
+    rimraf: "npm:^5.0.5"
+    slip44: "npm:^3.0.18"
+    ts-jest: "npm:^29.2.5"
+    ts-node: "npm:^10.9.1"
+    ts-patch: "npm:^3.1.2"
+    tsconfig-paths: "npm:^4.2.0"
+    typedoc: "npm:^0.25.12"
+    typedoc-plugin-markdown: "npm:^3.17.1"
+    typescript: "npm:^5.5.4"
+    typescript-transform-paths: "npm:^3.4.7"
+    webpack: "npm:^5.90.3"
+    webpack-cli: "npm:^5.1.4"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR simply moves `@heliaxdev/namada-sdk` into `@namada/sdk` for consistency.

- [x] Rename SDK package org and update references
- [x] Regenerate SDK docs
- [x] Update `yarn.lock` file