### PR TITLE
Namadillo: Displaying all validators

### DIFF
--- a/apps/namadillo/src/atoms/validators/services.ts
+++ b/apps/namadillo/src/atoms/validators/services.ts
@@ -1,6 +1,5 @@
 import {
   DefaultApi,
-  ValidatorStatus as IndexerValidatorStatus,
   VotingPower as IndexerVotingPower,
   MergedBond,
   Unbond,
@@ -23,10 +22,7 @@ export const fetchAllValidators = async (
   votingPower: IndexerVotingPower
 ): Promise<Validator[]> => {
   const nominalApr = chainParameters.apr;
-  const validatorsResponse = await api.apiV1PosValidatorAllGet([
-    IndexerValidatorStatus.Consensus,
-  ]);
-
+  const validatorsResponse = await api.apiV1PosValidatorAllGet();
   const validators = validatorsResponse.data;
   return validators.map((v) =>
     toValidator(v, votingPower, chainParameters.unbondingPeriod, nominalApr)


### PR DESCRIPTION
We were filtering the `all` validators query by the active ones only. This PR fixes this behavior and possibly closes #1339 .