### PR TITLE
fix: Namadillo - IBC transfer should also not have an empty string memo

### DIFF
--- a/apps/namadillo/src/lib/transactions.ts
+++ b/apps/namadillo/src/lib/transactions.ts
@@ -85,7 +85,7 @@ export const createIbcTransferMessage = (
   receiverAddress: string,
   amount: BigNumber,
   token: string,
-  memo: string = ""
+  memo?: string
 ): MsgTransferEncodeObject => {
   const timeoutTimestampNanoseconds =
     BigInt(Math.floor(Date.now() / 1000) + 60) * BigInt(1_000_000_000);


### PR DESCRIPTION
Relates to #1377 
