### PR TITLE
fix: Add missing ibc references, add assets for namadadryrun

### DIFF
--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -27,7 +27,7 @@
     "jotai": "^2.6.3",
     "jotai-tanstack-query": "^0.8.5",
     "lodash.debounce": "^4.0.8",
-    "namada-chain-registry": "https://github.com/anoma/namada-chain-registry",
+    "namada-chain-registry": "https://github.com/anoma/namada-chain-registry#commit=622fe20a38657f531ff3d59837b59f270468832c",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.1.0",

--- a/apps/namadillo/src/atoms/integrations/functions.ts
+++ b/apps/namadillo/src/atoms/integrations/functions.ts
@@ -29,11 +29,14 @@ import {
 import { toBaseAmount, toDisplayAmount } from "utils";
 import { getSdkInstance } from "utils/sdk";
 
+import dryrunAssets from "namada-chain-registry/namadadryrun/assetlist.json";
+import dryrunChain from "namada-chain-registry/namadadryrun/chain.json";
 import housefireAssets from "namada-chain-registry/namadahousefire/assetlist.json";
 import housefireChain from "namada-chain-registry/namadahousefire/chain.json";
 import internalDevnetAssets from "namada-chain-registry/namadainternaldevnet/assetlist.json";
 import internalDevnetChain from "namada-chain-registry/namadainternaldevnet/chain.json";
 
+import dryrunOsmosis from "namada-chain-registry/_IBC/namadadryrun-osmosis.json";
 import housefireCosmosTestnetIbc from "namada-chain-registry/_IBC/namadahousefire-cosmoshubtestnet.json";
 import housefireOsmosisTestnetIbc from "namada-chain-registry/_IBC/namadahousefire-osmosistestnet.json";
 import internalDevnetCosmosTestnetIbc from "namada-chain-registry/_IBC/namadainternaldevnet-cosmoshubtestnet.json";
@@ -41,14 +44,15 @@ import internalDevnetCosmosTestnetIbc from "namada-chain-registry/_IBC/namadaint
 // TODO: this causes a big increase on bundle size. See #1224.
 import cosmosRegistry from "chain-registry";
 
-cosmosRegistry.chains.push(internalDevnetChain, housefireChain);
+cosmosRegistry.chains.push(internalDevnetChain, housefireChain, dryrunChain);
 
-cosmosRegistry.assets.push(internalDevnetAssets, housefireAssets);
+cosmosRegistry.assets.push(internalDevnetAssets, housefireAssets, dryrunAssets);
 
 cosmosRegistry.ibc.push(
   internalDevnetCosmosTestnetIbc,
   housefireCosmosTestnetIbc,
-  housefireOsmosisTestnetIbc
+  housefireOsmosisTestnetIbc,
+  dryrunOsmosis
 );
 
 const mainnetChains: ChainRegistryEntry[] = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3678,7 +3678,7 @@ __metadata:
     jotai-tanstack-query: "npm:^0.8.5"
     local-cors-proxy: "npm:^1.1.0"
     lodash.debounce: "npm:^4.0.8"
-    namada-chain-registry: "https://github.com/anoma/namada-chain-registry"
+    namada-chain-registry: "https://github.com/anoma/namada-chain-registry#commit=622fe20a38657f531ff3d59837b59f270468832c"
     postcss: "npm:^8.4.32"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
@@ -15816,10 +15816,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"namada-chain-registry@https://github.com/anoma/namada-chain-registry":
+"namada-chain-registry@https://github.com/anoma/namada-chain-registry#commit=622fe20a38657f531ff3d59837b59f270468832c":
   version: 0.0.1
-  resolution: "namada-chain-registry@https://github.com/anoma/namada-chain-registry.git#commit=ca1d841d75f105fe91a907c678a4fe3077d0f1e8"
-  checksum: f9223374efee6af23f9485a82074d2fa34f4a38f5592bd947ee3be845bdfe648d692980805a03f15ada6b077585f6ef0e05baf0542e2ec6fc33dd4d683064f78
+  resolution: "namada-chain-registry@https://github.com/anoma/namada-chain-registry.git#commit=622fe20a38657f531ff3d59837b59f270468832c"
+  checksum: ab01cbc990ae66463737380fba48fc78aadfe3d3cabac544856b2dd4c70166e0a99ba407e7330c7a8d9651eee4507809344583a2d2520540e436afb1c1b00f78
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes an issue on Namada Dry-Run net on IBC form where NAM asset is not displayed properly.

This also adds the Osmosis mainnet channels!



### Screenshots

Before:
![Screen Shot 2024-11-18 at 9 09 00 AM](https://github.com/user-attachments/assets/d567e582-d791-4208-beb7-eb6cfe014d38)

After:
![Screen Shot 2024-11-18 at 9 35 40 AM](https://github.com/user-attachments/assets/e71a7556-59a7-4e08-a55a-e57ab3036ff3)
