### PR TITLE
WIP: feat/1078 - Extension permissions updates

### DIFF
--- a/apps/extension/src/background/permissions/index.ts
+++ b/apps/extension/src/background/permissions/index.ts
@@ -1,0 +1,1 @@
+export * from "./service";

--- a/apps/extension/src/background/permissions/service.ts
+++ b/apps/extension/src/background/permissions/service.ts
@@ -1,0 +1,72 @@
+import { AllowedPermissions, LocalStorage, PermissionKind } from "storage";
+
+export class PermissionsService {
+  constructor(protected readonly localStorage: LocalStorage) {}
+
+  async enablePermissions(
+    domain: string,
+    chainId: string,
+    allowed: AllowedPermissions
+  ): Promise<void> {
+    const existingPermissions = await this.localStorage.getPermissions();
+    const newPermissions = [...new Set<PermissionKind>(allowed)];
+
+    if (existingPermissions) {
+      existingPermissions[domain] = existingPermissions[domain] || {};
+      existingPermissions[domain][chainId] = newPermissions;
+      return await this.localStorage.setPermissions(existingPermissions);
+    }
+
+    return await this.localStorage.setPermissions({
+      [domain]: {
+        [chainId]: newPermissions,
+      },
+    });
+  }
+
+  async revokeChainPermissions(domain: string, chainId: string): Promise<void> {
+    const updatedPermissions = await this.localStorage.getPermissions();
+    if (
+      !updatedPermissions ||
+      !updatedPermissions[domain] ||
+      !updatedPermissions[domain][chainId]
+    ) {
+      return;
+    }
+    delete updatedPermissions[domain][chainId];
+    await this.localStorage.setPermissions(updatedPermissions);
+  }
+
+  async revokeDomainPermissions(domain: string): Promise<void> {
+    const updatedPermissions = await this.localStorage.getPermissions();
+    if (!updatedPermissions || !updatedPermissions[domain]) {
+      return;
+    }
+    delete updatedPermissions[domain];
+    await this.localStorage.setPermissions(updatedPermissions);
+  }
+
+  async permissionsByDomain(
+    domain: string
+  ): Promise<Record<string, AllowedPermissions> | undefined> {
+    const permissions = await this.localStorage.getPermissions();
+
+    if (permissions && permissions[domain]) {
+      return permissions[domain];
+    }
+  }
+
+  async permissionsByChain(
+    domain: string,
+    chainId: string
+  ): Promise<AllowedPermissions | undefined> {
+    const permissions = await this.localStorage.getPermissions();
+    if (permissions && permissions[domain] && permissions[domain][chainId]) {
+      return permissions[domain][chainId];
+    }
+  }
+
+  async getApprovedOrigins(): Promise<string[] | undefined> {
+    return await this.localStorage.getApprovedOrigins();
+  }
+}


### PR DESCRIPTION
Resolves #1078 

- [x] Establish new permissions model storage for approving features per chain per domain 
- [ ] When chain ID changes in interface (such as pointing to a different indexer) prompt for approval to enable signing for that chain, and update Permissions accordingly
- [ ] Update unit tests for Approvals service
