### PR TITLE
fix/1254 - Namadillo: Show advanced settings when a config.toml is present

### DIFF
--- a/apps/namadillo/src/App/Settings/Advanced.tsx
+++ b/apps/namadillo/src/App/Settings/Advanced.tsx
@@ -1,7 +1,9 @@
 import { ActionButton, Checkbox, Input, Stack } from "@namada/components";
 import { chainParametersAtom } from "atoms/chain";
 import {
+  indexerUrlAtom,
   maspIndexerUrlAtom,
+  rpcUrlAtom,
   settingsAtom,
   updateIndexerUrlAtom,
   updateMaspIndexerUrlAtom,
@@ -20,11 +22,13 @@ export const Advanced = (): JSX.Element => {
   const rpcMutation = useAtomValue(updateRpcUrlAtom);
   const indexerMutation = useAtomValue(updateIndexerUrlAtom);
   const [currentMaspIndexer] = useAtom(maspIndexerUrlAtom);
+  const [currentRpcUrl] = useAtom(rpcUrlAtom);
+  const [currentIndexerUrl] = useAtom(indexerUrlAtom);
   const [maspIndexerMutation] = useAtom(updateMaspIndexerUrlAtom);
   const { data: chainParameters } = useAtomValue(chainParametersAtom);
 
-  const [rpc, setRpc] = useState(settings.rpcUrl || "");
-  const [indexer, setIndexer] = useState(settings.indexerUrl);
+  const [rpc, setRpc] = useState(currentRpcUrl);
+  const [indexer, setIndexer] = useState(currentIndexerUrl);
   const [enableTestnets, setTestnetsEnabled] = useState<boolean>(
     settings.enableTestnets || false
   );


### PR DESCRIPTION
Resolves #1254 

### Testing

1. Delete `localStorage` values for `settings` (if any)
2. Use the following `config.toml` (or similar)

  ```toml
  # namadadryrun
  indexer_url = "https://indexer.namada-dryrun.tududes.com"
  rpc_url = "https://rpc.namada-dryrun.tududes.com"
  masp_indexer_url = "https://masp.namada-dryrun.tududes.com"
  ```

3. Load `Settings` -> `Advanced` - All fields should be present!
4. Change settings, should persist as usual

  ```bash
  # housefire
  https://indexer.knowable.run
  https://rpc.knowable.run
  https://masp.knowable.run
  ```

6. Test existing functionality when no `config.toml` is provided
