### PR TITLE
feat: update proposal description

### DIFF
--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@namada/namadillo",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Namadillo",
   "repository": "https://github.com/anoma/namada-interface/",
   "author": "Heliax Dev <info@heliax.dev>",

--- a/apps/namadillo/src/App/Governance/ProposalDescription.tsx
+++ b/apps/namadillo/src/App/Governance/ProposalDescription.tsx
@@ -5,6 +5,7 @@ import { useAtomValue } from "jotai";
 import { useState } from "react";
 
 import { proposalFamily } from "atoms/proposals";
+import { twMerge } from "tailwind-merge";
 
 export const ProposalDescription: React.FC<{
   proposalId: bigint;
@@ -42,15 +43,18 @@ export const Loaded: React.FC<{
 
   return (
     <>
-      <section>{abstract}</section>
-
-      {expanded &&
-        formattedDetails.map(([key, value], i) => (
+      <Stack
+        gap={4}
+        className={twMerge("overflow-hidden", !expanded && "max-h-[350px]")}
+      >
+        <section>{abstract}</section>
+        {formattedDetails.map(([key, value], i) => (
           <section key={i}>
             <h3 className="text-[#8A8A8A]">{key}</h3>
             <p>{value}</p>
           </section>
         ))}
+      </Stack>
 
       <a
         className={clsx(

--- a/apps/namadillo/src/App/Governance/ProposalDescription.tsx
+++ b/apps/namadillo/src/App/Governance/ProposalDescription.tsx
@@ -1,11 +1,21 @@
 import { SkeletonLoading, Stack } from "@namada/components";
 import { Proposal } from "@namada/types";
+import { proposalFamily } from "atoms/proposals";
 import clsx from "clsx";
 import { useAtomValue } from "jotai";
-import { useState } from "react";
-
-import { proposalFamily } from "atoms/proposals";
+import { ReactNode, useState } from "react";
 import { twMerge } from "tailwind-merge";
+
+const formatLinks = (string: string): ReactNode => {
+  const regex = /(http.*)/;
+  return string.split(regex).map((part, index) =>
+    regex.test(part) ?
+      <a key={index} href={part} rel="noreferrer nofollow">
+        {part}
+      </a>
+    : part
+  );
+};
 
 export const ProposalDescription: React.FC<{
   proposalId: bigint;
@@ -45,13 +55,16 @@ export const Loaded: React.FC<{
     <>
       <Stack
         gap={4}
-        className={twMerge("overflow-hidden", !expanded && "max-h-[350px]")}
+        className={twMerge(
+          "overflow-hidden whitespace-pre-line [&_a]:underline [&_a:hover]:text-yellow",
+          !expanded && "max-h-[350px]"
+        )}
       >
         <section>{abstract}</section>
         {formattedDetails.map(([key, value], i) => (
           <section key={i}>
             <h3 className="text-[#8A8A8A]">{key}</h3>
-            <p>{value}</p>
+            <p>{formatLinks(value ?? "")}</p>
           </section>
         ))}
       </Stack>

--- a/apps/namadillo/src/App/Governance/ProposalDescription.tsx
+++ b/apps/namadillo/src/App/Governance/ProposalDescription.tsx
@@ -10,7 +10,7 @@ const formatLinks = (string: string): ReactNode => {
   const regex = /(http.*)/;
   return string.split(regex).map((part, index) =>
     regex.test(part) ?
-      <a key={index} href={part} rel="noreferrer nofollow">
+      <a key={index} href={part} target="_blank" rel="noreferrer nofollow">
         {part}
       </a>
     : part


### PR DESCRIPTION
Update proposal description

- Render text until a max-height of 350px
- Enable links and line breaks

We can upgrade the format support for a markdown, for example. But I suggest to discuss this a little bit more before implementing it

closes #1406

https://github.com/user-attachments/assets/12e43fac-bec1-42b3-974e-943cbbc5f9a3

