### PR TITLE
bug/1329: Extension - Simplify chain service

### DIFF
--- a/apps/extension/src/App/Settings/Network.tsx
+++ b/apps/extension/src/App/Settings/Network.tsx
@@ -8,9 +8,8 @@ import {
   Stack,
 } from "@namada/components";
 import { PageHeader } from "App/Common";
-import { UpdateChainMsg } from "background/chains";
+import { GetChainMsg, UpdateChainMsg } from "background/chain";
 import { useRequester } from "hooks/useRequester";
-import { GetChainMsg } from "provider";
 import React, { useCallback, useEffect, useState } from "react";
 import { Ports } from "router";
 
@@ -32,14 +31,10 @@ export const Network = (): JSX.Element => {
   useEffect(() => {
     void (async () => {
       try {
-        const chain = await requester.sendMessage(
+        const chainId = await requester.sendMessage(
           Ports.Background,
           new GetChainMsg()
         );
-        if (!chain) {
-          throw new Error("Chain not found!");
-        }
-        const { chainId } = chain;
         const santizedChainId = sanitize(chainId);
         setChainId(santizedChainId);
       } catch (e) {

--- a/apps/extension/src/background/approvals/service.test.ts
+++ b/apps/extension/src/background/approvals/service.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { WrapperTxMsgValue } from "@namada/types";
-import { ChainsService } from "background/chains";
+import { ChainService } from "background/chain";
 import { KeyRingService } from "background/keyring";
 import { SdkService } from "background/sdk";
 import { VaultService } from "background/vault";
@@ -45,7 +45,7 @@ describe("approvals service", () => {
   let service: ApprovalsService;
   let sdkService: jest.Mocked<SdkService>;
   let keyRingService: jest.Mocked<KeyRingService>;
-  let chainService: jest.Mocked<ChainsService>;
+  let chainService: jest.Mocked<ChainService>;
   let dataStore: KVStoreMock<string>;
   let txStore: KVStoreMock<PendingTx>;
   let localStorage: LocalStorage;
@@ -508,7 +508,7 @@ describe("approvals service", () => {
   describe("getResolver", () => {
     it("should get the related tab id resolver from resolverMap", async () => {
       const popupTabId = 1;
-      const resolver = { resolve: () => { }, reject: () => { } };
+      const resolver = { resolve: () => {}, reject: () => {} };
       service["resolverMap"] = {
         [popupTabId]: resolver,
       };
@@ -519,7 +519,7 @@ describe("approvals service", () => {
     it("should throw an error if there is no resolver for the tab id", async () => {
       const popupTabId = 1;
       service["resolverMap"] = {
-        [popupTabId]: { resolve: () => { }, reject: () => { } },
+        [popupTabId]: { resolve: () => {}, reject: () => {} },
       };
 
       expect(() => service["getResolver"](999)).toThrow();
@@ -530,7 +530,7 @@ describe("approvals service", () => {
     it("should remove related tab id resolver from resolverMap", async () => {
       const popupTabId = 1;
       service["resolverMap"] = {
-        [popupTabId]: { resolve: () => { }, reject: () => { } },
+        [popupTabId]: { resolve: () => {}, reject: () => {} },
       };
       service["removeResolver"](popupTabId);
 

--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -8,7 +8,7 @@ import { paramsToUrl } from "@namada/utils";
 
 import { ResponseSign } from "@zondax/ledger-namada";
 import { TopLevelRoute } from "Approvals/types";
-import { ChainsService } from "background/chains";
+import { ChainService } from "background/chain";
 import { KeyRingService } from "background/keyring";
 import { SdkService } from "background/sdk";
 import { VaultService } from "background/vault";
@@ -35,7 +35,8 @@ export class ApprovalsService {
     protected readonly sdkService: SdkService,
     protected readonly keyRingService: KeyRingService,
     protected readonly vaultService: VaultService,
-    protected readonly chainService: ChainsService,
+    // TODO: This is not used here until #1298 is merged!
+    protected readonly chainService: ChainService,
     protected readonly broadcaster: ExtensionBroadcaster
   ) {
     browser.tabs.onRemoved.addListener((tabId) => {

--- a/apps/extension/src/background/approvals/types.ts
+++ b/apps/extension/src/background/approvals/types.ts
@@ -22,3 +22,7 @@ export type EncodedTxData = Pick<TxProps, "args" | "hash"> & {
   bytes: string;
   signingData: EncodedSigningData[];
 };
+
+export type ApprovedSigningChainStore = {
+  chainId: string;
+};

--- a/apps/extension/src/background/chain/constants.ts
+++ b/apps/extension/src/background/chain/constants.ts
@@ -1,0 +1,1 @@
+export const ROUTE = "chain-route";

--- a/apps/extension/src/background/chain/handler.ts
+++ b/apps/extension/src/background/chain/handler.ts
@@ -1,9 +1,8 @@
-import { GetChainMsg } from "provider/messages";
 import { Env, Handler, InternalHandler, Message } from "router";
-import { UpdateChainMsg } from "./messages";
-import { ChainsService } from "./service";
+import { GetChainMsg, UpdateChainMsg } from "./messages";
+import { ChainService } from "./service";
 
-export const getHandler: (service: ChainsService) => Handler = (service) => {
+export const getHandler: (service: ChainService) => Handler = (service) => {
   return (env: Env, msg: Message<unknown>) => {
     switch (msg.constructor) {
       case GetChainMsg:
@@ -17,7 +16,7 @@ export const getHandler: (service: ChainsService) => Handler = (service) => {
 };
 
 const handleGetChainMsg: (
-  service: ChainsService
+  service: ChainService
 ) => InternalHandler<GetChainMsg> = (service) => {
   return async () => {
     return await service.getChain();
@@ -25,7 +24,7 @@ const handleGetChainMsg: (
 };
 
 const handleUpdateChainMsg: (
-  service: ChainsService
+  service: ChainService
 ) => InternalHandler<UpdateChainMsg> = (service) => {
   return async (_, { chainId }) => {
     return await service.updateChain(chainId);

--- a/apps/extension/src/background/chain/index.ts
+++ b/apps/extension/src/background/chain/index.ts
@@ -1,4 +1,4 @@
-export * from "./handler";
+export * from "./constants";
 export * from "./init";
 export * from "./messages";
 export * from "./service";

--- a/apps/extension/src/background/chain/init.ts
+++ b/apps/extension/src/background/chain/init.ts
@@ -1,11 +1,11 @@
-import { GetChainMsg } from "provider/messages";
+import {} from "provider/messages";
 import { Router } from "router";
 import { ROUTE } from "./constants";
 import { getHandler } from "./handler";
-import { UpdateChainMsg } from "./messages";
-import { ChainsService } from "./service";
+import { GetChainMsg, UpdateChainMsg } from "./messages";
+import { ChainService } from "./service";
 
-export function init(router: Router, service: ChainsService): void {
+export function init(router: Router, service: ChainService): void {
   router.registerMessage(GetChainMsg);
   router.registerMessage(UpdateChainMsg);
 

--- a/apps/extension/src/background/chain/messages.ts
+++ b/apps/extension/src/background/chain/messages.ts
@@ -3,9 +3,8 @@ import { validateProps } from "utils";
 import { ROUTE } from "./constants";
 
 enum MessageType {
+  GetChain = "get-chain",
   UpdateChain = "update-chain",
-  AddTxWasmHashes = "add-tx-wasm-hashes",
-  GetTxWasmHashes = "get-tx-wasm-hashes",
 }
 
 export class UpdateChainMsg extends Message<void> {
@@ -27,5 +26,25 @@ export class UpdateChainMsg extends Message<void> {
 
   type(): string {
     return UpdateChainMsg.type();
+  }
+}
+
+export class GetChainMsg extends Message<string> {
+  public static type(): MessageType {
+    return MessageType.GetChain;
+  }
+
+  constructor() {
+    super();
+  }
+
+  validate(): void {}
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): MessageType {
+    return GetChainMsg.type();
   }
 }

--- a/apps/extension/src/background/chain/service.ts
+++ b/apps/extension/src/background/chain/service.ts
@@ -1,34 +1,21 @@
 import { chains } from "@namada/chains";
-import { Chain } from "@namada/types";
 import { SdkService } from "background/sdk";
 import { ExtensionBroadcaster } from "extension";
 import { LocalStorage } from "storage";
 
-export const CHAINS_KEY = "chains";
-
-export class ChainsService {
+export class ChainService {
   constructor(
     protected readonly sdkService: SdkService,
     protected readonly localStorage: LocalStorage,
     protected readonly broadcaster: ExtensionBroadcaster
   ) {}
 
-  async getChain(): Promise<Chain> {
-    return (await this.localStorage.getChain()) || chains.namada;
+  async getChain(): Promise<string> {
+    return (await this.localStorage.getChainId()) || chains.namada.chainId;
   }
 
   async updateChain(chainId: string): Promise<void> {
-    let chain = await this.getChain();
-    if (!chain) {
-      throw new Error("No chain found!");
-    }
-    // Update chain ID
-    chain = {
-      ...chain,
-      chainId,
-    };
-
-    await this.localStorage.setChain(chain);
+    await this.localStorage.setChainId(chainId);
     await this.broadcaster.updateNetwork();
   }
 }

--- a/apps/extension/src/background/chains/constants.ts
+++ b/apps/extension/src/background/chains/constants.ts
@@ -1,1 +1,0 @@
-export const ROUTE = "chains-route";

--- a/apps/extension/src/background/index.ts
+++ b/apps/extension/src/background/index.ts
@@ -22,7 +22,7 @@ import {
 import { KVPrefix, Ports } from "router";
 import { LocalStorage, VaultStorage } from "storage";
 import { ApprovalsService, init as initApprovals } from "./approvals";
-import { ChainsService, init as initChains } from "./chains";
+import { ChainService, init as initChain } from "./chain";
 import { KeyRingService, UtilityStore, init as initKeyRing } from "./keyring";
 import { SdkService } from "./sdk/service";
 import { VaultService, init as initVault } from "./vault";
@@ -55,7 +55,7 @@ const init = new Promise<void>(async (resolve) => {
   const routerId = await getNamadaRouterId(localStorage);
   const requester = new ExtensionRequester(messenger, routerId);
   const broadcaster = new ExtensionBroadcaster(localStorage, requester);
-  const sdkService = await SdkService.init(localStorage);
+  const sdkService = await SdkService.init();
 
   const vaultService = new VaultService(
     vaultStorage,
@@ -64,15 +64,11 @@ const init = new Promise<void>(async (resolve) => {
     broadcaster
   );
   await vaultService.initialize();
-  const chainsService = new ChainsService(
-    sdkService,
-    localStorage,
-    broadcaster
-  );
+  const chainService = new ChainService(sdkService, localStorage, broadcaster);
   const keyRingService = new KeyRingService(
     vaultService,
     sdkService,
-    chainsService,
+    chainService,
     utilityStore,
     localStorage,
     vaultStorage,
@@ -86,13 +82,13 @@ const init = new Promise<void>(async (resolve) => {
     sdkService,
     keyRingService,
     vaultService,
-    chainsService,
+    chainService,
     broadcaster
   );
 
   // Initialize messages and handlers
   initApprovals(router, approvalsService);
-  initChains(router, chainsService);
+  initChain(router, chainService);
   initKeyRing(router, keyRingService);
   initVault(router, vaultService);
   resolve();

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -9,7 +9,7 @@ import {
 } from "@namada/types";
 import { Result, truncateInMiddle } from "@namada/utils";
 
-import { ChainsService } from "background/chains";
+import { ChainService } from "background/chain";
 import { SdkService } from "background/sdk/service";
 import { VaultService } from "background/vault";
 import { ExtensionBroadcaster, ExtensionRequester } from "extension";
@@ -31,7 +31,7 @@ export class KeyRingService {
   constructor(
     protected readonly vaultService: VaultService,
     protected readonly sdkService: SdkService,
-    protected readonly chainsService: ChainsService,
+    protected readonly chainService: ChainService,
     protected readonly utilityStore: KVStore<UtilityStore>,
     protected readonly localStorage: LocalStorage,
     protected readonly vaultStorage: VaultStorage,
@@ -181,7 +181,7 @@ export class KeyRingService {
   }
 
   async sign(txProps: TxProps, signer: string): Promise<Uint8Array> {
-    const { chainId } = await this.chainsService.getChain();
+    const chainId = await this.chainService.getChain();
     return await this._keyRing.sign(txProps, signer, chainId);
   }
 

--- a/apps/extension/src/background/keyring/types.ts
+++ b/apps/extension/src/background/keyring/types.ts
@@ -48,8 +48,6 @@ export type SensitiveAccountStoreData = { text: string; passphrase?: string };
 
 export type UtilityStore = ActiveAccountStore | { [id: string]: CryptoRecord };
 
-export type RevealedPKStore = { [id: string]: string };
-
 export enum DeleteAccountError {
   BadPassword,
   KeyStoreError,

--- a/apps/extension/src/background/sdk/service.ts
+++ b/apps/extension/src/background/sdk/service.ts
@@ -1,7 +1,6 @@
 import { chains } from "@namada/chains";
 import { Sdk, getSdk } from "@namada/sdk/web";
 import sdkInit from "@namada/sdk/web-init";
-import { LocalStorage } from "storage";
 
 const {
   NAMADA_INTERFACE_NAMADA_TOKEN:
@@ -18,14 +17,10 @@ export class SdkService {
     private readonly cryptoMemory: WebAssembly.Memory
   ) {}
 
-  static async init(localStorage: LocalStorage): Promise<SdkService> {
-    // Get stored chain
-    const chain = await localStorage.getChain();
-    // If chain is not stored, use default chain information
-    const rpc = chain?.rpc || chains.namada.rpc;
-
+  static async init(): Promise<SdkService> {
+    // Use fake RPC, the extension does not actually issue RPC requests:
+    const rpc = chains.namada.rpc;
     const { cryptoMemory } = await sdkInit();
-
     return new SdkService(rpc, defaultTokenAddress, cryptoMemory);
   }
 

--- a/apps/extension/src/background/vault/tests/service.test.ts
+++ b/apps/extension/src/background/vault/tests/service.test.ts
@@ -2,7 +2,7 @@ import { AccountType } from "@namada/types";
 import { Result } from "@namada/utils";
 import { SdkService } from "background/sdk";
 import { KVPrefix } from "router";
-import { KeyStore, KeyStoreType, LocalStorage, VaultStorage } from "storage";
+import { KeyStore, KeyStoreType, VaultStorage } from "storage";
 import { KVStoreMock } from "test/init";
 import { VaultService } from "../service";
 import { SessionPassword } from "../types";
@@ -45,10 +45,7 @@ describe("Testing untouched Vault Service", () => {
       KVPrefix.SessionStorage
     );
 
-    const localStorage = new LocalStorage(
-      new KVStoreMock(KVPrefix.LocalStorage)
-    );
-    const sdkService = await SdkService.init(localStorage);
+    const sdkService = await SdkService.init();
     service = new VaultService(storage, sessionStore, sdkService);
     await service.initialize();
     await service.createPassword(password);

--- a/apps/extension/src/provider/InjectedNamada.ts
+++ b/apps/extension/src/provider/InjectedNamada.ts
@@ -1,5 +1,4 @@
 import {
-  Chain,
   DerivedAccount,
   Namada as INamada,
   Signer as ISigner,
@@ -66,10 +65,6 @@ export class InjectedNamada implements INamada {
       "verify",
       props
     );
-  }
-
-  public async getChain(): Promise<Chain | undefined> {
-    return await InjectedProxy.requestMethod<void, Chain>("getChain");
   }
 
   public getSigner(): ISigner | undefined {

--- a/apps/extension/src/provider/Namada.ts
+++ b/apps/extension/src/provider/Namada.ts
@@ -1,5 +1,4 @@
 import {
-  Chain,
   DerivedAccount,
   Namada as INamada,
   SignArbitraryProps,
@@ -17,7 +16,6 @@ import {
   ApproveSignTxMsg,
   ApproveUpdateDefaultAccountMsg,
   CheckDurabilityMsg,
-  GetChainMsg,
   IsConnectionApprovedMsg,
   QueryAccountsMsg,
   QueryDefaultAccountMsg,
@@ -104,13 +102,6 @@ export class Namada implements INamada {
     return await this.requester?.sendMessage(
       Ports.Background,
       new VerifyArbitraryMsg(publicKey, hash, signature)
-    );
-  }
-
-  public async getChain(): Promise<Chain | undefined> {
-    return await this.requester?.sendMessage(
-      Ports.Background,
-      new GetChainMsg()
     );
   }
 

--- a/apps/extension/src/provider/messages.ts
+++ b/apps/extension/src/provider/messages.ts
@@ -1,4 +1,4 @@
-import { Chain, DerivedAccount, SignArbitraryResponse } from "@namada/types";
+import { DerivedAccount, SignArbitraryResponse } from "@namada/types";
 import { EncodedTxData } from "background/approvals";
 import { Message } from "router";
 import { validateProps } from "utils";
@@ -25,8 +25,6 @@ enum MessageType {
   QueryDefaultAccount = "query-default-account",
   ApproveUpdateDefaultAccount = "approve-update-default-account",
   EncodeRevealPublicKey = "encode-reveal-public-key",
-  GetChain = "get-chain",
-  GetChains = "get-chains",
   ApproveEthBridgeTransfer = "approve-eth-bridge-transfer",
   CheckDurability = "check-durability",
   VerifyArbitrary = "verify-arbitrary",
@@ -154,26 +152,6 @@ export class ApproveDisconnectInterfaceMsg extends Message<void> {
 
   type(): string {
     return ApproveDisconnectInterfaceMsg.type();
-  }
-}
-
-export class GetChainMsg extends Message<Chain> {
-  public static type(): MessageType {
-    return MessageType.GetChain;
-  }
-
-  constructor() {
-    super();
-  }
-
-  validate(): void {}
-
-  route(): string {
-    return Route.Chains;
-  }
-
-  type(): MessageType {
-    return GetChainMsg.type();
   }
 }
 

--- a/apps/extension/src/test/init.ts
+++ b/apps/extension/src/test/init.ts
@@ -22,7 +22,7 @@ import {
   init as initApprovals,
 } from "../background/approvals";
 
-import { ChainsService } from "background/chains";
+import { ChainService } from "background/chain";
 import { SdkService } from "background/sdk";
 import { Namada } from "provider";
 import { LocalStorage, VaultStorage } from "storage";
@@ -81,16 +81,12 @@ export const init = async (): Promise<{
     localStorage
   );
 
-  const sdkService = await SdkService.init(localStorage);
+  const sdkService = await SdkService.init();
 
   const vaultService = new VaultService(vaultStorage, sessionStore, sdkService);
   await vaultService.initialize();
 
-  const chainsService = new ChainsService(
-    sdkService,
-    localStorage,
-    broadcaster
-  );
+  const chainsService = new ChainService(sdkService, localStorage, broadcaster);
 
   const keyRingService = new KeyRingService(
     vaultService,

--- a/packages/types/src/namada.ts
+++ b/packages/types/src/namada.ts
@@ -1,5 +1,4 @@
 import { DerivedAccount } from "./account";
-import { Chain } from "./chain";
 import { SignArbitraryResponse, Signer } from "./signer";
 import { TxProps } from "./tx";
 
@@ -37,7 +36,6 @@ export interface Namada {
     props: SignArbitraryProps
   ): Promise<SignArbitraryResponse | undefined>;
   verify(props: VerifyArbitraryProps): Promise<void>;
-  getChain: () => Promise<Chain | undefined>;
   version: () => string;
 }
 


### PR DESCRIPTION
As the extension only needs to know the `chainId` in order to validate signing requests, remove complex chain config and the associated validation (this is causing issues where old versions of the extension cannot update, and breaks the App popup!)

- [ ] Simply chain service, only track chain ID
- [ ] Remove unused `Namada` calls for `getChain`, etc.
- [ ] Remove any other unused items
- [ ] Fix any broken tests

### Testing

- Simply load this version if you're already running a local dev extension - it should gracefully update to the new storage and not throw any errors!