### PR TITLE
Registry update for Namada mainnet

### DIFF
--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -27,7 +27,7 @@
     "jotai": "^2.6.3",
     "jotai-tanstack-query": "^0.8.5",
     "lodash.debounce": "^4.0.8",
-    "namada-chain-registry": "https://github.com/anoma/namada-chain-registry",
+    "namada-chain-registry": "https://github.com/anoma/namada-chain-registry#bae038a3bd666cd7cb8886fcfecb94623dd3d843",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.1.0",

--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -27,7 +27,7 @@
     "jotai": "^2.6.3",
     "jotai-tanstack-query": "^0.8.5",
     "lodash.debounce": "^4.0.8",
-    "namada-chain-registry": "https://github.com/anoma/namada-chain-registry#a22fad61b14c67d68d65b67bee71c88253a84aae",
+    "namada-chain-registry": "https://github.com/anoma/namada-chain-registry",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.1.0",

--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -27,7 +27,7 @@
     "jotai": "^2.6.3",
     "jotai-tanstack-query": "^0.8.5",
     "lodash.debounce": "^4.0.8",
-    "namada-chain-registry": "https://github.com/anoma/namada-chain-registry#bae038a3bd666cd7cb8886fcfecb94623dd3d843",
+    "namada-chain-registry": "https://github.com/anoma/namada-chain-registry",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.1.0",

--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -27,7 +27,7 @@
     "jotai": "^2.6.3",
     "jotai-tanstack-query": "^0.8.5",
     "lodash.debounce": "^4.0.8",
-    "namada-chain-registry": "https://github.com/anoma/namada-chain-registry",
+    "namada-chain-registry": "https://github.com/anoma/namada-chain-registry#a22fad61b14c67d68d65b67bee71c88253a84aae",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.1.0",

