### PR TITLE
feat: listen for extension

### DIFF
--- a/apps/namadillo/src/App/Setup/ExtensionLoader.tsx
+++ b/apps/namadillo/src/App/Setup/ExtensionLoader.tsx
@@ -21,20 +21,24 @@ export const ExtensionLoader = ({
   );
 
   const chainId = chain?.chainId;
-  const keychainPromise = namadaKeychain.get();
 
   useEffect(() => {
-    keychainPromise.then((injectedNamada) => {
-      if (injectedNamada) {
-        return setAttachStatus("attached");
-      }
-      setAttachStatus("detached");
-    });
+    const getNamada = (): void => {
+      namadaKeychain.get().then((injectedNamada) => {
+        if (injectedNamada) {
+          setAttachStatus("attached");
+          return;
+        }
+        setAttachStatus("detached");
+        setTimeout(() => getNamada());
+      });
+    };
+    getNamada();
   }, []);
 
   useEffect(() => {
     if (chainId && attachStatus === "attached") {
-      keychainPromise.then((injectedNamada) => {
+      namadaKeychain.get().then((injectedNamada) => {
         injectedNamada.isConnected(chainId).then((isConnected) => {
           if (isConnected) {
             return setConnectionStatus("connected");


### PR DESCRIPTION
Listen for extension to be enabled.

Useful if the user allow the extension only on click or any other barrier that delay the extension to be loaded

https://github.com/user-attachments/assets/3c85d3aa-99ec-4b64-86b6-76b868f79165

