### PR TITLE
chore: Bump SDK version, regenerate docs, bump Namada

### DIFF
--- a/packages/sdk/docs/classes/Crypto.md
+++ b/packages/sdk/docs/classes/Crypto.md
@@ -40,7 +40,7 @@ Class Crypto handles AES encryption tasks
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/crypto.ts#L20)
+[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/crypto.ts#L20)
 
 ## Properties
 
@@ -52,7 +52,7 @@ WebAssembly Memory for crypto
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/crypto.ts#L20)
+[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/crypto.ts#L20)
 
 ## Methods
 
@@ -75,7 +75,7 @@ decrypted text
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:115](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/crypto.ts#L115)
+[sdk/src/crypto/crypto.ts:115](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/crypto.ts#L115)
 
 ___
 
@@ -100,7 +100,7 @@ crypto record
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:61](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/crypto.ts#L61)
+[sdk/src/crypto/crypto.ts:61](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/crypto.ts#L61)
 
 ___
 
@@ -126,7 +126,7 @@ array of encrypted bytes
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:98](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/crypto.ts#L98)
+[sdk/src/crypto/crypto.ts:98](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/crypto.ts#L98)
 
 ___
 
@@ -153,7 +153,7 @@ crypto record used for storage
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:30](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/crypto.ts#L30)
+[sdk/src/crypto/crypto.ts:30](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/crypto.ts#L30)
 
 ___
 
@@ -178,4 +178,4 @@ encryption parameters
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:73](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/crypto.ts#L73)
+[sdk/src/crypto/crypto.ts:73](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/crypto.ts#L73)

--- a/packages/sdk/docs/classes/Ledger.md
+++ b/packages/sdk/docs/classes/Ledger.md
@@ -44,7 +44,7 @@ Functionality for interacting with NamadaApp for Ledger Hardware Wallets
 
 #### Defined in
 
-[sdk/src/ledger.ts:68](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L68)
+[sdk/src/ledger.ts:68](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L68)
 
 ## Properties
 
@@ -56,7 +56,7 @@ Inititalized NamadaApp class from Zondax package
 
 #### Defined in
 
-[sdk/src/ledger.ts:68](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L68)
+[sdk/src/ledger.ts:68](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L68)
 
 ## Methods
 
@@ -77,7 +77,7 @@ void
 
 #### Defined in
 
-[sdk/src/ledger.ts:245](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L245)
+[sdk/src/ledger.ts:245](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L245)
 
 ___
 
@@ -104,7 +104,7 @@ Address and public key
 
 #### Defined in
 
-[sdk/src/ledger.ts:111](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L111)
+[sdk/src/ledger.ts:111](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L111)
 
 ___
 
@@ -132,7 +132,7 @@ ShieldedKeys
 
 #### Defined in
 
-[sdk/src/ledger.ts:157](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L157)
+[sdk/src/ledger.ts:157](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L157)
 
 ___
 
@@ -153,7 +153,7 @@ Error message if error is found
 
 #### Defined in
 
-[sdk/src/ledger.ts:228](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L228)
+[sdk/src/ledger.ts:228](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L228)
 
 ___
 
@@ -180,7 +180,7 @@ Address and public key
 
 #### Defined in
 
-[sdk/src/ledger.ts:131](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L131)
+[sdk/src/ledger.ts:131](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L131)
 
 ___
 
@@ -208,7 +208,7 @@ Response signature
 
 #### Defined in
 
-[sdk/src/ledger.ts:196](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L196)
+[sdk/src/ledger.ts:196](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L196)
 
 ___
 
@@ -236,7 +236,7 @@ Response signature
 
 #### Defined in
 
-[sdk/src/ledger.ts:213](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L213)
+[sdk/src/ledger.ts:213](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L213)
 
 ___
 
@@ -257,7 +257,7 @@ Version and info of NamadaApp
 
 #### Defined in
 
-[sdk/src/ledger.ts:94](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L94)
+[sdk/src/ledger.ts:94](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L94)
 
 ___
 
@@ -283,4 +283,4 @@ Ledger class instance
 
 #### Defined in
 
-[sdk/src/ledger.ts:76](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L76)
+[sdk/src/ledger.ts:76](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L76)

--- a/packages/sdk/docs/classes/Masp.md
+++ b/packages/sdk/docs/classes/Masp.md
@@ -42,7 +42,7 @@ Class representing utilities related to MASP
 
 #### Defined in
 
-[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/masp.ts#L10)
+[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/masp.ts#L10)
 
 ## Properties
 
@@ -54,7 +54,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/masp.ts#L10)
+[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/masp.ts#L10)
 
 ## Methods
 
@@ -81,7 +81,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:70](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/masp.ts#L70)
+[sdk/src/masp.ts:70](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/masp.ts#L70)
 
 ___
 
@@ -108,7 +108,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:48](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/masp.ts#L48)
+[sdk/src/masp.ts:48](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/masp.ts#L48)
 
 ___
 
@@ -135,7 +135,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:59](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/masp.ts#L59)
+[sdk/src/masp.ts:59](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/masp.ts#L59)
 
 ___
 
@@ -161,7 +161,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:27](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/masp.ts#L27)
+[sdk/src/masp.ts:27](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/masp.ts#L27)
 
 ___
 
@@ -181,7 +181,7 @@ True if MASP parameters are loaded
 
 #### Defined in
 
-[sdk/src/masp.ts:17](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/masp.ts#L17)
+[sdk/src/masp.ts:17](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/masp.ts#L17)
 
 ___
 
@@ -207,7 +207,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:37](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/masp.ts#L37)
+[sdk/src/masp.ts:37](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/masp.ts#L37)
 
 ___
 
@@ -226,4 +226,4 @@ the MASP address
 
 #### Defined in
 
-[sdk/src/masp.ts:79](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/masp.ts#L79)
+[sdk/src/masp.ts:79](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/masp.ts#L79)

--- a/packages/sdk/docs/classes/Mnemonic.md
+++ b/packages/sdk/docs/classes/Mnemonic.md
@@ -38,7 +38,7 @@ Class for accessing mnemonic functionality from wasm
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/mnemonic.ts#L18)
+[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/mnemonic.ts#L18)
 
 ## Properties
 
@@ -50,7 +50,7 @@ Memory accessor for crypto lib
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/mnemonic.ts#L18)
+[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/mnemonic.ts#L18)
 
 ## Methods
 
@@ -74,7 +74,7 @@ An array of words
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:25](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/mnemonic.ts#L25)
+[sdk/src/mnemonic.ts:25](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/mnemonic.ts#L25)
 
 ___
 
@@ -99,7 +99,7 @@ Seed bytes
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:43](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/mnemonic.ts#L43)
+[sdk/src/mnemonic.ts:43](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/mnemonic.ts#L43)
 
 ___
 
@@ -129,4 +129,4 @@ Object with validation result and error message if invalid
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:61](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/mnemonic.ts#L61)
+[sdk/src/mnemonic.ts:61](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/mnemonic.ts#L61)

--- a/packages/sdk/docs/classes/ProgressBarNames.md
+++ b/packages/sdk/docs/classes/ProgressBarNames.md
@@ -1,0 +1,73 @@
+[@namada/sdk](../README.md) / [Exports](../modules.md) / ProgressBarNames
+
+# Class: ProgressBarNames
+
+## Table of contents
+
+### Constructors
+
+- [constructor](ProgressBarNames.md#constructor)
+
+### Properties
+
+- [Applied](ProgressBarNames.md#applied)
+- [Fetched](ProgressBarNames.md#fetched)
+- [Scanned](ProgressBarNames.md#scanned)
+
+### Methods
+
+- [free](ProgressBarNames.md#free)
+
+## Constructors
+
+### constructor
+
+• **new ProgressBarNames**(): [`ProgressBarNames`](ProgressBarNames.md)
+
+#### Returns
+
+[`ProgressBarNames`](ProgressBarNames.md)
+
+## Properties
+
+### Applied
+
+▪ `Static` `Readonly` **Applied**: `string`
+
+#### Defined in
+
+shared/src/shared/shared.d.ts:134
+
+___
+
+### Fetched
+
+▪ `Static` `Readonly` **Fetched**: `string`
+
+#### Defined in
+
+shared/src/shared/shared.d.ts:137
+
+___
+
+### Scanned
+
+▪ `Static` `Readonly` **Scanned**: `string`
+
+#### Defined in
+
+shared/src/shared/shared.d.ts:140
+
+## Methods
+
+### free
+
+▸ **free**(): `void`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+shared/src/shared/shared.d.ts:131

--- a/packages/sdk/docs/classes/Rpc.md
+++ b/packages/sdk/docs/classes/Rpc.md
@@ -51,7 +51,7 @@ API for executing RPC requests with Namada
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:36](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L36)
+[sdk/src/rpc/rpc.ts:36](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L36)
 
 ## Properties
 
@@ -63,7 +63,7 @@ Instance of Query struct from wasm lib
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:38](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L38)
+[sdk/src/rpc/rpc.ts:38](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L38)
 
 ___
 
@@ -75,7 +75,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:37](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L37)
+[sdk/src/rpc/rpc.ts:37](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L37)
 
 ## Methods
 
@@ -102,7 +102,7 @@ TxResponseProps object
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:223](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L223)
+[sdk/src/rpc/rpc.ts:223](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L223)
 
 ___
 
@@ -122,7 +122,7 @@ Array of all validator addresses
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:78](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L78)
+[sdk/src/rpc/rpc.ts:78](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L78)
 
 ___
 
@@ -149,7 +149,7 @@ Query balances from chain
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:48](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L48)
+[sdk/src/rpc/rpc.ts:48](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L48)
 
 ___
 
@@ -169,7 +169,7 @@ Object
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:203](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L203)
+[sdk/src/rpc/rpc.ts:203](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L203)
 
 ___
 
@@ -195,7 +195,7 @@ Promise resolving to delegators votes
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:102](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L102)
+[sdk/src/rpc/rpc.ts:102](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L102)
 
 ___
 
@@ -215,7 +215,7 @@ Query gas costs
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:194](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L194)
+[sdk/src/rpc/rpc.ts:194](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L194)
 
 ___
 
@@ -235,7 +235,7 @@ Address of native token
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:57](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L57)
+[sdk/src/rpc/rpc.ts:57](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L57)
 
 ___
 
@@ -262,7 +262,7 @@ String of public key if found
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:68](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L68)
+[sdk/src/rpc/rpc.ts:68](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L68)
 
 ___
 
@@ -288,7 +288,7 @@ Promise resolving to pending ethereum transfers
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:185](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L185)
+[sdk/src/rpc/rpc.ts:185](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L185)
 
 ___
 
@@ -314,7 +314,7 @@ Promise resolving to staking positions
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:139](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L139)
+[sdk/src/rpc/rpc.ts:139](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L139)
 
 ___
 
@@ -340,7 +340,7 @@ Promise resolving to staking totals
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:112](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L112)
+[sdk/src/rpc/rpc.ts:112](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L112)
 
 ___
 
@@ -364,7 +364,7 @@ Total bonds amount
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:175](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L175)
+[sdk/src/rpc/rpc.ts:175](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L175)
 
 ___
 
@@ -391,7 +391,7 @@ Promise resolving to total delegations
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:89](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L89)
+[sdk/src/rpc/rpc.ts:89](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L89)
 
 ___
 
@@ -415,4 +415,4 @@ Sync the shielded context
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:241](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/rpc.ts#L241)
+[sdk/src/rpc/rpc.ts:241](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L241)

--- a/packages/sdk/docs/classes/Sdk.md
+++ b/packages/sdk/docs/classes/Sdk.md
@@ -64,7 +64,7 @@ API for interacting with Namada SDK
 
 #### Defined in
 
-[sdk/src/sdk.ts:24](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L24)
+[sdk/src/sdk.ts:26](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L26)
 
 ## Properties
 
@@ -76,7 +76,7 @@ Memory accessor for crypto lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:27](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L27)
+[sdk/src/sdk.ts:29](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L29)
 
 ___
 
@@ -88,7 +88,7 @@ Address of chain's native token
 
 #### Defined in
 
-[sdk/src/sdk.ts:29](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L29)
+[sdk/src/sdk.ts:31](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L31)
 
 ___
 
@@ -100,7 +100,7 @@ Instance of Query struct from wasm lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:26](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L26)
+[sdk/src/sdk.ts:28](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L28)
 
 ___
 
@@ -112,7 +112,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:25](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L25)
+[sdk/src/sdk.ts:27](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L27)
 
 ___
 
@@ -124,7 +124,7 @@ RPC url
 
 #### Defined in
 
-[sdk/src/sdk.ts:28](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L28)
+[sdk/src/sdk.ts:30](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L30)
 
 ## Accessors
 
@@ -142,7 +142,7 @@ Utilities for encrypting and decrypting data
 
 #### Defined in
 
-[sdk/src/sdk.ts:174](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L174)
+[sdk/src/sdk.ts:177](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L177)
 
 ___
 
@@ -160,7 +160,7 @@ key-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:150](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L150)
+[sdk/src/sdk.ts:153](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L153)
 
 ___
 
@@ -178,7 +178,7 @@ Masp utilities for handling params
 
 #### Defined in
 
-[sdk/src/sdk.ts:166](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L166)
+[sdk/src/sdk.ts:169](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L169)
 
 ___
 
@@ -196,7 +196,7 @@ mnemonic-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:142](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L142)
+[sdk/src/sdk.ts:145](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L145)
 
 ___
 
@@ -214,7 +214,7 @@ rpc client
 
 #### Defined in
 
-[sdk/src/sdk.ts:126](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L126)
+[sdk/src/sdk.ts:129](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L129)
 
 ___
 
@@ -232,7 +232,7 @@ Non-Tx signing functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:158](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L158)
+[sdk/src/sdk.ts:161](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L161)
 
 ___
 
@@ -250,7 +250,7 @@ tx-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:134](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L134)
+[sdk/src/sdk.ts:137](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L137)
 
 ___
 
@@ -268,7 +268,7 @@ Version from package.json
 
 #### Defined in
 
-[sdk/src/sdk.ts:182](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L182)
+[sdk/src/sdk.ts:185](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L185)
 
 ## Methods
 
@@ -286,7 +286,7 @@ Utilities for encrypting and decrypting data
 
 #### Defined in
 
-[sdk/src/sdk.ts:101](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L101)
+[sdk/src/sdk.ts:103](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L103)
 
 ___
 
@@ -304,7 +304,7 @@ key-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:77](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L77)
+[sdk/src/sdk.ts:79](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L79)
 
 ___
 
@@ -322,7 +322,7 @@ Masp utilities for handling params
 
 #### Defined in
 
-[sdk/src/sdk.ts:93](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L93)
+[sdk/src/sdk.ts:95](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L95)
 
 ___
 
@@ -340,7 +340,7 @@ mnemonic-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:69](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L69)
+[sdk/src/sdk.ts:71](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L71)
 
 ___
 
@@ -358,7 +358,7 @@ Namada RPC client
 
 #### Defined in
 
-[sdk/src/sdk.ts:53](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L53)
+[sdk/src/sdk.ts:55](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L55)
 
 ___
 
@@ -376,7 +376,7 @@ Non-Tx signing functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:85](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L85)
+[sdk/src/sdk.ts:87](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L87)
 
 ___
 
@@ -394,7 +394,7 @@ Tx-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:61](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L61)
+[sdk/src/sdk.ts:63](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L63)
 
 ___
 
@@ -408,9 +408,11 @@ Return SDK Package version
 
 `string`
 
+SDK version
+
 #### Defined in
 
-[sdk/src/sdk.ts:118](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L118)
+[sdk/src/sdk.ts:121](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L121)
 
 ___
 
@@ -436,7 +438,7 @@ Class for interacting with NamadaApp for Ledger Hardware Wallets
 
 #### Defined in
 
-[sdk/src/sdk.ts:111](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L111)
+[sdk/src/sdk.ts:113](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L113)
 
 ___
 
@@ -461,4 +463,4 @@ this instance of Sdk
 
 #### Defined in
 
-[sdk/src/sdk.ts:38](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/sdk.ts#L38)
+[sdk/src/sdk.ts:40](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L40)

--- a/packages/sdk/docs/classes/Signing.md
+++ b/packages/sdk/docs/classes/Signing.md
@@ -40,7 +40,7 @@ Signing constructor
 
 #### Defined in
 
-[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/signing.ts#L14)
+[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/signing.ts#L14)
 
 ## Properties
 
@@ -52,7 +52,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/signing.ts#L14)
+[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/signing.ts#L14)
 
 ## Methods
 
@@ -78,7 +78,7 @@ signed tx bytes - Promise resolving to Uint8Array
 
 #### Defined in
 
-[sdk/src/signing.ts:23](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/signing.ts#L23)
+[sdk/src/signing.ts:23](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/signing.ts#L23)
 
 ___
 
@@ -103,7 +103,7 @@ hash and signature
 
 #### Defined in
 
-[sdk/src/signing.ts:41](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/signing.ts#L41)
+[sdk/src/signing.ts:41](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/signing.ts#L41)
 
 ___
 
@@ -129,4 +129,4 @@ void
 
 #### Defined in
 
-[sdk/src/signing.ts:52](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/signing.ts#L52)
+[sdk/src/signing.ts:52](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/signing.ts#L52)

--- a/packages/sdk/docs/classes/Tx.md
+++ b/packages/sdk/docs/classes/Tx.md
@@ -54,7 +54,7 @@ SDK functionality related to transactions
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:56](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L56)
+[sdk/src/tx/tx.ts:56](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L56)
 
 ## Properties
 
@@ -66,7 +66,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:56](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L56)
+[sdk/src/tx/tx.ts:56](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L56)
 
 ## Methods
 
@@ -91,7 +91,7 @@ Append signature for transactions signed by Ledger Hardware Wallet
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:375](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L375)
+[sdk/src/tx/tx.ts:375](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L375)
 
 ___
 
@@ -115,7 +115,7 @@ a serialized TxMsgValue type
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:358](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L358)
+[sdk/src/tx/tx.ts:358](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L358)
 
 ___
 
@@ -142,7 +142,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:178](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L178)
+[sdk/src/tx/tx.ts:178](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L178)
 
 ___
 
@@ -169,7 +169,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:337](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L337)
+[sdk/src/tx/tx.ts:337](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L337)
 
 ___
 
@@ -196,7 +196,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:290](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L290)
+[sdk/src/tx/tx.ts:290](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L290)
 
 ___
 
@@ -225,7 +225,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:267](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L267)
+[sdk/src/tx/tx.ts:267](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L267)
 
 ___
 
@@ -252,7 +252,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:242](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L242)
+[sdk/src/tx/tx.ts:242](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L242)
 
 ___
 
@@ -278,7 +278,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:165](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L165)
+[sdk/src/tx/tx.ts:165](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L165)
 
 ___
 
@@ -305,7 +305,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:90](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L90)
+[sdk/src/tx/tx.ts:90](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L90)
 
 ___
 
@@ -332,7 +332,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:115](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L115)
+[sdk/src/tx/tx.ts:115](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L115)
 
 ___
 
