### PR TITLE
feat: shielded rewards intergration

### DIFF
--- a/apps/namadillo/src/App/AccountOverview/NamBalanceContainer.tsx
+++ b/apps/namadillo/src/App/AccountOverview/NamBalanceContainer.tsx
@@ -2,6 +2,7 @@ import { Heading, SkeletonLoading, Stack } from "@namada/components";
 import { AtomErrorBoundary } from "App/Common/AtomErrorBoundary";
 import { NamCurrency } from "App/Common/NamCurrency";
 import { ShieldedRewardsBox } from "App/Masp/ShieldedRewardsBox";
+import { shieldRewardsAtom } from "atoms/balance";
 import { applicationFeaturesAtom } from "atoms/settings";
 import BigNumber from "bignumber.js";
 import clsx from "clsx";
@@ -67,7 +68,7 @@ const NamBalanceListItem = ({
       </span>
       {isLoading ?
         <SkeletonLoading height="22px" width="100px" />
-      : <NamCurrency
+        : <NamCurrency
           amount={amount}
           className="text-2xl pl-5 font-light"
           currencySymbolClassName="hidden"
@@ -82,6 +83,7 @@ export const NamBalanceContainer = (): JSX.Element => {
   const { maspEnabled, shieldingRewardsEnabled } = useAtomValue(
     applicationFeaturesAtom
   );
+  const shieldRewards = useAtomValue(shieldRewardsAtom);
 
   const {
     balanceQuery,
@@ -145,7 +147,9 @@ export const NamBalanceContainer = (): JSX.Element => {
               isEnabled={shieldingRewardsEnabled}
               className="flex flex-1"
             >
-              <ShieldedRewardsBox />
+              <ShieldedRewardsBox
+                shieldedRewardsAmount={shieldRewards.data?.amount}
+              />
             </ListItemContainer>
           </Stack>
         </AtomErrorBoundary>

--- a/apps/namadillo/src/App/AccountOverview/NamBalanceContainer.tsx
+++ b/apps/namadillo/src/App/AccountOverview/NamBalanceContainer.tsx
@@ -2,7 +2,7 @@ import { Heading, SkeletonLoading, Stack } from "@namada/components";
 import { AtomErrorBoundary } from "App/Common/AtomErrorBoundary";
 import { NamCurrency } from "App/Common/NamCurrency";
 import { ShieldedRewardsBox } from "App/Masp/ShieldedRewardsBox";
-import { shieldRewardsAtom } from "atoms/balance";
+import { cachedShieldedRewardsAtom } from "atoms/balance";
 import { applicationFeaturesAtom } from "atoms/settings";
 import BigNumber from "bignumber.js";
 import clsx from "clsx";
@@ -68,7 +68,7 @@ const NamBalanceListItem = ({
       </span>
       {isLoading ?
         <SkeletonLoading height="22px" width="100px" />
-        : <NamCurrency
+      : <NamCurrency
           amount={amount}
           className="text-2xl pl-5 font-light"
           currencySymbolClassName="hidden"
@@ -83,7 +83,7 @@ export const NamBalanceContainer = (): JSX.Element => {
   const { maspEnabled, shieldingRewardsEnabled } = useAtomValue(
     applicationFeaturesAtom
   );
-  const shieldRewards = useAtomValue(shieldRewardsAtom);
+  const shieldedRewards = useAtomValue(cachedShieldedRewardsAtom);
 
   const {
     balanceQuery,
@@ -148,7 +148,7 @@ export const NamBalanceContainer = (): JSX.Element => {
               className="flex flex-1"
             >
               <ShieldedRewardsBox
-                shieldedRewardsAmount={shieldRewards.data?.amount}
+                shieldedRewardsAmount={shieldedRewards.amount}
               />
             </ListItemContainer>
           </Stack>

--- a/apps/namadillo/src/App/AccountOverview/__tests__/NamBalanceContainer.test.tsx
+++ b/apps/namadillo/src/App/AccountOverview/__tests__/NamBalanceContainer.test.tsx
@@ -1,11 +1,16 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import BigNumber from "bignumber.js";
 import { mockUseBalances } from "hooks/__mocks__/mockUseBalance";
+import { atom } from "jotai";
 import { AtomWithQueryResult } from "jotai-tanstack-query";
 import { NamBalanceContainer } from "../NamBalanceContainer";
 
 jest.mock("hooks/useBalances", () => ({
   useBalances: jest.fn(),
+}));
+
+jest.mock("atoms/shield/atoms", () => ({
+  shieldRewardsAtom: atom({ data: undefined }),
 }));
 
 describe("Component: NamBalanceContainer", () => {

--- a/apps/namadillo/src/App/AccountOverview/__tests__/NamBalanceContainer.test.tsx
+++ b/apps/namadillo/src/App/AccountOverview/__tests__/NamBalanceContainer.test.tsx
@@ -9,8 +9,8 @@ jest.mock("hooks/useBalances", () => ({
   useBalances: jest.fn(),
 }));
 
-jest.mock("atoms/shield/atoms", () => ({
-  shieldRewardsAtom: atom({ data: undefined }),
+jest.mock("atoms/balance", () => ({
+  cachedShieldedRewardsAtom: atom({ data: undefined }),
 }));
 
 describe("Component: NamBalanceContainer", () => {

--- a/apps/namadillo/src/App/Masp/ShieldedNamBalance.tsx
+++ b/apps/namadillo/src/App/Masp/ShieldedNamBalance.tsx
@@ -1,7 +1,7 @@
 import { SkeletonLoading, Stack, Tooltip } from "@namada/components";
 import { AtomErrorBoundary } from "App/Common/AtomErrorBoundary";
 import { NamCurrency } from "App/Common/NamCurrency";
-import { shieldedTokensAtom } from "atoms/balance/atoms";
+import { shieldedTokensAtom, shieldRewardsAtom } from "atoms/balance/atoms";
 import { getTotalNam } from "atoms/balance/functions";
 import { applicationFeaturesAtom } from "atoms/settings/atoms";
 import BigNumber from "bignumber.js";
@@ -29,7 +29,7 @@ const AsyncNamCurrency = ({
 
   return (
     <NamCurrency
-      amount={new BigNumber(amount)}
+      amount={amount}
       className={twMerge("block text-center text-3xl leading-none", className)}
       currencySymbolClassName="block text-xs mt-1"
     />
@@ -39,6 +39,7 @@ const AsyncNamCurrency = ({
 export const ShieldedNamBalance = (): JSX.Element => {
   const shieldedTokensQuery = useAtomValue(shieldedTokensAtom);
   const { shieldingRewardsEnabled } = useAtomValue(applicationFeaturesAtom);
+  const shieldRewards = useAtomValue(shieldRewardsAtom);
 
   const shieldedNam =
     shieldedTokensQuery.isPending ? undefined : (
@@ -88,7 +89,7 @@ export const ShieldedNamBalance = (): JSX.Element => {
             "flex flex-col gap-4 justify-between",
             "rounded-sm bg-neutral-900 p-4",
             !shieldingRewardsEnabled &&
-              "opacity-25 pointer-events-none select-none"
+            "opacity-25 pointer-events-none select-none"
           )}
         >
           <div className="absolute top-2 right-2 group/tooltip">
@@ -109,9 +110,8 @@ export const ShieldedNamBalance = (): JSX.Element => {
             rewards per Epoch
           </div>
           {shieldingRewardsEnabled ?
-            // TODO shielding rewards
-            <AsyncNamCurrency amount={new BigNumber(0)} />
-          : <div className="block text-center text-3xl">--</div>}
+            <AsyncNamCurrency amount={shieldRewards.data?.amount} />
+            : <div className="block text-center text-3xl">--</div>}
           <div
             className={twMerge(
               "border border-white rounded-md p-2 max-w-[200px] mx-auto mt-4",
@@ -120,7 +120,7 @@ export const ShieldedNamBalance = (): JSX.Element => {
           >
             {shieldingRewardsEnabled ?
               "Shielding more assets will increase your rewards"
-            : "Shielding Rewards will be enabled in phase 4"}
+              : "Shielding Rewards will be enabled in phase 4"}
           </div>
         </div>
       </div>

--- a/apps/namadillo/src/App/Masp/ShieldedNamBalance.tsx
+++ b/apps/namadillo/src/App/Masp/ShieldedNamBalance.tsx
@@ -1,7 +1,10 @@
 import { SkeletonLoading, Stack, Tooltip } from "@namada/components";
 import { AtomErrorBoundary } from "App/Common/AtomErrorBoundary";
 import { NamCurrency } from "App/Common/NamCurrency";
-import { shieldedTokensAtom, shieldRewardsAtom } from "atoms/balance/atoms";
+import {
+  cachedShieldedRewardsAtom,
+  shieldedTokensAtom,
+} from "atoms/balance/atoms";
 import { getTotalNam } from "atoms/balance/functions";
 import { applicationFeaturesAtom } from "atoms/settings/atoms";
 import BigNumber from "bignumber.js";
@@ -39,7 +42,7 @@ const AsyncNamCurrency = ({
 export const ShieldedNamBalance = (): JSX.Element => {
   const shieldedTokensQuery = useAtomValue(shieldedTokensAtom);
   const { shieldingRewardsEnabled } = useAtomValue(applicationFeaturesAtom);
-  const shieldRewards = useAtomValue(shieldRewardsAtom);
+  const shieldedRewards = useAtomValue(cachedShieldedRewardsAtom);
 
   const shieldedNam =
     shieldedTokensQuery.isPending ? undefined : (
@@ -89,7 +92,7 @@ export const ShieldedNamBalance = (): JSX.Element => {
             "flex flex-col gap-4 justify-between",
             "rounded-sm bg-neutral-900 p-4",
             !shieldingRewardsEnabled &&
-            "opacity-25 pointer-events-none select-none"
+              "opacity-25 pointer-events-none select-none"
           )}
         >
           <div className="absolute top-2 right-2 group/tooltip">
@@ -110,8 +113,8 @@ export const ShieldedNamBalance = (): JSX.Element => {
             rewards per Epoch
           </div>
           {shieldingRewardsEnabled ?
-            <AsyncNamCurrency amount={shieldRewards.data?.amount} />
-            : <div className="block text-center text-3xl">--</div>}
+            <AsyncNamCurrency amount={shieldedRewards.amount} />
+          : <div className="block text-center text-3xl">--</div>}
           <div
             className={twMerge(
               "border border-white rounded-md p-2 max-w-[200px] mx-auto mt-4",
@@ -120,7 +123,7 @@ export const ShieldedNamBalance = (): JSX.Element => {
           >
             {shieldingRewardsEnabled ?
               "Shielding more assets will increase your rewards"
-              : "Shielding Rewards will be enabled in phase 4"}
+            : "Shielding Rewards will be enabled in phase 4"}
           </div>
         </div>
       </div>

--- a/apps/namadillo/src/App/Settings/SettingsMASP.tsx
+++ b/apps/namadillo/src/App/Settings/SettingsMASP.tsx
@@ -3,6 +3,7 @@ import { routes } from "App/routes";
 import {
   lastCompletedShieldedSyncAtom,
   storageShieldedBalanceAtom,
+  storageShieldedRewardsAtom,
 } from "atoms/balance/atoms";
 import { clearShieldedContextAtom } from "atoms/settings";
 import { useAtom, useSetAtom } from "jotai";
@@ -14,11 +15,13 @@ export const SettingsMASP = (): JSX.Element => {
   const setLastCompletedShieldedSync = useSetAtom(
     lastCompletedShieldedSyncAtom
   );
+  const setStorageShieldedRewards = useSetAtom(storageShieldedRewardsAtom);
 
   const onInvalidateShieldedContext = async (): Promise<void> => {
     await clearShieldedContext.mutateAsync();
     setStorageShieldedBalance(RESET);
     setLastCompletedShieldedSync(undefined);
+    setStorageShieldedRewards(RESET);
     location.href = routes.root;
   };
 

--- a/apps/namadillo/src/atoms/balance/atoms.ts
+++ b/apps/namadillo/src/atoms/balance/atoms.ts
@@ -21,6 +21,7 @@ import { atom, getDefaultStore } from "jotai";
 import { atomWithQuery } from "jotai-tanstack-query";
 import { atomWithStorage } from "jotai/utils";
 import { Address, AddressWithAsset } from "types";
+import { namadaAsset, toDisplayAmount } from "utils";
 import {
   mapNamadaAddressesToAssets,
   mapNamadaAssetsToTokenBalances,
@@ -28,6 +29,7 @@ import {
 import {
   fetchBlockHeightByTimestamp,
   fetchShieldedBalance,
+  fetchShieldRewards,
   shieldedSync,
 } from "./services";
 
@@ -280,5 +282,21 @@ export const transparentTokensAtom = atomWithQuery<TokenBalance[]>((get) => {
         ),
       [transparentAssets, tokenPrices]
     ),
+  };
+});
+
+export const shieldRewardsAtom = atomWithQuery((get) => {
+  const viewingKeysQuery = get(viewingKeysAtom);
+
+  return {
+    queryKey: ["shield-rewards", viewingKeysQuery.data],
+    ...queryDependentFn(async () => {
+      const [vk] = viewingKeysQuery.data!;
+      const minDenomAmount = await fetchShieldRewards(vk);
+
+      return {
+        amount: toDisplayAmount(namadaAsset(), BigNumber(minDenomAmount)),
+      };
+    }, [viewingKeysQuery]),
   };
 });

--- a/apps/namadillo/src/atoms/balance/services.ts
+++ b/apps/namadillo/src/atoms/balance/services.ts
@@ -113,3 +113,13 @@ export const fetchShieldRewards = async (
 
   return await sdk.rpc.shieldedRewards(viewingKey.key, chainId);
 };
+
+export const simulateRewardPerToken = async (
+  chainId: string,
+  token: string,
+  amount: string
+): Promise<string> => {
+  const sdk = await getSdkInstance();
+
+  return await sdk.rpc.simulateShieldedRewards(chainId, token, amount);
+};

--- a/apps/namadillo/src/atoms/balance/services.ts
+++ b/apps/namadillo/src/atoms/balance/services.ts
@@ -104,3 +104,11 @@ export const fetchBlockHeightByTimestamp = async (
 
   return Number(response.data.height);
 };
+
+export const fetchShieldRewards = async (
+  viewingKey: DatedViewingKey
+): Promise<string> => {
+  const sdk = await getSdkInstance();
+
+  return await sdk.rpc.shieldedRewards(viewingKey.key);
+};

--- a/apps/namadillo/src/atoms/balance/services.ts
+++ b/apps/namadillo/src/atoms/balance/services.ts
@@ -106,9 +106,10 @@ export const fetchBlockHeightByTimestamp = async (
 };
 
 export const fetchShieldRewards = async (
-  viewingKey: DatedViewingKey
+  viewingKey: DatedViewingKey,
+  chainId: string
 ): Promise<string> => {
   const sdk = await getSdkInstance();
 
-  return await sdk.rpc.shieldedRewards(viewingKey.key);
+  return await sdk.rpc.shieldedRewards(viewingKey.key, chainId);
 };

--- a/packages/sdk/src/rpc/rpc.ts
+++ b/packages/sdk/src/rpc/rpc.ts
@@ -258,9 +258,10 @@ export class Rpc {
    * Return shielded rewards for specific owner
    * @async
    * @param owner - Viewing key of an owner
+   * @param chainId - Chain ID to load the context for
    * @returns amount in base units
    */
-  async shieldedRewards(owner: string): Promise<string> {
-    return await this.sdk.get_shielded_rewards(owner);
+  async shieldedRewards(owner: string, chainId: string): Promise<string> {
+    return await this.sdk.get_shielded_rewards(owner, chainId);
   }
 }

--- a/packages/sdk/src/rpc/rpc.ts
+++ b/packages/sdk/src/rpc/rpc.ts
@@ -253,4 +253,14 @@ export class Rpc {
 
     await this.query.shielded_sync(datedViewingKeys, chainId);
   }
+
+  /**
+   * Return shielded rewards for specific owner
+   * @async
+   * @param owner - Viewing key of an owner
+   * @returns amount in base units
+   */
+  async shieldedRewards(owner: string): Promise<string> {
+    return await this.sdk.get_shielded_rewards(owner);
+  }
 }

--- a/packages/sdk/src/rpc/rpc.ts
+++ b/packages/sdk/src/rpc/rpc.ts
@@ -255,13 +255,28 @@ export class Rpc {
   }
 
   /**
-   * Return shielded rewards for specific owner
+   * Return shielded rewards for specific owner for next epoch
    * @async
    * @param owner - Viewing key of an owner
    * @param chainId - Chain ID to load the context for
    * @returns amount in base units
    */
   async shieldedRewards(owner: string, chainId: string): Promise<string> {
-    return await this.sdk.get_shielded_rewards(owner, chainId);
+    return await this.sdk.shielded_rewards(owner, chainId);
+  }
+
+  /**
+   * Simulate shielded rewards per token and amount in next epoch
+   * @param chainId - Chain ID to load the context for
+   * @param token - Token address
+   * @param amount - Denominated amount
+   * @returns amount in base units
+   */
+  async simulateShieldedRewards(
+    chainId: string,
+    token: string,
+    amount: string
+  ): Promise<string> {
+    return await this.sdk.simulate_shielded_rewards(chainId, token, amount);
   }
 }

--- a/packages/shared/lib/src/sdk/mod.rs
+++ b/packages/shared/lib/src/sdk/mod.rs
@@ -758,8 +758,13 @@ impl Sdk {
     }
 
     // This should be a part of query.rs but we have to pass whole "namada" into estimate_next_epoch_rewards
-    pub async fn get_shielded_rewards(&self, owner: String) -> Result<JsValue, JsError> {
+    pub async fn get_shielded_rewards(
+        &self,
+        owner: String,
+        chain_id: String,
+    ) -> Result<JsValue, JsError> {
         let mut shielded: ShieldedContext<masp::JSShieldedUtils> = ShieldedContext::default();
+        shielded.utils.chain_id = chain_id.clone();
         shielded.load().await?;
 
         let xvk = ExtendedViewingKey::from_str(&owner)?;
@@ -772,8 +777,9 @@ impl Sdk {
             Some(balance) => shielded
                 .estimate_next_epoch_rewards(&self.namada, &balance)
                 .await
+                .map(|r| r.amount())
                 .map_err(|e| JsError::new(&e.to_string()))?,
-            None => DenominatedAmount::native(Amount::zero()),
+            None => Amount::zero(),
         };
 
         to_js_result(rewards.to_string())

--- a/packages/shared/lib/src/sdk/mod.rs
+++ b/packages/shared/lib/src/sdk/mod.rs
@@ -763,7 +763,6 @@ impl Sdk {
         shielded.load().await?;
 
         let xvk = ExtendedViewingKey::from_str(&owner)?;
-
         let raw_balance = shielded
             .compute_shielded_balance(&xvk.as_viewing_key())
             .await


### PR DESCRIPTION
Resolves #1371

This  integrates the shielded rewards.
~~The downside is that is seems that the endpoint in namada rpc returns some weird values,  so testing might be a bit tricky.
How  it works for me atm is that if I shield a lot of nam and wait one masp epoch I will see some rewards for one masp epoch, but then it will go back to 0.
You can shield more and repeat  the process~~

Not sure if campfire has nam rewards enabled :/ 
Also added a function which can simulate rewards for this:
![image](https://github.com/user-attachments/assets/10ae7e8b-84f5-43fe-811b-8d7e8a5797ad)
