### PR TITLE
chore: bump extension version to 0.3.7

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@namada/extension",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Namada Keychain",
   "repository": "https://github.com/anoma/namada-interface/",
   "author": "Heliax Dev <info@heliax.dev>",


### PR DESCRIPTION
bump extension version to 0.3.7