### PR TITLE
BUG: Extension - Update index of Setup to fix errors & warnings

### DIFF
--- a/apps/extension/src/Setup/Common/Completion.tsx
+++ b/apps/extension/src/Setup/Common/Completion.tsx
@@ -1,50 +1,44 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import browser from "webextension-polyfill";
 
 import { chains } from "@namada/chains";
 import { ActionButton, Alert, Loading, ViewKeys } from "@namada/components";
 import { makeBip44Path } from "@namada/sdk/web";
-import { AccountType, Bip44Path } from "@namada/types";
-import { assertNever } from "@namada/utils";
+import { Bip44Path, DerivedAccount } from "@namada/types";
 import {
   AccountSecret,
   AccountStore,
   DEFAULT_BIP44_PATH,
-  DeriveAccountMsg,
-  SaveAccountSecretMsg,
 } from "background/keyring";
-import { CreatePasswordMsg } from "background/vault";
-import { useRequester } from "hooks/useRequester";
 import { useNavigate } from "react-router-dom";
-import { Ports } from "router";
+import { CompletionStatus } from "Setup/Setup";
 import { isCustomPath } from "utils";
 
 type Props = {
   alias: string;
   accountSecret?: AccountSecret;
+  status?: CompletionStatus;
+  statusInfo: string;
+  parentAccountStore?: AccountStore;
+  shieldedAccount?: DerivedAccount;
   password?: string;
   passwordRequired: boolean | undefined;
   path: Bip44Path;
 };
 
