### PR TITLE
feat/1047: Ledger transport updates, Updated Step 2 text

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -41,9 +41,9 @@
   "dependencies": {
     "@cosmjs/encoding": "^0.29.0",
     "@dao-xyz/borsh": "^5.1.5",
-    "@ledgerhq/hw-transport": "^6.30.0",
-    "@ledgerhq/hw-transport-webhid": "^6.28.0",
-    "@ledgerhq/hw-transport-webusb": "^6.28.0",
+    "@ledgerhq/hw-transport": "^6.31.4",
+    "@ledgerhq/hw-transport-webhid": "^6.29.4",
+    "@ledgerhq/hw-transport-webusb": "^6.29.4",
     "@zondax/ledger-namada": "^1.0.0",
     "bignumber.js": "^9.1.1",
     "buffer": "^6.0.3",

--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@namada/namadillo",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Namadillo",
   "repository": "https://github.com/anoma/namada-interface/",
   "author": "Heliax Dev <info@heliax.dev>",

--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@namada/namadillo",
-  "version": "1.0.3",
+  "version": "1.0.2",
   "description": "Namadillo",
   "repository": "https://github.com/anoma/namada-interface/",
   "author": "Heliax Dev <info@heliax.dev>",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -7,10 +7,10 @@ The Namada SDK package
 ### Installation
 
 ```bash
-npm install @heliaxdev/namada-sdk
+npm install @namada/sdk
 
 # Or, via yarn
-yarn add @heliaxdev/namada-sdk
+yarn add @namada/sdk
 ```
 
 ### Initializing the SDK
@@ -19,8 +19,8 @@ As this package depends on Wasm compiled from Rust to integrate with Namada, thi
 developing for the Web. The following is a quick overview of some of the features of the SDK package:
 
 ```typescript
-import { Sdk, getSdk } from "@heliaxdev/namada-sdk/web";
-import sdkInit from "@heliaxdev/namada-sdk/web-init";
+import { Sdk, getSdk } from "@namada/sdk/web";
+import sdkInit from "@namada/sdk/web-init";
 
 // Load Tx props from types package
 import { BondProps, WrapperTxProps } from "@namada/types";

--- a/packages/sdk/docs/README.md
+++ b/packages/sdk/docs/README.md
@@ -9,10 +9,10 @@ The Namada SDK package
 ### Installation
 
 ```bash
-npm install @heliaxdev/namada-sdk
+npm install @namada/sdk
 
 # Or, via yarn
-yarn add @heliaxdev/namada-sdk
+yarn add @namada/sdk
 ```
 
 ### Initializing the SDK
@@ -21,8 +21,8 @@ As this package depends on Wasm compiled from Rust to integrate with Namada, thi
 developing for the Web. The following is a quick overview of some of the features of the SDK package:
 
 ```typescript
-import { Sdk, getSdk } from "@heliaxdev/namada-sdk/web";
-import sdkInit from "@heliaxdev/namada-sdk/web-init";
+import { Sdk, getSdk } from "@namada/sdk/web";
+import sdkInit from "@namada/sdk/web-init";
 
 // Load Tx props from types package
 import { BondProps, WrapperTxProps } from "@namada/types";

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -62,9 +62,9 @@
   "dependencies": {
     "@cosmjs/encoding": "^0.29.0",
     "@dao-xyz/borsh": "^5.1.5",
-    "@ledgerhq/hw-transport": "^6.30.0",
-    "@ledgerhq/hw-transport-webhid": "^6.28.0",
-    "@ledgerhq/hw-transport-webusb": "^6.28.0",
+    "@ledgerhq/hw-transport": "^6.31.4",
+    "@ledgerhq/hw-transport-webhid": "^6.29.4",
+    "@ledgerhq/hw-transport-webusb": "^6.29.4",
     "@zondax/ledger-namada": "^1.0.0",
     "bignumber.js": "^9.1.1",
     "buffer": "^6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3233,6 +3233,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ledgerhq/devices@npm:^8.4.4":
+  version: 8.4.4
+  resolution: "@ledgerhq/devices@npm:8.4.4"
+  dependencies:
+    "@ledgerhq/errors": "npm:^6.19.1"
+    "@ledgerhq/logs": "npm:^6.12.0"
+    rxjs: "npm:^7.8.1"
+    semver: "npm:^7.3.5"
+  checksum: ea4c3dada124c5c0aad59837e1c399bf2f41f8b4da5c996aaf73bbf8719082598808947c505dc728266ff83fc5fea71170d3f0d18a9b5d59e6e2737ae8a38f39
+  languageName: node
+  linkType: hard
+
 "@ledgerhq/errors@npm:^6.18.0":
   version: 6.18.0
   resolution: "@ledgerhq/errors@npm:6.18.0"
@@ -3240,31 +3252,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ledgerhq/hw-transport-webhid@npm:^6.28.0":
-  version: 6.29.2
-  resolution: "@ledgerhq/hw-transport-webhid@npm:6.29.2"
-  dependencies:
-    "@ledgerhq/devices": "npm:^8.4.2"
-    "@ledgerhq/errors": "npm:^6.18.0"
-    "@ledgerhq/hw-transport": "npm:^6.31.2"
-    "@ledgerhq/logs": "npm:^6.12.0"
-  checksum: 86a610bf99eb44fbd93a7d0afc621f13a5f43e63fc86c64f686f88cc528d0ea62a51f674b8a6148aaa4330cc8ef2c2b2e461bbea5a71ae39305f82124a83377b
+"@ledgerhq/errors@npm:^6.19.1":
+  version: 6.19.1
+  resolution: "@ledgerhq/errors@npm:6.19.1"
+  checksum: 5cfbd5ff5e4316afc88c456a74d3dc0e0032dafd88f656e80a5cb5b297a75ba6701c53ce38ef3f38a84a8591c499b0b9248cdf352ff34c97a550440cdaddd8d2
   languageName: node
   linkType: hard
 
-"@ledgerhq/hw-transport-webusb@npm:^6.28.0":
-  version: 6.29.2
-  resolution: "@ledgerhq/hw-transport-webusb@npm:6.29.2"
+"@ledgerhq/hw-transport-webhid@npm:^6.29.4":
+  version: 6.29.4
+  resolution: "@ledgerhq/hw-transport-webhid@npm:6.29.4"
   dependencies:
-    "@ledgerhq/devices": "npm:^8.4.2"
-    "@ledgerhq/errors": "npm:^6.18.0"
-    "@ledgerhq/hw-transport": "npm:^6.31.2"
+    "@ledgerhq/devices": "npm:^8.4.4"
+    "@ledgerhq/errors": "npm:^6.19.1"
+    "@ledgerhq/hw-transport": "npm:^6.31.4"
     "@ledgerhq/logs": "npm:^6.12.0"
-  checksum: 6499398c90ccd1210d9a6b91846df49001b0de7b74a97a8df0020fc35f22b90f3b886499c5237cdf198e914a616f310ccd22238f5136df46699561f6dd2412ed
+  checksum: 85db88aa9c9ca4911645b9421e1a1ce828c48c32b03b7ed15caed8f8e24749dc31007540ec4f0088603d1a315274dbc06d30e4cb71c86b57160b721a664fc8dd
   languageName: node
   linkType: hard
 
-"@ledgerhq/hw-transport@npm:^6.30.0, @ledgerhq/hw-transport@npm:^6.30.6, @ledgerhq/hw-transport@npm:^6.31.2":
+"@ledgerhq/hw-transport-webusb@npm:^6.29.4":
+  version: 6.29.4
+  resolution: "@ledgerhq/hw-transport-webusb@npm:6.29.4"
+  dependencies:
+    "@ledgerhq/devices": "npm:^8.4.4"
+    "@ledgerhq/errors": "npm:^6.19.1"
+    "@ledgerhq/hw-transport": "npm:^6.31.4"
+    "@ledgerhq/logs": "npm:^6.12.0"
+  checksum: cddd324c12de64e755422c6dc0d509bc344f2f048c2b743bc5737db9c097ffb6c201fc577d971543e196ccb34a72507450ed3262a2b6d39c753424d299fafc2f
+  languageName: node
+  linkType: hard
+
+"@ledgerhq/hw-transport@npm:^6.30.6":
   version: 6.31.2
   resolution: "@ledgerhq/hw-transport@npm:6.31.2"
   dependencies:
@@ -3273,6 +3292,18 @@ __metadata:
     "@ledgerhq/logs": "npm:^6.12.0"
     events: "npm:^3.3.0"
   checksum: 3fc61c2e844639b7ec73e5eaec2f34235a414ec802df2491ea3d32d854f5f53c592b35b874a9ce899a6087a74a5a750b20c91aae19aaa44eea2faa390edf593f
+  languageName: node
+  linkType: hard
+
+"@ledgerhq/hw-transport@npm:^6.31.4":
+  version: 6.31.4
+  resolution: "@ledgerhq/hw-transport@npm:6.31.4"
+  dependencies:
+    "@ledgerhq/devices": "npm:^8.4.4"
+    "@ledgerhq/errors": "npm:^6.19.1"
+    "@ledgerhq/logs": "npm:^6.12.0"
+    events: "npm:^3.3.0"
+  checksum: 033acb802d991788efcda9223356528d0987a268e94c34cbafde499541722363e7cfa6e2734365ef3282c0a80a69f4964a6d728690ff7494662a650516530b02
   languageName: node
   linkType: hard
 
@@ -3441,9 +3472,9 @@ __metadata:
     "@babel/plugin-transform-modules-commonjs": "npm:^7.20.11"
     "@cosmjs/encoding": "npm:^0.29.0"
     "@dao-xyz/borsh": "npm:^5.1.5"
-    "@ledgerhq/hw-transport": "npm:^6.30.0"
-    "@ledgerhq/hw-transport-webhid": "npm:^6.28.0"
-    "@ledgerhq/hw-transport-webusb": "npm:^6.28.0"
+    "@ledgerhq/hw-transport": "npm:^6.31.4"
+    "@ledgerhq/hw-transport-webhid": "npm:^6.29.4"
+    "@ledgerhq/hw-transport-webusb": "npm:^6.29.4"
     "@svgr/webpack": "npm:^6.3.1"
     "@types/chrome": "npm:^0.0.237"
     "@types/dompurify": "npm:^3.0.5"
@@ -3719,9 +3750,9 @@ __metadata:
     "@babel/preset-typescript": "npm:^7.23.3"
     "@cosmjs/encoding": "npm:^0.29.0"
     "@dao-xyz/borsh": "npm:^5.1.5"
-    "@ledgerhq/hw-transport": "npm:^6.30.0"
-    "@ledgerhq/hw-transport-webhid": "npm:^6.28.0"
-    "@ledgerhq/hw-transport-webusb": "npm:^6.28.0"
+    "@ledgerhq/hw-transport": "npm:^6.31.4"
+    "@ledgerhq/hw-transport-webhid": "npm:^6.29.4"
+    "@ledgerhq/hw-transport-webusb": "npm:^6.29.4"
     "@release-it/conventional-changelog": "npm:^8.0.1"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.11.4"


### PR DESCRIPTION
Resolves #1047 

- [x] Bump USB transport packages
- [x] Bump Namadillo
- [x] Display which Tx out of all Txs are currently being prompted for signing
  - If only one Tx is being signed, just display `Approve on your device`
  - If more than one needs signing, also display `Tx x of y`


### Design

Suggested updated Step 2 text:

![Screenshot 2024-12-06 at 12 52 16](https://github.com/user-attachments/assets/2a4e5004-c999-4057-af71-91d664bd2e3d)

### Updated Ledger Approval Step 2

![Screen Shot 2024-12-06 at 9 44 21 AM](https://github.com/user-attachments/assets/f4bbe763-aef5-476e-a0dd-4701b94c858e)
