### PR TITLE
Namadillo: increasing decimal places on redelegation

### DIFF
--- a/apps/namadillo/src/App/Staking/BondingAmountOverview.tsx
+++ b/apps/namadillo/src/App/Staking/BondingAmountOverview.tsx
@@ -41,7 +41,6 @@ export const BondingAmountOverview = ({
               [updatedValueClassList]: hasUpdatedValue,
             })}
             currencySymbolClassName="text-lg"
-            decimalPlaces={2}
           />
           {amountToDelegate && amountToDelegate.gt(0) && (
             <span className="text-success text-md font-light mt-1.5 ml-3">


### PR DESCRIPTION
When the amount you want re-delegate contains some dust, the "Total amount to redelegate" was not showing all decimal places, making hard to proceed. This PR fixes this error.