### PR TITLE
feat: auto-fill IBC channel inputs

### DIFF
--- a/apps/namadillo/src/App/Ibc/IbcTransfer.tsx
+++ b/apps/namadillo/src/App/Ibc/IbcTransfer.tsx
@@ -11,6 +11,7 @@ import {
   assetBalanceAtomFamily,
   availableChainsAtom,
   chainRegistryAtom,
+  ibcChannelsFamily,
   ibcTransferAtom,
 } from "atoms/integrations";
 import clsx from "clsx";
@@ -34,6 +35,9 @@ export const IbcTransfer: React.FC = () => {
   const [shielded, setShielded] = useState<boolean>(true);
   const [selectedAssetAddress, setSelectedAssetAddress] = useState<Address>();
   const [generalErrorMessage, setGeneralErrorMessage] = useState("");
+  const [sourceChannel, setSourceChannel] = useState("");
+  const [destinationChannel, setDestinationChannel] = useState("");
+
   const performIbcTransfer = useAtomValue(ibcTransferAtom);
   const defaultAccounts = useAtomValue(allDefaultAccountsAtom);
   const {
@@ -91,10 +95,18 @@ export const IbcTransfer: React.FC = () => {
     );
   }, [defaultAccounts, shielded]);
 
+  const { data: ibcChannels } = useAtomValue(
+    ibcChannelsFamily(registry?.chain.chain_name)
+  );
+
+  useEffect(() => {
+    setSourceChannel(ibcChannels?.cosmosChannelId || "");
+    setDestinationChannel(ibcChannels?.namadaChannelId || "");
+  }, [ibcChannels]);
+
   const onSubmitTransfer = async ({
     amount,
     destinationAddress,
-    ibcOptions,
   }: OnSubmitTransferParams): Promise<void> => {
     try {
       setGeneralErrorMessage("");
@@ -120,11 +132,11 @@ export const IbcTransfer: React.FC = () => {
         throw new Error("Invalid chain");
       }
 
-      if (!ibcOptions?.sourceChannel) {
+      if (!sourceChannel) {
         throw new Error("Invalid IBC source channel");
       }
 
-      if (shielded && !ibcOptions.destinationChannel) {
+      if (shielded && !destinationChannel) {
         throw new Error("Invalid IBC destination channel");
       }
 
@@ -164,11 +176,11 @@ export const IbcTransfer: React.FC = () => {
             amount,
             asset: selectedAsset,
             transactionFee,
-            sourceChannelId: ibcOptions.sourceChannel,
+            sourceChannelId: sourceChannel.trim(),
             ...(shielded ?
               {
                 isShielded: true,
-                destinationChannelId: ibcOptions.destinationChannel,
+                destinationChannelId: destinationChannel.trim(),
               }
             : {
                 isShielded: false,
@@ -230,6 +242,12 @@ export const IbcTransfer: React.FC = () => {
               transactionFee={transactionFee}
               isSubmitting={performIbcTransfer.isPending}
               isIbcTransfer={true}
+              ibcOptions={{
+                sourceChannel,
+                onChangeSourceChannel: setSourceChannel,
+                destinationChannel,
+                onChangeDestinationChannel: setDestinationChannel,
+              }}
               errorMessage={generalErrorMessage}
               onSubmitTransfer={onSubmitTransfer}
             />

--- a/apps/namadillo/src/App/Transfer/TransferModule.tsx
+++ b/apps/namadillo/src/App/Transfer/TransferModule.tsx
@@ -42,8 +42,10 @@ export type TransferSourceProps = TransferModuleConfig & {
 };
 
 export type IbcOptions = {
-  destinationChannel: string;
   sourceChannel: string;
+  onChangeSourceChannel: (channel: string) => void;
+  destinationChannel?: string;
+  onChangeDestinationChannel?: (channel: string) => void;
 };
 
 export type TransferDestinationProps = TransferModuleConfig & {
@@ -55,7 +57,6 @@ export type OnSubmitTransferParams = {
   amount: BigNumber;
   destinationAddress: Address;
   memo?: string;
-  ibcOptions?: IbcOptions;
 };
 
 export type TransferModuleProps = {
@@ -63,10 +64,12 @@ export type TransferModuleProps = {
   destination: TransferDestinationProps;
   transactionFee?: TransactionFee;
   isSubmitting?: boolean;
-  isIbcTransfer?: boolean;
   errorMessage?: string;
   onSubmitTransfer: (params: OnSubmitTransferParams) => void;
-};
+} & (
+  | { isIbcTransfer?: false; ibcOptions?: undefined }
+  | { isIbcTransfer: true; ibcOptions: IbcOptions }
+);
 
 type ValidationResult =
   | "NoAmount"
@@ -85,6 +88,7 @@ export const TransferModule = ({
   transactionFee,
   isSubmitting,
   isIbcTransfer,
+  ibcOptions,
   onSubmitTransfer,
   errorMessage,
 }: TransferModuleProps): JSX.Element => {
@@ -97,8 +101,6 @@ export const TransferModule = ({
   const [memo, setMemo] = useState<undefined | string>("");
   const [customAddress, setCustomAddress] = useState<undefined | string>("");
   const [amount, setAmount] = useState<BigNumber | undefined>(new BigNumber(0));
-  const [sourceIbcChannel, setSourceIbcChannel] = useState("");
-  const [destinationIbcChannel, setDestinationIbcChannel] = useState("");
 
   const selectedAsset = mapUndefined(
     (address) => source.availableAssets?.[address],
@@ -171,13 +173,6 @@ export const TransferModule = ({
       destinationAddress: address.trim(),
       memo,
     };
-
-    if (isIbcTransfer) {
-      params.ibcOptions = {
-        sourceChannel: sourceIbcChannel.trim(),
-        destinationChannel: destinationIbcChannel.trim(),
-      };
-    }
 
     onSubmitTransfer?.(params);
   };
@@ -315,10 +310,10 @@ export const TransferModule = ({
           {isIbcTransfer && (
             <IbcChannels
               isShielded={Boolean(source.isShielded || destination.isShielded)}
-              sourceChannel={sourceIbcChannel}
-              onChangeSource={setSourceIbcChannel}
-              destinationChannel={destinationIbcChannel}
-              onChangeDestination={setDestinationIbcChannel}
+              sourceChannel={ibcOptions.sourceChannel}
+              onChangeSource={ibcOptions.onChangeSourceChannel}
+              destinationChannel={ibcOptions.destinationChannel}
+              onChangeDestination={ibcOptions.onChangeDestinationChannel}
             />
           )}
           <InlineError errorMessage={errorMessage} />

--- a/apps/namadillo/src/atoms/integrations/functions.ts
+++ b/apps/namadillo/src/atoms/integrations/functions.ts
@@ -283,6 +283,53 @@ export const getRestApiAddressByIndex = (chain: Chain, index = 0): string => {
   return randomRestApi.address;
 };
 
+export type IbcChannels = {
+  namadaChannelId: string;
+  cosmosChannelId: string;
+};
+
+export const getIbcChannels = (
+  namadaChainId: string,
+  cosmosChainName: string
+): IbcChannels | undefined => {
+  const namadaChainName = cosmosRegistry.chains.find(
+    (chain) => chain.chain_id === namadaChainId
+  )?.chain_name;
+
+  if (typeof namadaChainName === "undefined") {
+    return undefined;
+  }
+
+  for (const ibcEntry of cosmosRegistry.ibc) {
+    const { chain_1, chain_2, channels } = ibcEntry;
+    const channelEntry = channels[0];
+
+    if (typeof channelEntry === "undefined") {
+      continue;
+    }
+
+    if (
+      chain_1.chain_name === namadaChainName &&
+      chain_2.chain_name === cosmosChainName
+    ) {
+      return {
+        namadaChannelId: channelEntry.chain_1.channel_id,
+        cosmosChannelId: channelEntry.chain_2.channel_id,
+      };
+    }
+
+    if (
+      chain_1.chain_name === cosmosChainName &&
+      chain_2.chain_name === namadaChainName
+    ) {
+      return {
+        cosmosChannelId: channelEntry.chain_1.channel_id,
+        namadaChannelId: channelEntry.chain_2.channel_id,
+      };
+    }
+  }
+};
+
 export const createIbcTx = async (
   account: Account,
   destinationAddress: string,


### PR DESCRIPTION
This PR makes the IBC channels on the IBC Transfer and IBC Withdraw pages be auto-filled when there is a known IBC config, but still supports manually changing the inputs.

Closes #1241.