### PR TITLE
Namadillo: handling IBC transfer errors + rolling back `originalAddress` change

### DIFF
--- a/apps/namadillo/src/App/Common/InlineError.tsx
+++ b/apps/namadillo/src/App/Common/InlineError.tsx
@@ -1,6 +1,5 @@
 import clsx from "clsx";
 import React from "react";
-import { GoXCircle } from "react-icons/go";
 
 type InlineErrorProps = {
   errorMessage?: React.ReactNode;
@@ -13,10 +12,10 @@ export const InlineError = ({
   return (
     <div
       className={clsx(
-        "text-fail text-sm flex items-center gap-1.5 selection:bg-fail selection:text-black"
+        "text-fail text-sm items-center gap-1.5 selection:bg-fail selection:text-black",
+        "break-words"
       )}
     >
-      <GoXCircle />
       {errorMessage}
     </div>
   );

--- a/apps/namadillo/src/atoms/integrations/services.ts
+++ b/apps/namadillo/src/atoms/integrations/services.ts
@@ -5,6 +5,7 @@ import {
   DeliverTxResponse,
   SigningStargateClient,
   StargateClient,
+  assertIsDeliverTxSuccess,
 } from "@cosmjs/stargate";
 import { TransactionFee } from "App/Transfer/TransferModule";
 import { queryForAck, queryForIbcTimeout } from "atoms/transactions";
@@ -116,7 +117,7 @@ export const submitIbcTransfer = async (
     sourceAddress,
     receiver,
     baseAmount,
-    asset.asset.base,
+    asset.originalAddress,
     memo
   );
 
@@ -126,10 +127,7 @@ export const submitIbcTransfer = async (
     fee
   );
 
-  if (response.code !== 0) {
-    throw new Error(response.code + " " + response.transactionHash);
-  }
-
+  assertIsDeliverTxSuccess(response);
   return response;
 };
 


### PR DESCRIPTION
Fixes the way errors on IBC transfers are handled (only from IBC chains to Namada) and rollbacks a change made on #1250 to use `originalAddress` instead of `asset.base`. 