### PR TITLE
fix: Namadillo - import proxy env correctly

### DIFF
--- a/apps/namadillo/src/hooks/useRegistryFeatures.tsx
+++ b/apps/namadillo/src/hooks/useRegistryFeatures.tsx
@@ -7,7 +7,7 @@ import {
 import { useAtom, useAtomValue } from "jotai";
 import { useEffect } from "react";
 
-const { VITE_PROXY } = process.env;
+const { VITE_PROXY } = import.meta.env;
 
 const namadaChainRegistryUrl =
   VITE_PROXY ?


### PR DESCRIPTION
Apparently, the proxy env import was incorrect, but went unnoticed as CORS issues stopped being a prominent issue. This PR fixes the env import, in the event we get blocked by CORS for this request.