--- a/apps/namadillo/src/atoms/integrations/functions.ts
+++ b/apps/namadillo/src/atoms/integrations/functions.ts
@@ -30,30 +30,28 @@ import {
 import { toBaseAmount, toDisplayAmount } from "utils";
 import { getSdkInstance } from "utils/sdk";
 
-import dryrunAssets from "namada-chain-registry/namadadryrun/assetlist.json";
-import dryrunChain from "namada-chain-registry/namadadryrun/chain.json";
-import housefireAssets from "namada-chain-registry/namadahousefire/assetlist.json";
-import housefireChain from "namada-chain-registry/namadahousefire/chain.json";
-import internalDevnetAssets from "namada-chain-registry/namadainternaldevnet/assetlist.json";
-import internalDevnetChain from "namada-chain-registry/namadainternaldevnet/chain.json";
+import housefireAssets from "namada-chain-registry/_testnets/namadahousefire/assetlist.json";
+import housefireChain from "namada-chain-registry/_testnets/namadahousefire/chain.json";
+import internalDevnetAssets from "namada-chain-registry/_testnets/namadainternaldevnet/assetlist.json";
+import internalDevnetChain from "namada-chain-registry/_testnets/namadainternaldevnet/chain.json";
+import namadaAssets from "namada-chain-registry/namada/assetlist.json";
+import namadaChain from "namada-chain-registry/namada/chain.json";
 
-import dryrunOsmosis from "namada-chain-registry/_IBC/namadadryrun-osmosis.json";
-import housefireCosmosTestnetIbc from "namada-chain-registry/_IBC/namadahousefire-cosmoshubtestnet.json";
-import housefireOsmosisTestnetIbc from "namada-chain-registry/_IBC/namadahousefire-osmosistestnet.json";
-import internalDevnetCosmosTestnetIbc from "namada-chain-registry/_IBC/namadainternaldevnet-cosmoshubtestnet.json";
+import housefireCosmosTestnetIbc from "namada-chain-registry/_testnets/_IBC/namadahousefire-cosmoshubtestnet.json";
+import housefireOsmosisTestnetIbc from "namada-chain-registry/_testnets/_IBC/namadahousefire-osmosistestnet.json";
+import internalDevnetCosmosTestnetIbc from "namada-chain-registry/_testnets/_IBC/namadainternaldevnet-cosmoshubtestnet.json";
 
 // TODO: this causes a big increase on bundle size. See #1224.
 import cosmosRegistry from "chain-registry";
 
-cosmosRegistry.chains.push(internalDevnetChain, housefireChain, dryrunChain);
+cosmosRegistry.chains.push(internalDevnetChain, housefireChain, namadaChain);
 
-cosmosRegistry.assets.push(internalDevnetAssets, housefireAssets, dryrunAssets);
+cosmosRegistry.assets.push(internalDevnetAssets, housefireAssets, namadaAssets);
 
 cosmosRegistry.ibc.push(
   internalDevnetCosmosTestnetIbc,
   housefireCosmosTestnetIbc,
-  housefireOsmosisTestnetIbc,
-  dryrunOsmosis
+  housefireOsmosisTestnetIbc
 );
 
 const mainnetChains: ChainRegistryEntry[] = [

--- a/apps/namadillo/src/hooks/useRegistryFeatures.tsx
+++ b/apps/namadillo/src/hooks/useRegistryFeatures.tsx
@@ -12,7 +12,7 @@ const { VITE_PROXY } = import.meta.env;
 const namadaChainRegistryUrl =
   VITE_PROXY ?
     "http://localhost:8010/proxy"
-    : "https://raw.githubusercontent.com/anoma/namada-chain-registry/refs/heads/main";
+  : "https://raw.githubusercontent.com/anoma/namada-chain-registry/refs/heads/main";
 
 const namadaChainRegistryMap = new Map<string, string>([
   ["namada.5f5de2dd1b88cba30586420", "namada"],

--- a/apps/namadillo/src/hooks/useRegistryFeatures.tsx
+++ b/apps/namadillo/src/hooks/useRegistryFeatures.tsx
@@ -12,12 +12,12 @@ const { VITE_PROXY } = import.meta.env;
 const namadaChainRegistryUrl =
   VITE_PROXY ?
     "http://localhost:8010/proxy"
-  : "https://raw.githubusercontent.com/anoma/namada-chain-registry/refs/heads/main";
+    : "https://raw.githubusercontent.com/anoma/namada-chain-registry/refs/heads/main";
 
 const namadaChainRegistryMap = new Map<string, string>([
-  ["namada-dryrun.abaaeaf7b78cb3ac", "namadadryrun"],
-  ["housefire-equal.130b1076e3250f", "namadahousefire"],
-  ["internal-devnet-44a.1bd3e6ca62", "namadainternaldevnet"],
+  ["namada.5f5de2dd1b88cba30586420", "namada"],
+  ["housefire-creek.76ed2d08793c14", "_testnets/namadahousefire"],
+  ["internal-devnet-45a.1881abcfec", "_testnets/namadainternaldevnet"],
 ]);
 
 type Feature =

--- a/apps/namadillo/src/utils/index.ts
+++ b/apps/namadillo/src/utils/index.ts
@@ -5,7 +5,7 @@ import BigNumber from "bignumber.js";
 import * as fns from "date-fns";
 import { getDefaultStore } from "jotai";
 import { DateTime } from "luxon";
-import internalDevnetAssets from "namada-chain-registry/namadainternaldevnet/assetlist.json";
+import internalDevnetAssets from "namada-chain-registry/_testnets/namadainternaldevnet/assetlist.json";
 import { useEffect } from "react";
 
 export const proposalStatusToString = (status: ProposalStatus): string => {

--- a/apps/namadillo/src/utils/index.ts
+++ b/apps/namadillo/src/utils/index.ts
@@ -5,7 +5,7 @@ import BigNumber from "bignumber.js";
 import * as fns from "date-fns";
 import { getDefaultStore } from "jotai";
 import { DateTime } from "luxon";
-import internalDevnetAssets from "namada-chain-registry/_testnets/namadainternaldevnet/assetlist.json";
+import namadaAssets from "namada-chain-registry/namada/assetlist.json";
 import { useEffect } from "react";
 
 export const proposalStatusToString = (status: ProposalStatus): string => {
@@ -123,14 +123,13 @@ const findDisplayUnit = (asset: Asset): AssetDenomUnit | undefined => {
   return denom_units.find((unit) => unit.denom === display);
 };
 
-// TODO update to mainnet asset
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export const namadaAsset = () => {
   const store = getDefaultStore();
   const config = store.get(localnetConfigAtom);
 
   const configTokenAddress = config.data?.tokenAddress;
-  const registryAsset = internalDevnetAssets.assets[0];
+  const registryAsset = namadaAssets.assets[0];
   const asset =
     configTokenAddress ?
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3680,7 +3680,7 @@ __metadata:
     jotai-tanstack-query: "npm:^0.8.5"
     local-cors-proxy: "npm:^1.1.0"
     lodash.debounce: "npm:^4.0.8"
-    namada-chain-registry: "https://github.com/anoma/namada-chain-registry"
+    namada-chain-registry: "https://github.com/anoma/namada-chain-registry#bae038a3bd666cd7cb8886fcfecb94623dd3d843"
     postcss: "npm:^8.4.32"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
@@ -15837,10 +15837,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"namada-chain-registry@https://github.com/anoma/namada-chain-registry":
+"namada-chain-registry@https://github.com/anoma/namada-chain-registry#bae038a3bd666cd7cb8886fcfecb94623dd3d843":
   version: 0.0.1
-  resolution: "namada-chain-registry@https://github.com/anoma/namada-chain-registry.git#commit=aa3e4a524d4a8eed71c124272711de63bcded849"
-  checksum: 28855dec819a03d1d7411ccf0e878c4ce246abefa18caf768e4e1205f1f31aa89bc0daf2949e167055cea31afa09cf7b6f2f8a5340356d16339afcccbf81d8c5
+  resolution: "namada-chain-registry@https://github.com/anoma/namada-chain-registry.git#commit=bae038a3bd666cd7cb8886fcfecb94623dd3d843"
+  checksum: fa6e067ae662dbfb7076a14439bb7b2e39fc3d581ab50ce1fd5e4cd222f8e3e87d945653ac1cadef48f0cd36eaf0f40e7aca06152a007ab40c0594819cd48512
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3680,7 +3680,7 @@ __metadata:
     jotai-tanstack-query: "npm:^0.8.5"
     local-cors-proxy: "npm:^1.1.0"
     lodash.debounce: "npm:^4.0.8"
-    namada-chain-registry: "https://github.com/anoma/namada-chain-registry"
+    namada-chain-registry: "https://github.com/anoma/namada-chain-registry#a22fad61b14c67d68d65b67bee71c88253a84aae"
     postcss: "npm:^8.4.32"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
@@ -15837,10 +15837,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"namada-chain-registry@https://github.com/anoma/namada-chain-registry":
+"namada-chain-registry@https://github.com/anoma/namada-chain-registry#a22fad61b14c67d68d65b67bee71c88253a84aae":
   version: 0.0.1
-  resolution: "namada-chain-registry@https://github.com/anoma/namada-chain-registry.git#commit=5531bd0c9fa08b9be53e1994ef998719dc618314"
-  checksum: 0b336e4bb5f7bd39b87828b5da3b90d69a3e8f629f567bf72a36d930c7d52431598ac6545f61aba4e11a4f4485830084971e8b65e3bba29078c22e2e2c98efe1
+  resolution: "namada-chain-registry@https://github.com/anoma/namada-chain-registry.git#commit=a22fad61b14c67d68d65b67bee71c88253a84aae"
+  checksum: f87159375f4e9308d0b47357a982411b8c83b427abf46bad28b65beb0eb489f3e2c25a2bbc7290d31090bd448ca1fa7f72ba1dfbf85241501cf2fa7d3a8904a5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3680,7 +3680,7 @@ __metadata:
     jotai-tanstack-query: "npm:^0.8.5"
     local-cors-proxy: "npm:^1.1.0"
     lodash.debounce: "npm:^4.0.8"
-    namada-chain-registry: "https://github.com/anoma/namada-chain-registry#bae038a3bd666cd7cb8886fcfecb94623dd3d843"
+    namada-chain-registry: "https://github.com/anoma/namada-chain-registry"
     postcss: "npm:^8.4.32"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
@@ -15837,10 +15837,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"namada-chain-registry@https://github.com/anoma/namada-chain-registry#bae038a3bd666cd7cb8886fcfecb94623dd3d843":
+"namada-chain-registry@https://github.com/anoma/namada-chain-registry":
   version: 0.0.1
-  resolution: "namada-chain-registry@https://github.com/anoma/namada-chain-registry.git#commit=bae038a3bd666cd7cb8886fcfecb94623dd3d843"
-  checksum: fa6e067ae662dbfb7076a14439bb7b2e39fc3d581ab50ce1fd5e4cd222f8e3e87d945653ac1cadef48f0cd36eaf0f40e7aca06152a007ab40c0594819cd48512
+  resolution: "namada-chain-registry@https://github.com/anoma/namada-chain-registry.git#commit=5531bd0c9fa08b9be53e1994ef998719dc618314"
+  checksum: 0b336e4bb5f7bd39b87828b5da3b90d69a3e8f629f567bf72a36d930c7d52431598ac6545f61aba4e11a4f4485830084971e8b65e3bba29078c22e2e2c98efe1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3680,7 +3680,7 @@ __metadata:
     jotai-tanstack-query: "npm:^0.8.5"
     local-cors-proxy: "npm:^1.1.0"
     lodash.debounce: "npm:^4.0.8"
-    namada-chain-registry: "https://github.com/anoma/namada-chain-registry#a22fad61b14c67d68d65b67bee71c88253a84aae"
+    namada-chain-registry: "https://github.com/anoma/namada-chain-registry"
     postcss: "npm:^8.4.32"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
@@ -15837,10 +15837,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"namada-chain-registry@https://github.com/anoma/namada-chain-registry#a22fad61b14c67d68d65b67bee71c88253a84aae":
+"namada-chain-registry@https://github.com/anoma/namada-chain-registry":
   version: 0.0.1
-  resolution: "namada-chain-registry@https://github.com/anoma/namada-chain-registry.git#commit=a22fad61b14c67d68d65b67bee71c88253a84aae"
-  checksum: f87159375f4e9308d0b47357a982411b8c83b427abf46bad28b65beb0eb489f3e2c25a2bbc7290d31090bd448ca1fa7f72ba1dfbf85241501cf2fa7d3a8904a5
+  resolution: "namada-chain-registry@https://github.com/anoma/namada-chain-registry.git#commit=bbcc8535461ae2e939629740628ae455feca8225"
+  checksum: a4b2ab0789cb20dbb2299572fa3749e2c737eedd26823c1bfb9e4484dda701a1cb0a255d1f8944bd4bff1b6315f9cb494ec63482c3dcdd1c05d85deb59f9afeb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
See registry updates in https://github.com/anoma/namada-chain-registry/pull/17

- [x] Update for Namada Mainnet!
- [x] Update for structural changes in [#17](https://github.com/anoma/namada-chain-registry/pull/17)
- [x] Remove reference to Dry-Run as it no longer exists
- [x] Remove commit hash in `apps/namadillo/package.json` once [#18](https://github.com/anoma/namada-chain-registry/pull/18) is merged