### PR TITLE
feat: enable IBC withdrawals for all tokens

### DIFF
--- a/apps/namadillo/src/atoms/balance/index.ts
+++ b/apps/namadillo/src/atoms/balance/index.ts
@@ -1,0 +1,1 @@
+export * from "./atoms";

--- a/apps/namadillo/src/atoms/fees/atoms.ts
+++ b/apps/namadillo/src/atoms/fees/atoms.ts
@@ -1,4 +1,3 @@
-import { GasLimitTableInnerTxKindEnum as GasLimitTableIndexer } from "@namada/indexer-client";
 import { defaultAccountAtom } from "atoms/accounts";
 import { indexerApiAtom } from "atoms/api";
 import { nativeTokenAddressAtom } from "atoms/chain";
@@ -8,32 +7,9 @@ import { atom } from "jotai";
 import { atomWithQuery } from "jotai-tanstack-query";
 import { atomFamily } from "jotai/utils";
 import { isPublicKeyRevealed } from "lib/query";
-import { GasConfig, GasTable, TxKind } from "types";
+import { GasConfig, GasTable } from "types";
+import { TxKind } from "types/txKind";
 import { fetchGasLimit, fetchMinimumGasPrice } from "./services";
-
-// TODO: I think we should find a better solution for this
-export const txKindFromIndexer = (
-  txKind: GasLimitTableIndexer
-): TxKind | undefined => {
-  switch (txKind) {
-    case GasLimitTableIndexer.Bond:
-      return "Bond";
-    case GasLimitTableIndexer.Unbond:
-      return "Unbond";
-    case GasLimitTableIndexer.Redelegation:
-      return "Redelegate";
-    case GasLimitTableIndexer.Withdraw:
-      return "Withdraw";
-    case GasLimitTableIndexer.ClaimRewards:
-      return "ClaimRewards";
-    case GasLimitTableIndexer.VoteProposal:
-      return "VoteProposal";
-    case GasLimitTableIndexer.RevealPk:
-      return "RevealPk";
-    default:
-      return undefined;
-  }
-};
 
 export const gasCostTxKindAtom = atom<TxKind | undefined>(undefined);
 

--- a/apps/namadillo/src/atoms/fees/functions.ts
+++ b/apps/namadillo/src/atoms/fees/functions.ts
@@ -1,0 +1,28 @@
+import { GasLimitTableInnerTxKindEnum as GasLimitTableIndexer } from "@namada/indexer-client";
+import { assertNever } from "@namada/utils";
+import { TxKind } from "types/txKind";
+
+export const txKindToIndexer = (txKind: TxKind): GasLimitTableIndexer => {
+  switch (txKind) {
+    case "Bond":
+      return GasLimitTableIndexer.Bond;
+    case "Unbond":
+      return GasLimitTableIndexer.Unbond;
+    case "Redelegate":
+      return GasLimitTableIndexer.Redelegation;
+    case "Withdraw":
+      return GasLimitTableIndexer.Withdraw;
+    case "ClaimRewards":
+      return GasLimitTableIndexer.ClaimRewards;
+    case "VoteProposal":
+      return GasLimitTableIndexer.VoteProposal;
+    case "RevealPk":
+      return GasLimitTableIndexer.RevealPk;
+    case "IbcTransfer":
+      return GasLimitTableIndexer.IbcMsgTransfer;
+    case "Unknown":
+      return GasLimitTableIndexer.Unknown;
+    default:
+      return assertNever(txKind);
+  }
+};

--- a/apps/namadillo/src/types.d.ts
+++ b/apps/namadillo/src/types.d.ts
@@ -6,6 +6,7 @@ import {
 } from "@namada/indexer-client";
 import { ChainKey, ClaimRewardsMsgValue, ExtensionKey } from "@namada/types";
 import BigNumber from "bignumber.js";
