### PR TITLE
bug/1047: Namadillo Ledger Notifications

### DIFF
--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@namada/namadillo",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Namadillo",
   "repository": "https://github.com/anoma/namada-interface/",
   "author": "Heliax Dev <info@heliax.dev>",

--- a/apps/namadillo/src/App/Governance/SubmitVote.tsx
+++ b/apps/namadillo/src/App/Governance/SubmitVote.tsx
@@ -29,14 +29,12 @@ import { IoClose } from "react-icons/io5";
 import { useNavigate } from "react-router-dom";
 
 const dispatchVoteTx = (tx: TransactionPair<VoteProposalProps>): void => {
-  tx.signedTxs.forEach((signedTx) => {
-    broadcastTx(
-      tx.encodedTxData,
-      signedTx,
-      tx.encodedTxData.meta?.props,
-      "VoteProposal"
-    );
-  });
+  broadcastTx(
+    tx.encodedTxData,
+    tx.signedTxs,
+    tx.encodedTxData.meta?.props,
+    "VoteProposal"
+  );
 };
 
 export const SubmitVote: React.FC = () => {

--- a/apps/namadillo/src/App/Ibc/IbcWithdraw.tsx
+++ b/apps/namadillo/src/App/Ibc/IbcWithdraw.tsx
@@ -135,15 +135,11 @@ export const IbcWithdraw: React.FC = () => {
       };
 
       setTransaction(tx);
-      await Promise.allSettled(
-        signedTxs.map((signedTx) => {
-          return broadcastTx(
-            encodedTxData,
-            signedTx,
-            encodedTxData.meta?.props,
-            "IbcTransfer"
-          );
-        })
+      await broadcastTx(
+        encodedTxData,
+        signedTxs,
+        encodedTxData.meta?.props,
+        "IbcTransfer"
       );
     } catch (err) {
       setGeneralErrorMessage(err + "");

--- a/apps/namadillo/src/hooks/useTransaction.tsx
+++ b/apps/namadillo/src/hooks/useTransaction.tsx
@@ -74,16 +74,12 @@ export const useTransaction = <T,>({
     );
   };
 
-  const broadcast = (tx: TransactionPair<T>): Promise<void[]> =>
-    Promise.all(
-      tx.signedTxs.map((signedTx) =>
-        broadcastTx(
-          tx.encodedTxData,
-          signedTx,
-          tx.encodedTxData.meta?.props,
-          eventType
-        )
-      )
+  const broadcast = (txPair: TransactionPair<T>): Promise<void> =>
+    broadcastTx(
+      txPair.encodedTxData,
+      txPair.signedTxs,
+      txPair.encodedTxData.meta?.props,
+      eventType
     );
 
   const dispatchPendingTxNotification = (

--- a/apps/namadillo/src/lib/query.ts
+++ b/apps/namadillo/src/lib/query.ts
@@ -219,7 +219,7 @@ export const broadcastTx = async <T>(
   if (encodedTx.txs.length !== signedTxs.length) {
     throw new Error("Did not receive enough signatures!");
   }
-  // We use the first Tx to construct toast ID in both pending and success/partial success/error
+
   eventType &&
     window.dispatchEvent(
       new CustomEvent(`${eventType}.Pending`, {
@@ -245,7 +245,7 @@ export const broadcastTx = async <T>(
           throw new Error(`Broadcast Tx failed! ${result.reason}`);
         }
       });
-      const { status, successData, failedData } = parseBroadcastResults(
+      const { status, successData, failedData } = parseTxAppliedErrors(
         commitments.flat(),
         hashes,
         data!
@@ -277,7 +277,7 @@ export const broadcastTx = async <T>(
   });
 };
 
-type BroadcastResults<T> = {
+type TxAppliedResults<T> = {
   status: TransactionEventsStatus;
   successData?: T[];
   failedData?: T[];
@@ -285,11 +285,11 @@ type BroadcastResults<T> = {
 
 // Given an array of broadcasted Tx results,
 // collect any errors
-const parseBroadcastResults = <T>(
+const parseTxAppliedErrors = <T>(
   results: BatchTxResultMsgValue[],
   txHashes: string[],
   data: T[]
-): BroadcastResults<T> => {
+): TxAppliedResults<T> => {
   const txErrors: string[] = [];
   const dataWithHash = data?.map((d, i) => ({
     ...d,


### PR DESCRIPTION
Resolves #1047 

- [x] Submitting any number of signed Ledger transactions results in one Pending notification, and one Success/PartialSuccess/Error notification that clears the pending one
- [x] Bump Namadillo version - this should be in next tagged release! `1.0.2` -> `1.0.3`

_NOTE_ - the major change in this PR was collecting commitments from any number of Txs, such that when we launch the notification, batch Tx & multiple-Txs can be handled the same way.

### Testing

I'm testing on Housefire, which has 3 validators.

- Faucet: https://faucet.knowable.run
- Indexer: https://indexer.knowable.run
- RPC: https://indexer.knowable.run

#### Txs

- Test Txs with mnemonic/private key Keychain accounts (single & multiple Bond, for example)
- Test single and multiple Ledger HW Wallet Tx (single & multiple Bond, with & without `RevealPK` _NOTE_ If you've already revealed PK on Housefire, simply go to `Add Keys`, and on the Ledger connection page, click `Advanced` and specify a different path, thus generating a different Public Key & Address, then transfer from faucet to that address!)

#### Errors

- You can trigger error states by overriding the `feeAmount` & `gasLimit`
  - Setting `gasLimit` too low should trigger the wrapper rejection (2nd to last screenshot below)
  - Setting `feeAmount` too low should trigger the Tx applied errors (last screenshot)

### Screenshots

#### Example Tx sent for signing with Ledger:
![Screen Shot 2024-12-07 at 8 35 09 AM](https://github.com/user-attachments/assets/b88f1746-70ad-43fb-b689-c2d01dd3d5c8)

#### Pending Ledger Tx notification (bonds summed):
![Screen Shot 2024-12-07 at 8 35 34 AM](https://github.com/user-attachments/assets/02cdbd6c-d9fc-43cd-b0c9-6f98234872c1)

#### Multiple Ledger-signed Txs combined into one Success message with appropriate details:
![Screen Shot 2024-12-07 at 8 35 44 AM](https://github.com/user-attachments/assets/c67b6b14-ec28-4012-8a17-e490260cef93)

#### Wrapper error (rejects quickly if gas limit is incorrect)
![Screen Shot 2024-12-07 at 8 58 26 AM](https://github.com/user-attachments/assets/f709e412-529c-4197-87a9-786d0f1c86d7)

#### Tx applied error if all fail
![Screen Shot 2024-12-07 at 9 00 51 AM](https://github.com/user-attachments/assets/a722ea4f-ebc1-4ad7-b563-43710ce7d596)
