### PR TITLE
BUG - Namadillo: Fix issue where 0 enabled features returns ALL features

### DIFF
--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@namada/namadillo",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Namadillo",
   "repository": "https://github.com/anoma/namada-interface/",
   "author": "Heliax Dev <info@heliax.dev>",

--- a/apps/namadillo/src/hooks/useRegistryFeatures.tsx
+++ b/apps/namadillo/src/hooks/useRegistryFeatures.tsx
@@ -59,7 +59,7 @@ const fetchEnabledFeatures = async (
     features: Feature[];
   };
 
-  if (!enabledFeatures || enabledFeatures.length === 0) {
+  if (!enabledFeatures) {
     // Enable every feature for non-registry chains
     return allFeaturesEnabled;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "namada",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "workspaces": [
     "apps/namadillo",


### PR DESCRIPTION
To reproduce this, connect to a mainnet indexer where features = `[]` (no enabled features)
- `https://indexer.namada.tududes.com`

- With this fix, only enabled features are displayed
- Without it, all are displayed because of a logic bug :( 