### PR TITLE
fix: simple way to detect/install keplr (#1267)

### DIFF
--- a/apps/namadillo/src/integrations/Keplr.ts
+++ b/apps/namadillo/src/integrations/Keplr.ts
@@ -1,4 +1,5 @@
 import {
+  Keplr,
   Window as KeplrWindow,
   OfflineAminoSigner,
   OfflineDirectSigner,
@@ -8,21 +9,31 @@ import { WalletConnector } from "./types";
 import { basicConvertToKeplrChain } from "./utils";
 
 type Signer = OfflineAminoSigner & OfflineDirectSigner;
-const keplr = (window as KeplrWindow).keplr!;
 
 export class KeplrWalletManager implements WalletConnector {
+  get(): Keplr {
+    const keplr = (window as KeplrWindow).keplr;
+
+    if (!keplr) {
+      console.warn("Keplr is not available. Redirecting to the Keplr download page...");
+      window.open("https://www.keplr.app/get", "_blank");
+    }
+
+    return keplr!;
+  }
+
   async connect(registry: ChainRegistryEntry): Promise<void> {
-    await keplr.experimentalSuggestChain(
+    await this.get().experimentalSuggestChain(
       basicConvertToKeplrChain(registry.chain, registry.assets.assets)
     );
   }
 
   async getAddress(chainId: string): Promise<string> {
-    const keplrKey = await keplr.getKey(chainId);
+    const keplrKey = await this.get().getKey(chainId);
     return keplrKey.bech32Address;
   }
 
   getSigner(chainId: string): Signer {
-    return keplr.getOfflineSigner(chainId);
+    return this.get().getOfflineSigner(chainId);
   }
 }

--- a/apps/namadillo/src/integrations/types.ts
+++ b/apps/namadillo/src/integrations/types.ts
@@ -1,6 +1,7 @@
 import { ChainRegistryEntry } from "types";
 
 export interface WalletConnector {
+  get(): unknown;
   connect(registry: ChainRegistryEntry): Promise<void>;
   getAddress(chainId: string): Promise<string>;
   getSigner(chainId: string): unknown | undefined;


### PR DESCRIPTION
Hey, **I recommend using #1282, which is a robuster way to detect Keplr**, but this is a simpler method with less code to get rid of the detect issue (#1267). It also opens the keplr download page once it goes undetected.

It's mostly up to how you guys are going to continue implementing wallets and the logic you decide to use.


ZEN