+import { TxKind } from "types/txKind";
 
 declare module "*.module.css" {
   const content: Record<string, string>;
@@ -144,16 +145,6 @@ export type BuildTxAtomParams<T> = {
   params: T[];
   gasConfig: GasConfig;
 };
-
-export type TxKind =
-  | "Bond"
-  | "Unbond"
-  | "Redelegate"
-  | "Withdraw"
-  | "ClaimRewards"
-  | "VoteProposal"
-  | "RevealPk"
-  | "Unknown";
 
 export type SortOptions = "asc" | "desc" | undefined;
 

--- a/apps/namadillo/src/types/events.ts
+++ b/apps/namadillo/src/types/events.ts
@@ -6,7 +6,8 @@ import {
   VoteProposalProps,
   WithdrawProps,
 } from "@namada/types";
-import { ClaimRewardsProps, TxKind } from "types";
+import { ClaimRewardsProps } from "types";
+import { TxKind } from "types/txKind";
 
 export type TransactionEventsClasses = Partial<TxKind>;
 

--- a/apps/namadillo/src/types/txKind.ts
+++ b/apps/namadillo/src/types/txKind.ts
@@ -1,0 +1,13 @@
+export const txKinds = [
+  "Bond",
+  "Unbond",
+  "Redelegate",
+  "Withdraw",
+  "ClaimRewards",
+  "VoteProposal",
+  "RevealPk",
+  "IbcTransfer",
+  "Unknown",
+] as const;
+
+export type TxKind = (typeof txKinds)[number];

--- a/packages/integrations/src/Keplr.ts
+++ b/packages/integrations/src/Keplr.ts
@@ -166,7 +166,7 @@ class Keplr implements Integration<Account, OfflineSigner> {
         source,
         receiver,
         token,
-        amount,
+        amountInBaseDenom,
         portId = "transfer",
         channelId,
       } = props.ibcProps;
@@ -189,7 +189,7 @@ class Keplr implements Integration<Account, OfflineSigner> {
         .sendIbcTokens(
           source,
           receiver,
-          coin(amount.toString(), minDenom),
+          coin(amountInBaseDenom.toString(), minDenom),
           portId,
           channelId,
           // TODO: Should we enable timeout height versus timestamp?

--- a/packages/sdk/docs/classes/Crypto.md
+++ b/packages/sdk/docs/classes/Crypto.md
@@ -40,7 +40,7 @@ Class Crypto handles AES encryption tasks
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/crypto/crypto.ts#L20)
+[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/crypto.ts#L20)
 
 ## Properties
 
@@ -52,7 +52,7 @@ WebAssembly Memory for crypto
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/crypto/crypto.ts#L20)
+[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/crypto.ts#L20)
 
 ## Methods
 
@@ -75,7 +75,7 @@ decrypted text
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:115](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/crypto/crypto.ts#L115)
+[sdk/src/crypto/crypto.ts:115](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/crypto.ts#L115)
 
 ___
 
@@ -100,7 +100,7 @@ crypto record
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:61](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/crypto/crypto.ts#L61)
+[sdk/src/crypto/crypto.ts:61](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/crypto.ts#L61)
 
 ___
 
@@ -126,7 +126,7 @@ array of encrypted bytes
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:98](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/crypto/crypto.ts#L98)
+[sdk/src/crypto/crypto.ts:98](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/crypto.ts#L98)
 
 ___
 
@@ -153,7 +153,7 @@ crypto record used for storage
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:30](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/crypto/crypto.ts#L30)
+[sdk/src/crypto/crypto.ts:30](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/crypto.ts#L30)
 
 ___
 
@@ -178,4 +178,4 @@ encryption parameters
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:73](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/crypto/crypto.ts#L73)
+[sdk/src/crypto/crypto.ts:73](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/crypto.ts#L73)

--- a/packages/sdk/docs/classes/Ledger.md
+++ b/packages/sdk/docs/classes/Ledger.md
@@ -44,7 +44,7 @@ Functionality for interacting with NamadaApp for Ledger Hardware Wallets
 
 #### Defined in
 
-[sdk/src/ledger.ts:68](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/ledger.ts#L68)
+[sdk/src/ledger.ts:68](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L68)
 
 ## Properties
 
@@ -56,7 +56,7 @@ Inititalized NamadaApp class from Zondax package
 
 #### Defined in
 
-[sdk/src/ledger.ts:68](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/ledger.ts#L68)
+[sdk/src/ledger.ts:68](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L68)
 
 ## Methods
 
@@ -77,7 +77,7 @@ void
 
 #### Defined in
 
-[sdk/src/ledger.ts:245](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/ledger.ts#L245)
+[sdk/src/ledger.ts:245](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L245)
 
 ___
 
@@ -104,7 +104,7 @@ Address and public key
 
 #### Defined in
 
-[sdk/src/ledger.ts:111](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/ledger.ts#L111)
+[sdk/src/ledger.ts:111](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L111)
 
 ___
 
@@ -132,7 +132,7 @@ ShieldedKeys
 
 #### Defined in
 
-[sdk/src/ledger.ts:157](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/ledger.ts#L157)
+[sdk/src/ledger.ts:157](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L157)
 
 ___
 
@@ -153,7 +153,7 @@ Error message if error is found
 
 #### Defined in
 
-[sdk/src/ledger.ts:228](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/ledger.ts#L228)
+[sdk/src/ledger.ts:228](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L228)
 
 ___
 
@@ -180,7 +180,7 @@ Address and public key
 
 #### Defined in
 
-[sdk/src/ledger.ts:131](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/ledger.ts#L131)
+[sdk/src/ledger.ts:131](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L131)
 
 ___
 
@@ -208,7 +208,7 @@ Response signature
 
 #### Defined in
 
-[sdk/src/ledger.ts:196](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/ledger.ts#L196)
+[sdk/src/ledger.ts:196](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L196)
 
 ___
 
@@ -236,7 +236,7 @@ Response signature
 
 #### Defined in
 
-[sdk/src/ledger.ts:213](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/ledger.ts#L213)
+[sdk/src/ledger.ts:213](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L213)
 
 ___
 
@@ -257,7 +257,7 @@ Version and info of NamadaApp
 
 #### Defined in
 
-[sdk/src/ledger.ts:94](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/ledger.ts#L94)
+[sdk/src/ledger.ts:94](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L94)
 
 ___
 
@@ -283,4 +283,4 @@ Ledger class instance
 
 #### Defined in
 
-[sdk/src/ledger.ts:76](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/ledger.ts#L76)
+[sdk/src/ledger.ts:76](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L76)

--- a/packages/sdk/docs/classes/Masp.md
+++ b/packages/sdk/docs/classes/Masp.md
@@ -42,7 +42,7 @@ Class representing utilities related to MASP
 
 #### Defined in
 
-[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/masp.ts#L10)
+[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/masp.ts#L10)
 
 ## Properties
 
@@ -54,7 +54,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/masp.ts#L10)
+[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/masp.ts#L10)
 
 ## Methods
 
@@ -81,7 +81,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:70](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/masp.ts#L70)
+[sdk/src/masp.ts:70](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/masp.ts#L70)
 
 ___
 
@@ -108,7 +108,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:48](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/masp.ts#L48)
+[sdk/src/masp.ts:48](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/masp.ts#L48)
 
 ___
 
@@ -135,7 +135,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:59](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/masp.ts#L59)
+[sdk/src/masp.ts:59](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/masp.ts#L59)
 
 ___
 
@@ -161,7 +161,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:27](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/masp.ts#L27)
+[sdk/src/masp.ts:27](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/masp.ts#L27)
 
 ___
 
@@ -181,7 +181,7 @@ True if MASP parameters are loaded
 
 #### Defined in
 
-[sdk/src/masp.ts:17](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/masp.ts#L17)
+[sdk/src/masp.ts:17](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/masp.ts#L17)
 
 ___
 
@@ -207,7 +207,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:37](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/masp.ts#L37)
+[sdk/src/masp.ts:37](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/masp.ts#L37)
 
 ___
 
@@ -226,4 +226,4 @@ the MASP address
 
 #### Defined in
 
-[sdk/src/masp.ts:79](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/masp.ts#L79)
+[sdk/src/masp.ts:79](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/masp.ts#L79)

--- a/packages/sdk/docs/classes/Mnemonic.md
+++ b/packages/sdk/docs/classes/Mnemonic.md
@@ -38,7 +38,7 @@ Class for accessing mnemonic functionality from wasm
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/mnemonic.ts#L18)
+[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/mnemonic.ts#L18)
 
 ## Properties
 
@@ -50,7 +50,7 @@ Memory accessor for crypto lib
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/mnemonic.ts#L18)
+[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/mnemonic.ts#L18)
 
 ## Methods
 
@@ -74,7 +74,7 @@ An array of words
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:25](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/mnemonic.ts#L25)
+[sdk/src/mnemonic.ts:25](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/mnemonic.ts#L25)
 
 ___
 
@@ -99,7 +99,7 @@ Seed bytes
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:43](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/mnemonic.ts#L43)
+[sdk/src/mnemonic.ts:43](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/mnemonic.ts#L43)
 
 ___
 
@@ -129,4 +129,4 @@ Object with validation result and error message if invalid
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:61](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/mnemonic.ts#L61)
+[sdk/src/mnemonic.ts:61](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/mnemonic.ts#L61)

--- a/packages/sdk/docs/classes/Rpc.md
+++ b/packages/sdk/docs/classes/Rpc.md
@@ -51,7 +51,7 @@ API for executing RPC requests with Namada
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:36](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/rpc.ts#L36)
+[sdk/src/rpc/rpc.ts:36](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L36)
 
 ## Properties
 
@@ -63,7 +63,7 @@ Instance of Query struct from wasm lib
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:38](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/rpc.ts#L38)
+[sdk/src/rpc/rpc.ts:38](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L38)
 
 ___
 
@@ -75,7 +75,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:37](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/rpc.ts#L37)
+[sdk/src/rpc/rpc.ts:37](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L37)
 
 ## Methods
 
@@ -102,7 +102,7 @@ TxResponseProps object
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:223](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/rpc.ts#L223)
+[sdk/src/rpc/rpc.ts:223](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L223)
 
 ___
 
@@ -122,7 +122,7 @@ Array of all validator addresses
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:78](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/rpc.ts#L78)
+[sdk/src/rpc/rpc.ts:78](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L78)
 
 ___
 
@@ -149,7 +149,7 @@ Query balances from chain
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:48](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/rpc.ts#L48)
+[sdk/src/rpc/rpc.ts:48](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L48)
 
 ___
 
@@ -169,7 +169,7 @@ Object
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:203](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/rpc.ts#L203)
+[sdk/src/rpc/rpc.ts:203](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L203)
 
 ___
 
@@ -195,7 +195,7 @@ Promise resolving to delegators votes
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:102](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/rpc.ts#L102)
+[sdk/src/rpc/rpc.ts:102](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L102)
 
 ___
 
@@ -215,7 +215,7 @@ Query gas costs
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:194](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/rpc.ts#L194)
+[sdk/src/rpc/rpc.ts:194](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L194)
 
 ___
 
@@ -235,7 +235,7 @@ Address of native token
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:57](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/rpc.ts#L57)
+[sdk/src/rpc/rpc.ts:57](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L57)
 
 ___
 
@@ -262,7 +262,7 @@ String of public key if found
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:68](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/rpc.ts#L68)
+[sdk/src/rpc/rpc.ts:68](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L68)
 
 ___
 
@@ -288,7 +288,7 @@ Promise resolving to pending ethereum transfers
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:185](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/rpc.ts#L185)
+[sdk/src/rpc/rpc.ts:185](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L185)
 
 ___
 
@@ -314,7 +314,7 @@ Promise resolving to staking positions
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:139](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/rpc.ts#L139)
+[sdk/src/rpc/rpc.ts:139](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L139)
 
 ___
 
@@ -340,7 +340,7 @@ Promise resolving to staking totals
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:112](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/rpc.ts#L112)
+[sdk/src/rpc/rpc.ts:112](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L112)
 
 ___
 
@@ -364,7 +364,7 @@ Total bonds amount
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:175](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/rpc.ts#L175)
+[sdk/src/rpc/rpc.ts:175](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L175)
 
 ___
 
@@ -391,7 +391,7 @@ Promise resolving to total delegations
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:89](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/rpc.ts#L89)
+[sdk/src/rpc/rpc.ts:89](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L89)
 
 ___
 
@@ -415,4 +415,4 @@ Sync the shielded context
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:241](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/rpc.ts#L241)
+[sdk/src/rpc/rpc.ts:241](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L241)

--- a/packages/sdk/docs/classes/Sdk.md
+++ b/packages/sdk/docs/classes/Sdk.md
@@ -64,7 +64,7 @@ API for interacting with Namada SDK
 
 #### Defined in
 
-[sdk/src/sdk.ts:24](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L24)
+[sdk/src/sdk.ts:24](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L24)
 
 ## Properties
 
@@ -76,7 +76,7 @@ Memory accessor for crypto lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:27](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L27)
+[sdk/src/sdk.ts:27](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L27)
 
 ___
 
@@ -88,7 +88,7 @@ Address of chain's native token
 
 #### Defined in
 
-[sdk/src/sdk.ts:29](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L29)
+[sdk/src/sdk.ts:29](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L29)
 
 ___
 
@@ -100,7 +100,7 @@ Instance of Query struct from wasm lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:26](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L26)
+[sdk/src/sdk.ts:26](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L26)
 
 ___
 
@@ -112,7 +112,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:25](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L25)
+[sdk/src/sdk.ts:25](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L25)
 
 ___
 
@@ -124,7 +124,7 @@ RPC url
 
 #### Defined in
 
-[sdk/src/sdk.ts:28](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L28)
+[sdk/src/sdk.ts:28](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L28)
 
 ## Accessors
 
@@ -142,7 +142,7 @@ Utilities for encrypting and decrypting data
 
 #### Defined in
 
-[sdk/src/sdk.ts:174](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L174)
+[sdk/src/sdk.ts:174](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L174)
 
 ___
 
@@ -160,7 +160,7 @@ key-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:150](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L150)
+[sdk/src/sdk.ts:150](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L150)
 
 ___
 
@@ -178,7 +178,7 @@ Masp utilities for handling params
 
 #### Defined in
 
-[sdk/src/sdk.ts:166](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L166)
+[sdk/src/sdk.ts:166](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L166)
 
 ___
 
@@ -196,7 +196,7 @@ mnemonic-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:142](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L142)
+[sdk/src/sdk.ts:142](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L142)
 
 ___
 
@@ -214,7 +214,7 @@ rpc client
 
 #### Defined in
 
-[sdk/src/sdk.ts:126](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L126)
+[sdk/src/sdk.ts:126](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L126)
 
 ___
 
@@ -232,7 +232,7 @@ Non-Tx signing functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:158](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L158)
+[sdk/src/sdk.ts:158](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L158)
 
 ___
 
@@ -250,7 +250,7 @@ tx-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:134](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L134)
+[sdk/src/sdk.ts:134](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L134)
 
 ___
 
@@ -268,7 +268,7 @@ Version from package.json
 
 #### Defined in
 
-[sdk/src/sdk.ts:182](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L182)
+[sdk/src/sdk.ts:182](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L182)
 
 ## Methods
 
@@ -286,7 +286,7 @@ Utilities for encrypting and decrypting data
 
 #### Defined in
 
-[sdk/src/sdk.ts:101](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L101)
+[sdk/src/sdk.ts:101](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L101)
 
 ___
 
@@ -304,7 +304,7 @@ key-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:77](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L77)
+[sdk/src/sdk.ts:77](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L77)
 
 ___
 
@@ -322,7 +322,7 @@ Masp utilities for handling params
 
 #### Defined in
 
-[sdk/src/sdk.ts:93](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L93)
+[sdk/src/sdk.ts:93](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L93)
 
 ___
 
@@ -340,7 +340,7 @@ mnemonic-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:69](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L69)
+[sdk/src/sdk.ts:69](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L69)
 
 ___
 
@@ -358,7 +358,7 @@ Namada RPC client
 
 #### Defined in
 
-[sdk/src/sdk.ts:53](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L53)
+[sdk/src/sdk.ts:53](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L53)
 
 ___
 
@@ -376,7 +376,7 @@ Non-Tx signing functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:85](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L85)
+[sdk/src/sdk.ts:85](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L85)
 
 ___
 
@@ -394,7 +394,7 @@ Tx-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:61](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L61)
+[sdk/src/sdk.ts:61](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L61)
 
 ___
 
@@ -410,7 +410,7 @@ Return SDK Package version
 
 #### Defined in
 
-[sdk/src/sdk.ts:118](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L118)
+[sdk/src/sdk.ts:118](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L118)
 
 ___
 
@@ -436,7 +436,7 @@ Class for interacting with NamadaApp for Ledger Hardware Wallets
 
 #### Defined in
 
-[sdk/src/sdk.ts:111](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L111)
+[sdk/src/sdk.ts:111](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L111)
 
 ___
 
@@ -461,4 +461,4 @@ this instance of Sdk
 
 #### Defined in
 
-[sdk/src/sdk.ts:38](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/sdk.ts#L38)
+[sdk/src/sdk.ts:38](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L38)

--- a/packages/sdk/docs/classes/Signing.md
+++ b/packages/sdk/docs/classes/Signing.md
@@ -40,7 +40,7 @@ Signing constructor
 
 #### Defined in
 
-[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/signing.ts#L14)
+[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/signing.ts#L14)
 
 ## Properties
 
@@ -52,7 +52,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/signing.ts#L14)
+[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/signing.ts#L14)
 
 ## Methods
 
@@ -78,7 +78,7 @@ signed tx bytes - Promise resolving to Uint8Array
 
 #### Defined in
 
-[sdk/src/signing.ts:23](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/signing.ts#L23)
+[sdk/src/signing.ts:23](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/signing.ts#L23)
 
 ___
 
@@ -103,7 +103,7 @@ hash and signature
 
 #### Defined in
 
-[sdk/src/signing.ts:41](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/signing.ts#L41)
+[sdk/src/signing.ts:41](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/signing.ts#L41)
 
 ___
 
@@ -129,4 +129,4 @@ void
 
 #### Defined in
 
-[sdk/src/signing.ts:52](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/signing.ts#L52)
+[sdk/src/signing.ts:52](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/signing.ts#L52)

--- a/packages/sdk/docs/classes/Tx.md
+++ b/packages/sdk/docs/classes/Tx.md
@@ -54,7 +54,7 @@ SDK functionality related to transactions
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:56](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/tx/tx.ts#L56)
+[sdk/src/tx/tx.ts:56](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L56)
 
 ## Properties
 
@@ -66,7 +66,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:56](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/tx/tx.ts#L56)
+[sdk/src/tx/tx.ts:56](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L56)
 
 ## Methods
 
@@ -91,7 +91,7 @@ Append signature for transactions signed by Ledger Hardware Wallet
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:373](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/tx/tx.ts#L373)
+[sdk/src/tx/tx.ts:375](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L375)
 
 ___
 
@@ -115,7 +115,7 @@ a serialized TxMsgValue type
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:356](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/tx/tx.ts#L356)
+[sdk/src/tx/tx.ts:358](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L358)
 
 ___
 
@@ -142,7 +142,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:178](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/tx/tx.ts#L178)
+[sdk/src/tx/tx.ts:178](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L178)
 
 ___
 
@@ -169,7 +169,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:335](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/tx/tx.ts#L335)
+[sdk/src/tx/tx.ts:337](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L337)
 
 ___
 
@@ -196,7 +196,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:288](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/tx/tx.ts#L288)
+[sdk/src/tx/tx.ts:290](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L290)
 
 ___
 
@@ -205,6 +205,8 @@ ___
 ▸ **buildIbcTransfer**(`wrapperTxProps`, `ibcTransferProps`): `Promise`\<`TxMsgValue`\>
 
 Build Ibc Transfer Tx
+`ibcTransferProps.amountInBaseDenom` is the amount in the **base** denom
+e.g. the value of 1 NAM should be BigNumber(1_000_000), not BigNumber(1).
 
 #### Parameters
 
@@ -223,7 +225,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:265](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/tx/tx.ts#L265)
+[sdk/src/tx/tx.ts:267](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L267)
 
 ___
 
@@ -250,7 +252,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:242](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/tx/tx.ts#L242)
+[sdk/src/tx/tx.ts:242](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L242)
 
 ___
 
@@ -276,7 +278,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:165](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/tx/tx.ts#L165)
+[sdk/src/tx/tx.ts:165](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L165)
 
 ___
 
@@ -303,7 +305,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:90](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/tx/tx.ts#L90)
+[sdk/src/tx/tx.ts:90](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L90)
 
 ___
 
@@ -330,7 +332,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:115](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/tx/tx.ts#L115)
+[sdk/src/tx/tx.ts:115](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L115)
 
 ___
 
@@ -357,7 +359,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:65](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/tx/tx.ts#L65)
+[sdk/src/tx/tx.ts:65](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L65)
 
 ___
 
@@ -384,7 +386,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:199](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/tx/tx.ts#L199)
+[sdk/src/tx/tx.ts:199](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L199)
 
 ___
 
@@ -411,7 +413,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:141](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/tx/tx.ts#L141)
+[sdk/src/tx/tx.ts:141](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L141)
 
 ___
 
@@ -438,7 +440,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:311](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/tx/tx.ts#L311)
+[sdk/src/tx/tx.ts:313](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L313)
 
 ___
 
@@ -465,7 +467,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:221](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/tx/tx.ts#L221)
+[sdk/src/tx/tx.ts:221](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L221)
 
 ___
 
@@ -490,7 +492,7 @@ a TxDetails object
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:426](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/tx/tx.ts#L426)
+[sdk/src/tx/tx.ts:428](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L428)
 
 ___
 
@@ -514,7 +516,7 @@ Serialized WrapperTxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:414](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/tx/tx.ts#L414)
+[sdk/src/tx/tx.ts:416](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L416)
 
 ___
 
@@ -544,7 +546,7 @@ promise that resolves to the shielding memo
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:489](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/tx/tx.ts#L489)
+[sdk/src/tx/tx.ts:491](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L491)
 
 ___
 
@@ -568,4 +570,4 @@ array of inner Tx hashes
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:508](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/tx/tx.ts#L508)
+[sdk/src/tx/tx.ts:510](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L510)

--- a/packages/sdk/docs/enums/KdfType.md
+++ b/packages/sdk/docs/enums/KdfType.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:38](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/crypto/types.ts#L38)
+[sdk/src/crypto/types.ts:38](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/types.ts#L38)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:39](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/crypto/types.ts#L39)
+[sdk/src/crypto/types.ts:39](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/types.ts#L39)

--- a/packages/sdk/docs/enums/TxType.md
+++ b/packages/sdk/docs/enums/TxType.md
@@ -26,7 +26,7 @@
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:41
+shared/src/shared/shared.d.ts:37
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:32
+shared/src/shared/shared.d.ts:28
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:42
+shared/src/shared/shared.d.ts:38
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:37
+shared/src/shared/shared.d.ts:33
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:36
+shared/src/shared/shared.d.ts:32
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:40
+shared/src/shared/shared.d.ts:36
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:38
+shared/src/shared/shared.d.ts:34
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:35
+shared/src/shared/shared.d.ts:31
 
 ___
 
@@ -106,7 +106,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:33
+shared/src/shared/shared.d.ts:29
 
 ___
 
@@ -116,7 +116,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:39
+shared/src/shared/shared.d.ts:35
 
 ___
 
@@ -126,4 +126,4 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:34
+shared/src/shared/shared.d.ts:30

--- a/packages/sdk/docs/modules.md
+++ b/packages/sdk/docs/modules.md
@@ -69,7 +69,7 @@ Address and public key type
 
 #### Defined in
 
-[sdk/src/keys/types.ts:4](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/keys/types.ts#L4)
+[sdk/src/keys/types.ts:4](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/keys/types.ts#L4)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:23](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/crypto/types.ts#L23)
+[sdk/src/crypto/types.ts:23](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/types.ts#L23)
 
 ___
 
@@ -92,7 +92,7 @@ Balance
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:69](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/types.ts#L69)
+[sdk/src/rpc/types.ts:69](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/types.ts#L69)
 
 ___
 
@@ -111,7 +111,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:27](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/types.ts#L27)
+[sdk/src/rpc/types.ts:27](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/types.ts#L27)
 
 ___
 
@@ -139,7 +139,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:42](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/crypto/types.ts#L42)
+[sdk/src/crypto/types.ts:42](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/types.ts#L42)
 
 ___
 
@@ -152,7 +152,7 @@ Record<address, totalDelegations>
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:51](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/types.ts#L51)
+[sdk/src/rpc/types.ts:51](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/types.ts#L51)
 
 ___
 
@@ -165,7 +165,7 @@ Record<address, boolean>
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:57](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/types.ts#L57)
+[sdk/src/rpc/types.ts:57](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/types.ts#L57)
 
 ___
 
@@ -184,7 +184,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:30](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/crypto/types.ts#L30)
+[sdk/src/crypto/types.ts:30](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/types.ts#L30)
 
 ___
 
@@ -201,7 +201,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:19](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/ledger.ts#L19)
+[sdk/src/ledger.ts:19](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L19)
 
 ___
 
@@ -223,7 +223,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:20](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/ledger.ts#L20)
+[sdk/src/ledger.ts:20](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L20)
 
 ___
 
@@ -240,7 +240,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:32](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/ledger.ts#L32)
+[sdk/src/ledger.ts:32](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L32)
 
 ___
 
@@ -260,7 +260,7 @@ Shielded keys and address
 
 #### Defined in
 
-[sdk/src/keys/types.ts:19](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/keys/types.ts#L19)
+[sdk/src/keys/types.ts:19](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/keys/types.ts#L19)
 
 ___
 
@@ -277,7 +277,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:42](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/types.ts#L42)
+[sdk/src/rpc/types.ts:42](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/types.ts#L42)
 
 ___
 
@@ -297,7 +297,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:19](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/types.ts#L19)
+[sdk/src/rpc/types.ts:19](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/types.ts#L19)
 
 ___
 
@@ -307,7 +307,7 @@ ___
 
 #### Defined in
 
-[shared/src/types.ts:3](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/shared/src/types.ts#L3)
+[shared/src/types.ts:3](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/shared/src/types.ts#L3)
 
 ___
 
@@ -319,7 +319,7 @@ Public and private keypair with address
 
 #### Defined in
 
-[sdk/src/keys/types.ts:12](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/keys/types.ts#L12)
+[sdk/src/keys/types.ts:12](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/keys/types.ts#L12)
 
 ___
 
@@ -339,7 +339,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:34](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/rpc/types.ts#L34)
+[sdk/src/rpc/types.ts:34](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/types.ts#L34)
 
 ## Variables
 
@@ -357,7 +357,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:3](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/crypto/types.ts#L3)
+[sdk/src/crypto/types.ts:3](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/types.ts#L3)
 
 ___
 
@@ -367,7 +367,7 @@ ___
 
 #### Defined in
 
-[shared/src/types.ts:28](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/shared/src/types.ts#L28)
+[shared/src/types.ts:28](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/shared/src/types.ts#L28)
 
 ## Functions
 
@@ -387,7 +387,7 @@ Transport object
 
 #### Defined in
 
-[sdk/src/ledger.ts:51](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/ledger.ts#L51)
+[sdk/src/ledger.ts:51](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L51)
 
 ___
 
@@ -407,7 +407,7 @@ Transport object
 
 #### Defined in
 
-[sdk/src/ledger.ts:42](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/ledger.ts#L42)
+[sdk/src/ledger.ts:42](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L42)
 
 ___
 
@@ -427,4 +427,4 @@ ___
 
 #### Defined in
 
-[sdk/src/keys/keys.ts:213](https://github.com/anoma/namada-interface/blob/08d7e68aa81c77115b4753e6531ec58175ea84a2/packages/sdk/src/keys/keys.ts#L213)
+[sdk/src/keys/keys.ts:213](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/keys/keys.ts#L213)

--- a/packages/sdk/src/tx/tx.ts
+++ b/packages/sdk/src/tx/tx.ts
@@ -257,6 +257,8 @@ export class Tx {
 
   /**
    * Build Ibc Transfer Tx
+   * `ibcTransferProps.amountInBaseDenom` is the amount in the **base** denom
+   * e.g. the value of 1 NAM should be BigNumber(1_000_000), not BigNumber(1).
    * @async
    * @param wrapperTxProps - properties of the transaction
    * @param ibcTransferProps - properties of the ibc transfer tx

--- a/packages/shared/lib/src/sdk/args.rs
+++ b/packages/shared/lib/src/sdk/args.rs
@@ -691,7 +691,7 @@ pub struct IbcTransferMsg {
     source: String,
     receiver: String,
     token: String,
-    amount: String,
+    amount_in_base_denom: String,
     port_id: String,
     channel_id: String,
     timeout_height: Option<u64>,
@@ -705,7 +705,7 @@ impl IbcTransferMsg {
         source: String,
         receiver: String,
         token: String,
-        amount: String,
+        amount_in_base_denom: String,
         port_id: String,
         channel_id: String,
         timeout_height: Option<u64>,
@@ -717,7 +717,7 @@ impl IbcTransferMsg {
             source,
             receiver,
             token,
-            amount,
+            amount_in_base_denom,
             port_id,
             channel_id,
             timeout_height,
@@ -748,7 +748,7 @@ pub fn ibc_transfer_tx_args(
         source,
         receiver,
         token,
-        amount,
+        amount_in_base_denom,
         port_id,
         channel_id,
         timeout_height,
@@ -760,8 +760,14 @@ pub fn ibc_transfer_tx_args(
     let source_address = Address::from_str(&source)?;
     let source = TransferSource::Address(source_address);
     let token = Address::from_str(&token)?;
-    let denom_amount = DenominatedAmount::from_str(&amount).expect("Amount to be valid.");
-    let amount = InputAmount::Unvalidated(denom_amount);
+    let amount = Amount::from_str(
+        &amount_in_base_denom,
+        0u8
+    ).expect("Amount to be valid.");
+    // Using InputAmount::Validated because the amount is already in the base
+    // denom. If Unvalidated is used, the SDK will change the denom based on the
+    // token address, which complicates knowing which amount to pass to this function.
+    let amount = InputAmount::Validated(amount.into());
     let port_id = PortId::from_str(&port_id).expect("Port id to be valid");
     let channel_id = ChannelId::from_str(&channel_id).expect("Channel id to be valid");
     let ibc_shielding_data = match shielding_data {

--- a/packages/types/src/tx/schema/ibcTransfer.ts
+++ b/packages/types/src/tx/schema/ibcTransfer.ts
@@ -15,7 +15,7 @@ export class IbcTransferMsgValue {
   token!: string;
 
   @field(BigNumberSerializer)
-  amount!: BigNumber;
+  amountInBaseDenom!: BigNumber;
 
   @field({ type: "string" })
   portId!: string;


### PR DESCRIPTION
This PR allows IBC withdrawals for all assets, instead of just NAM.

There is still zero indication to the user about whether the transaction failed or succeeded, but for testing this information should be displayed in the console.

---

### Changed
- Use base denom amounts when building IBC transfers with JS SDK
- Use unknown gas limit value for txs without an indexer type

### Added
- Enable IBC withdrawals for all tokens. Closes #1242

### Fixed
- Use same gas limit and price for IBC withdrawal as rest of Namadillo
- Reveal public key if needed for IBC withdrawal. Fixes #1222