### PR TITLE
fix: Namadillo - Use correct text for VoteProposal notification event

### DIFF
--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@namada/namadillo",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Namadillo",
   "repository": "https://github.com/anoma/namada-interface/",
   "author": "Heliax Dev <info@heliax.dev>",

--- a/apps/namadillo/src/hooks/useTransactionNotifications.tsx
+++ b/apps/namadillo/src/hooks/useTransactionNotifications.tsx
@@ -327,8 +327,8 @@ export const useTransactionNotifications = (): void => {
     dispatchNotification({
       id,
       type: "error",
-      title: "Staking transaction failed",
-      description: <>Your vote transaction has failed.</>,
+      title: "Governance transaction failed",
+      description: <>Your governance transaction has failed.</>,
       details: e.detail.error?.message,
     });
   });
@@ -338,8 +338,8 @@ export const useTransactionNotifications = (): void => {
     clearPendingNotifications(id);
     dispatchNotification({
       id,
-      title: "Staking transaction succeeded",
-      description: `Your vote transaction has succeeded`,
+      title: "Governance transaction succeeded",
+      description: `Your governance transaction has succeeded`,
       type: "success",
     });
   });


### PR DESCRIPTION
Simple bugfix PR - use the correct notification text for `VoteProposal` success & error.

- Use correct text for `VoteProposal` notifications
- Bump Namadillo version

### Screenshots
![Screen Shot 2024-12-12 at 8 04 07 AM](https://github.com/user-attachments/assets/cc458902-11b3-4d51-8c7f-62bf6b98f6fc)

![Screen Shot 2024-12-12 at 8 12 31 AM](https://github.com/user-attachments/assets/ffbb3667-95af-49c8-b92e-7538c05ef4f4)
