### PR TITLE
Namadillo: fixing denomination for Namada transfers

### DIFF
--- a/apps/namadillo/src/App/NamadaTransfer/NamadaTransfer.tsx
+++ b/apps/namadillo/src/App/NamadaTransfer/NamadaTransfer.tsx
@@ -36,11 +36,7 @@ import {
   PartialTransferTransactionData,
   TransferStep,
 } from "types";
-import {
-  isNamadaAsset,
-  toBaseAmount,
-  useTransactionEventListListener,
-} from "utils";
+import { isNamadaAsset, useTransactionEventListListener } from "utils";
 import { NamadaTransferTopHeader } from "./NamadaTransferTopHeader";
 
 export const NamadaTransfer: React.FC = () => {
@@ -93,10 +89,7 @@ export const NamadaTransfer: React.FC = () => {
   const token = selectedAsset?.originalAddress ?? "";
   const source = sourceAddress ?? "";
   const target = customAddress ?? "";
-  const txAmount =
-    selectedAsset && displayAmount ?
-      toBaseAmount(selectedAsset?.asset, displayAmount)
-    : new BigNumber(0);
+  const txAmount = displayAmount || new BigNumber(0);
 
   const commomProps = {
     parsePendingTxNotification: () => ({

--- a/apps/namadillo/src/lib/transactions.ts
+++ b/apps/namadillo/src/lib/transactions.ts
@@ -23,7 +23,7 @@ import {
   TransferStep,
   TransferTransactionData,
 } from "types";
-import { isNamadaAsset, toDisplayAmount } from "utils";
+import { toDisplayAmount } from "utils";
 import { TransactionPair } from "./query";
 
 export const getEventAttribute = (
@@ -191,10 +191,9 @@ export const createTransferDataFromNamada = (
           sourceAddress,
           destinationAddress,
           asset,
-          displayAmount:
-            isNamadaAsset(asset) ? amount : toDisplayAmount(asset, amount),
           memo,
           rpc: rpcUrl,
+          displayAmount: amount,
           chainId: txResponse?.encodedTxData.txs[0]?.args.chainId ?? "",
           hash: txResponse?.encodedTxData.txs[0].hash,
           feePaid: txResponse?.encodedTxData.txs[0].args.feeAmount,


### PR DESCRIPTION
After the implementation of `minDenomAmount` on the indexer, we've noticed that Namada transfers ended up dealing with the wrong amount. This PR fixes again this issue.