### PR TITLE
feat: use namada registry + IBC decoding fixes

### DIFF
--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -27,6 +27,7 @@
     "jotai": "^2.6.3",
     "jotai-tanstack-query": "^0.8.5",
     "lodash.debounce": "^4.0.8",
+    "namada-chain-registry": "https://github.com/anoma/namada-chain-registry",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.1.0",

--- a/apps/namadillo/src/App/Ibc/IbcWithdraw.tsx
+++ b/apps/namadillo/src/App/Ibc/IbcWithdraw.tsx
@@ -1,4 +1,4 @@
-import { Asset, Chain } from "@chain-registry/types";
+import { Chain } from "@chain-registry/types";
 import { WindowWithNamada } from "@namada/types";
 import { mapUndefined } from "@namada/utils";
 import {
@@ -16,6 +16,7 @@ import { useAtomValue } from "jotai";
 import { useState } from "react";
 import namadaChainRegistry from "registry/namada.json";
 import { namadaAsset } from "registry/namadaAsset";
+import { Address, AddressWithAssetAndAmountMap } from "types";
 import { getSdkInstance } from "utils/sdk";
 import { IbcTopHeader } from "./IbcTopHeader";
 
@@ -30,16 +31,26 @@ export const IbcWithdraw: React.FC = () => {
   const namadaChainParams = useAtomValue(chainParametersAtom);
   const namadaChain = useAtomValue(chainAtom);
 
-  const [selectedAsset, setSelectedAsset] = useState<Asset>();
+  const [selectedAssetAddress, setSelectedAssetAddress] = useState<Address>();
 
   // TODO: remove hardcoding and display assets other than NAM
   const availableAmount = useAtomValue(accountBalanceAtom).data;
-  const availableAssets = [namadaAsset];
+  const availableAssets: AddressWithAssetAndAmountMap =
+    availableAmount ?
+      {
+        [namadaAsset.address]: {
+          asset: namadaAsset,
+          originalAddress: namadaAsset.address,
+          amount: availableAmount,
+        },
+      }
+    : {};
 
   const GAS_PRICE = BigNumber(0.000001); // 0.000001 NAM
   const GAS_LIMIT = BigNumber(1_000_000);
   const transactionFee = {
-    token: namadaAsset,
+    originalAddress: namadaAsset.address,
+    asset: namadaAsset,
     amount: GAS_PRICE.multipliedBy(GAS_LIMIT),
   };
 
@@ -115,8 +126,8 @@ export const IbcWithdraw: React.FC = () => {
           isShielded: false,
           availableAssets,
           availableAmount,
-          selectedAsset,
-          onChangeSelectedAsset: setSelectedAsset,
+          selectedAssetAddress,
+          onChangeSelectedAsset: setSelectedAssetAddress,
         }}
         destination={{
           wallet: wallets.keplr,

--- a/apps/namadillo/src/App/Ibc/ShieldAllAssetList.tsx
+++ b/apps/namadillo/src/App/Ibc/ShieldAllAssetList.tsx
@@ -4,15 +4,14 @@ import { TokenCurrency } from "App/Common/TokenCurrency";
 import BigNumber from "bignumber.js";
 import clsx from "clsx";
 import { getAssetImageUrl } from "integrations/utils";
-import { AddressWithAssetAndBalance } from "types";
+import { AddressWithAssetAndAmount } from "types";
 
-export type SelectableAddressWithAssetAndBalance =
-  AddressWithAssetAndBalance & {
-    checked: boolean;
-  };
+export type SelectableAddressWithAssetAndAmount = AddressWithAssetAndAmount & {
+  checked: boolean;
+};
 
 type ShieldAllAssetListProps = {
-  assets: SelectableAddressWithAssetAndBalance[];
+  assets: SelectableAddressWithAssetAndAmount[];
   onToggleAsset: (asset: Asset) => void;
 };
 
@@ -24,7 +23,7 @@ export const ShieldAllAssetList = ({
     <ul className="max-h-[200px] dark-scrollbar -mr-2">
       {assets.map(
         (
-          assetWithBalance: SelectableAddressWithAssetAndBalance,
+          assetWithBalance: SelectableAddressWithAssetAndAmount,
           idx: number
         ) => {
           const image = getAssetImageUrl(assetWithBalance.asset);
@@ -55,7 +54,7 @@ export const ShieldAllAssetList = ({
                 <TokenCurrency
                   currencySymbolClassName="hidden"
                   asset={assetWithBalance.asset}
-                  amount={assetWithBalance.balance || new BigNumber(0)}
+                  amount={assetWithBalance.amount || new BigNumber(0)}
                 />
               </span>
             </li>

--- a/apps/namadillo/src/App/Ibc/ShieldAllPanel.tsx
+++ b/apps/namadillo/src/App/Ibc/ShieldAllPanel.tsx
@@ -11,12 +11,12 @@ import { TransferTransactionFee } from "App/Transfer/TransferTransactionFee";
 import { getTransactionFee } from "integrations/utils";
 import { useEffect, useMemo, useState } from "react";
 import {
-  AddressWithAssetAndBalance,
+  AddressWithAssetAndAmount,
   ChainRegistryEntry,
   WalletProvider,
 } from "types";
 import {
-  SelectableAddressWithAssetAndBalance,
+  SelectableAddressWithAssetAndAmount,
   ShieldAllAssetList,
 } from "./ShieldAllAssetList";
 import { ShieldAllContainer } from "./ShieldAllContainer";
@@ -26,7 +26,7 @@ type ShieldAllPanelProps = {
   wallet: WalletProvider;
   walletAddress: string;
   isLoading: boolean;
-  assetList: AddressWithAssetAndBalance[];
+  assetList: AddressWithAssetAndAmount[];
   onShieldAll: (assets: Asset[]) => void;
 };
 
@@ -39,7 +39,7 @@ export const ShieldAllPanel = ({
   onShieldAll,
 }: ShieldAllPanelProps): JSX.Element => {
   const [selectableAssets, setSelectableAssets] = useState<
-    SelectableAddressWithAssetAndBalance[]
+    SelectableAddressWithAssetAndAmount[]
   >([]);
 
   useEffect(() => {

--- a/apps/namadillo/src/App/Transfer/SelectAssetModal.tsx
+++ b/apps/namadillo/src/App/Transfer/SelectAssetModal.tsx
@@ -1,18 +1,17 @@
-import { Asset } from "@chain-registry/types";
 import { Stack } from "@namada/components";
 import { Search } from "App/Common/Search";
 import { SelectModal } from "App/Common/SelectModal";
 import clsx from "clsx";
 import { useMemo, useState } from "react";
 import { twMerge } from "tailwind-merge";
-import { WalletProvider } from "types";
+import { Address, AddressWithAsset, WalletProvider } from "types";
 import { AssetCard } from "./AssetCard";
 import { ConnectedWalletInfo } from "./ConnectedWalletInfo";
 
 type SelectWalletModalProps = {
   onClose: () => void;
-  onSelect: (asset: Asset) => void;
-  assets: Asset[];
+  onSelect: (address: Address) => void;
+  assets: AddressWithAsset[];
   wallet: WalletProvider;
   walletAddress: string;
 };
@@ -28,7 +27,7 @@ export const SelectAssetModal = ({
 
   const filteredAssets = useMemo(() => {
     return assets.filter(
-      (asset) =>
+      ({ asset }) =>
         asset.name.toLowerCase().indexOf(filter.toLowerCase()) >= 0 ||
         asset.symbol.toLowerCase().indexOf(filter.toLowerCase()) >= 0
     );
@@ -45,11 +44,11 @@ export const SelectAssetModal = ({
         gap={0}
         className="max-h-[400px] overflow-auto dark-scrollbar pb-4 mr-[-0.5rem]"
       >
-        {filteredAssets.map((asset: Asset, index: number) => (
-          <li key={index} className="text-sm">
+        {filteredAssets.map(({ asset, originalAddress }) => (
+          <li key={originalAddress} className="text-sm">
             <button
               onClick={() => {
-                onSelect(asset);
+                onSelect(originalAddress);
                 onClose();
               }}
               className={twMerge(

--- a/apps/namadillo/src/App/Transfer/TransferTransactionFee.tsx
+++ b/apps/namadillo/src/App/Transfer/TransferTransactionFee.tsx
@@ -34,7 +34,7 @@ export const TransferTransactionFee = ({
       )}
       <TokenCurrency
         amount={transactionFee.amount}
-        asset={transactionFee.token}
+        asset={transactionFee.asset}
       />
     </footer>
   );

--- a/apps/namadillo/src/App/Transfer/__mocks__/assets.tsx
+++ b/apps/namadillo/src/App/Transfer/__mocks__/assets.tsx
@@ -1,19 +1,83 @@
 import { Asset } from "@chain-registry/types";
+import { AddressWithAsset } from "types";
 
-export const assetMock: Partial<Asset> = {
+export const assetMock: Asset = {
+  description:
+    "Ethereum is a decentralized blockchain platform for running smart contracts and dApps, with Ether (ETH) as its native cryptocurrency, enabling a versatile ecosystem beyond just digital currency.",
+  extended_description:
+    "Ethereum, symbolized as ETH, is a groundbreaking cryptocurrency and blockchain platform introduced in 2015 by a team led by Vitalik Buterin. Unlike Bitcoin, which primarily serves as a digital currency, Ethereum is designed to be a decentralized platform for running smart contracts and decentralized applications (dApps). These smart contracts are self-executing contracts with the terms directly written into code, enabling trustless and automated transactions without intermediaries. Ethereum's blockchain can host a wide variety of applications, from financial services to gaming, making it a versatile and powerful tool in the world of blockchain technology.\n\nOne of the most notable features of Ethereum is its native cryptocurrency, Ether (ETH), which is used to pay for transaction fees and computational services on the network. Ethereum has also been the backbone for the explosive growth of decentralized finance (DeFi), which seeks to recreate traditional financial systems with blockchain-based alternatives. Additionally, Ethereum is undergoing a significant upgrade known as Ethereum 2.0, which aims to improve scalability, security, and energy efficiency through a shift from proof-of-work (PoW) to proof-of-stake (PoS) consensus mechanisms. This transition is expected to enhance the network's performance and reduce its environmental impact, further solidifying Ethereum's position as a leading platform in the blockchain ecosystem.",
+  denom_units: [
+    {
+      denom: "wei",
+      exponent: 0,
+    },
+    {
+      denom: "gwei",
+      exponent: 9,
+    },
+    {
+      denom: "eth",
+      exponent: 18,
+      aliases: ["ether"],
+    },
+  ],
+  type_asset: "evm-base",
+  base: "wei",
   name: "Ethereum",
+  display: "eth",
   symbol: "ETH",
   logo_URIs: {
     svg: "https://example.com/eth-icon.png",
   },
+  coingecko_id: "ethereum",
+  images: [
+    {
+      png: "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-white.png",
+      svg: "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/eth-white.svg",
+      theme: {
+        primary_color_hex: "#303030",
+      },
+    },
+  ],
 };
 
-export const assetMock2: Partial<Asset> = {
+export const assetMock2: Asset = {
+  description:
+    'Bitcoin, the first and most well-known cryptocurrency, allows decentralized peer-to-peer transactions on a secure blockchain network, serving as "digital gold."',
+  extended_description:
+    'Bitcoin, often referred to as BTC, is the first and most well-known cryptocurrency, introduced in 2009 by an anonymous entity known as Satoshi Nakamoto. It was designed as a decentralized digital currency, allowing peer-to-peer transactions without the need for a central authority or intermediary. Bitcoin operates on a technology called blockchain, a distributed ledger that records all transactions across a network of computers. The security and integrity of the blockchain are maintained through a process called mining, where participants solve complex mathematical problems to validate and add new transactions to the blockchain. Bitcoin\'s decentralized nature and limited supply, capped at 21 million coins, have contributed to its status as "digital gold" and a store of value.\n\nBitcoin has significantly influenced the financial world, inspiring the development of thousands of other cryptocurrencies and blockchain technologies. Its adoption has grown over the years, with numerous merchants and service providers accepting it as a payment method. Additionally, Bitcoin has become a popular investment asset, attracting both individual and institutional investors. Despite its volatility and regulatory challenges, Bitcoin remains a dominant force in the crypto space, symbolizing the potential for a more open and inclusive financial system. Its impact extends beyond finance, as it continues to drive innovation in areas such as decentralized finance (DeFi), supply chain management, and digital identity verification.',
+  denom_units: [
+    {
+      denom: "sat",
+      exponent: 0,
+    },
+    {
+      denom: "btc",
+      exponent: 8,
+    },
+  ],
+  type_asset: "bitcoin-like",
+  base: "sat",
   name: "Bitcoin",
+  display: "btc",
   symbol: "BTC",
   logo_URIs: { svg: "btc.svg" },
+  coingecko_id: "bitcoin",
+  images: [
+    {
+      svg: "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/bitcoin/images/btc.svg",
+      png: "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/bitcoin/images/btc.png",
+      theme: {
+        primary_color_hex: "#f4941c",
+        background_color_hex: "#f4941c",
+        circle: true,
+      },
+    },
+  ],
 };
 
-export const assetMockList: Array<Partial<Asset>> = [assetMock, assetMock2];
+export const assetMockList: AddressWithAsset[] = [assetMock, assetMock2].map(
+  (asset) => ({ asset, originalAddress: asset.base })
+);
 
-export const assetWithoutLogo: Partial<Asset> = { ...assetMock, logo_URIs: {} };
+export const assetWithoutLogo: Asset = { ...assetMock, logo_URIs: {} };

--- a/apps/namadillo/src/App/Transfer/__tests__/AssetCard.test.tsx
+++ b/apps/namadillo/src/App/Transfer/__tests__/AssetCard.test.tsx
@@ -1,23 +1,22 @@
-import { Asset } from "@chain-registry/types";
 import { render, screen } from "@testing-library/react";
 import { AssetCard } from "App/Transfer/AssetCard";
 import { assetMock, assetWithoutLogo } from "App/Transfer/__mocks__/assets";
 
 describe("Component: AssetCard", () => {
   it("should render asset name", () => {
-    render(<AssetCard asset={assetMock as Asset} />);
+    render(<AssetCard asset={assetMock} />);
     expect(screen.getByText("Ethereum")).toBeInTheDocument();
   });
 
   it("should render asset logo if available", () => {
-    render(<AssetCard asset={assetMock as Asset} />);
+    render(<AssetCard asset={assetMock} />);
     const logo = screen.getByAltText("Ethereum logo");
     expect(logo).toBeInTheDocument();
     expect(logo).toHaveAttribute("src", assetMock.logo_URIs?.svg);
   });
 
   it("should render placeholder if logo is not available", () => {
-    render(<AssetCard asset={assetWithoutLogo as Asset} />);
+    render(<AssetCard asset={assetWithoutLogo} />);
     expect(screen.getByAltText(/logo not available/i)).toBeInTheDocument();
   });
 });

--- a/apps/namadillo/src/App/Transfer/__tests__/SelectAssetModal.test.tsx
+++ b/apps/namadillo/src/App/Transfer/__tests__/SelectAssetModal.test.tsx
@@ -1,4 +1,3 @@
-import { Asset } from "@chain-registry/types";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { SelectAssetModal } from "App/Transfer/SelectAssetModal";
 import { assetMockList } from "../__mocks__/assets";
@@ -14,7 +13,7 @@ describe("SelectAssetModal", () => {
       <SelectAssetModal
         onClose={onCloseMock}
         onSelect={onSelectMock}
-        assets={assetMockList as Asset[]}
+        assets={assetMockList}
         wallet={walletMock}
         walletAddress={mockAddress}
       />
@@ -27,7 +26,7 @@ describe("SelectAssetModal", () => {
       <SelectAssetModal
         onClose={onCloseMock}
         onSelect={onSelectMock}
-        assets={assetMockList as Asset[]}
+        assets={assetMockList}
         wallet={walletMock}
         walletAddress={mockAddress}
       />
@@ -41,7 +40,7 @@ describe("SelectAssetModal", () => {
       <SelectAssetModal
         onClose={onCloseMock}
         onSelect={onSelectMock}
-        assets={assetMockList as Asset[]}
+        assets={assetMockList}
         wallet={walletMock}
         walletAddress={mockAddress}
       />
@@ -62,13 +61,13 @@ describe("SelectAssetModal", () => {
       <SelectAssetModal
         onClose={onCloseMock}
         onSelect={onSelectMock}
-        assets={assetMockList as Asset[]}
+        assets={assetMockList}
         wallet={walletMock}
         walletAddress={mockAddress}
       />
     );
     fireEvent.click(screen.getByText("Bitcoin"));
-    expect(onSelectMock).toHaveBeenCalledWith(assetMockList[1]);
+    expect(onSelectMock).toHaveBeenCalledWith(assetMockList[1].originalAddress);
     expect(onCloseMock).toHaveBeenCalled();
   });
 });

--- a/apps/namadillo/src/App/Transfer/__tests__/TransferDestination.test.tsx
+++ b/apps/namadillo/src/App/Transfer/__tests__/TransferDestination.test.tsx
@@ -100,7 +100,11 @@ describe("TransferDestination", () => {
     const fee = BigNumber(0.000001);
     render(
       <TransferDestination
-        transactionFee={{ amount: fee, token: namadaAsset }}
+        transactionFee={{
+          amount: fee,
+          asset: namadaAsset,
+          originalAddress: namadaAsset.address,
+        }}
       />
     );
     const transactionFee = screen.getByText("Transaction Fee");

--- a/apps/namadillo/src/atoms/balance/atoms.ts
+++ b/apps/namadillo/src/atoms/balance/atoms.ts
@@ -15,7 +15,7 @@ import { queryDependentFn } from "atoms/utils";
 import BigNumber from "bignumber.js";
 import { atomWithQuery } from "jotai-tanstack-query";
 import { namadaAsset } from "registry/namadaAsset";
-import { AddressWithAssetAndBalance } from "types";
+import { AddressWithAsset } from "types";
 import {
   findAssetByToken,
   mapNamadaAddressesToAssets,
@@ -23,7 +23,8 @@ import {
 } from "./functions";
 import { fetchCoinPrices, fetchShieldedBalance } from "./services";
 
-export type TokenBalance = AddressWithAssetAndBalance & {
+export type TokenBalance = AddressWithAsset & {
+  balance: BigNumber;
   dollar?: BigNumber;
 };
 

--- a/apps/namadillo/src/atoms/integrations/atoms.ts
+++ b/apps/namadillo/src/atoms/integrations/atoms.ts
@@ -66,7 +66,7 @@ export const assetBalanceAtomFamily = atomFamily(
           const assetsBalances = await queryAssetBalances(walletAddress!, rpc);
           return await mapCoinsToAssets(
             assetsBalances,
-            chain!.chain_name,
+            chain!.chain_id,
             ibcAddressToDenomTrace(rpc)
           );
         });

--- a/apps/namadillo/src/atoms/integrations/services.ts
+++ b/apps/namadillo/src/atoms/integrations/services.ts
@@ -1,4 +1,4 @@
-import { Asset, Chain } from "@chain-registry/types";
+import { Chain } from "@chain-registry/types";
 import { Coin, OfflineSigner } from "@cosmjs/launchpad";
 import { coin, coins } from "@cosmjs/proto-signing";
 import {
@@ -9,6 +9,7 @@ import {
 import { TransactionFee } from "App/Transfer/TransferModule";
 import BigNumber from "bignumber.js";
 import { getDefaultStore } from "jotai";
+import { AddressWithAsset } from "types";
 import { toBaseAmount } from "utils";
 import { getSdkInstance } from "utils/sdk";
 import { workingRpcsAtom } from "./atoms";
@@ -19,7 +20,7 @@ type CommonParams = {
   sourceAddress: string;
   destinationAddress: string;
   amount: BigNumber;
-  asset: Asset;
+  asset: AddressWithAsset;
   sourceChannelId: string;
   transactionFee: TransactionFee;
 };
@@ -83,18 +84,18 @@ export const submitIbcTransfer =
     });
 
     // cosmjs expects amounts to be represented in the base denom, so convert
-    const baseAmount = toBaseAmount(asset, displayAmount);
-    const baseFee = toBaseAmount(transactionFee.token, transactionFee.amount);
+    const baseAmount = toBaseAmount(asset.asset, displayAmount);
+    const baseFee = toBaseAmount(transactionFee.asset, transactionFee.amount);
 
     const fee = {
-      amount: coins(baseFee.toString(), transactionFee.token.base),
+      amount: coins(baseFee.toString(), transactionFee.originalAddress),
       gas: "222000", // TODO: what should this be?
     };
 
     const timeoutTimestampNanoseconds =
       BigInt(Math.floor(Date.now() / 1000) + 60) * BigInt(1_000_000_000);
 
-    const token = asset.base;
+    const token = asset.originalAddress;
 
     const { receiver, memo }: { receiver: string; memo?: string } =
       isShielded ?

--- a/apps/namadillo/src/hooks/useAssetAmount.tsx
+++ b/apps/namadillo/src/hooks/useAssetAmount.tsx
@@ -3,7 +3,7 @@ import { assetBalanceAtomFamily } from "atoms/integrations";
 import BigNumber from "bignumber.js";
 import { useAtomValue } from "jotai";
 import { useMemo } from "react";
-import { AddressWithAssetAndBalance, ChainRegistryEntry } from "types";
+import { AddressWithAssetAndAmount, ChainRegistryEntry } from "types";
 
 type useAmountTransferProps = {
   registry?: ChainRegistryEntry;
@@ -15,7 +15,7 @@ type UseAmountTransferOutput = {
   isLoading: boolean;
   balance: BigNumber | undefined;
   availableAssets?: Asset[];
-  assetsBalances?: Record<string, AddressWithAssetAndBalance>;
+  assetsBalances?: Record<string, AddressWithAssetAndAmount>;
 };
 
 export const useAssetAmount = ({
@@ -35,7 +35,7 @@ export const useAssetAmount = ({
     if (!asset || !assetsBalances) {
       return undefined;
     }
-    return assetsBalances[asset.base].balance;
+    return assetsBalances[asset.base].amount;
   }, [asset, assetsBalances]);
 
   const availableAssets = useMemo<Asset[] | undefined>(() => {

--- a/apps/namadillo/src/integrations/utils.ts
+++ b/apps/namadillo/src/integrations/utils.ts
@@ -44,7 +44,8 @@ export const getTransactionFee = (
     if (typeof asset !== "undefined") {
       return {
         amount: BigNumber(0.003), // TODO: remove hardcoding
-        token: asset,
+        asset,
+        originalAddress: asset.base,
       };
     }
   }

--- a/apps/namadillo/src/registry/namadaAsset.ts
+++ b/apps/namadillo/src/registry/namadaAsset.ts
@@ -1,16 +1,16 @@
 import { Asset } from "@chain-registry/types";
 import namadaShieldedSvg from "./assets/namada-shielded.svg";
 
-export const namadaAsset: Asset = {
+export const namadaAsset = {
   name: "Namada",
-  base: "tnam1qy440ynh9fwrx8aewjvvmu38zxqgukgc259fzp6h",
+  base: "unam",
+  address: "tnam1qy440ynh9fwrx8aewjvvmu38zxqgukgc259fzp6h",
   display: "nam",
   symbol: "NAM",
   denom_units: [
     {
-      denom: "tnam1qy440ynh9fwrx8aewjvvmu38zxqgukgc259fzp6h",
+      denom: "unam",
       exponent: 0,
-      aliases: ["unam"],
     },
     {
       denom: "nam",
@@ -18,4 +18,4 @@ export const namadaAsset: Asset = {
     },
   ],
   logo_URIs: { svg: namadaShieldedSvg },
-};
+} satisfies Asset;

--- a/apps/namadillo/src/types.d.ts
+++ b/apps/namadillo/src/types.d.ts
@@ -189,13 +189,16 @@ export type ChainRegistryEntry = {
   ibc: IBCInfo[];
 };
 
-export type AddressWithAssetAndBalance = {
-  address: string;
+export type AddressWithAsset = {
+  originalAddress: Address;
   asset: Asset;
-  balance: BigNumber;
 };
 
-export type AddressWithAssetAndBalanceMap = Record<
-  string,
-  AddressWithAssetAndBalance
+export type AddressWithAssetAndAmount = AddressWithAsset & {
+  amount: BigNumber;
+};
+
+export type AddressWithAssetAndAmountMap = Record<
+  Address,
+  AddressWithAssetAndAmount
 >;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3678,6 +3678,7 @@ __metadata:
     jotai-tanstack-query: "npm:^0.8.5"
     local-cors-proxy: "npm:^1.1.0"
     lodash.debounce: "npm:^4.0.8"
+    namada-chain-registry: "https://github.com/anoma/namada-chain-registry"
     postcss: "npm:^8.4.32"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
@@ -15812,6 +15813,13 @@ __metadata:
     object-assign: "npm:^4.0.1"
     thenify-all: "npm:^1.0.0"
   checksum: 103114e93f87362f0b56ab5b2e7245051ad0276b646e3902c98397d18bb8f4a77f2ea4a2c9d3ad516034ea3a56553b60d3f5f78220001ca4c404bd711bd0af39
+  languageName: node
+  linkType: hard
+
+"namada-chain-registry@https://github.com/anoma/namada-chain-registry":
+  version: 0.0.1
+  resolution: "namada-chain-registry@https://github.com/anoma/namada-chain-registry.git#commit=ca1d841d75f105fe91a907c678a4fe3077d0f1e8"
+  checksum: f9223374efee6af23f9485a82074d2fa34f4a38f5592bd947ee3be845bdfe648d692980805a03f15ada6b077585f6ef0e05baf0542e2ec6fc33dd4d683064f78
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR integrates Namadillo with Namada registry, as well as fixing some other things related to decoding addresses to assets. This adds support for holding the same asset from multiple chains. To test, you can transfer some NAM from the internal devnet to cosmoshub testnet to housefire, and you should see both your housefire NAM and your internal devnet NAM listed on your account.

The package.json points to a specific branch of namada-chain-registry, but I can update this as soon as anoma/namada-chain-registry#3 is merged. The code integrating the registry is a bit clunky, but this can be improved as the registry develops.

---

### Added
- Use Namada chain registry. Closes #1217

### Fixed
- Index assets by their original address, not by base denom. Fixes #1220
  - Also refactor TransferModule accordingly
- Look up registry asset by base denom, alias or address
- Use address to index assets in 'Select Asset' list