### PR TITLE
feat/1248: Display Sha256 hash of Proposal Wasm

### DIFF
--- a/apps/namadillo/src/App/Governance/VoteInfoCards.tsx
+++ b/apps/namadillo/src/App/Governance/VoteInfoCards.tsx
@@ -4,8 +4,10 @@ import { twMerge } from "tailwind-merge";
 import { SkeletonLoading } from "@namada/components";
 import { AddRemove, PgfActions, Proposal } from "@namada/types";
 
+import { sha256Hash } from "@namada/utils";
 import { proposalFamily } from "atoms/proposals";
 import { useAtomValue } from "jotai";
+import { useEffect, useState } from "react";
 import { secondsToDateTimeString } from "utils";
 
 const InfoCard: React.FC<
@@ -114,6 +116,19 @@ const LoadingCard: React.FC<{ className?: string }> = ({ className }) => (
 const Loaded: React.FC<{
   proposal: Proposal;
 }> = ({ proposal }) => {
+  const [dataHash, setDataHash] = useState<string>();
+
+  useEffect(() => {
+    if (
+      proposal.proposalType.type === "default_with_wasm" &&
+      proposal.proposalType.data.length > 0
+    ) {
+      sha256Hash(proposal.proposalType.data).then((hash) =>
+        setDataHash(hash.toUpperCase())
+      );
+    }
+  }, [proposal.proposalType]);
+
   return (
     <>
       <InfoCard
@@ -136,6 +151,13 @@ const Loaded: React.FC<{
         content={proposal.author}
         className="col-span-full"
       />
+      {dataHash && (
+        <InfoCard
+          title="Data Hash"
+          content={dataHash}
+          className="col-span-full"
+        />
+      )}
       {proposal.proposalType.type === "pgf_steward" && (
         <PgfStewardInfoCards addRemove={proposal.proposalType.data} />
       )}

--- a/packages/utils/src/crypto.ts
+++ b/packages/utils/src/crypto.ts
@@ -1,0 +1,10 @@
+/**
+ * Compute SHA256 hash from byte array, return as hexadecimal string
+ * @param msg - byte array
+ * @returns hash string
+ */
+export const sha256Hash = async (msg: Uint8Array): Promise<string> => {
+  const hashBuffer = await crypto.subtle.digest("SHA-256", msg);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((byte) => byte.toString(16).padStart(2, "0")).join("");
+};

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./async";
+export * from "./crypto";
 export * from "./helpers";
 export * from "./theme";


### PR DESCRIPTION
Resolves #1248 

When a proposal contains wasm data, display the sha256 checksum hash in the UI


## Screenshots

Namadillo (Proposal 1 on Dry-run)
![Screen Shot 2024-11-19 at 12 44 09 PM](https://github.com/user-attachments/assets/f78f0bc2-a6a1-4a95-ba68-efee48324c5d)

CLI (Proposal 1 on Dry-run):
<img width="703" alt="385420156-b69d879f-a440-4155-a8b9-47b12e031072" src="https://github.com/user-attachments/assets/8482b42b-6898-4be1-82b8-aa7ac44ae302">
