### PR TITLE
feat: shorten unknown asset symbol

### DIFF
--- a/apps/namadillo/src/App/Masp/ShieldedFungibleTable.tsx
+++ b/apps/namadillo/src/App/Masp/ShieldedFungibleTable.tsx
@@ -44,7 +44,7 @@ export const ShieldedFungibleTable = ({
         >
           <div className="aspect-square w-8 h-8">
             {icon ?
-              <img src={icon} />
+              <img src={icon} className="w-full h-full" />
             : <div className="rounded-full h-full border border-white" />}
           </div>
           {asset.symbol}

--- a/apps/namadillo/src/atoms/integrations/functions.ts
+++ b/apps/namadillo/src/atoms/integrations/functions.ts
@@ -2,7 +2,7 @@ import { Asset, AssetList, Chain, IBCInfo } from "@chain-registry/types";
 import { QueryClient, setupIbcExtension } from "@cosmjs/stargate";
 import { Tendermint34Client } from "@cosmjs/tendermint-rpc";
 import { Account, IbcTransferProps } from "@namada/types";
-import { mapUndefined } from "@namada/utils";
+import { mapUndefined, shortenAddress } from "@namada/utils";
 import BigNumber from "bignumber.js";
 import * as celestia from "chain-registry/mainnet/celestia";
 import * as cosmos from "chain-registry/mainnet/cosmoshub";
@@ -223,7 +223,7 @@ const unknownAsset = (denom: string): Asset => ({
   base: denom,
   name: denom,
   display: denom,
-  symbol: denom,
+  symbol: shortenAddress(denom, 4, 4),
 });
 
 const findOriginalAsset = async (


### PR DESCRIPTION
Shorten unknown asset symbol to be something like `tnam...zp6h`, instead of the full address, which breaks the UI

![Screenshot 2024-12-06 at 11 20 32](https://github.com/user-attachments/assets/8f617720-93fc-4c67-bcce-9496f5259725)

![Screenshot 2024-12-06 at 11 20 23](https://github.com/user-attachments/assets/c5c8e0db-7472-46e3-9f04-3b603df2cdac)
