### PR TITLE
chore: Remove unneeded Firefox instruction

### DIFF
--- a/apps/extension/FIREFOX_README.md
+++ b/apps/extension/FIREFOX_README.md
@@ -52,12 +52,6 @@ cd apps/extension
 yarn wasm:build
 ```
 
-Before building the extension, you must specify the following value in a `.env` file in `apps/extension`:
-
-```bash
-NAMADA_INTERFACE_NAMADA_CHAIN_ID=internal-devnet-43.d9368f80c60
-```
-
 Then, issue the final build command for the Firefox add-on:
 
 ```bash


### PR DESCRIPTION
As we no longer need to specify a chain ID in the extension `.env`, I'm removing this step in the build instructions. This will not be used in the 0.3.3 Firefox release!