### PR TITLE
fix: unify asset decoding for Namada and Cosmos

### DIFF
--- a/apps/namadillo/src/App/Ibc/ShieldAllAssetList.tsx
+++ b/apps/namadillo/src/App/Ibc/ShieldAllAssetList.tsx
@@ -4,15 +4,15 @@ import { TokenCurrency } from "App/Common/TokenCurrency";
 import BigNumber from "bignumber.js";
 import clsx from "clsx";
 import { getAssetImageUrl } from "integrations/utils";
-import { AssetWithBalanceAndIbcInfo } from "types";
+import { AddressWithAssetAndBalance } from "types";
 
-export type SelectableAssetWithBalanceAndIbcInfo =
-  AssetWithBalanceAndIbcInfo & {
+export type SelectableAddressWithAssetAndBalance =
+  AddressWithAssetAndBalance & {
     checked: boolean;
   };
 
 type ShieldAllAssetListProps = {
-  assets: SelectableAssetWithBalanceAndIbcInfo[];
+  assets: SelectableAddressWithAssetAndBalance[];
   onToggleAsset: (asset: Asset) => void;
 };
 
@@ -24,7 +24,7 @@ export const ShieldAllAssetList = ({
     <ul className="max-h-[200px] dark-scrollbar -mr-2">
       {assets.map(
         (
-          assetWithBalance: SelectableAssetWithBalanceAndIbcInfo,
+          assetWithBalance: SelectableAddressWithAssetAndBalance,
           idx: number
         ) => {
           const image = getAssetImageUrl(assetWithBalance.asset);

--- a/apps/namadillo/src/App/Ibc/ShieldAllPanel.tsx
+++ b/apps/namadillo/src/App/Ibc/ShieldAllPanel.tsx
@@ -11,12 +11,12 @@ import { TransferTransactionFee } from "App/Transfer/TransferTransactionFee";
 import { getTransactionFee } from "integrations/utils";
 import { useEffect, useMemo, useState } from "react";
 import {
-  AssetWithBalanceAndIbcInfo,
+  AddressWithAssetAndBalance,
   ChainRegistryEntry,
   WalletProvider,
 } from "types";
 import {
-  SelectableAssetWithBalanceAndIbcInfo,
+  SelectableAddressWithAssetAndBalance,
   ShieldAllAssetList,
 } from "./ShieldAllAssetList";
 import { ShieldAllContainer } from "./ShieldAllContainer";
@@ -26,7 +26,7 @@ type ShieldAllPanelProps = {
   wallet: WalletProvider;
   walletAddress: string;
   isLoading: boolean;
-  assetList: AssetWithBalanceAndIbcInfo[];
+  assetList: AddressWithAssetAndBalance[];
   onShieldAll: (assets: Asset[]) => void;
 };
 
@@ -39,7 +39,7 @@ export const ShieldAllPanel = ({
   onShieldAll,
 }: ShieldAllPanelProps): JSX.Element => {
   const [selectableAssets, setSelectableAssets] = useState<
-    SelectableAssetWithBalanceAndIbcInfo[]
+    SelectableAddressWithAssetAndBalance[]
   >([]);
 
   useEffect(() => {

--- a/apps/namadillo/src/atoms/balance/functions.ts
+++ b/apps/namadillo/src/atoms/balance/functions.ts
@@ -1,7 +1,10 @@
 import { IbcToken, NativeToken } from "@anomaorg/namada-indexer-client";
 import { Asset, AssetList } from "@chain-registry/types";
+import { mapCoinsToAssets } from "atoms/integrations";
 import BigNumber from "bignumber.js";
+import { DenomTrace } from "cosmjs-types/ibc/applications/transfer/v1/transfer";
 import { namadaAsset } from "registry/namadaAsset";
+import { AddressWithAssetAndBalanceMap } from "types";
 import { TokenBalance } from "./atoms";
 
 // TODO upgrade this function to be as smart as possible
@@ -56,3 +59,59 @@ export const getTotalDollar = (list?: TokenBalance[]): BigNumber | undefined =>
 export const getTotalNam = (list?: TokenBalance[]): BigNumber =>
   list?.find((i) => i.asset.base === namadaAsset.base)?.balance ??
   new BigNumber(0);
+
+const tnamAddressToDenomTrace = (
+  address: string,
+  tokenAddresses: (NativeToken | IbcToken)[]
+): DenomTrace | undefined => {
+  const token = tokenAddresses.find((entry) => entry.address === address);
+  const trace = token && "trace" in token ? token.trace : undefined;
+
+  // If no trace, the token is NAM, but return undefined because we only care
+  // about IBC tokens here
+  if (typeof trace === "undefined") {
+    return undefined;
+  }
+
+  const separatorIndex = trace.lastIndexOf("/");
+
+  if (separatorIndex === -1) {
+    return undefined;
+  }
+
+  return {
+    path: trace.substring(0, separatorIndex),
+    baseDenom: trace.substring(separatorIndex + 1),
+  };
+};
+
+export const mapNamadaAddressesToAssets = async (
+  balances: { address: string; amount: BigNumber }[],
+  tokenAddresses: (NativeToken | IbcToken)[],
+  chainName: string
+): Promise<AddressWithAssetAndBalanceMap> => {
+  const coins = balances.map(({ address, amount }) => ({
+    denom: address,
+    amount: amount.toString(), // TODO: don't convert back to string
+  }));
+
+  return await mapCoinsToAssets(coins, chainName, (tnamAddress) =>
+    Promise.resolve(tnamAddressToDenomTrace(tnamAddress, tokenAddresses))
+  );
+};
+
+export const mapNamadaAssetsToTokenBalances = (
+  assets: AddressWithAssetAndBalanceMap,
+  tokenPrices: Record<string, BigNumber>
+): TokenBalance[] => {
+  return Object.values(assets).map((assetEntry) => {
+    const tokenPrice = tokenPrices[assetEntry.address];
+    const dollar =
+      tokenPrice ? assetEntry.balance.multipliedBy(tokenPrice) : undefined;
+
+    return {
+      ...assetEntry,
+      dollar,
+    };
+  });
+};

--- a/apps/namadillo/src/atoms/integrations/atoms.ts
+++ b/apps/namadillo/src/atoms/integrations/atoms.ts
@@ -6,7 +6,11 @@ import { atom } from "jotai";
 import { atomWithMutation, atomWithQuery } from "jotai-tanstack-query";
 import { atomFamily, atomWithStorage } from "jotai/utils";
 import { ChainId, ChainRegistryEntry } from "types";
-import { getKnownChains, mapCoinsToAssets } from "./functions";
+import {
+  getKnownChains,
+  ibcAddressToDenomTrace,
+  mapCoinsToAssets,
+} from "./functions";
 import {
   IbcTransferParams,
   queryAndStoreRpc,
@@ -60,7 +64,11 @@ export const assetBalanceAtomFamily = atomFamily(
       ...queryDependentFn(async () => {
         return await queryAndStoreRpc(chain!, async (rpc: string) => {
           const assetsBalances = await queryAssetBalances(walletAddress!, rpc);
-          return await mapCoinsToAssets(assetsBalances, chain!.chain_name, rpc);
+          return await mapCoinsToAssets(
+            assetsBalances,
+            chain!.chain_name,
+            ibcAddressToDenomTrace(rpc)
+          );
         });
       }, [!!walletAddress, !!chain]),
     }));

--- a/apps/namadillo/src/hooks/useAssetAmount.tsx
+++ b/apps/namadillo/src/hooks/useAssetAmount.tsx
@@ -3,7 +3,7 @@ import { assetBalanceAtomFamily } from "atoms/integrations";
 import BigNumber from "bignumber.js";
 import { useAtomValue } from "jotai";
 import { useMemo } from "react";
-import { AssetWithBalanceAndIbcInfo, ChainRegistryEntry } from "types";
+import { AddressWithAssetAndBalance, ChainRegistryEntry } from "types";
 
 type useAmountTransferProps = {
   registry?: ChainRegistryEntry;
@@ -15,7 +15,7 @@ type UseAmountTransferOutput = {
   isLoading: boolean;
   balance: BigNumber | undefined;
   availableAssets?: Asset[];
-  assetsBalances?: Record<string, AssetWithBalanceAndIbcInfo>;
+  assetsBalances?: Record<string, AddressWithAssetAndBalance>;
 };
 
 export const useAssetAmount = ({

--- a/apps/namadillo/src/registry/namadaAsset.ts
+++ b/apps/namadillo/src/registry/namadaAsset.ts
@@ -3,13 +3,14 @@ import namadaShieldedSvg from "./assets/namada-shielded.svg";
 
 export const namadaAsset: Asset = {
   name: "Namada",
-  base: "namnam",
+  base: "tnam1qy440ynh9fwrx8aewjvvmu38zxqgukgc259fzp6h",
   display: "nam",
   symbol: "NAM",
   denom_units: [
     {
-      denom: "namnam",
+      denom: "tnam1qy440ynh9fwrx8aewjvvmu38zxqgukgc259fzp6h",
       exponent: 0,
+      aliases: ["unam"],
     },
     {
       denom: "nam",

--- a/apps/namadillo/src/registry/unknownAsset.ts
+++ b/apps/namadillo/src/registry/unknownAsset.ts
@@ -1,9 +1,0 @@
-import { Asset } from "@chain-registry/types";
-
-export const unknownAsset: Asset = {
-  name: "Unknown",
-  base: "?",
-  display: "?",
-  symbol: "?",
-  denom_units: [{ denom: "?", exponent: 0 }],
-};

--- a/apps/namadillo/src/types.d.ts
+++ b/apps/namadillo/src/types.d.ts
@@ -189,17 +189,13 @@ export type ChainRegistryEntry = {
   ibc: IBCInfo[];
 };
 
-export type AssetWithBalanceAndIbcInfo = {
+export type AddressWithAssetAndBalance = {
+  address: string;
   asset: Asset;
-  balance?: BigNumber;
-  ibc?: {
-    // undefined for non-IBC assets
-    ibcAddress: string;
-    denomTracePath: string;
-  };
+  balance: BigNumber;
 };
 
-export type AssetWithBalanceAndIbcInfoMap = Record<
+export type AddressWithAssetAndBalanceMap = Record<
   string,
-  AssetWithBalanceAndIbcInfo
+  AddressWithAssetAndBalance
 >;


### PR DESCRIPTION
This PR makes sure we use the same method for translating addresses to assets for both Namada and Cosmos chains. It follows on from #1227 and #1228.

This will only work with the internal devnet, but I'll add a PR tomorrow to get it working with housefire too.

I think we still should refactor more, because it is quite confusing to have `namadaTransparentAssetsAtom` (turning Namada addresses into assets with balances), and `transparentTokensAtom` (returning the same thing but also with balances in dollars). I've left the refactoring for now because my goal was just to make sure we use the same code for Namada and Cosmos. There are also other things that could be refactored (e.g. turning BigNumbers back into strings, using `Coin` type even though it is basically the same as the `Balance` type).

---

### Changed
- Store addresses for all assets, replacing IBC-specific address entry

### Fixed
- Unify asset decoding for Namada and Cosmos
  - Fixes cases where Namada addresses are decoded to the wrong chain's
    asset
- Add NAM address to registry and remove special handling for Namada
- Remove unused chain lookup in mapCoinsToAssets