@@ -359,7 +359,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:65](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L65)
+[sdk/src/tx/tx.ts:65](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L65)
 
 ___
 
@@ -386,7 +386,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:199](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L199)
+[sdk/src/tx/tx.ts:199](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L199)
 
 ___
 
@@ -413,7 +413,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:141](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L141)
+[sdk/src/tx/tx.ts:141](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L141)
 
 ___
 
@@ -440,7 +440,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:313](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L313)
+[sdk/src/tx/tx.ts:313](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L313)
 
 ___
 
@@ -467,7 +467,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:221](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L221)
+[sdk/src/tx/tx.ts:221](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L221)
 
 ___
 
@@ -492,7 +492,7 @@ a TxDetails object
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:428](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L428)
+[sdk/src/tx/tx.ts:428](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L428)
 
 ___
 
@@ -516,7 +516,7 @@ Serialized WrapperTxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:416](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L416)
+[sdk/src/tx/tx.ts:416](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L416)
 
 ___
 
@@ -546,7 +546,7 @@ promise that resolves to the shielding memo
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:491](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L491)
+[sdk/src/tx/tx.ts:491](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L491)
 
 ___
 
@@ -570,4 +570,4 @@ array of inner Tx hashes
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:510](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/tx/tx.ts#L510)
+[sdk/src/tx/tx.ts:510](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L510)

--- a/packages/sdk/docs/enums/KdfType.md
+++ b/packages/sdk/docs/enums/KdfType.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:38](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/types.ts#L38)
+[sdk/src/crypto/types.ts:38](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/types.ts#L38)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:39](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/types.ts#L39)
+[sdk/src/crypto/types.ts:39](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/types.ts#L39)

--- a/packages/sdk/docs/enums/SdkEvents.md
+++ b/packages/sdk/docs/enums/SdkEvents.md
@@ -1,0 +1,41 @@
+[@namada/sdk](../README.md) / [Exports](../modules.md) / SdkEvents
+
+# Enumeration: SdkEvents
+
+## Table of contents
+
+### Enumeration Members
+
+- [ProgressBarFinished](SdkEvents.md#progressbarfinished)
+- [ProgressBarIncremented](SdkEvents.md#progressbarincremented)
+- [ProgressBarStarted](SdkEvents.md#progressbarstarted)
+
+## Enumeration Members
+
+### ProgressBarFinished
+
+• **ProgressBarFinished** = ``"namada_sdk::progress_bar::finished"``
+
+#### Defined in
+
+shared/src/shared/shared.d.ts:44
+
+___
+
+### ProgressBarIncremented
+
+• **ProgressBarIncremented** = ``"namada_sdk::progress_bar::incremented"``
+
+#### Defined in
+
+shared/src/shared/shared.d.ts:43
+
+___
+
+### ProgressBarStarted
+
+• **ProgressBarStarted** = ``"namada_sdk::progress_bar::started"``
+
+#### Defined in
+
+shared/src/shared/shared.d.ts:42

--- a/packages/sdk/docs/modules.md
+++ b/packages/sdk/docs/modules.md
@@ -8,6 +8,7 @@
 
 - [KdfType](enums/KdfType.md)
 - [PhraseSize](enums/PhraseSize.md)
+- [SdkEvents](enums/SdkEvents.md)
 - [TxType](enums/TxType.md)
 
 ### Classes
@@ -16,6 +17,7 @@
 - [Ledger](classes/Ledger.md)
 - [Masp](classes/Masp.md)
 - [Mnemonic](classes/Mnemonic.md)
+- [ProgressBarNames](classes/ProgressBarNames.md)
 - [Rpc](classes/Rpc.md)
 - [Sdk](classes/Sdk.md)
 - [Signing](classes/Signing.md)
@@ -69,7 +71,7 @@ Address and public key type
 
 #### Defined in
 
-[sdk/src/keys/types.ts:4](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/keys/types.ts#L4)
+[sdk/src/keys/types.ts:4](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/keys/types.ts#L4)
 
 ___
 
@@ -79,7 +81,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:23](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/types.ts#L23)
+[sdk/src/crypto/types.ts:23](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/types.ts#L23)
 
 ___
 
@@ -92,7 +94,7 @@ Balance
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:69](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/types.ts#L69)
+[sdk/src/rpc/types.ts:69](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/types.ts#L69)
 
 ___
 
@@ -111,7 +113,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:27](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/types.ts#L27)
+[sdk/src/rpc/types.ts:27](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/types.ts#L27)
 
 ___
 
@@ -139,7 +141,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:42](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/types.ts#L42)
+[sdk/src/crypto/types.ts:42](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/types.ts#L42)
 
 ___
 
@@ -152,7 +154,7 @@ Record<address, totalDelegations>
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:51](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/types.ts#L51)
+[sdk/src/rpc/types.ts:51](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/types.ts#L51)
 
 ___
 
@@ -165,7 +167,7 @@ Record<address, boolean>
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:57](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/types.ts#L57)
+[sdk/src/rpc/types.ts:57](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/types.ts#L57)
 
 ___
 
@@ -184,7 +186,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:30](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/types.ts#L30)
+[sdk/src/crypto/types.ts:30](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/types.ts#L30)
 
 ___
 
@@ -201,7 +203,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:19](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L19)
+[sdk/src/ledger.ts:19](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L19)
 
 ___
 
@@ -223,7 +225,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:20](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L20)
+[sdk/src/ledger.ts:20](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L20)
 
 ___
 
@@ -240,7 +242,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:32](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L32)
+[sdk/src/ledger.ts:32](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L32)
 
 ___
 
@@ -260,7 +262,7 @@ Shielded keys and address
 
 #### Defined in
 
-[sdk/src/keys/types.ts:19](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/keys/types.ts#L19)
+[sdk/src/keys/types.ts:19](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/keys/types.ts#L19)
 
 ___
 
@@ -277,7 +279,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:42](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/types.ts#L42)
+[sdk/src/rpc/types.ts:42](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/types.ts#L42)
 
 ___
 
@@ -297,7 +299,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:19](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/types.ts#L19)
+[sdk/src/rpc/types.ts:19](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/types.ts#L19)
 
 ___
 
@@ -307,7 +309,7 @@ ___
 
 #### Defined in
 
-[shared/src/types.ts:3](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/shared/src/types.ts#L3)
+[shared/src/types.ts:3](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/shared/src/types.ts#L3)
 
 ___
 
@@ -319,7 +321,7 @@ Public and private keypair with address
 
 #### Defined in
 
-[sdk/src/keys/types.ts:12](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/keys/types.ts#L12)
+[sdk/src/keys/types.ts:12](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/keys/types.ts#L12)
 
 ___
 
@@ -339,7 +341,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:34](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/rpc/types.ts#L34)
+[sdk/src/rpc/types.ts:34](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/types.ts#L34)
 
 ## Variables
 
@@ -357,7 +359,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:3](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/crypto/types.ts#L3)
+[sdk/src/crypto/types.ts:3](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/types.ts#L3)
 
 ___
 
@@ -367,7 +369,7 @@ ___
 
 #### Defined in
 
-[shared/src/types.ts:28](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/shared/src/types.ts#L28)
+[shared/src/types.ts:28](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/shared/src/types.ts#L28)
 
 ## Functions
 
@@ -387,7 +389,7 @@ Transport object
 
 #### Defined in
 
-[sdk/src/ledger.ts:51](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L51)
+[sdk/src/ledger.ts:51](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L51)
 
 ___
 
@@ -407,7 +409,7 @@ Transport object
 
 #### Defined in
 
-[sdk/src/ledger.ts:42](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/ledger.ts#L42)
+[sdk/src/ledger.ts:42](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L42)
 
 ___
 
@@ -427,4 +429,4 @@ ___
 
 #### Defined in
 
-[sdk/src/keys/keys.ts:213](https://github.com/anoma/namada-interface/blob/401d05c2b27f843316f882bbde6378581bdf06a9/packages/sdk/src/keys/keys.ts#L213)
+[sdk/src/keys/keys.ts:213](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/keys/keys.ts#L213)

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@namada/sdk",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Namada SDK package",
   "exports": {
     "./web": {

--- a/packages/shared/lib/Cargo.lock
+++ b/packages/shared/lib/Cargo.lock
@@ -2889,18 +2889,30 @@ version = "0.46.0"
 source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "borsh",
- "namada_core",
- "namada_macros",
- "namada_storage",
+ "namada_core 0.46.0",
+ "namada_macros 0.46.0",
+ "namada_storage 0.46.0",
+ "serde",
+]
+
+[[package]]
+name = "namada_account"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
+dependencies = [
+ "borsh",
+ "namada_core 0.46.1",
+ "namada_macros 0.46.1",
+ "namada_storage 0.46.1",
  "serde",
 ]
 
 [[package]]
 name = "namada_controller"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
 dependencies = [
- "namada_core",
+ "namada_core 0.46.1",
  "smooth-operator",
  "thiserror",
 ]
@@ -2925,9 +2937,54 @@ dependencies = [
  "index-set",
  "indexmap 2.2.4",
  "k256",
+ "masp_primitives",
+ "namada_macros 0.46.0",
+ "num-integer",
+ "num-rational",
+ "num-traits 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num256",
+ "num_enum",
+ "primitive-types",
+ "prost-types 0.13.2",
+ "rayon",
+ "ripemd",
+ "serde",
+ "serde_json",
+ "sha2 0.9.9",
+ "smooth-operator",
+ "sparse-merkle-tree",
+ "tendermint 0.38.1",
+ "tendermint-proto 0.38.1",
+ "thiserror",
+ "tiny-keccak",
+ "tracing",
+ "uint",
+ "zeroize",
+]
+
+[[package]]
+name = "namada_core"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
+dependencies = [
+ "bech32 0.8.1",
+ "borsh",
+ "borsh-ext",
+ "chrono",
+ "data-encoding",
+ "ed25519-consensus",
+ "ethabi",
+ "ethbridge-structs",
+ "eyre",
+ "ibc",
+ "ics23",
+ "impl-num-traits",
+ "index-set",
+ "indexmap 2.2.4",
+ "k256",
  "lazy_static",
  "masp_primitives",
- "namada_macros",
+ "namada_macros 0.46.1",
  "num-integer",
  "num-rational",
  "num-traits 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2957,24 +3014,24 @@ dependencies = [
 
 [[package]]
 name = "namada_ethereum_bridge"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
 dependencies = [
  "borsh",
  "ethers",
  "eyre",
  "itertools 0.12.1",
  "konst",
- "namada_core",
- "namada_events",
- "namada_macros",
+ "namada_core 0.46.1",
+ "namada_events 0.46.1",
+ "namada_macros 0.46.1",
  "namada_parameters",
  "namada_proof_of_stake",
  "namada_state",
- "namada_storage",
+ "namada_storage 0.46.1",
  "namada_systems",
  "namada_trans_token",
- "namada_tx",
+ "namada_tx 0.46.1",
  "namada_vote_ext",
  "namada_vp_env",
  "serde",
@@ -2989,8 +3046,22 @@ version = "0.46.0"
 source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "borsh",
- "namada_core",
- "namada_macros",
+ "namada_core 0.46.0",
+ "namada_macros 0.46.0",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "namada_events"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
+dependencies = [
+ "borsh",
+ "namada_core 0.46.1",
+ "namada_macros 0.46.1",
  "serde",
  "serde_json",
  "thiserror",
@@ -3003,28 +3074,41 @@ version = "0.46.0"
 source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
  "borsh",
- "namada_core",
- "namada_events",
- "namada_macros",
+ "namada_core 0.46.0",
+ "namada_events 0.46.0",
+ "namada_macros 0.46.0",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "namada_gas"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
+dependencies = [
+ "borsh",
+ "namada_core 0.46.1",
+ "namada_events 0.46.1",
+ "namada_macros 0.46.1",
  "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "namada_governance"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
  "konst",
- "namada_account",
- "namada_core",
- "namada_events",
- "namada_macros",
+ "namada_account 0.46.1",
+ "namada_core 0.46.1",
+ "namada_events 0.46.1",
+ "namada_macros 0.46.1",
  "namada_state",
  "namada_systems",
- "namada_tx",
+ "namada_tx 0.46.1",
  "namada_vp_env",
  "serde",
  "serde_json",
@@ -3035,8 +3119,8 @@ dependencies = [
 
 [[package]]
 name = "namada_ibc"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
 dependencies = [
  "borsh",
  "data-encoding",
@@ -3045,13 +3129,13 @@ dependencies = [
  "ics23",
  "konst",
  "masp_primitives",
- "namada_core",
- "namada_events",
- "namada_gas",
- "namada_macros",
+ "namada_core 0.46.1",
+ "namada_events 0.46.1",
+ "namada_gas 0.46.1",
+ "namada_macros 0.46.1",
  "namada_state",
  "namada_systems",
- "namada_tx",
+ "namada_tx 0.46.1",
  "namada_vp",
  "primitive-types",
  "prost 0.13.2",
@@ -3065,12 +3149,12 @@ dependencies = [
 
 [[package]]
 name = "namada_io"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
 dependencies = [
  "async-trait",
  "kdam",
- "namada_core",
+ "namada_core 0.46.1",
  "tendermint-rpc",
  "thiserror",
  "tokio",
@@ -3089,6 +3173,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "namada_macros"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
+dependencies = [
+ "data-encoding",
+ "proc-macro2",
+ "quote",
+ "sha2 0.9.9",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "namada_merkle_tree"
 version = "0.46.0"
 source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
@@ -3096,8 +3192,23 @@ dependencies = [
  "borsh",
  "eyre",
  "ics23",
- "namada_core",
- "namada_macros",
+ "namada_core 0.46.0",
+ "namada_macros 0.46.0",
+ "prost 0.13.2",
+ "sparse-merkle-tree",
+ "thiserror",
+]
+
+[[package]]
+name = "namada_merkle_tree"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
+dependencies = [
+ "borsh",
+ "eyre",
+ "ics23",
+ "namada_core 0.46.1",
+ "namada_macros 0.46.1",
  "prost 0.13.2",
  "sparse-merkle-tree",
  "thiserror",
@@ -3105,14 +3216,14 @@ dependencies = [
 
 [[package]]
 name = "namada_parameters"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
 dependencies = [
- "namada_core",
- "namada_macros",
+ "namada_core 0.46.1",
+ "namada_macros 0.46.1",
  "namada_state",
  "namada_systems",
- "namada_tx",
+ "namada_tx 0.46.1",
  "namada_vp_env",
  "smooth-operator",
  "thiserror",
@@ -3120,20 +3231,20 @@ dependencies = [
 
 [[package]]
 name = "namada_proof_of_stake"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
  "konst",
- "namada_account",
+ "namada_account 0.46.1",
  "namada_controller",
- "namada_core",
- "namada_events",
- "namada_macros",
+ "namada_core 0.46.1",
+ "namada_events 0.46.1",
+ "namada_macros 0.46.1",
  "namada_state",
  "namada_systems",
- "namada_tx",
+ "namada_tx 0.46.1",
  "namada_vp_env",
  "once_cell",
  "serde",
@@ -3147,13 +3258,21 @@ name = "namada_replay_protection"
 version = "0.46.0"
 source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
 dependencies = [
- "namada_core",
+ "namada_core 0.46.0",
+]
+
+[[package]]
+name = "namada_replay_protection"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
+dependencies = [
+ "namada_core 0.46.1",
 ]
 
 [[package]]
 name = "namada_sdk"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
 dependencies = [
  "async-trait",
  "bimap",
@@ -3173,21 +3292,21 @@ dependencies = [
  "lazy_static",
  "masp_primitives",
  "masp_proofs",
- "namada_account",
- "namada_core",
+ "namada_account 0.46.1",
+ "namada_core 0.46.1",
  "namada_ethereum_bridge",
- "namada_events",
- "namada_gas",
+ "namada_events 0.46.1",
+ "namada_gas 0.46.1",
  "namada_governance",
  "namada_ibc",
  "namada_io",
- "namada_macros",
+ "namada_macros 0.46.1",
  "namada_parameters",
  "namada_proof_of_stake",
  "namada_state",
- "namada_storage",
+ "namada_storage 0.46.1",
  "namada_token",
- "namada_tx",
+ "namada_tx 0.46.1",
  "namada_vm",
  "namada_vote_ext",
  "namada_vp",
@@ -3221,8 +3340,8 @@ dependencies = [
 
 [[package]]
 name = "namada_shielded_token"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3233,16 +3352,16 @@ dependencies = [
  "lazy_static",
  "masp_primitives",
  "masp_proofs",
- "namada_account",
+ "namada_account 0.46.1",
  "namada_controller",
- "namada_core",
- "namada_events",
- "namada_gas",
+ "namada_core 0.46.1",
+ "namada_events 0.46.1",
+ "namada_gas 0.46.1",
  "namada_io",
- "namada_macros",
+ "namada_macros 0.46.1",
  "namada_state",
  "namada_systems",
- "namada_tx",
+ "namada_tx 0.46.1",
  "namada_vp_env",
  "namada_wallet",
  "rand 0.8.5",
@@ -3262,21 +3381,21 @@ dependencies = [
 
 [[package]]
 name = "namada_state"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
 dependencies = [
  "borsh",
  "clru",
  "itertools 0.12.1",
- "namada_core",
- "namada_events",
- "namada_gas",
- "namada_macros",
- "namada_merkle_tree",
- "namada_replay_protection",
- "namada_storage",
+ "namada_core 0.46.1",
+ "namada_events 0.46.1",
+ "namada_gas 0.46.1",
+ "namada_macros 0.46.1",
+ "namada_merkle_tree 0.46.1",
+ "namada_replay_protection 0.46.1",
+ "namada_storage 0.46.1",
  "namada_systems",
- "namada_tx",
+ "namada_tx 0.46.1",
  "patricia_tree",
  "smooth-operator",
  "thiserror",
@@ -3290,11 +3409,30 @@ source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221d
 dependencies = [
  "borsh",
  "itertools 0.12.1",
- "namada_core",
- "namada_gas",
- "namada_macros",
- "namada_merkle_tree",
- "namada_replay_protection",
+ "namada_core 0.46.0",
+ "namada_gas 0.46.0",
+ "namada_macros 0.46.0",
+ "namada_merkle_tree 0.46.0",
+ "namada_replay_protection 0.46.0",
+ "regex",
+ "serde",
+ "smooth-operator",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "namada_storage"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
+dependencies = [
+ "borsh",
+ "itertools 0.12.1",
+ "namada_core 0.46.1",
+ "namada_gas 0.46.1",
+ "namada_macros 0.46.1",
+ "namada_merkle_tree 0.46.1",
+ "namada_replay_protection 0.46.1",
  "regex",
  "serde",
  "smooth-operator",
@@ -3304,43 +3442,43 @@ dependencies = [
 
 [[package]]
 name = "namada_systems"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
 dependencies = [
- "namada_core",
- "namada_events",
- "namada_storage",
+ "namada_core 0.46.1",
+ "namada_events 0.46.1",
+ "namada_storage 0.46.1",
 ]
 
 [[package]]
 name = "namada_token"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
 dependencies = [
  "borsh",
- "namada_core",
- "namada_events",
- "namada_macros",
+ "namada_core 0.46.1",
+ "namada_events 0.46.1",
+ "namada_macros 0.46.1",
  "namada_shielded_token",
- "namada_storage",
+ "namada_storage 0.46.1",
  "namada_systems",
  "namada_trans_token",
- "namada_tx",
+ "namada_tx 0.46.1",
  "namada_tx_env",
  "serde",
 ]
 
 [[package]]
 name = "namada_trans_token"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
 dependencies = [
  "konst",
- "namada_core",
- "namada_events",
+ "namada_core 0.46.1",
+ "namada_events 0.46.1",
  "namada_state",
  "namada_systems",
- "namada_tx",
+ "namada_tx 0.46.1",
  "namada_tx_env",
  "namada_vp_env",
  "thiserror",
@@ -3359,11 +3497,40 @@ dependencies = [
  "either",
  "konst",
  "masp_primitives",
- "namada_account",
- "namada_core",
- "namada_events",
- "namada_gas",
- "namada_macros",
+ "namada_account 0.46.0",
+ "namada_core 0.46.0",
+ "namada_events 0.46.0",
+ "namada_gas 0.46.0",
+ "namada_macros 0.46.0",
+ "num-derive 0.4.2",
+ "num-traits 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.13.2",
+ "prost-types 0.13.2",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_json",
+ "sha2 0.9.9",
+ "thiserror",
+ "tonic-build",
+]
+
+[[package]]
+name = "namada_tx"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
+dependencies = [
+ "ark-bls12-381",
+ "bitflags 2.5.0",
+ "borsh",
+ "data-encoding",
+ "either",
+ "konst",
+ "masp_primitives",
+ "namada_account 0.46.1",
+ "namada_core 0.46.1",
+ "namada_events 0.46.1",
+ "namada_gas 0.46.1",
+ "namada_macros 0.46.1",
  "num-derive 0.4.2",
  "num-traits 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.13.2",
@@ -3378,29 +3545,29 @@ dependencies = [
 
 [[package]]
 name = "namada_tx_env"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
 dependencies = [
- "namada_core",
- "namada_events",
- "namada_storage",
+ "namada_core 0.46.1",
+ "namada_events 0.46.1",
+ "namada_storage 0.46.1",
 ]
 
 [[package]]
 name = "namada_vm"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
 dependencies = [
  "borsh",
  "clru",
- "namada_account",
- "namada_core",
- "namada_events",
- "namada_gas",
+ "namada_account 0.46.1",
+ "namada_core 0.46.1",
+ "namada_events 0.46.1",
+ "namada_gas 0.46.1",
  "namada_parameters",
  "namada_state",
  "namada_token",
- "namada_tx",
+ "namada_tx 0.46.1",
  "namada_vp",
  "smooth-operator",
  "thiserror",
@@ -3410,26 +3577,26 @@ dependencies = [
 
 [[package]]
 name = "namada_vote_ext"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
 dependencies = [
  "borsh",
- "namada_core",
- "namada_macros",
- "namada_tx",
+ "namada_core 0.46.1",
+ "namada_macros 0.46.1",
+ "namada_tx 0.46.1",
  "serde",
 ]
 
 [[package]]
 name = "namada_vp"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
 dependencies = [
- "namada_core",
- "namada_events",
- "namada_gas",
+ "namada_core 0.46.1",
+ "namada_events 0.46.1",
+ "namada_gas 0.46.1",
  "namada_state",
- "namada_tx",
+ "namada_tx 0.46.1",
  "namada_vp_env",
  "smooth-operator",
  "thiserror",
@@ -3438,23 +3605,23 @@ dependencies = [
 
 [[package]]
 name = "namada_vp_env"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
 dependencies = [
  "derivative",
  "masp_primitives",
- "namada_core",
- "namada_events",
- "namada_gas",
- "namada_storage",
- "namada_tx",
+ "namada_core 0.46.1",
+ "namada_events 0.46.1",
+ "namada_gas 0.46.1",
+ "namada_storage 0.46.1",
+ "namada_tx 0.46.1",
  "smooth-operator",
 ]
 
 [[package]]
 name = "namada_wallet"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?tag=v0.46.0#cc531ec513b8ade85b221dd0a6c11818927fd247"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?tag=v0.46.1#b24938efd948cb43fc996a729138cb099abcadc0"
 dependencies = [
  "bimap",
  "borsh",
@@ -3463,9 +3630,9 @@ dependencies = [
  "derivation-path",
  "itertools 0.12.1",
  "masp_primitives",
- "namada_core",
+ "namada_core 0.46.1",
  "namada_ibc",
- "namada_macros",
+ "namada_macros 0.46.1",
  "orion",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -4930,7 +5097,7 @@ dependencies = [
  "hex",
  "js-sys",
  "namada_sdk",
- "namada_tx",
+ "namada_tx 0.46.0",
  "rand 0.8.5",
  "rayon",
  "reqwest",

--- a/packages/shared/lib/Cargo.toml
+++ b/packages/shared/lib/Cargo.toml
@@ -27,7 +27,7 @@ chrono = "0.4.22"
 getrandom = { version = "0.2.7", features = ["js"] }
 gloo-utils = { version = "0.1.5", features = ["serde"] }
 js-sys = "0.3.60"
-namada_sdk = { git = "https://github.com/anoma/namada", tag="v0.46.0", default-features = false }
+namada_sdk = { git = "https://github.com/anoma/namada", tag="v0.46.1", default-features = false }
 rand = "0.8.5"
 rayon = { version = "1.5.3", optional = true }
 rexie = "0.5"


### PR DESCRIPTION
- SDK -> version 0.11.0, needed for this Extension & SDK release
- Rebuild `packages/sdk` docs
- Bump namada to `v0.46.1` in `@namada/shared` lib (no other changes needed!)