### PR TITLE
Namadillo: Use latest registry to update osmosis-testnet

### DIFF
--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "dependencies": {
     "@anomaorg/namada-indexer-client": "0.0.27",
-    "@chain-registry/client": "^1.48.80",
+    "@chain-registry/client": "^1.53.5",
     "@cosmjs/encoding": "^0.32.3",
     "@keplr-wallet/types": "^0.12.136",
     "@tailwindcss/container-queries": "^0.1.1",

--- a/apps/namadillo/src/atoms/integrations/functions.ts
+++ b/apps/namadillo/src/atoms/integrations/functions.ts
@@ -12,7 +12,7 @@ import * as stargaze from "chain-registry/mainnet/stargaze";
 import * as celestiaTestnet from "chain-registry/testnet/celestiatestnet3";
 import * as cosmosTestnet from "chain-registry/testnet/cosmoshubtestnet";
 import * as dydxTestnet from "chain-registry/testnet/dydxtestnet";
-import * as osmosisTestnet from "chain-registry/testnet/osmosistestnet4";
+import * as osmosisTestnet from "chain-registry/testnet/osmosistestnet";
 import * as stargazeTestnet from "chain-registry/testnet/stargazetestnet";
 import { DenomTrace } from "cosmjs-types/ibc/applications/transfer/v1/transfer";
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1588,15 +1588,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chain-registry/client@npm:^1.48.80":
-  version: 1.48.80
-  resolution: "@chain-registry/client@npm:1.48.80"
+"@chain-registry/client@npm:^1.53.5":
+  version: 1.53.5
+  resolution: "@chain-registry/client@npm:1.53.5"
   dependencies:
-    "@chain-registry/types": "npm:^0.45.80"
-    "@chain-registry/utils": "npm:^1.46.80"
+    "@chain-registry/types": "npm:^0.50.5"
+    "@chain-registry/utils": "npm:^1.51.5"
     bfs-path: "npm:^1.0.2"
     cross-fetch: "npm:^3.1.5"
-  checksum: 63a8b398add4547145740b2ab40977a6305cd8b5c7f9c6339c46a36a28a52c476eb3a263328611db0fc986bcd24ea0e8a9fe54688acf38c8086988ce4b370ae0
+  checksum: d4d50c1cfc6602b3203979497dbe93f443e012f7054cd8e1403e7380e3346cfe60166aa9dbb85f774dad30945408305d2d47e77b1b22da5f909b9050d595fcca
   languageName: node
   linkType: hard
 
@@ -1607,14 +1607,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chain-registry/utils@npm:^1.46.80":
-  version: 1.46.80
-  resolution: "@chain-registry/utils@npm:1.46.80"
+"@chain-registry/types@npm:^0.50.5":
+  version: 0.50.5
+  resolution: "@chain-registry/types@npm:0.50.5"
+  checksum: 99db1dbb1b31b26a9ae542228f0b6ddb866144f08e967f682328550f09a213ce39309169ce09772905bac087f1b9cf5f6a604d685559dc23106d871d427ef543
+  languageName: node
+  linkType: hard
+
+"@chain-registry/utils@npm:^1.51.5":
+  version: 1.51.5
+  resolution: "@chain-registry/utils@npm:1.51.5"
   dependencies:
-    "@chain-registry/types": "npm:^0.45.80"
+    "@chain-registry/types": "npm:^0.50.5"
     bignumber.js: "npm:9.1.2"
     sha.js: "npm:^2.4.11"
-  checksum: 096b47bc36b275ee100bb9a1dd9ce3fca6e1079230ccccbf663159376d39e743278f56bf95a2e9037a289cb6f19d1f48434f58d55c45e4ea09610d065cdf387b
+  checksum: 8a4acb0ff53c234ddd246c939b4f697f28959fa0083aa4ae50d8bc09206349443759a314b883a2165af96d0e7979d79ce7abe9716d11803a4609f05200407ebd
   languageName: node
   linkType: hard
 
@@ -3617,7 +3624,7 @@ __metadata:
   resolution: "@namada/namadillo@workspace:apps/namadillo"
   dependencies:
     "@anomaorg/namada-indexer-client": "npm:0.0.27"
-    "@chain-registry/client": "npm:^1.48.80"
+    "@chain-registry/client": "npm:^1.53.5"
     "@cosmjs/encoding": "npm:^0.32.3"
     "@eslint/js": "npm:^9.9.1"
     "@keplr-wallet/types": "npm:^0.12.136"


### PR DESCRIPTION
This PR simply upgrades the `@chain-registry/client` version to the latest so we can query and see balances for `osmo-test-5`


![Screen Shot 2024-11-05 at 11 21 45 AM](https://github.com/user-attachments/assets/b9851530-55b1-4ddf-919c-c19b599293ef)
