### PR TITLE
bug: Namadillo - Add git revision var to build:only script

### DIFF
--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -52,7 +52,7 @@
     "dev:local": "NODE_ENV=development NAMADA_INTERFACE_LOCAL=\"true\" yarn dev",
     "dev:proxy": "VITE_PROXY=true && ./scripts/start-proxies.sh && yarn dev:local",
     "build": "NODE_ENV=production && yarn wasm:build && VITE_REVISION=$(git rev-parse HEAD) vite build",
-    "build:only": "NODE_ENV=production && vite build",
+    "build:only": "NODE_ENV=production && VITE_REVISION=$(git rev-parse HEAD) vite build",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "yarn lint -- --fix",
     "lint:ci": "yarn lint --max-warnings 0",


### PR DESCRIPTION
Very simple PR to add git revision var to the `yarn build:only` script on Namadillo (I missed this the first time around)