### PR TITLE
SDK/Namadillo: feat/1324 - Move to SDK Imports

### DIFF
--- a/apps/namadillo/src/App/Masp/ShieldedBalanceChart.tsx
+++ b/apps/namadillo/src/App/Masp/ShieldedBalanceChart.tsx
@@ -1,5 +1,5 @@
 import { Heading, PieChart, SkeletonLoading } from "@namada/components";
-import { ProgressBarNames, SdkEvents } from "@namada/shared";
+import { ProgressBarNames, SdkEvents } from "@namada/sdk/web";
 import { AtomErrorBoundary } from "App/Common/AtomErrorBoundary";
 import { FiatCurrency } from "App/Common/FiatCurrency";
 import { shieldedSyncAtom, shieldedTokensAtom } from "atoms/balance/atoms";

--- a/apps/namadillo/src/atoms/balance/atoms.ts
+++ b/apps/namadillo/src/atoms/balance/atoms.ts
@@ -1,4 +1,4 @@
-import { SdkEvents } from "@namada/shared";
+import { SdkEvents } from "@namada/sdk/web";
 import { Namada } from "@namada/types";
 import {
   accountsAtom,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -33,7 +33,7 @@ export type {
 export { TxType, TxTypeLabel } from "./tx";
 export type { SupportedTx } from "./tx";
 
-export { Sdk, SdkEvents } from "./sdk";
+export { ProgressBarNames, Sdk, SdkEvents } from "./sdk";
 
 export { publicKeyToBech32 } from "./keys";
 

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -10,7 +10,7 @@ import { Rpc } from "./rpc";
 import { Signing } from "./signing";
 import { Tx } from "./tx";
 
-export { SdkEvents } from "@namada/shared";
+export { ProgressBarNames, SdkEvents } from "@namada/shared";
 
 /**
  * API for interacting with Namada SDK


### PR DESCRIPTION
Relates to #1324 

- Move any `@namada/shared` imports in Namadillo to `@namada/sdk`, as that is the package that will be published