### PR TITLE
feat/1231: Extension - Generate shielded keys from private key import

### DIFF
--- a/apps/extension/src/App/Accounts/ViewingKey.tsx
+++ b/apps/extension/src/App/Accounts/ViewingKey.tsx
@@ -15,7 +15,7 @@ export const ViewingKey = (): JSX.Element => {
         <PageHeader title="Viewing Key" />
         <p className="text-white">
           Your viewing key grants the holder access to all your balances and
-          transadction data. Please keep it secure to protect your data.
+          transaction data. Please keep it secure to protect your data.
         </p>
         <Input
           label="Viewing Key"

--- a/apps/extension/src/Setup/Common/Completion.tsx
+++ b/apps/extension/src/Setup/Common/Completion.tsx
@@ -106,16 +106,16 @@ export const Completion: React.FC<Props> = (props) => {
 
         // Do not derive shielded if this is an imported private key, and
         // ignore accounts with a non-zero 'change' path component:
-        if (accountSecret.t !== "PrivateKey" && path.change === 0) {
+        if (path.change === 0) {
           setStatusInfo("Generating Shielded Account");
           const shieldedAccount = await requester.sendMessage<DeriveAccountMsg>(
             Ports.Background,
-            // If this is a default path, don't use zip32 index
-            // TODO: Should we include index of 0 on default path?
             new DeriveAccountMsg(
               path,
               AccountType.ShieldedKeys,
-              storedAccount.alias
+              storedAccount.alias,
+              // Set the parent ID of this shielded account to the transparent account above
+              storedAccount.id
             )
           );
           setShieldedAccountAddress(shieldedAccount.address);

--- a/apps/extension/src/background/keyring/handler.ts
+++ b/apps/extension/src/background/keyring/handler.ts
@@ -153,8 +153,8 @@ const handleDeriveAccountMsg: (
   service: KeyRingService
 ) => InternalHandler<DeriveAccountMsg> = (service) => {
   return async (_, msg) => {
-    const { path, accountType, alias } = msg;
-    return await service.deriveAccount(path, accountType, alias);
+    const { path, accountType, alias, parentId } = msg;
+    return await service.deriveAccount(path, accountType, alias, parentId);
   };
 };
 

--- a/apps/extension/src/background/keyring/messages.ts
+++ b/apps/extension/src/background/keyring/messages.ts
@@ -3,7 +3,7 @@ import { AccountType, Bip44Path, DerivedAccount } from "@namada/types";
 import { Result } from "@namada/utils";
 import { ResponseSign } from "@zondax/ledger-namada";
 import { Message } from "router";
-import { validatePrivateKey } from "utils";
+import { validatePrivateKey, validateProps } from "utils";
 import { ROUTE } from "./constants";
 import {
   AccountSecret,
@@ -221,18 +221,14 @@ export class DeriveAccountMsg extends Message<DerivedAccount> {
   constructor(
     public readonly path: Bip44Path,
     public readonly accountType: AccountType,
-    public readonly alias: string
+    public readonly alias: string,
+    public readonly parentId: string
   ) {
     super();
   }
 
   validate(): void {
-    if (!this.accountType) {
-      throw new Error("An account type is required!");
-    }
-    if (!this.path) {
-      throw new Error("A Bip44Path object must be provided!");
-    }
+    validateProps(this, ["path", "accountType", "alias", "parentId"]);
 
     const { account, change } = this.path;
 

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -99,15 +99,21 @@ export class KeyRingService {
   async deriveAccount(
     path: Bip44Path,
     type: AccountType,
-    alias: string
+    alias: string,
+    parentId: string
   ): Promise<DerivedAccount> {
-    const account = await this._keyRing.deriveAccount(path, type, alias);
+    const account = await this._keyRing.deriveAccount(
+      path,
+      type,
+      alias,
+      parentId
+    );
     await this.broadcaster.updateAccounts();
     return account;
   }
 
   async queryAccountById(id: string): Promise<DerivedAccount[]> {
-    return await this._keyRing.queryAccountById(id);
+    return await this._keyRing.queryAccountsById(id);
   }
 
   async queryAccounts(): Promise<DerivedAccount[]> {


### PR DESCRIPTION
Resolves #1231 

- [x] When user imports private key, also derive shielded keys (default path)
- [x] Ensure any changes to custom path form are ignored for these
- [x] Fixed issue with Zip32 derivation: As the shielded keys are derived from a private key (which was derived with either a default or custom path), shielded keys on import should be derived with the default Zip32 path `/0'` - in the future we can allow users to derive additional keys either by incrementing (`/1'`) or providing a full path (e.g., `/0'/1`, etc.)

The confirmation page and `View Keys` views are automatically updated, as the private key account (which seeds the shielded keys) is also treated as a parent.

### Testing

- Start with a new extension install (Optional)
- Import or generate Mnemonic account (ensure existing functionality remains)
- Import another account from Private Key (can use: `00bebb118517e09c950841d849eb3e07e27e6cb9c59a8e71179220fa570d5d770f`) - should receive a shielded address
- Import mnemonic with custom path (existing functionality)
- Delete private key account, and then `Add Keys` - In the Import Mnemonic page under `Advanced`, set a custom path, then go to `Private Key` and import a private key as usual - this is to ensure that the custom path you entered is ignored when you import from private key (you shouldn't see a custom path here, because it is a default path)

Following all of this, it's good to check in the console with `await namada.accounts()` and inspect the accounts, ensuring:
- Shielded accounts' parent IDs line up with their parents
- The derivation paths are correct

### Screenshots

Private-key import confirmation:
![Screen Shot 2024-11-04 at 12 09 30 PM](https://github.com/user-attachments/assets/1368adb0-1fd1-4ec6-bf81-5e81cee6f77d)

View Keys
![Screen Shot 2024-11-04 at 12 09 46 PM](https://github.com/user-attachments/assets/84a82432-2b4a-40e7-a0af-6ffad8b2e689)
