### PR TITLE
chore: Bump to namada v0.46.0

### DIFF
--- a/packages/shared/lib/Cargo.lock
+++ b/packages/shared/lib/Cargo.lock
@@ -2885,8 +2885,8 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "namada_account"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2897,8 +2897,8 @@ dependencies = [
 
 [[package]]
 name = "namada_controller"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "namada_core",
  "smooth-operator",
@@ -2907,8 +2907,8 @@ dependencies = [
 
 [[package]]
 name = "namada_core"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "bech32 0.8.1",
  "borsh",
@@ -2957,8 +2957,8 @@ dependencies = [
 
 [[package]]
 name = "namada_ethereum_bridge"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "borsh",
  "ethers",
@@ -2985,8 +2985,8 @@ dependencies = [
 
 [[package]]
 name = "namada_events"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2999,8 +2999,8 @@ dependencies = [
 
 [[package]]
 name = "namada_gas"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3012,8 +3012,8 @@ dependencies = [
 
 [[package]]
 name = "namada_governance"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3035,8 +3035,8 @@ dependencies = [
 
 [[package]]
 name = "namada_ibc"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "borsh",
  "data-encoding",
@@ -3065,8 +3065,8 @@ dependencies = [
 
 [[package]]
 name = "namada_io"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "async-trait",
  "kdam",
@@ -3078,8 +3078,8 @@ dependencies = [
 
 [[package]]
 name = "namada_macros"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "data-encoding",
  "proc-macro2",
@@ -3090,8 +3090,8 @@ dependencies = [
 
 [[package]]
 name = "namada_merkle_tree"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "borsh",
  "eyre",
@@ -3105,8 +3105,8 @@ dependencies = [
 
 [[package]]
 name = "namada_parameters"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "namada_core",
  "namada_macros",
@@ -3120,8 +3120,8 @@ dependencies = [
 
 [[package]]
 name = "namada_proof_of_stake"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3144,16 +3144,16 @@ dependencies = [
 
 [[package]]
 name = "namada_replay_protection"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "namada_core",
 ]
 
 [[package]]
 name = "namada_sdk"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "async-trait",
  "bimap",
@@ -3221,8 +3221,8 @@ dependencies = [
 
 [[package]]
 name = "namada_shielded_token"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3262,8 +3262,8 @@ dependencies = [
 
 [[package]]
 name = "namada_state"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "borsh",
  "clru",
@@ -3285,8 +3285,8 @@ dependencies = [
 
 [[package]]
 name = "namada_storage"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3304,8 +3304,8 @@ dependencies = [
 
 [[package]]
 name = "namada_systems"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -3314,8 +3314,8 @@ dependencies = [
 
 [[package]]
 name = "namada_token"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3332,8 +3332,8 @@ dependencies = [
 
 [[package]]
 name = "namada_trans_token"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "konst",
  "namada_core",
@@ -3349,8 +3349,8 @@ dependencies = [
 
 [[package]]
 name = "namada_tx"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "ark-bls12-381",
  "bitflags 2.5.0",
@@ -3378,8 +3378,8 @@ dependencies = [
 
 [[package]]
 name = "namada_tx_env"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -3388,8 +3388,8 @@ dependencies = [
 
 [[package]]
 name = "namada_vm"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "borsh",
  "clru",
@@ -3410,8 +3410,8 @@ dependencies = [
 
 [[package]]
 name = "namada_vote_ext"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3422,8 +3422,8 @@ dependencies = [
 
 [[package]]
 name = "namada_vp"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -3438,8 +3438,8 @@ dependencies = [
 
 [[package]]
 name = "namada_vp_env"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "derivative",
  "masp_primitives",
@@ -3453,8 +3453,8 @@ dependencies = [
 
 [[package]]
 name = "namada_wallet"
-version = "0.45.1"
-source = "git+https://github.com/anoma/namada?tag=v0.45.1#207fe50a8fab63e0c84a0e6b4a4ef31de7f4ce98"
+version = "0.46.0"
+source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "bimap",
  "borsh",

--- a/packages/shared/lib/Cargo.toml
+++ b/packages/shared/lib/Cargo.toml
@@ -24,7 +24,7 @@ chrono = "0.4.22"
 getrandom = { version = "0.2.7", features = ["js"] }
 gloo-utils = { version = "0.1.5", features = ["serde"] }
 js-sys = "0.3.60"
-namada_sdk = { git = "https://github.com/anoma/namada", tag="v0.45.1", default-features = false }
+namada_sdk = { git = "https://github.com/anoma/namada", tag="v0.46.0", default-features = false }
 rand = "0.8.5"
 rayon = { version = "1.5.3", optional = true }
 rexie = "0.5"

--- a/packages/shared/lib/src/query.rs
+++ b/packages/shared/lib/src/query.rs
@@ -32,14 +32,15 @@ use namada_sdk::state::BlockHeight;
 use namada_sdk::state::Key;
 use namada_sdk::token;
 use namada_sdk::tx::{
-    TX_BOND_WASM, TX_CLAIM_REWARDS_WASM, TX_REDELEGATE_WASM, TX_REVEAL_PK, TX_TRANSFER_WASM,
-    TX_UNBOND_WASM, TX_VOTE_PROPOSAL, TX_WITHDRAW_WASM, TX_IBC_WASM,
+    TX_BOND_WASM, TX_CLAIM_REWARDS_WASM, TX_IBC_WASM, TX_REDELEGATE_WASM, TX_REVEAL_PK,
+    TX_TRANSFER_WASM, TX_UNBOND_WASM, TX_VOTE_PROPOSAL, TX_WITHDRAW_WASM,
 };
 use namada_sdk::uint::I256;
 use namada_sdk::wallet::DatedKeypair;
 use namada_sdk::ExtendedViewingKey;
 use std::collections::BTreeMap;
 use std::str::FromStr;
+use std::time::Duration;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsError;
 
@@ -63,6 +64,8 @@ pub struct Query {
     masp_client: MaspClient,
 }
 
+const MAX_CONCURRENT_FETCHES: usize = 10;
+
 #[wasm_bindgen]
 impl Query {
     #[wasm_bindgen(constructor)]
@@ -77,7 +80,11 @@ impl Query {
 
             MaspClient::Indexer(IndexerMaspClient::new(client, url, true, 10))
         } else {
-            MaspClient::Ledger(LedgerMaspClient::new(client.clone(), 10))
+            MaspClient::Ledger(LedgerMaspClient::new(
+                client.clone(),
+                MAX_CONCURRENT_FETCHES,
+                Duration::from_millis(5),
+            ))
         };
 
         Query {


### PR DESCRIPTION
This PR simply updates our `shared` lib to use Namada `v0.46.0`