### PR TITLE
feat: force bond in the claim and stake flow

### DIFF
--- a/apps/namadillo/src/atoms/staking/services.ts
+++ b/apps/namadillo/src/atoms/staking/services.ts
@@ -129,6 +129,9 @@ export const createClaimAndStakeTx = async (
     props: ClaimRewardsProps | BondProps
   ): Promise<TxMsgValue> => {
     if ("amount" in props) {
+      // We have to force it in case: current balance < rewards to claim
+      // This will still log the error msg in the terminal, unfortunately we can't do much about it
+      wrapperTxProps.force = true;
       return tx.buildBond(wrapperTxProps, props as BondProps);
     } else {
       return tx.buildClaimRewards(wrapperTxProps, props as ClaimRewardsProps);

--- a/packages/shared/lib/src/sdk/args.rs
+++ b/packages/shared/lib/src/sdk/args.rs
@@ -38,6 +38,7 @@ pub struct WrapperTxMsg {
     chain_id: String,
     public_key: Option<String>,
     memo: Option<String>,
+    force: Option<bool>,
 }
 
 impl WrapperTxMsg {
@@ -48,6 +49,7 @@ impl WrapperTxMsg {
         chain_id: String,
         public_key: Option<String>,
         memo: Option<String>,
+        force: Option<bool>,
     ) -> WrapperTxMsg {
         WrapperTxMsg {
             token,
@@ -56,6 +58,7 @@ impl WrapperTxMsg {
             chain_id,
             public_key,
             memo,
+            force,
         }
     }
 }
@@ -884,6 +887,7 @@ fn tx_msg_into_args(tx_msg: &[u8]) -> Result<args::Tx, JsError> {
         chain_id,
         public_key,
         memo,
+        force,
     } = tx_msg;
 
     let token = Address::from_str(&token)?;
@@ -911,12 +915,14 @@ fn tx_msg_into_args(tx_msg: &[u8]) -> Result<args::Tx, JsError> {
 
     let memo = memo.map(|v| v.as_bytes().to_vec());
 
+    let force = force.unwrap_or(false);
+
     let args = args::Tx {
         dry_run: false,
         dry_run_wrapper: false,
         dump_tx: false,
         dump_wrapper_tx: false,
-        force: false,
+        force,
         broadcast_only: false,
         ledger_address,
         wallet_alias_force: false,

--- a/packages/shared/lib/src/sdk/tx.rs
+++ b/packages/shared/lib/src/sdk/tx.rs
@@ -234,7 +234,7 @@ impl TxDetails {
                 let token = wrapper.fee.token.to_string();
 
                 let wrapper_tx =
-                    WrapperTxMsg::new(token, fee_amount, gas_limit, chain_id, None, None);
+                    WrapperTxMsg::new(token, fee_amount, gas_limit, chain_id, None, None, None);
                 let mut commitments: Vec<Commitment> = vec![];
                 let wasm_hashes: Vec<WasmHash> = wasm_hashes.into_serde().unwrap();
 

--- a/packages/types/src/tx/schema/wrapperTx.ts
+++ b/packages/types/src/tx/schema/wrapperTx.ts
@@ -23,6 +23,9 @@ export class WrapperTxMsgValue {
   @field({ type: option("string") })
   memo?: string;
 
+  @field({ type: option("bool") })
+  force?: boolean;
+
   constructor(data: WrapperTxProps) {
     Object.assign(this, data);
   }


### PR DESCRIPTION
We have to do this otherwise in the scenario that we have more rewards than balance, the namada_sdk validation will fail with `NotEnoughBalance` error. Forcing bond will still log error in terminal, but we can't do much about it atm.