### PR TITLE
fix: robuster way to detect/install keplr (#1267)

### DIFF
--- a/apps/namadillo/src/App/Ibc/IbcTransfer.tsx
+++ b/apps/namadillo/src/App/Ibc/IbcTransfer.tsx
@@ -171,7 +171,7 @@ export const IbcTransfer: React.FC = () => {
         const tx = await performIbcTransfer.mutateAsync({
           chain: registry.chain,
           transferParams: {
-            signer: keplr.getSigner(chainId),
+            signer: await keplr.getSigner(chainId),
             chainId,
             sourceAddress,
             destinationAddress,

--- a/apps/namadillo/src/integrations/Keplr.ts
+++ b/apps/namadillo/src/integrations/Keplr.ts
@@ -15,9 +15,30 @@ export class KeplrWalletManager implements WalletConnector {
     console.warn("Keplr is not available. Redirecting to the Keplr download page...");
     window.open("https://www.keplr.app/get", "_blank");
   }
+  
+  private async _get(): Promise<Keplr | undefined> {
+    if ((window as KeplrWindow).keplr) {
+      return (window as KeplrWindow).keplr;
+    }
 
+    if (document.readyState === "complete") {
+      return (window as KeplrWindow).keplr;
+    }
+
+    return new Promise<Keplr | undefined>((resolve) => {
+      const documentStateChange = (event: Event): void => {
+        if (event.target && (event.target as Document).readyState === "complete") {
+          resolve((window as KeplrWindow).keplr);
+          document.removeEventListener("readystatechange", documentStateChange);
+        }
+      };
+      
+      document.addEventListener("readystatechange", documentStateChange);
+    });
+  }
+  
   async get(): Promise<Keplr> {
-    const keplr = await this._getKeplr();
+    const keplr = await this._get();
     if(!keplr) this.install();
     return keplr!;
   }
@@ -38,26 +59,5 @@ export class KeplrWalletManager implements WalletConnector {
   async getSigner(chainId: string): Promise<Signer> {
     const keplr = await this.get();
     return keplr.getOfflineSigner(chainId);
-  }
-  
-  private async _getKeplr(): Promise<Keplr | undefined> {
-    if ((window as KeplrWindow).keplr) {
-      return (window as KeplrWindow).keplr;
-    }
-
-    if (document.readyState === "complete") {
-      return (window as KeplrWindow).keplr;
-    }
-
-    return new Promise<Keplr | undefined>((resolve) => {
-      const documentStateChange = (event: Event): void => {
-        if (event.target && (event.target as Document).readyState === "complete") {
-          resolve((window as KeplrWindow).keplr);
-          document.removeEventListener("readystatechange", documentStateChange);
-        }
-      };
-      
-      document.addEventListener("readystatechange", documentStateChange);
-    });
   }
 }

--- a/apps/namadillo/src/integrations/Keplr.ts
+++ b/apps/namadillo/src/integrations/Keplr.ts
@@ -1,4 +1,5 @@
 import {
+  Keplr,
   Window as KeplrWindow,
   OfflineAminoSigner,
   OfflineDirectSigner,
@@ -8,21 +9,55 @@ import { WalletConnector } from "./types";
 import { basicConvertToKeplrChain } from "./utils";
 
 type Signer = OfflineAminoSigner & OfflineDirectSigner;
-const keplr = (window as KeplrWindow).keplr!;
 
 export class KeplrWalletManager implements WalletConnector {
+  install(): void {
+    console.warn("Keplr is not available. Redirecting to the Keplr download page...");
+    window.open("https://www.keplr.app/get", "_blank");
+  }
+
+  async get(): Promise<Keplr> {
+    const keplr = await this._getKeplr();
+    if(!keplr) this.install();
+    return keplr!;
+  }
+
   async connect(registry: ChainRegistryEntry): Promise<void> {
+    const keplr = await this.get();
     await keplr.experimentalSuggestChain(
       basicConvertToKeplrChain(registry.chain, registry.assets.assets)
     );
   }
 
   async getAddress(chainId: string): Promise<string> {
+    const keplr = await this.get();
     const keplrKey = await keplr.getKey(chainId);
     return keplrKey.bech32Address;
   }
 
-  getSigner(chainId: string): Signer {
+  async getSigner(chainId: string): Promise<Signer> {
+    const keplr = await this.get();
     return keplr.getOfflineSigner(chainId);
+  }
+  
+  private async _getKeplr(): Promise<Keplr | undefined> {
+    if ((window as KeplrWindow).keplr) {
+      return (window as KeplrWindow).keplr;
+    }
+
+    if (document.readyState === "complete") {
+      return (window as KeplrWindow).keplr;
+    }
+
+    return new Promise<Keplr | undefined>((resolve) => {
+      const documentStateChange = (event: Event): void => {
+        if (event.target && (event.target as Document).readyState === "complete") {
+          resolve((window as KeplrWindow).keplr);
+          document.removeEventListener("readystatechange", documentStateChange);
+        }
+      };
+      
+      document.addEventListener("readystatechange", documentStateChange);
+    });
   }
 }

--- a/apps/namadillo/src/integrations/Keplr.ts
+++ b/apps/namadillo/src/integrations/Keplr.ts
@@ -39,7 +39,6 @@ export class KeplrWalletManager implements WalletConnector {
   
   async get(): Promise<Keplr> {
     const keplr = await this._get();
-    if(!keplr) this.install();
     return keplr!;
   }
 

--- a/apps/namadillo/src/integrations/types.ts
+++ b/apps/namadillo/src/integrations/types.ts
@@ -1,6 +1,8 @@
 import { ChainRegistryEntry } from "types";
 
 export interface WalletConnector {
+  install(): void;
+  get(): unknown;
   connect(registry: ChainRegistryEntry): Promise<void>;
   getAddress(chainId: string): Promise<string>;
   getSigner(chainId: string): unknown | undefined;


### PR DESCRIPTION
PR to fix #1267. This makes use of a method described in https://docs.keplr.app/api/#how-to-detect-keplr to detect the Keplr wallet extension.

- This not only checks the `window`-object, but also checks the `document` state before it eventually decides whether Keplr is installed or not.
- Added an install method which opens the keplr download page in a _blank tab.
- Added the `install()` and `get()` functions to the `WalletConnector`-interface as this is likely going to become common among other integrations. But unsure about this, so tell me if this needs to go.
- `getSigner` needed to become an async function due to this detection method.

In my testing I didn't get problems with detecting Keplr anymore, but please double check if it's resolved. I'll also open another PR with a simpler approach, but I don't think that one is as robust as this method (#1283).


ZEN