### PR TITLE
fix: fix type and add error to claim rewards toast

### DIFF
--- a/apps/namadillo/src/hooks/useTransactionNotifications.tsx
+++ b/apps/namadillo/src/hooks/useTransactionNotifications.tsx
@@ -1,6 +1,6 @@
 import { Stack } from "@namada/components";
 import { RedelegateMsgValue, TxProps } from "@namada/types";
-import { shortenAddress } from "@namada/utils";
+import { mapUndefined, shortenAddress } from "@namada/utils";
 import { NamCurrency } from "App/Common/NamCurrency";
 import {
   createNotificationId,
@@ -314,7 +314,8 @@ export const useTransactionNotifications = (): void => {
       id,
       title: "Claim Rewards",
       description: `An error occurred while trying to claim your rewards.`,
-      type: "success",
+      type: "error",
+      details: mapUndefined(failureDetails, e.detail.error?.message),
     });
   });
 


### PR DESCRIPTION
This PR adds the error details to the claim rewards toast and fixes the types so it does not appear as a success toast.

I think we could hide the error details behind the "View details" link, but this seems to not be displayed for error toasts as of #1084. We could probably move the details added in #1084 to the `decription` prop instead of the `details` prop, and then remove the hiding of "View details" for error toasts, but I haven't done it in this PR.

Before: 
![image](https://github.com/user-attachments/assets/ab7d68d4-47c4-4416-81be-bc95fe0585e1)

After:
![2024-11-28-114601_773x601_scrot](https://github.com/user-attachments/assets/0d4096ec-6ea9-4818-bd92-80906020424c)

---

### Added
- Add error details to claim rewards error toast

### Fixed
- Make claim rewards error toast error type instead of success