-enum Status {
-  Pending,
-  Completed,
-  Failed,
-}
-
 export const Completion: React.FC<Props> = (props) => {
-  const { alias, accountSecret, password, passwordRequired, path } = props;
+  const {
+    alias,
+    accountSecret,
+    password,
+    passwordRequired,
+    path,
+    parentAccountStore,
+    shieldedAccount,
+    status,
+    statusInfo,
+  } = props;
 
-  const [mnemonicStatus, setMnemonicStatus] = useState<Status>(Status.Pending);
-  const [statusInfo, setStatusInfo] = useState<string>("");
-  const [publicKeyAddress, setPublicKeyAddress] = useState("");
-  const [transparentAccountAddress, setTransparentAccountAddress] =
-    useState<string>("");
-  const [shieldedAccountAddress, setShieldedAccountAddress] =
-    useState<string>(); // undefined for private key accounts
-
-  const requester = useRequester();
   const navigate = useNavigate();
 
   const derivationPath =
@@ -67,64 +61,6 @@ export const Completion: React.FC<Props> = (props) => {
       navigate("/");
       return;
     }
-
-    const saveMnemonic = async (): Promise<void> => {
-      try {
-        setStatusInfo("Setting a password for the extension.");
-
-        if (passwordRequired && !password) {
-          throw new Error("Password is required and it was not provided");
-        }
-
-        if (passwordRequired) {
-          await requester.sendMessage<CreatePasswordMsg>(
-            Ports.Background,
-            new CreatePasswordMsg(password || "")
-          );
-        }
-
-        const prettyAccountSecret =
-          accountSecret.t === "Mnemonic" ? "mnemonic"
-          : accountSecret.t === "PrivateKey" ? "private key"
-          : assertNever(accountSecret);
-
-        setStatusInfo(`Encrypting and storing ${prettyAccountSecret}.`);
-        const storedAccount =
-          (await requester.sendMessage<SaveAccountSecretMsg>(
-            Ports.Background,
-            new SaveAccountSecretMsg(accountSecret, alias, derivationPath)
-          )) as AccountStore;
-
-        if (!storedAccount) {
-          throw new Error("Background returned failure when creating account");
-        }
-
-        setPublicKeyAddress(storedAccount.publicKey ?? "");
-        setTransparentAccountAddress(storedAccount.address);
-
-        setStatusInfo("Generating Shielded Account");
-        const shieldedAccount = await requester.sendMessage<DeriveAccountMsg>(
-          Ports.Background,
-          new DeriveAccountMsg(
-            derivationPath,
-            AccountType.ShieldedKeys,
-            storedAccount.alias,
-            // Set the parent ID of this shielded account to the transparent account above
-            storedAccount.id
-          )
-        );
-        setShieldedAccountAddress(shieldedAccount.address);
-
-        setMnemonicStatus(Status.Completed);
-        setStatusInfo("Done!");
-      } catch (e) {
-        setStatusInfo((s) => `Failed while "${s}". ${e}`);
-        console.error(e);
-        setMnemonicStatus(Status.Failed);
-      }
-    };
-
-    void saveMnemonic();
   }, []);
 
   return (
@@ -132,23 +68,23 @@ export const Completion: React.FC<Props> = (props) => {
       <Loading
         status={statusInfo}
         imageUrl="/assets/images/loading.gif"
-        visible={mnemonicStatus === Status.Pending}
+        visible={status === CompletionStatus.Pending}
       />
-      {mnemonicStatus === Status.Failed && (
+      {status === CompletionStatus.Failed && (
         <Alert data-testid="setup-error-alert" type="error">
           {statusInfo}
         </Alert>
       )}
-      {mnemonicStatus === Status.Completed && (
+      {status === CompletionStatus.Completed && (
         <>
           <p className="text-white text-center text-base w-full -mt-3 mb-8">
             Here are the accounts generated from your keys
           </p>
           <ViewKeys
-            publicKeyAddress={publicKeyAddress}
-            transparentAccountAddress={transparentAccountAddress}
+            publicKeyAddress={parentAccountStore?.publicKey}
+            transparentAccountAddress={parentAccountStore?.address}
             transparentAccountPath={transparentAccountPath}
-            shieldedAccountAddress={shieldedAccountAddress}
+            shieldedAccountAddress={shieldedAccount?.address}
             trimCharacters={35}
             footer={
               <ActionButton

--- a/apps/extension/src/Setup/Setup.tsx
+++ b/apps/extension/src/Setup/Setup.tsx
@@ -11,11 +11,13 @@ import {
   Container,
   LifecycleExecutionWrapper as Wrapper,
 } from "@namada/components";
-import { Bip44Path } from "@namada/types";
-import { AccountSecret } from "background/keyring";
+import { Bip44Path, DerivedAccount } from "@namada/types";
+import { assertNever } from "@namada/utils";
+import { AccountSecret, AccountStore } from "background/keyring";
 import { AnimatePresence, motion } from "framer-motion";
 import { useCloseTabOnExtensionLock } from "hooks/useCloseTabOnExtensionLock";
 import { usePasswordInitialized } from "hooks/usePasswordInitialized";
+import { useRequester } from "hooks/useRequester";
 import { SeedPhrase, SeedPhraseConfirmation } from "./AccountCreation";
 import { SeedPhraseWarning } from "./AccountCreation/SeedPhraseWarning";
 import { Completion, ContainerHeader } from "./Common";
@@ -23,14 +25,20 @@ import CreateKeyForm from "./Common/CreateKeyForm";
 import { SeedPhraseImport } from "./ImportAccount";
 import { LedgerConfirmation, LedgerConnect, LedgerImport } from "./Ledger";
 import { Start } from "./Start";
+import { saveAccountSecret, savePassword, saveShieldedAccount } from "./query";
 import routes from "./routes";
-import { AccountDetails } from "./types";
+import { AccountDetails, DeriveAccountDetails } from "./types";
 
 type AnimatedTransitionProps = {
   elementKey: string;
   children: JSX.Element;
 };
 
+export enum CompletionStatus {
+  Pending,
+  Completed,
+  Failed,
+}
 /**
  * This is a utility to animate transitions
  */
@@ -52,6 +60,7 @@ const AnimatedTransition: React.FC<AnimatedTransitionProps> = (props) => {
 export const Setup: React.FC = () => {
   useCloseTabOnExtensionLock();
 
+  const requester = useRequester();
   const passwordInitialized = usePasswordInitialized();
   const navigate = useNavigate();
   const location = useLocation();
@@ -71,12 +80,61 @@ export const Setup: React.FC = () => {
     index: 0,
   });
 
+  const [parentAccountStore, setParentAccountStore] = useState<AccountStore>();
+  const [shieldedAccount, setShieldedAccount] = useState<DerivedAccount>();
+  const [completionStatus, setCompletionStatus] = useState<CompletionStatus>();
+  const [completionStatusInfo, setCompletionStatusInfo] = useState<string>("");
+
   const seedPhrase =
     accountSecret?.t === "Mnemonic" ? accountSecret.seedPhrase : undefined;
 
   const setCurrentPage = (pageTitle: string, step: number) => () => {
     setCurrentStep(step);
     setCurrentPageTitle(pageTitle);
+  };
+
+  const storeAccount = async (details: DeriveAccountDetails): Promise<void> => {
+    setCompletionStatus(CompletionStatus.Pending);
+    const { accountSecret, passwordRequired, password } = details;
+    setCompletionStatusInfo("Setting a password for the extension.");
+
+    try {
+      if (passwordRequired && !password) {
+        throw new Error("Password is required and it was not provided");
+      }
+
+      if (password) {
+        await savePassword(requester, password);
+      }
+
+      const prettyAccountSecret =
+        accountSecret.t === "Mnemonic" ? "mnemonic"
+        : accountSecret.t === "PrivateKey" ? "private key"
+        : assertNever(accountSecret);
+      setCompletionStatusInfo(`Encrypting and storing ${prettyAccountSecret}.`);
+
+      // Create parent account
+      const parentAccount = await saveAccountSecret(requester, details);
+      if (!parentAccount) {
+        throw new Error("Background returned failure when creating account");
+      }
+      setParentAccountStore(parentAccount);
+
+      // Create shielded account
+      setCompletionStatusInfo("Generating Shielded Account");
+      const shieldedAccount = await saveShieldedAccount(
+        requester,
+        details,
+        parentAccount
+      );
+      setShieldedAccount(shieldedAccount);
+      setCompletionStatus(CompletionStatus.Completed);
+      setCompletionStatusInfo("Done!");
+    } catch (e) {
+      setCompletionStatusInfo((s) => `Failed while "${s}". ${e}`);
+      console.error(e);
+      setCompletionStatus(CompletionStatus.Failed);
+    }
   };
 
   return (
@@ -190,7 +248,14 @@ export const Setup: React.FC = () => {
                           passphrase: "",
                         });
                         setAccountSecret(undefined); // this also sets seedPhrase to undefined
-                        navigate(routes.accountCreationComplete());
+                        if (accountSecret) {
+                          void storeAccount({
+                            ...accountCreationDetails,
+                            path,
+                            accountSecret,
+                          });
+                          navigate(routes.accountCreationComplete());
+                        }
                       }}
                     />
                   </Wrapper>
@@ -208,6 +273,10 @@ export const Setup: React.FC = () => {
                       accountSecret={selectedAccountSecret}
                       password={accountCreationDetails.password || ""}
                       path={path}
+                      parentAccountStore={parentAccountStore}
+                      shieldedAccount={shieldedAccount}
+                      status={completionStatus}
+                      statusInfo={completionStatusInfo}
                     />
                   </Wrapper>
                 }
@@ -255,7 +324,14 @@ export const Setup: React.FC = () => {
                         }
                         setSelectedAccountSecret(accountSecret);
                         setAccountCreationDetails(accountCreationDetails);
-                        navigate(routes.accountImportComplete());
+                        if (accountSecret) {
+                          void storeAccount({
+                            ...accountCreationDetails,
+                            path,
+                            accountSecret,
+                          });
+                          navigate(routes.accountImportComplete());
+                        }
                       }}
                     />
                   </Wrapper>
@@ -273,6 +349,10 @@ export const Setup: React.FC = () => {
                       accountSecret={selectedAccountSecret}
                       password={accountCreationDetails.password || ""}
                       path={path}
+                      parentAccountStore={parentAccountStore}
+                      shieldedAccount={shieldedAccount}
+                      status={completionStatus}
+                      statusInfo={completionStatusInfo}
                     />
                   </Wrapper>
                 }

--- a/apps/extension/src/Setup/Setup.tsx
+++ b/apps/extension/src/Setup/Setup.tsx
@@ -25,7 +25,7 @@ import CreateKeyForm from "./Common/CreateKeyForm";
 import { SeedPhraseImport } from "./ImportAccount";
 import { LedgerConfirmation, LedgerConnect, LedgerImport } from "./Ledger";
 import { Start } from "./Start";
-import { saveAccountSecret, savePassword, saveShieldedAccount } from "./query";
+import { AccountManager } from "./query";
 import routes from "./routes";
 import { AccountDetails, DeriveAccountDetails } from "./types";
 
@@ -97,6 +97,7 @@ export const Setup: React.FC = () => {
     setCompletionStatus(CompletionStatus.Pending);
     const { accountSecret, passwordRequired, password } = details;
     setCompletionStatusInfo("Setting a password for the extension.");
+    const accountManager = new AccountManager(requester);
 
     try {
       if (passwordRequired && !password) {
@@ -104,7 +105,7 @@ export const Setup: React.FC = () => {
       }
 
       if (password) {
-        await savePassword(requester, password);
+        await accountManager.savePassword(password);
       }
 
       const prettyAccountSecret =
@@ -114,7 +115,7 @@ export const Setup: React.FC = () => {
       setCompletionStatusInfo(`Encrypting and storing ${prettyAccountSecret}.`);
 
       // Create parent account
-      const parentAccount = await saveAccountSecret(requester, details);
+      const parentAccount = await accountManager.saveAccountSecret(details);
       if (!parentAccount) {
         throw new Error("Background returned failure when creating account");
       }
@@ -122,8 +123,7 @@ export const Setup: React.FC = () => {
 
       // Create shielded account
       setCompletionStatusInfo("Generating Shielded Account");
-      const shieldedAccount = await saveShieldedAccount(
-        requester,
+      const shieldedAccount = await accountManager.saveShieldedAccount(
         details,
         parentAccount
       );

--- a/apps/extension/src/Setup/index.tsx
+++ b/apps/extension/src/Setup/index.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import { HashRouter } from "react-router-dom";
 import { RequesterProvider } from "services";
 import { Setup } from "./Setup";
@@ -8,15 +7,12 @@ import "@namada/components/src/base.css";
 import "../global.css";
 import "../tailwind.css";
 
-export default ((): void => {
-  ReactDOM.render(
-    <React.StrictMode>
-      <HashRouter>
-        <RequesterProvider>
-          <Setup />
-        </RequesterProvider>
-      </HashRouter>
-    </React.StrictMode>,
-    document.getElementById("root")
-  );
-})();
+const container = document.getElementById("root")!;
+
+createRoot(container).render(
+  <HashRouter>
+    <RequesterProvider>
+      <Setup />
+    </RequesterProvider>
+  </HashRouter>
+);

--- a/apps/extension/src/Setup/index.tsx
+++ b/apps/extension/src/Setup/index.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { createRoot } from "react-dom/client";
 import { HashRouter } from "react-router-dom";
 import { RequesterProvider } from "services";
@@ -10,9 +11,11 @@ import "../tailwind.css";
 const container = document.getElementById("root")!;
 
 createRoot(container).render(
-  <HashRouter>
-    <RequesterProvider>
-      <Setup />
-    </RequesterProvider>
-  </HashRouter>
+  <React.StrictMode>
+    <HashRouter>
+      <RequesterProvider>
+        <Setup />
+      </RequesterProvider>
+    </HashRouter>
+  </React.StrictMode>
 );

--- a/apps/extension/src/Setup/query.ts
+++ b/apps/extension/src/Setup/query.ts
@@ -1,0 +1,80 @@
+import { AccountType, DerivedAccount } from "@namada/types";
+import {
+  AccountStore,
+  DEFAULT_BIP44_PATH,
+  DeriveAccountMsg,
+  SaveAccountSecretMsg,
+} from "background/keyring";
+import { CreatePasswordMsg } from "background/vault";
+import { ExtensionRequester } from "extension";
+import { Ports } from "router";
+import { DeriveAccountDetails } from "./types";
+
+/**
+ * Set password for the extension
+ * @async
+ * @param requester - Extension Requester
+ * @param password - user password
+ * @returns void
+ */
+export const savePassword = async (
+  requester: ExtensionRequester,
+  password: string
+): Promise<void> => {
+  await requester.sendMessage<CreatePasswordMsg>(
+    Ports.Background,
+    new CreatePasswordMsg(password || "")
+  );
+};
+
+/**
+ * Store account secret, which can be a mnemonic or private key
+ * @async
+ * @param requester - Extension Requester
+ * @param details - account parameters
+ * @returns AccountStore type
+ */
+export const saveAccountSecret = async (
+  requester: ExtensionRequester,
+  details: DeriveAccountDetails
+): Promise<AccountStore> => {
+  const { accountSecret, alias, path } = details;
+  const derivationPath =
+    accountSecret?.t === "PrivateKey" ? DEFAULT_BIP44_PATH : path;
+
+  const parentAccountStore = await requester.sendMessage<SaveAccountSecretMsg>(
+    Ports.Background,
+    new SaveAccountSecretMsg(accountSecret, alias, derivationPath)
+  );
+
+  return parentAccountStore as AccountStore;
+};
+
+/**
+ * Save shielded keys based on parent account
+ * @async
+ * @param requester - Extension requester
+ * @param details - parent account parameters
+ * @param parentAccount - stored parent account
+ */
+export const saveShieldedAccount = async (
+  requester: ExtensionRequester,
+  details: DeriveAccountDetails,
+  parentAccount: AccountStore
+): Promise<DerivedAccount | undefined> => {
+  const { path, accountSecret } = details;
+  const derivationPath =
+    accountSecret?.t === "PrivateKey" ? DEFAULT_BIP44_PATH : path;
+
+  const { alias, id } = parentAccount;
+  return await requester.sendMessage<DeriveAccountMsg>(
+    Ports.Background,
+    new DeriveAccountMsg(
+      derivationPath,
+      AccountType.ShieldedKeys,
+      alias,
+      // Sets the parent ID of this shielded account
+      id
+    )
+  );
+};

--- a/apps/extension/src/Setup/types.ts
+++ b/apps/extension/src/Setup/types.ts
@@ -1,5 +1,14 @@
+import { Bip44Path } from "@namada/types";
+import { AccountSecret } from "background/keyring";
+
 // Alias and optional password (in the case of Ledger accounts)
 export type AccountDetails = {
   alias: string;
   password?: string;
+};
+
+export type DeriveAccountDetails = AccountDetails & {
+  accountSecret: AccountSecret;
+  path: Bip44Path;
+  passwordRequired?: boolean;
 };

--- a/apps/extension/src/Setup/types.ts
+++ b/apps/extension/src/Setup/types.ts
@@ -12,3 +12,10 @@ export type DeriveAccountDetails = AccountDetails & {
   path: Bip44Path;
   passwordRequired?: boolean;
 };
+
+export type LedgerAccountDetails = {
+  alias: string;
+  path: Bip44Path;
+  address: string;
+  publicKey: string;
+};


### PR DESCRIPTION
Currently, the `Setup` app within the extension throws errors as the method of invoking React root is out of date. However, doing this introduced a new issue, where the `useEffect` would fire twice (`React.StrictMode`) in development, throwing an error where accounts are attempted to save twice. This has been resolved.

- [x] Refactored `Setup` -> `Completion` so that the save accounts logic is only initiated by the `onConfirm` handler, which means it won't fire twice in development mode when using `React.StrictMode`
- [x] Moved all extension requester calls to single class, incorporated into Ledger Import
- [x] Re-test all possible account creation/importing flows

### Testing

Run extension in development mode: `yarn start:chrome`

- Ensure Generate Mnemonic works
- Ensure Import Mnemonic works (with and without custom path & Bip39 passphrase)
- Ensure Import Private key works
- Ensure everything works from a new install of the extension (or zero accounts, where a password must be set)
- Ensure Ledger HW wallet import works as before

None of these should result in duplicate accounts.