### PR TITLE
chore: Update docs in SDK & types

### DIFF
--- a/packages/sdk/docs/classes/Crypto.md
+++ b/packages/sdk/docs/classes/Crypto.md
@@ -40,7 +40,7 @@ Class Crypto handles AES encryption tasks
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/crypto.ts#L20)
+[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/crypto/crypto.ts#L20)
 
 ## Properties
 
@@ -52,7 +52,7 @@ WebAssembly Memory for crypto
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/crypto.ts#L20)
+[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/crypto/crypto.ts#L20)
 
 ## Methods
 
@@ -75,7 +75,7 @@ decrypted text
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:115](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/crypto.ts#L115)
+[sdk/src/crypto/crypto.ts:115](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/crypto/crypto.ts#L115)
 
 ___
 
@@ -100,7 +100,7 @@ crypto record
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:61](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/crypto.ts#L61)
+[sdk/src/crypto/crypto.ts:61](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/crypto/crypto.ts#L61)
 
 ___
 
@@ -126,7 +126,7 @@ array of encrypted bytes
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:98](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/crypto.ts#L98)
+[sdk/src/crypto/crypto.ts:98](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/crypto/crypto.ts#L98)
 
 ___
 
@@ -153,7 +153,7 @@ crypto record used for storage
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:30](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/crypto.ts#L30)
+[sdk/src/crypto/crypto.ts:30](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/crypto/crypto.ts#L30)
 
 ___
 
@@ -178,4 +178,4 @@ encryption parameters
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:73](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/crypto.ts#L73)
+[sdk/src/crypto/crypto.ts:73](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/crypto/crypto.ts#L73)

--- a/packages/sdk/docs/classes/Ledger.md
+++ b/packages/sdk/docs/classes/Ledger.md
@@ -22,7 +22,6 @@ Functionality for interacting with NamadaApp for Ledger Hardware Wallets
 - [queryErrors](Ledger.md#queryerrors)
 - [showAddressAndPublicKey](Ledger.md#showaddressandpublickey)
 - [sign](Ledger.md#sign)
-- [signMasp](Ledger.md#signmasp)
 - [status](Ledger.md#status)
 - [init](Ledger.md#init)
 
@@ -44,7 +43,7 @@ Functionality for interacting with NamadaApp for Ledger Hardware Wallets
 
 #### Defined in
 
-[sdk/src/ledger.ts:68](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L68)
+[sdk/src/ledger.ts:68](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/ledger.ts#L68)
 
 ## Properties
 
@@ -56,7 +55,7 @@ Inititalized NamadaApp class from Zondax package
 
 #### Defined in
 
-[sdk/src/ledger.ts:68](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L68)
+[sdk/src/ledger.ts:68](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/ledger.ts#L68)
 
 ## Methods
 
@@ -77,7 +76,7 @@ void
 
 #### Defined in
 
-[sdk/src/ledger.ts:245](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L245)
+[sdk/src/ledger.ts:228](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/ledger.ts#L228)
 
 ___
 
@@ -104,7 +103,7 @@ Address and public key
 
 #### Defined in
 
-[sdk/src/ledger.ts:111](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L111)
+[sdk/src/ledger.ts:111](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/ledger.ts#L111)
 
 ___
 
@@ -132,7 +131,7 @@ ShieldedKeys
 
 #### Defined in
 
-[sdk/src/ledger.ts:157](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L157)
+[sdk/src/ledger.ts:157](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/ledger.ts#L157)
 
 ___
 
@@ -153,7 +152,7 @@ Error message if error is found
 
 #### Defined in
 
-[sdk/src/ledger.ts:228](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L228)
+[sdk/src/ledger.ts:211](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/ledger.ts#L211)
 
 ___
 
@@ -180,7 +179,7 @@ Address and public key
 
 #### Defined in
 
-[sdk/src/ledger.ts:131](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L131)
+[sdk/src/ledger.ts:131](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/ledger.ts#L131)
 
 ___
 
@@ -208,35 +207,7 @@ Response signature
 
 #### Defined in
 
-[sdk/src/ledger.ts:196](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L196)
-
-___
-
-### signMasp
-
-▸ **signMasp**(`tx`, `path?`): `Promise`\<`ResponseSign`\>
-
-Sign a Masp tx with the shielded keys associated with the provided (or default) path.
-Throw exception if app is not initialized.
-
-#### Parameters
-
-| Name | Type | Default value | Description |
-| :------ | :------ | :------ | :------ |
-| `tx` | `Uint8Array` | `undefined` | masp tx data blob to sign |
-| `path?` | `string` | `DEFAULT_LEDGER_BIP44_PATH` | Bip44 path for signing account |
-
-#### Returns
-
-`Promise`\<`ResponseSign`\>
-
-Response signature
-
-**`Async`**
-
-#### Defined in
-
-[sdk/src/ledger.ts:213](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L213)
+[sdk/src/ledger.ts:196](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/ledger.ts#L196)
 
 ___
 
@@ -257,7 +228,7 @@ Version and info of NamadaApp
 
 #### Defined in
 
-[sdk/src/ledger.ts:94](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L94)
+[sdk/src/ledger.ts:94](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/ledger.ts#L94)
 
 ___
 
@@ -283,4 +254,4 @@ Ledger class instance
 
 #### Defined in
 
-[sdk/src/ledger.ts:76](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L76)
+[sdk/src/ledger.ts:76](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/ledger.ts#L76)

--- a/packages/sdk/docs/classes/Masp.md
+++ b/packages/sdk/docs/classes/Masp.md
@@ -19,6 +19,7 @@ Class representing utilities related to MASP
 - [addDefaultPaymentAddress](Masp.md#adddefaultpaymentaddress)
 - [addSpendingKey](Masp.md#addspendingkey)
 - [addViewingKey](Masp.md#addviewingkey)
+- [clearShieldedContext](Masp.md#clearshieldedcontext)
 - [fetchAndStoreMaspParams](Masp.md#fetchandstoremaspparams)
 - [hasMaspParams](Masp.md#hasmaspparams)
 - [loadMaspParams](Masp.md#loadmaspparams)
@@ -42,7 +43,7 @@ Class representing utilities related to MASP
 
 #### Defined in
 
-[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/masp.ts#L10)
+[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/masp.ts#L10)
 
 ## Properties
 
@@ -54,7 +55,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/masp.ts#L10)
+[sdk/src/masp.ts:10](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/masp.ts#L10)
 
 ## Methods
 
@@ -81,7 +82,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:70](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/masp.ts#L70)
+[sdk/src/masp.ts:71](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/masp.ts#L71)
 
 ___
 
@@ -108,7 +109,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:48](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/masp.ts#L48)
+[sdk/src/masp.ts:49](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/masp.ts#L49)
 
 ___
 
@@ -135,7 +136,31 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:59](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/masp.ts#L59)
+[sdk/src/masp.ts:60](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/masp.ts#L60)
+
+___
+
+### clearShieldedContext
+
+▸ **clearShieldedContext**(`chainId`): `Promise`\<`void`\>
+
+Clear shilded context
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `chainId` | `string` | Chain ID to clear the shielded context for |
+
+#### Returns
+
+`Promise`\<`void`\>
+
+void
+
+#### Defined in
+
+[sdk/src/masp.ts:89](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/masp.ts#L89)
 
 ___
 
@@ -161,7 +186,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:27](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/masp.ts#L27)
+[sdk/src/masp.ts:27](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/masp.ts#L27)
 
 ___
 
@@ -181,13 +206,13 @@ True if MASP parameters are loaded
 
 #### Defined in
 
-[sdk/src/masp.ts:17](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/masp.ts#L17)
+[sdk/src/masp.ts:17](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/masp.ts#L17)
 
 ___
 
 ### loadMaspParams
 
-▸ **loadMaspParams**(`pathOrDbName`): `Promise`\<`void`\>
+▸ **loadMaspParams**(`pathOrDbName`, `chainId`): `Promise`\<`void`\>
 
 Load stored MASP params
 
@@ -196,6 +221,7 @@ Load stored MASP params
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `pathOrDbName` | `string` | Path to stored MASP params(nodejs) or name of the database(browser) |
+| `chainId` | `string` | Chain ID to read the MASP params for |
 
 #### Returns
 
@@ -207,7 +233,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp.ts:37](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/masp.ts#L37)
+[sdk/src/masp.ts:38](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/masp.ts#L38)
 
 ___
 
@@ -226,4 +252,4 @@ the MASP address
 
 #### Defined in
 
-[sdk/src/masp.ts:79](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/masp.ts#L79)
+[sdk/src/masp.ts:80](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/masp.ts#L80)

--- a/packages/sdk/docs/classes/Mnemonic.md
+++ b/packages/sdk/docs/classes/Mnemonic.md
@@ -38,7 +38,7 @@ Class for accessing mnemonic functionality from wasm
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/mnemonic.ts#L18)
+[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/mnemonic.ts#L18)
 
 ## Properties
 
@@ -50,7 +50,7 @@ Memory accessor for crypto lib
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/mnemonic.ts#L18)
+[sdk/src/mnemonic.ts:18](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/mnemonic.ts#L18)
 
 ## Methods
 
@@ -74,7 +74,7 @@ An array of words
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:25](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/mnemonic.ts#L25)
+[sdk/src/mnemonic.ts:25](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/mnemonic.ts#L25)
 
 ___
 
@@ -99,7 +99,7 @@ Seed bytes
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:43](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/mnemonic.ts#L43)
+[sdk/src/mnemonic.ts:43](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/mnemonic.ts#L43)
 
 ___
 
@@ -129,4 +129,4 @@ Object with validation result and error message if invalid
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:61](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/mnemonic.ts#L61)
+[sdk/src/mnemonic.ts:61](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/mnemonic.ts#L61)

--- a/packages/sdk/docs/classes/ProgressBarNames.md
+++ b/packages/sdk/docs/classes/ProgressBarNames.md
@@ -36,7 +36,7 @@
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:134
+shared/src/shared/shared.d.ts:152
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:137
+shared/src/shared/shared.d.ts:155
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:140
+shared/src/shared/shared.d.ts:158
 
 ## Methods
 
@@ -70,4 +70,4 @@ shared/src/shared/shared.d.ts:140
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:131
+shared/src/shared/shared.d.ts:149

--- a/packages/sdk/docs/classes/Rpc.md
+++ b/packages/sdk/docs/classes/Rpc.md
@@ -51,7 +51,7 @@ API for executing RPC requests with Namada
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:36](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L36)
+[sdk/src/rpc/rpc.ts:38](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/rpc.ts#L38)
 
 ## Properties
 
@@ -63,7 +63,7 @@ Instance of Query struct from wasm lib
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:38](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L38)
+[sdk/src/rpc/rpc.ts:40](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/rpc.ts#L40)
 
 ___
 
@@ -75,7 +75,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:37](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L37)
+[sdk/src/rpc/rpc.ts:39](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/rpc.ts#L39)
 
 ## Methods
 
@@ -102,7 +102,7 @@ TxResponseProps object
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:223](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L223)
+[sdk/src/rpc/rpc.ts:230](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/rpc.ts#L230)
 
 ___
 
@@ -122,13 +122,13 @@ Array of all validator addresses
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:78](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L78)
+[sdk/src/rpc/rpc.ts:85](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/rpc.ts#L85)
 
 ___
 
 ### queryBalance
 
-▸ **queryBalance**(`owner`, `tokens`): `Promise`\<[`Balance`](../modules.md#balance)\>
+▸ **queryBalance**(`owner`, `tokens`, `chainId`): `Promise`\<[`Balance`](../modules.md#balance)\>
 
 Query balances from chain
 
@@ -138,6 +138,7 @@ Query balances from chain
 | :------ | :------ | :------ |
 | `owner` | `string` | Owner address |
 | `tokens` | `string`[] | Array of token addresses |
+| `chainId` | `string` | Chain id needed to load specific context |
 
 #### Returns
 
@@ -149,7 +150,7 @@ Query balances from chain
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:48](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L48)
+[sdk/src/rpc/rpc.ts:51](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/rpc.ts#L51)
 
 ___
 
@@ -169,7 +170,7 @@ Object
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:203](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L203)
+[sdk/src/rpc/rpc.ts:210](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/rpc.ts#L210)
 
 ___
 
@@ -195,7 +196,7 @@ Promise resolving to delegators votes
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:102](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L102)
+[sdk/src/rpc/rpc.ts:109](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/rpc.ts#L109)
 
 ___
 
@@ -215,7 +216,7 @@ Query gas costs
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:194](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L194)
+[sdk/src/rpc/rpc.ts:201](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/rpc.ts#L201)
 
 ___
 
@@ -235,7 +236,7 @@ Address of native token
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:57](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L57)
+[sdk/src/rpc/rpc.ts:64](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/rpc.ts#L64)
 
 ___
 
@@ -262,7 +263,7 @@ String of public key if found
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:68](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L68)
+[sdk/src/rpc/rpc.ts:75](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/rpc.ts#L75)
 
 ___
 
@@ -288,7 +289,7 @@ Promise resolving to pending ethereum transfers
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:185](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L185)
+[sdk/src/rpc/rpc.ts:192](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/rpc.ts#L192)
 
 ___
 
@@ -314,7 +315,7 @@ Promise resolving to staking positions
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:139](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L139)
+[sdk/src/rpc/rpc.ts:146](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/rpc.ts#L146)
 
 ___
 
@@ -340,7 +341,7 @@ Promise resolving to staking totals
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:112](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L112)
+[sdk/src/rpc/rpc.ts:119](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/rpc.ts#L119)
 
 ___
 
@@ -364,7 +365,7 @@ Total bonds amount
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:175](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L175)
+[sdk/src/rpc/rpc.ts:182](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/rpc.ts#L182)
 
 ___
 
@@ -391,13 +392,13 @@ Promise resolving to total delegations
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:89](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L89)
+[sdk/src/rpc/rpc.ts:96](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/rpc.ts#L96)
 
 ___
 
 ### shieldedSync
 
-▸ **shieldedSync**(`vks`): `Promise`\<`void`\>
+▸ **shieldedSync**(`vks`, `chainId`): `Promise`\<`void`\>
 
 Sync the shielded context
 
@@ -405,7 +406,8 @@ Sync the shielded context
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `vks` | `string`[] | Array of viewing keys |
+| `vks` | `DatedViewingKey`[] | Array of dated viewing keys |
+| `chainId` | `string` | Chain ID to sync the shielded context for |
 
 #### Returns
 
@@ -415,4 +417,4 @@ Sync the shielded context
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:241](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/rpc.ts#L241)
+[sdk/src/rpc/rpc.ts:249](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/rpc.ts#L249)

--- a/packages/sdk/docs/classes/Sdk.md
+++ b/packages/sdk/docs/classes/Sdk.md
@@ -64,7 +64,7 @@ API for interacting with Namada SDK
 
 #### Defined in
 
-[sdk/src/sdk.ts:26](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L26)
+[sdk/src/sdk.ts:26](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L26)
 
 ## Properties
 
@@ -76,7 +76,7 @@ Memory accessor for crypto lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:29](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L29)
+[sdk/src/sdk.ts:29](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L29)
 
 ___
 
@@ -88,7 +88,7 @@ Address of chain's native token
 
 #### Defined in
 
-[sdk/src/sdk.ts:31](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L31)
+[sdk/src/sdk.ts:31](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L31)
 
 ___
 
@@ -100,7 +100,7 @@ Instance of Query struct from wasm lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:28](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L28)
+[sdk/src/sdk.ts:28](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L28)
 
 ___
 
@@ -112,7 +112,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:27](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L27)
+[sdk/src/sdk.ts:27](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L27)
 
 ___
 
@@ -124,7 +124,7 @@ RPC url
 
 #### Defined in
 
-[sdk/src/sdk.ts:30](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L30)
+[sdk/src/sdk.ts:30](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L30)
 
 ## Accessors
 
@@ -142,7 +142,7 @@ Utilities for encrypting and decrypting data
 
 #### Defined in
 
-[sdk/src/sdk.ts:177](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L177)
+[sdk/src/sdk.ts:177](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L177)
 
 ___
 
@@ -160,7 +160,7 @@ key-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:153](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L153)
+[sdk/src/sdk.ts:153](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L153)
 
 ___
 
@@ -178,7 +178,7 @@ Masp utilities for handling params
 
 #### Defined in
 
-[sdk/src/sdk.ts:169](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L169)
+[sdk/src/sdk.ts:169](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L169)
 
 ___
 
@@ -196,7 +196,7 @@ mnemonic-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:145](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L145)
+[sdk/src/sdk.ts:145](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L145)
 
 ___
 
@@ -214,7 +214,7 @@ rpc client
 
 #### Defined in
 
-[sdk/src/sdk.ts:129](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L129)
+[sdk/src/sdk.ts:129](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L129)
 
 ___
 
@@ -232,7 +232,7 @@ Non-Tx signing functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:161](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L161)
+[sdk/src/sdk.ts:161](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L161)
 
 ___
 
@@ -250,7 +250,7 @@ tx-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:137](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L137)
+[sdk/src/sdk.ts:137](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L137)
 
 ___
 
@@ -268,7 +268,7 @@ Version from package.json
 
 #### Defined in
 
-[sdk/src/sdk.ts:185](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L185)
+[sdk/src/sdk.ts:185](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L185)
 
 ## Methods
 
@@ -286,7 +286,7 @@ Utilities for encrypting and decrypting data
 
 #### Defined in
 
-[sdk/src/sdk.ts:103](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L103)
+[sdk/src/sdk.ts:103](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L103)
 
 ___
 
@@ -304,7 +304,7 @@ key-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:79](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L79)
+[sdk/src/sdk.ts:79](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L79)
 
 ___
 
@@ -322,7 +322,7 @@ Masp utilities for handling params
 
 #### Defined in
 
-[sdk/src/sdk.ts:95](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L95)
+[sdk/src/sdk.ts:95](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L95)
 
 ___
 
@@ -340,7 +340,7 @@ mnemonic-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:71](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L71)
+[sdk/src/sdk.ts:71](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L71)
 
 ___
 
@@ -358,7 +358,7 @@ Namada RPC client
 
 #### Defined in
 
-[sdk/src/sdk.ts:55](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L55)
+[sdk/src/sdk.ts:55](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L55)
 
 ___
 
@@ -376,7 +376,7 @@ Non-Tx signing functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:87](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L87)
+[sdk/src/sdk.ts:87](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L87)
 
 ___
 
@@ -394,7 +394,7 @@ Tx-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:63](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L63)
+[sdk/src/sdk.ts:63](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L63)
 
 ___
 
@@ -412,7 +412,7 @@ SDK version
 
 #### Defined in
 
-[sdk/src/sdk.ts:121](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L121)
+[sdk/src/sdk.ts:121](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L121)
 
 ___
 
@@ -438,7 +438,7 @@ Class for interacting with NamadaApp for Ledger Hardware Wallets
 
 #### Defined in
 
-[sdk/src/sdk.ts:113](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L113)
+[sdk/src/sdk.ts:113](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L113)
 
 ___
 
@@ -463,4 +463,4 @@ this instance of Sdk
 
 #### Defined in
 
-[sdk/src/sdk.ts:40](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/sdk.ts#L40)
+[sdk/src/sdk.ts:40](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/sdk.ts#L40)

--- a/packages/sdk/docs/classes/Signing.md
+++ b/packages/sdk/docs/classes/Signing.md
@@ -40,7 +40,7 @@ Signing constructor
 
 #### Defined in
 
-[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/signing.ts#L14)
+[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/signing.ts#L14)
 
 ## Properties
 
@@ -52,13 +52,13 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/signing.ts#L14)
+[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/signing.ts#L14)
 
 ## Methods
 
 ### sign
 
-▸ **sign**(`txProps`, `signingKey`, `chainId?`): `Promise`\<`Uint8Array`\>
+▸ **sign**(`txProps`, `signingKey`, `xsks?`, `chainId?`): `Promise`\<`Uint8Array`\>
 
 Sign Namada transaction
 
@@ -68,6 +68,7 @@ Sign Namada transaction
 | :------ | :------ | :------ |
 | `txProps` | `TxMsgValue` | TxProps |
 | `signingKey` | `string` | private key |
+| `xsks?` | `string`[] | spending keys |
 | `chainId?` | `string` | optional chain ID, will enforce validation if present |
 
 #### Returns
@@ -78,7 +79,7 @@ signed tx bytes - Promise resolving to Uint8Array
 
 #### Defined in
 
-[sdk/src/signing.ts:23](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/signing.ts#L23)
+[sdk/src/signing.ts:24](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/signing.ts#L24)
 
 ___
 
@@ -103,7 +104,7 @@ hash and signature
 
 #### Defined in
 
-[sdk/src/signing.ts:41](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/signing.ts#L41)
+[sdk/src/signing.ts:47](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/signing.ts#L47)
 
 ___
 
@@ -129,4 +130,4 @@ void
 
 #### Defined in
 
-[sdk/src/signing.ts:52](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/signing.ts#L52)
+[sdk/src/signing.ts:58](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/signing.ts#L58)

--- a/packages/sdk/docs/classes/Tx.md
+++ b/packages/sdk/docs/classes/Tx.md
@@ -54,7 +54,7 @@ SDK functionality related to transactions
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:56](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L56)
+[sdk/src/tx/tx.ts:56](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/tx/tx.ts#L56)
 
 ## Properties
 
@@ -66,7 +66,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:56](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L56)
+[sdk/src/tx/tx.ts:56](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/tx/tx.ts#L56)
 
 ## Methods
 
@@ -91,7 +91,7 @@ Append signature for transactions signed by Ledger Hardware Wallet
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:375](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L375)
+[sdk/src/tx/tx.ts:375](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/tx/tx.ts#L375)
 
 ___
 
@@ -115,7 +115,7 @@ a serialized TxMsgValue type
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:358](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L358)
+[sdk/src/tx/tx.ts:358](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/tx/tx.ts#L358)
 
 ___
 
@@ -142,7 +142,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:178](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L178)
+[sdk/src/tx/tx.ts:178](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/tx/tx.ts#L178)
 
 ___
 
@@ -169,7 +169,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:337](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L337)
+[sdk/src/tx/tx.ts:337](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/tx/tx.ts#L337)
 
 ___
 
@@ -196,7 +196,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:290](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L290)
+[sdk/src/tx/tx.ts:290](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/tx/tx.ts#L290)
 
 ___
 
@@ -225,7 +225,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:267](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L267)
+[sdk/src/tx/tx.ts:267](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/tx/tx.ts#L267)
 
 ___
 
@@ -252,7 +252,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:242](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L242)
+[sdk/src/tx/tx.ts:242](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/tx/tx.ts#L242)
 
 ___
 
@@ -278,7 +278,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:165](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L165)
+[sdk/src/tx/tx.ts:165](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/tx/tx.ts#L165)
 
 ___
 
@@ -305,7 +305,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:90](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L90)
+[sdk/src/tx/tx.ts:90](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/tx/tx.ts#L90)
 
 ___
 
@@ -332,7 +332,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:115](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L115)
+[sdk/src/tx/tx.ts:115](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/tx/tx.ts#L115)
 
 ___
 
@@ -359,7 +359,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:65](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L65)
+[sdk/src/tx/tx.ts:65](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/tx/tx.ts#L65)
 
 ___
 
@@ -386,7 +386,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:199](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L199)
+[sdk/src/tx/tx.ts:199](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/tx/tx.ts#L199)
 
 ___
 
@@ -413,7 +413,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:141](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L141)
+[sdk/src/tx/tx.ts:141](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/tx/tx.ts#L141)
 
 ___
 
@@ -440,7 +440,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:313](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L313)
+[sdk/src/tx/tx.ts:313](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/tx/tx.ts#L313)
 
 ___
 
@@ -467,7 +467,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:221](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L221)
+[sdk/src/tx/tx.ts:221](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/tx/tx.ts#L221)
 
 ___
 
@@ -492,7 +492,7 @@ a TxDetails object
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:428](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L428)
+[sdk/src/tx/tx.ts:428](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/tx/tx.ts#L428)
 
 ___
 
@@ -516,7 +516,7 @@ Serialized WrapperTxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:416](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L416)
+[sdk/src/tx/tx.ts:416](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/tx/tx.ts#L416)
 
 ___
 
@@ -546,7 +546,7 @@ promise that resolves to the shielding memo
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:491](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L491)
+[sdk/src/tx/tx.ts:491](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/tx/tx.ts#L491)
 
 ___
 
@@ -570,4 +570,4 @@ array of inner Tx hashes
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:510](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/tx/tx.ts#L510)
+[sdk/src/tx/tx.ts:510](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/tx/tx.ts#L510)

--- a/packages/sdk/docs/enums/KdfType.md
+++ b/packages/sdk/docs/enums/KdfType.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:38](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/types.ts#L38)
+[sdk/src/crypto/types.ts:38](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/crypto/types.ts#L38)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:39](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/types.ts#L39)
+[sdk/src/crypto/types.ts:39](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/crypto/types.ts#L39)

--- a/packages/sdk/docs/modules.md
+++ b/packages/sdk/docs/modules.md
@@ -71,7 +71,7 @@ Address and public key type
 
 #### Defined in
 
-[sdk/src/keys/types.ts:4](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/keys/types.ts#L4)
+[sdk/src/keys/types.ts:4](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/keys/types.ts#L4)
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:23](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/types.ts#L23)
+[sdk/src/crypto/types.ts:23](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/crypto/types.ts#L23)
 
 ___
 
@@ -94,7 +94,7 @@ Balance
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:69](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/types.ts#L69)
+[sdk/src/rpc/types.ts:69](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/types.ts#L69)
 
 ___
 
@@ -113,7 +113,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:27](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/types.ts#L27)
+[sdk/src/rpc/types.ts:27](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/types.ts#L27)
 
 ___
 
@@ -141,7 +141,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:42](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/types.ts#L42)
+[sdk/src/crypto/types.ts:42](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/crypto/types.ts#L42)
 
 ___
 
@@ -154,7 +154,7 @@ Record<address, totalDelegations>
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:51](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/types.ts#L51)
+[sdk/src/rpc/types.ts:51](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/types.ts#L51)
 
 ___
 
@@ -167,7 +167,7 @@ Record<address, boolean>
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:57](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/types.ts#L57)
+[sdk/src/rpc/types.ts:57](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/types.ts#L57)
 
 ___
 
@@ -186,7 +186,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:30](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/types.ts#L30)
+[sdk/src/crypto/types.ts:30](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/crypto/types.ts#L30)
 
 ___
 
@@ -203,7 +203,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:19](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L19)
+[sdk/src/ledger.ts:19](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/ledger.ts#L19)
 
 ___
 
@@ -225,7 +225,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:20](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L20)
+[sdk/src/ledger.ts:20](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/ledger.ts#L20)
 
 ___
 
@@ -242,7 +242,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:32](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L32)
+[sdk/src/ledger.ts:32](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/ledger.ts#L32)
 
 ___
 
@@ -257,12 +257,13 @@ Shielded keys and address
 | Name | Type |
 | :------ | :------ |
 | `address` | `string` |
+| `pseudoExtendedKey` | `string` |
 | `spendingKey` | `string` |
 | `viewingKey` | `string` |
 
 #### Defined in
 
-[sdk/src/keys/types.ts:19](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/keys/types.ts#L19)
+[sdk/src/keys/types.ts:19](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/keys/types.ts#L19)
 
 ___
 
@@ -279,7 +280,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:42](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/types.ts#L42)
+[sdk/src/rpc/types.ts:42](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/types.ts#L42)
 
 ___
 
@@ -299,7 +300,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:19](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/types.ts#L19)
+[sdk/src/rpc/types.ts:19](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/types.ts#L19)
 
 ___
 
@@ -309,7 +310,7 @@ ___
 
 #### Defined in
 
-[shared/src/types.ts:3](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/shared/src/types.ts#L3)
+[shared/src/types.ts:3](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/shared/src/types.ts#L3)
 
 ___
 
@@ -321,7 +322,7 @@ Public and private keypair with address
 
 #### Defined in
 
-[sdk/src/keys/types.ts:12](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/keys/types.ts#L12)
+[sdk/src/keys/types.ts:12](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/keys/types.ts#L12)
 
 ___
 
@@ -341,7 +342,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:34](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/rpc/types.ts#L34)
+[sdk/src/rpc/types.ts:34](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/rpc/types.ts#L34)
 
 ## Variables
 
@@ -359,7 +360,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:3](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/crypto/types.ts#L3)
+[sdk/src/crypto/types.ts:3](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/crypto/types.ts#L3)
 
 ___
 
@@ -369,7 +370,7 @@ ___
 
 #### Defined in
 
-[shared/src/types.ts:28](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/shared/src/types.ts#L28)
+[shared/src/types.ts:28](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/shared/src/types.ts#L28)
 
 ## Functions
 
@@ -389,7 +390,7 @@ Transport object
 
 #### Defined in
 
-[sdk/src/ledger.ts:51](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L51)
+[sdk/src/ledger.ts:51](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/ledger.ts#L51)
 
 ___
 
@@ -409,7 +410,7 @@ Transport object
 
 #### Defined in
 
-[sdk/src/ledger.ts:42](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/ledger.ts#L42)
+[sdk/src/ledger.ts:42](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/ledger.ts#L42)
 
 ___
 
@@ -429,4 +430,4 @@ ___
 
 #### Defined in
 
-[sdk/src/keys/keys.ts:213](https://github.com/anoma/namada-interface/blob/5bb72cf800fa4254312ea7fd624843feeaa5abf0/packages/sdk/src/keys/keys.ts#L213)
+[sdk/src/keys/keys.ts:245](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/sdk/src/keys/keys.ts#L245)

--- a/packages/sdk/examples/queryBalance.ts
+++ b/packages/sdk/examples/queryBalance.ts
@@ -17,7 +17,7 @@ export const queryBalance = async (
   try {
     const { cryptoMemory } = initSync();
     const sdk = getSdk(cryptoMemory, nodeUrl, "storage path", nativeToken);
-    const [[t, a]] = await sdk.rpc.queryBalance(owner, [token]);
+    const [[t, a]] = await sdk.rpc.queryBalance(owner, [token], "chainId");
     console.log(`Balance for ${owner} - Token: ${t} - Amount: ${a}`);
   } catch (error) {
     console.error("Error:", error);

--- a/packages/types/docs/classes/BatchTxResultMsgValue.md
+++ b/packages/types/docs/classes/BatchTxResultMsgValue.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[tx/schema/batchTxResult.ts:12](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/batchTxResult.ts#L12)
+[tx/schema/batchTxResult.ts:12](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/batchTxResult.ts#L12)
 
 ## Properties
 
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[tx/schema/batchTxResult.ts:7](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/batchTxResult.ts#L7)
+[tx/schema/batchTxResult.ts:7](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/batchTxResult.ts#L7)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[tx/schema/batchTxResult.ts:10](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/batchTxResult.ts#L10)
+[tx/schema/batchTxResult.ts:10](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/batchTxResult.ts#L10)

--- a/packages/types/docs/classes/BondMsgValue.md
+++ b/packages/types/docs/classes/BondMsgValue.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[tx/schema/bond.ts:17](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/bond.ts#L17)
+[tx/schema/bond.ts:17](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/bond.ts#L17)
 
 ## Properties
 
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[tx/schema/bond.ts:15](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/bond.ts#L15)
+[tx/schema/bond.ts:15](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/bond.ts#L15)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[tx/schema/bond.ts:9](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/bond.ts#L9)
+[tx/schema/bond.ts:9](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/bond.ts#L9)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[tx/schema/bond.ts:12](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/bond.ts#L12)
+[tx/schema/bond.ts:12](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/bond.ts#L12)

--- a/packages/types/docs/classes/ClaimRewardsMsgValue.md
+++ b/packages/types/docs/classes/ClaimRewardsMsgValue.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[tx/schema/claimRewards.ts:12](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/claimRewards.ts#L12)
+[tx/schema/claimRewards.ts:12](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/claimRewards.ts#L12)
 
 ## Properties
 
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[tx/schema/claimRewards.ts:10](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/claimRewards.ts#L10)
+[tx/schema/claimRewards.ts:10](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/claimRewards.ts#L10)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[tx/schema/claimRewards.ts:7](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/claimRewards.ts#L7)
+[tx/schema/claimRewards.ts:7](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/claimRewards.ts#L7)

--- a/packages/types/docs/classes/CommitmentMsgValue.md
+++ b/packages/types/docs/classes/CommitmentMsgValue.md
@@ -34,7 +34,7 @@
 
 #### Defined in
 
-[tx/schema/txDetails.ts:19](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/txDetails.ts#L19)
+[tx/schema/txDetails.ts:16](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/txDetails.ts#L16)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:10](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/txDetails.ts#L10)
+[tx/schema/txDetails.ts:10](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/txDetails.ts#L10)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:16](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/txDetails.ts#L16)
+[tx/schema/txDetails.ts:19](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/txDetails.ts#L19)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:13](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/txDetails.ts#L13)
+[tx/schema/txDetails.ts:13](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/txDetails.ts#L13)
 
 ___
 
@@ -74,4 +74,4 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:7](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/txDetails.ts#L7)
+[tx/schema/txDetails.ts:7](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/txDetails.ts#L7)

--- a/packages/types/docs/classes/EthBridgeTransferMsgValue.md
+++ b/packages/types/docs/classes/EthBridgeTransferMsgValue.md
@@ -37,7 +37,7 @@
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:32](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/ethBridgeTransfer.ts#L32)
+[tx/schema/ethBridgeTransfer.ts:32](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/ethBridgeTransfer.ts#L32)
 
 ## Properties
 
@@ -47,7 +47,7 @@
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:21](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/ethBridgeTransfer.ts#L21)
+[tx/schema/ethBridgeTransfer.ts:21](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/ethBridgeTransfer.ts#L21)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:12](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/ethBridgeTransfer.ts#L12)
+[tx/schema/ethBridgeTransfer.ts:12](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/ethBridgeTransfer.ts#L12)
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:24](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/ethBridgeTransfer.ts#L24)
+[tx/schema/ethBridgeTransfer.ts:24](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/ethBridgeTransfer.ts#L24)
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:27](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/ethBridgeTransfer.ts#L27)
+[tx/schema/ethBridgeTransfer.ts:27](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/ethBridgeTransfer.ts#L27)
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:30](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/ethBridgeTransfer.ts#L30)
+[tx/schema/ethBridgeTransfer.ts:30](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/ethBridgeTransfer.ts#L30)
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:9](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/ethBridgeTransfer.ts#L9)
+[tx/schema/ethBridgeTransfer.ts:9](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/ethBridgeTransfer.ts#L9)
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:15](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/ethBridgeTransfer.ts#L15)
+[tx/schema/ethBridgeTransfer.ts:15](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/ethBridgeTransfer.ts#L15)
 
 ___
 
@@ -117,4 +117,4 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:18](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/ethBridgeTransfer.ts#L18)
+[tx/schema/ethBridgeTransfer.ts:18](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/ethBridgeTransfer.ts#L18)

--- a/packages/types/docs/classes/IbcTransferMsgValue.md
+++ b/packages/types/docs/classes/IbcTransferMsgValue.md
@@ -39,7 +39,7 @@
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:38](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/ibcTransfer.ts#L38)
+[tx/schema/ibcTransfer.ts:38](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/ibcTransfer.ts#L38)
 
 ## Properties
 
@@ -49,7 +49,7 @@
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:18](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/ibcTransfer.ts#L18)
+[tx/schema/ibcTransfer.ts:18](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/ibcTransfer.ts#L18)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:24](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/ibcTransfer.ts#L24)
+[tx/schema/ibcTransfer.ts:24](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/ibcTransfer.ts#L24)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:33](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/ibcTransfer.ts#L33)
+[tx/schema/ibcTransfer.ts:33](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/ibcTransfer.ts#L33)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:21](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/ibcTransfer.ts#L21)
+[tx/schema/ibcTransfer.ts:21](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/ibcTransfer.ts#L21)
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:12](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/ibcTransfer.ts#L12)
+[tx/schema/ibcTransfer.ts:12](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/ibcTransfer.ts#L12)
 
 ___
 
@@ -99,7 +99,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:36](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/ibcTransfer.ts#L36)
+[tx/schema/ibcTransfer.ts:36](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/ibcTransfer.ts#L36)
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:9](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/ibcTransfer.ts#L9)
+[tx/schema/ibcTransfer.ts:9](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/ibcTransfer.ts#L9)
 
 ___
 
@@ -119,7 +119,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:27](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/ibcTransfer.ts#L27)
+[tx/schema/ibcTransfer.ts:27](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/ibcTransfer.ts#L27)
 
 ___
 
@@ -129,7 +129,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:30](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/ibcTransfer.ts#L30)
+[tx/schema/ibcTransfer.ts:30](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/ibcTransfer.ts#L30)
 
 ___
 
@@ -139,4 +139,4 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:15](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/ibcTransfer.ts#L15)
+[tx/schema/ibcTransfer.ts:15](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/ibcTransfer.ts#L15)

--- a/packages/types/docs/classes/Message.md
+++ b/packages/types/docs/classes/Message.md
@@ -61,7 +61,7 @@
 
 #### Defined in
 
-[tx/messages/index.ts:9](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/messages/index.ts#L9)
+[tx/messages/index.ts:9](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/messages/index.ts#L9)
 
 ___
 
@@ -88,4 +88,4 @@ ___
 
 #### Defined in
 
-[tx/messages/index.ts:17](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/messages/index.ts#L17)
+[tx/messages/index.ts:17](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/messages/index.ts#L17)

--- a/packages/types/docs/classes/RedelegateMsgValue.md
+++ b/packages/types/docs/classes/RedelegateMsgValue.md
@@ -33,7 +33,7 @@
 
 #### Defined in
 
-[tx/schema/redelegate.ts:19](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/redelegate.ts#L19)
+[tx/schema/redelegate.ts:19](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/redelegate.ts#L19)
 
 ## Properties
 
@@ -43,7 +43,7 @@
 
 #### Defined in
 
-[tx/schema/redelegate.ts:17](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/redelegate.ts#L17)
+[tx/schema/redelegate.ts:17](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/redelegate.ts#L17)
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 #### Defined in
 
-[tx/schema/redelegate.ts:14](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/redelegate.ts#L14)
+[tx/schema/redelegate.ts:14](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/redelegate.ts#L14)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[tx/schema/redelegate.ts:8](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/redelegate.ts#L8)
+[tx/schema/redelegate.ts:8](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/redelegate.ts#L8)
 
 ___
 
@@ -73,4 +73,4 @@ ___
 
 #### Defined in
 
-[tx/schema/redelegate.ts:11](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/redelegate.ts#L11)
+[tx/schema/redelegate.ts:11](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/redelegate.ts#L11)

--- a/packages/types/docs/classes/RevealPkMsgValue.md
+++ b/packages/types/docs/classes/RevealPkMsgValue.md
@@ -30,7 +30,7 @@
 
 #### Defined in
 
-[tx/schema/revealPk.ts:8](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/revealPk.ts#L8)
+[tx/schema/revealPk.ts:8](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/revealPk.ts#L8)
 
 ## Properties
 
@@ -40,4 +40,4 @@
 
 #### Defined in
 
-[tx/schema/revealPk.ts:6](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/revealPk.ts#L6)
+[tx/schema/revealPk.ts:6](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/revealPk.ts#L6)

--- a/packages/types/docs/classes/ShieldedTransferDataMsgValue.md
+++ b/packages/types/docs/classes/ShieldedTransferDataMsgValue.md
@@ -35,7 +35,7 @@ Shielded Transfer schemas
 
 #### Defined in
 
-[tx/schema/transfer.ts:66](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L66)
+[tx/schema/transfer.ts:66](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L66)
 
 ## Properties
 
@@ -45,7 +45,7 @@ Shielded Transfer schemas
 
 #### Defined in
 
-[tx/schema/transfer.ts:64](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L64)
+[tx/schema/transfer.ts:64](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L64)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:55](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L55)
+[tx/schema/transfer.ts:55](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L55)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:58](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L58)
+[tx/schema/transfer.ts:58](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L58)
 
 ___
 
@@ -75,4 +75,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:61](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L61)
+[tx/schema/transfer.ts:61](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L61)

--- a/packages/types/docs/classes/ShieldedTransferMsgValue.md
+++ b/packages/types/docs/classes/ShieldedTransferMsgValue.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:78](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L78)
+[tx/schema/transfer.ts:78](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L78)
 
 ## Properties
 
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:73](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L73)
+[tx/schema/transfer.ts:73](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L73)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:76](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L76)
+[tx/schema/transfer.ts:76](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L76)

--- a/packages/types/docs/classes/ShieldingTransferDataMsgValue.md
+++ b/packages/types/docs/classes/ShieldingTransferDataMsgValue.md
@@ -34,7 +34,7 @@ Shielding Transfer schemas
 
 #### Defined in
 
-[tx/schema/transfer.ts:102](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L102)
+[tx/schema/transfer.ts:102](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L102)
 
 ## Properties
 
@@ -44,7 +44,7 @@ Shielding Transfer schemas
 
 #### Defined in
 
-[tx/schema/transfer.ts:100](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L100)
+[tx/schema/transfer.ts:100](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L100)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:94](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L94)
+[tx/schema/transfer.ts:94](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L94)
 
 ___
 
@@ -64,4 +64,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:97](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L97)
+[tx/schema/transfer.ts:97](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L97)

--- a/packages/types/docs/classes/ShieldingTransferMsgValue.md
+++ b/packages/types/docs/classes/ShieldingTransferMsgValue.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:114](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L114)
+[tx/schema/transfer.ts:114](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L114)
 
 ## Properties
 
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:112](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L112)
+[tx/schema/transfer.ts:112](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L112)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:109](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L109)
+[tx/schema/transfer.ts:109](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L109)

--- a/packages/types/docs/classes/SignatureMsgValue.md
+++ b/packages/types/docs/classes/SignatureMsgValue.md
@@ -34,7 +34,7 @@
 
 #### Defined in
 
-[tx/schema/signature.ts:21](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/signature.ts#L21)
+[tx/schema/signature.ts:21](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/signature.ts#L21)
 
 ## Properties
 
@@ -44,7 +44,7 @@
 
 #### Defined in
 
-[tx/schema/signature.ts:7](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/signature.ts#L7)
+[tx/schema/signature.ts:7](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/signature.ts#L7)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[tx/schema/signature.ts:10](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/signature.ts#L10)
+[tx/schema/signature.ts:10](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/signature.ts#L10)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[tx/schema/signature.ts:13](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/signature.ts#L13)
+[tx/schema/signature.ts:13](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/signature.ts#L13)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[tx/schema/signature.ts:16](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/signature.ts#L16)
+[tx/schema/signature.ts:16](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/signature.ts#L16)
 
 ___
 
@@ -84,4 +84,4 @@ ___
 
 #### Defined in
 
-[tx/schema/signature.ts:19](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/signature.ts#L19)
+[tx/schema/signature.ts:19](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/signature.ts#L19)

--- a/packages/types/docs/classes/SigningDataMsgValue.md
+++ b/packages/types/docs/classes/SigningDataMsgValue.md
@@ -12,8 +12,10 @@
 
 - [accountPublicKeysMap](SigningDataMsgValue.md#accountpublickeysmap)
 - [feePayer](SigningDataMsgValue.md#feepayer)
+- [masp](SigningDataMsgValue.md#masp)
 - [owner](SigningDataMsgValue.md#owner)
 - [publicKeys](SigningDataMsgValue.md#publickeys)
+- [shieldedHash](SigningDataMsgValue.md#shieldedhash)
 - [threshold](SigningDataMsgValue.md#threshold)
 
 ## Constructors
@@ -34,7 +36,7 @@
 
 #### Defined in
 
-[tx/schema/tx.ts:26](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/tx.ts#L26)
+[tx/schema/tx.ts:32](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/tx.ts#L32)
 
 ## Properties
 
@@ -44,7 +46,7 @@
 
 #### Defined in
 
-[tx/schema/tx.ts:21](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/tx.ts#L21)
+[tx/schema/tx.ts:21](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/tx.ts#L21)
 
 ___
 
@@ -54,7 +56,17 @@ ___
 
 #### Defined in
 
-[tx/schema/tx.ts:24](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/tx.ts#L24)
+[tx/schema/tx.ts:24](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/tx.ts#L24)
+
+___
+
+### masp
+
+• `Optional` **masp**: `Uint8Array`
+
+#### Defined in
+
+[tx/schema/tx.ts:30](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/tx.ts#L30)
 
 ___
 
@@ -64,7 +76,7 @@ ___
 
 #### Defined in
 
-[tx/schema/tx.ts:8](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/tx.ts#L8)
+[tx/schema/tx.ts:8](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/tx.ts#L8)
 
 ___
 
@@ -74,7 +86,17 @@ ___
 
 #### Defined in
 
-[tx/schema/tx.ts:11](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/tx.ts#L11)
+[tx/schema/tx.ts:11](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/tx.ts#L11)
+
+___
+
+### shieldedHash
+
+• `Optional` **shieldedHash**: `Uint8Array`
+
+#### Defined in
+
+[tx/schema/tx.ts:27](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/tx.ts#L27)
 
 ___
 
@@ -84,4 +106,4 @@ ___
 
 #### Defined in
 
-[tx/schema/tx.ts:14](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/tx.ts#L14)
+[tx/schema/tx.ts:14](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/tx.ts#L14)

--- a/packages/types/docs/classes/TransferDataMsgValue.md
+++ b/packages/types/docs/classes/TransferDataMsgValue.md
@@ -34,7 +34,7 @@ General Transfer schema used for displaying details
 
 #### Defined in
 
-[tx/schema/transfer.ts:176](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L176)
+[tx/schema/transfer.ts:176](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L176)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:170](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L170)
+[tx/schema/transfer.ts:170](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L170)
 
 ___
 
@@ -54,4 +54,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:173](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L173)
+[tx/schema/transfer.ts:173](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L173)

--- a/packages/types/docs/classes/TransferMsgValue.md
+++ b/packages/types/docs/classes/TransferMsgValue.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:187](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L187)
+[tx/schema/transfer.ts:187](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L187)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:181](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L181)
+[tx/schema/transfer.ts:181](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L181)
 
 ___
 
@@ -52,4 +52,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:184](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L184)
+[tx/schema/transfer.ts:184](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L184)

--- a/packages/types/docs/classes/TransparentTransferDataMsgValue.md
+++ b/packages/types/docs/classes/TransparentTransferDataMsgValue.md
@@ -35,7 +35,7 @@ Transparent Transfer schemas
 
 #### Defined in
 
-[tx/schema/transfer.ts:32](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L32)
+[tx/schema/transfer.ts:32](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L32)
 
 ## Properties
 
@@ -45,7 +45,7 @@ Transparent Transfer schemas
 
 #### Defined in
 
-[tx/schema/transfer.ts:30](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L30)
+[tx/schema/transfer.ts:30](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L30)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:21](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L21)
+[tx/schema/transfer.ts:21](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L21)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:24](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L24)
+[tx/schema/transfer.ts:24](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L24)
 
 ___
 
@@ -75,4 +75,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:27](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L27)
+[tx/schema/transfer.ts:27](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L27)

--- a/packages/types/docs/classes/TransparentTransferMsgValue.md
+++ b/packages/types/docs/classes/TransparentTransferMsgValue.md
@@ -30,7 +30,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:41](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L41)
+[tx/schema/transfer.ts:41](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L41)
 
 ## Properties
 
@@ -40,4 +40,4 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:39](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L39)
+[tx/schema/transfer.ts:39](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L39)

--- a/packages/types/docs/classes/TxDetailsMsgValue.md
+++ b/packages/types/docs/classes/TxDetailsMsgValue.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[tx/schema/txDetails.ts:27](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/txDetails.ts#L27)
+[tx/schema/txDetails.ts:27](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/txDetails.ts#L27)
 
 ___
 
@@ -41,4 +41,4 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:24](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/txDetails.ts#L24)
+[tx/schema/txDetails.ts:24](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/txDetails.ts#L24)

--- a/packages/types/docs/classes/TxMsgValue.md
+++ b/packages/types/docs/classes/TxMsgValue.md
@@ -33,7 +33,7 @@
 
 #### Defined in
 
-[tx/schema/tx.ts:44](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/tx.ts#L44)
+[tx/schema/tx.ts:50](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/tx.ts#L50)
 
 ## Properties
 
@@ -43,7 +43,7 @@
 
 #### Defined in
 
-[tx/schema/tx.ts:33](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/tx.ts#L33)
+[tx/schema/tx.ts:39](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/tx.ts#L39)
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 #### Defined in
 
-[tx/schema/tx.ts:39](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/tx.ts#L39)
+[tx/schema/tx.ts:45](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/tx.ts#L45)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[tx/schema/tx.ts:36](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/tx.ts#L36)
+[tx/schema/tx.ts:42](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/tx.ts#L42)
 
 ___
 
@@ -73,4 +73,4 @@ ___
 
 #### Defined in
 
-[tx/schema/tx.ts:42](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/tx.ts#L42)
+[tx/schema/tx.ts:48](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/tx.ts#L48)

--- a/packages/types/docs/classes/TxResponseMsgValue.md
+++ b/packages/types/docs/classes/TxResponseMsgValue.md
@@ -36,7 +36,7 @@
 
 #### Defined in
 
-[tx/schema/txResponse.ts:28](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/txResponse.ts#L28)
+[tx/schema/txResponse.ts:28](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/txResponse.ts#L28)
 
 ## Properties
 
@@ -46,7 +46,7 @@
 
 #### Defined in
 
-[tx/schema/txResponse.ts:8](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/txResponse.ts#L8)
+[tx/schema/txResponse.ts:8](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/txResponse.ts#L8)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:11](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/txResponse.ts#L11)
+[tx/schema/txResponse.ts:11](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/txResponse.ts#L11)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:14](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/txResponse.ts#L14)
+[tx/schema/txResponse.ts:14](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/txResponse.ts#L14)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:17](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/txResponse.ts#L17)
+[tx/schema/txResponse.ts:17](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/txResponse.ts#L17)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:20](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/txResponse.ts#L20)
+[tx/schema/txResponse.ts:20](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/txResponse.ts#L20)
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:23](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/txResponse.ts#L23)
+[tx/schema/txResponse.ts:23](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/txResponse.ts#L23)
 
 ___
 
@@ -106,4 +106,4 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:26](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/txResponse.ts#L26)
+[tx/schema/txResponse.ts:26](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/txResponse.ts#L26)

--- a/packages/types/docs/classes/UnbondMsgValue.md
+++ b/packages/types/docs/classes/UnbondMsgValue.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[tx/schema/unbond.ts:17](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/unbond.ts#L17)
+[tx/schema/unbond.ts:17](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/unbond.ts#L17)
 
 ## Properties
 
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[tx/schema/unbond.ts:15](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/unbond.ts#L15)
+[tx/schema/unbond.ts:15](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/unbond.ts#L15)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[tx/schema/unbond.ts:9](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/unbond.ts#L9)
+[tx/schema/unbond.ts:9](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/unbond.ts#L9)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[tx/schema/unbond.ts:12](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/unbond.ts#L12)
+[tx/schema/unbond.ts:12](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/unbond.ts#L12)

--- a/packages/types/docs/classes/UnshieldingTransferDataMsgValue.md
+++ b/packages/types/docs/classes/UnshieldingTransferDataMsgValue.md
@@ -34,7 +34,7 @@ Unshielding Transfer schemas
 
 #### Defined in
 
-[tx/schema/transfer.ts:138](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L138)
+[tx/schema/transfer.ts:138](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L138)
 
 ## Properties
 
@@ -44,7 +44,7 @@ Unshielding Transfer schemas
 
 #### Defined in
 
-[tx/schema/transfer.ts:136](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L136)
+[tx/schema/transfer.ts:136](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L136)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:130](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L130)
+[tx/schema/transfer.ts:130](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L130)
 
 ___
 
@@ -64,4 +64,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:133](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L133)
+[tx/schema/transfer.ts:133](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L133)

--- a/packages/types/docs/classes/UnshieldingTransferMsgValue.md
+++ b/packages/types/docs/classes/UnshieldingTransferMsgValue.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:153](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L153)
+[tx/schema/transfer.ts:153](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L153)
 
 ## Properties
 
@@ -42,17 +42,17 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:148](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L148)
+[tx/schema/transfer.ts:148](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L148)
 
 ___
 
 ### gasSpendingKey
 
-• `Optional` **gasSpendingKey**: `string`[]
+• `Optional` **gasSpendingKey**: `string`
 
 #### Defined in
 
-[tx/schema/transfer.ts:151](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L151)
+[tx/schema/transfer.ts:151](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L151)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:145](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/transfer.ts#L145)
+[tx/schema/transfer.ts:145](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/transfer.ts#L145)

--- a/packages/types/docs/classes/VoteProposalMsgValue.md
+++ b/packages/types/docs/classes/VoteProposalMsgValue.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[tx/schema/voteProposal.ts:15](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/voteProposal.ts#L15)
+[tx/schema/voteProposal.ts:15](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/voteProposal.ts#L15)
 
 ## Properties
 
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[tx/schema/voteProposal.ts:10](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/voteProposal.ts#L10)
+[tx/schema/voteProposal.ts:10](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/voteProposal.ts#L10)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[tx/schema/voteProposal.ts:7](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/voteProposal.ts#L7)
+[tx/schema/voteProposal.ts:7](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/voteProposal.ts#L7)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[tx/schema/voteProposal.ts:13](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/voteProposal.ts#L13)
+[tx/schema/voteProposal.ts:13](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/voteProposal.ts#L13)

--- a/packages/types/docs/classes/WithdrawMsgValue.md
+++ b/packages/types/docs/classes/WithdrawMsgValue.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[tx/schema/withdraw.ts:12](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/withdraw.ts#L12)
+[tx/schema/withdraw.ts:12](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/withdraw.ts#L12)
 
 ## Properties
 
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[tx/schema/withdraw.ts:7](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/withdraw.ts#L7)
+[tx/schema/withdraw.ts:7](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/withdraw.ts#L7)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[tx/schema/withdraw.ts:10](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/withdraw.ts#L10)
+[tx/schema/withdraw.ts:10](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/withdraw.ts#L10)

--- a/packages/types/docs/classes/WrapperTxMsgValue.md
+++ b/packages/types/docs/classes/WrapperTxMsgValue.md
@@ -12,6 +12,7 @@
 
 - [chainId](WrapperTxMsgValue.md#chainid)
 - [feeAmount](WrapperTxMsgValue.md#feeamount)
+- [force](WrapperTxMsgValue.md#force)
 - [gasLimit](WrapperTxMsgValue.md#gaslimit)
 - [memo](WrapperTxMsgValue.md#memo)
 - [publicKey](WrapperTxMsgValue.md#publickey)
@@ -35,7 +36,7 @@
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:26](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/wrapperTx.ts#L26)
+[tx/schema/wrapperTx.ts:29](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/wrapperTx.ts#L29)
 
 ## Properties
 
@@ -45,7 +46,7 @@
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:18](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/wrapperTx.ts#L18)
+[tx/schema/wrapperTx.ts:18](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/wrapperTx.ts#L18)
 
 ___
 
@@ -55,7 +56,17 @@ ___
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:12](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/wrapperTx.ts#L12)
+[tx/schema/wrapperTx.ts:12](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/wrapperTx.ts#L12)
+
+___
+
+### force
+
+• `Optional` **force**: `boolean`
+
+#### Defined in
+
+[tx/schema/wrapperTx.ts:27](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/wrapperTx.ts#L27)
 
 ___
 
@@ -65,7 +76,7 @@ ___
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:15](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/wrapperTx.ts#L15)
+[tx/schema/wrapperTx.ts:15](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/wrapperTx.ts#L15)
 
 ___
 
@@ -75,7 +86,7 @@ ___
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:24](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/wrapperTx.ts#L24)
+[tx/schema/wrapperTx.ts:24](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/wrapperTx.ts#L24)
 
 ___
 
@@ -85,7 +96,7 @@ ___
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:21](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/wrapperTx.ts#L21)
+[tx/schema/wrapperTx.ts:21](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/wrapperTx.ts#L21)
 
 ___
 
@@ -95,4 +106,4 @@ ___
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:9](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/wrapperTx.ts#L9)
+[tx/schema/wrapperTx.ts:9](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/wrapperTx.ts#L9)

--- a/packages/types/docs/enums/AccountType.md
+++ b/packages/types/docs/enums/AccountType.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[account.ts:28](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/account.ts#L28)
+[account.ts:28](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/account.ts#L28)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[account.ts:22](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/account.ts#L22)
+[account.ts:22](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/account.ts#L22)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[account.ts:24](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/account.ts#L24)
+[account.ts:24](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/account.ts#L24)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[account.ts:26](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/account.ts#L26)
+[account.ts:26](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/account.ts#L26)

--- a/packages/types/docs/enums/BridgeType.md
+++ b/packages/types/docs/enums/BridgeType.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[chain.ts:14](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/chain.ts#L14)
+[chain.ts:14](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/chain.ts#L14)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[chain.ts:13](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/chain.ts#L13)
+[chain.ts:13](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/chain.ts#L13)

--- a/packages/types/docs/enums/Events.md
+++ b/packages/types/docs/enums/Events.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[events.ts:5](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/events.ts#L5)
+[events.ts:5](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/events.ts#L5)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[events.ts:9](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/events.ts#L9)
+[events.ts:9](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/events.ts#L9)
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 #### Defined in
 
-[events.ts:7](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/events.ts#L7)
+[events.ts:7](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/events.ts#L7)
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 #### Defined in
 
-[events.ts:8](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/events.ts#L8)
+[events.ts:8](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/events.ts#L8)
 
 ___
 
@@ -60,4 +60,4 @@ ___
 
 #### Defined in
 
-[events.ts:6](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/events.ts#L6)
+[events.ts:6](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/events.ts#L6)

--- a/packages/types/docs/enums/KeplrEvents.md
+++ b/packages/types/docs/enums/KeplrEvents.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[events.ts:14](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/events.ts#L14)
+[events.ts:14](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/events.ts#L14)

--- a/packages/types/docs/enums/MetamaskEvents.md
+++ b/packages/types/docs/enums/MetamaskEvents.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[events.ts:19](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/events.ts#L19)
+[events.ts:19](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/events.ts#L19)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[events.ts:20](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/events.ts#L20)
+[events.ts:20](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/events.ts#L20)

--- a/packages/types/docs/interfaces/IMessage.md
+++ b/packages/types/docs/interfaces/IMessage.md
@@ -36,4 +36,4 @@
 
 #### Defined in
 
-[tx/messages/index.ts:5](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/messages/index.ts#L5)
+[tx/messages/index.ts:5](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/messages/index.ts#L5)

--- a/packages/types/docs/interfaces/Namada.md
+++ b/packages/types/docs/interfaces/Namada.md
@@ -14,6 +14,7 @@
 - [connect](Namada.md#connect)
 - [defaultAccount](Namada.md#defaultaccount)
 - [disconnect](Namada.md#disconnect)
+- [genDisposableKeypair](Namada.md#gendisposablekeypair)
 - [isConnected](Namada.md#isconnected)
 - [sign](Namada.md#sign)
 - [signArbitrary](Namada.md#signarbitrary)
@@ -36,7 +37,7 @@
 
 #### Defined in
 
-[namada.ts:39](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/namada.ts#L39)
+[namada.ts:44](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/namada.ts#L44)
 
 ## Methods
 
@@ -50,7 +51,7 @@
 
 #### Defined in
 
-[namada.ts:28](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/namada.ts#L28)
+[namada.ts:32](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/namada.ts#L32)
 
 ___
 
@@ -70,7 +71,7 @@ ___
 
 #### Defined in
 
-[namada.ts:29](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/namada.ts#L29)
+[namada.ts:33](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/namada.ts#L33)
 
 ___
 
@@ -84,7 +85,7 @@ ___
 
 #### Defined in
 
-[namada.ts:32](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/namada.ts#L32)
+[namada.ts:36](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/namada.ts#L36)
 
 ___
 
@@ -104,7 +105,21 @@ ___
 
 #### Defined in
 
-[namada.ts:30](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/namada.ts#L30)
+[namada.ts:34](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/namada.ts#L34)
+
+___
+
+### genDisposableKeypair
+
+▸ **genDisposableKeypair**(): `Promise`\<`undefined` \| [`GenDisposableSignerResponse`](../modules.md#gendisposablesignerresponse)\>
+
+#### Returns
+
+`Promise`\<`undefined` \| [`GenDisposableSignerResponse`](../modules.md#gendisposablesignerresponse)\>
+
+#### Defined in
+
+[namada.ts:43](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/namada.ts#L43)
 
 ___
 
@@ -124,7 +139,7 @@ ___
 
 #### Defined in
 
-[namada.ts:31](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/namada.ts#L31)
+[namada.ts:35](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/namada.ts#L35)
 
 ___
 
@@ -144,7 +159,7 @@ ___
 
 #### Defined in
 
-[namada.ts:34](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/namada.ts#L34)
+[namada.ts:38](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/namada.ts#L38)
 
 ___
 
@@ -164,7 +179,7 @@ ___
 
 #### Defined in
 
-[namada.ts:35](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/namada.ts#L35)
+[namada.ts:39](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/namada.ts#L39)
 
 ___
 
@@ -184,7 +199,7 @@ ___
 
 #### Defined in
 
-[namada.ts:33](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/namada.ts#L33)
+[namada.ts:37](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/namada.ts#L37)
 
 ___
 
@@ -204,4 +219,4 @@ ___
 
 #### Defined in
 
-[namada.ts:38](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/namada.ts#L38)
+[namada.ts:42](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/namada.ts#L42)

--- a/packages/types/docs/interfaces/Signer.md
+++ b/packages/types/docs/interfaces/Signer.md
@@ -6,11 +6,30 @@
 
 ### Properties
 
+- [genDisposableKeypair](Signer.md#gendisposablekeypair)
 - [sign](Signer.md#sign)
 - [signArbitrary](Signer.md#signarbitrary)
 - [verify](Signer.md#verify)
 
 ## Properties
+
+### genDisposableKeypair
+
+• **genDisposableKeypair**: () => `Promise`\<`undefined` \| [`GenDisposableSignerResponse`](../modules.md#gendisposablesignerresponse)\>
+
+#### Type declaration
+
+▸ (): `Promise`\<`undefined` \| [`GenDisposableSignerResponse`](../modules.md#gendisposablesignerresponse)\>
+
+##### Returns
+
+`Promise`\<`undefined` \| [`GenDisposableSignerResponse`](../modules.md#gendisposablesignerresponse)\>
+
+#### Defined in
+
+[signer.ts:24](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/signer.ts#L24)
+
+___
 
 ### sign
 
@@ -34,7 +53,7 @@
 
 #### Defined in
 
-[signer.ts:9](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/signer.ts#L9)
+[signer.ts:14](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/signer.ts#L14)
 
 ___
 
@@ -59,7 +78,7 @@ ___
 
 #### Defined in
 
-[signer.ts:14](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/signer.ts#L14)
+[signer.ts:19](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/signer.ts#L19)
 
 ___
 
@@ -85,4 +104,4 @@ ___
 
 #### Defined in
 
-[signer.ts:18](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/signer.ts#L18)
+[signer.ts:23](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/signer.ts#L23)

--- a/packages/types/docs/modules.md
+++ b/packages/types/docs/modules.md
@@ -64,6 +64,7 @@
 - [CosmosMinDenom](modules.md#cosmosmindenom)
 - [CosmosTokenType](modules.md#cosmostokentype)
 - [Currency](modules.md#currency)
+- [DatedViewingKey](modules.md#datedviewingkey)
 - [Default](modules.md#default)
 - [DefaultWithWasm](modules.md#defaultwithwasm)
 - [DelegatorVote](modules.md#delegatorvote)
@@ -71,6 +72,7 @@
 - [EthBridgeTransferProps](modules.md#ethbridgetransferprops)
 - [ExtensionInfo](modules.md#extensioninfo)
 - [ExtensionKey](modules.md#extensionkey)
+- [GenDisposableSignerResponse](modules.md#gendisposablesignerresponse)
 - [IbcTransferProps](modules.md#ibctransferprops)
 - [JsonCompatibleArray](modules.md#jsoncompatiblearray)
 - [JsonCompatibleDictionary](modules.md#jsoncompatibledictionary)
@@ -147,11 +149,11 @@
 
 ### Account
 
-Ƭ **Account**: `Pick`\<[`DerivedAccount`](modules.md#derivedaccount), ``"address"`` \| ``"alias"`` \| ``"type"`` \| ``"publicKey"``\> & \{ `viewingKey?`: `string`  }
+Ƭ **Account**: `Pick`\<[`DerivedAccount`](modules.md#derivedaccount), ``"address"`` \| ``"alias"`` \| ``"type"`` \| ``"publicKey"`` \| ``"owner"`` \| ``"pseudoExtendedKey"`` \| ``"source"`` \| ``"timestamp"``\> & \{ `viewingKey?`: `string`  }
 
 #### Defined in
 
-[account.ts:42](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/account.ts#L42)
+[account.ts:45](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/account.ts#L45)
 
 ___
 
@@ -168,7 +170,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:34](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L34)
+[proposals.ts:34](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L34)
 
 ___
 
@@ -185,7 +187,7 @@ ___
 
 #### Defined in
 
-[namada.ts:22](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/namada.ts#L22)
+[namada.ts:26](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/namada.ts#L26)
 
 ___
 
@@ -195,7 +197,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:28](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L28)
+[tx/types.ts:28](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L28)
 
 ___
 
@@ -213,7 +215,7 @@ ___
 
 #### Defined in
 
-[account.ts:1](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/account.ts#L1)
+[account.ts:1](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/account.ts#L1)
 
 ___
 
@@ -223,7 +225,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:29](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L29)
+[tx/types.ts:29](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L29)
 
 ___
 
@@ -250,7 +252,7 @@ ___
 
 #### Defined in
 
-[chain.ts:49](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/chain.ts#L49)
+[chain.ts:49](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/chain.ts#L49)
 
 ___
 
@@ -260,7 +262,7 @@ ___
 
 #### Defined in
 
-[chain.ts:21](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/chain.ts#L21)
+[chain.ts:21](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/chain.ts#L21)
 
 ___
 
@@ -270,7 +272,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:48](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L48)
+[tx/types.ts:48](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L48)
 
 ___
 
@@ -280,7 +282,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:65](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L65)
+[tx/types.ts:65](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L65)
 
 ___
 
@@ -290,7 +292,7 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:13](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tokens/Cosmos.ts#L13)
+[tokens/Cosmos.ts:13](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tokens/Cosmos.ts#L13)
 
 ___
 
@@ -300,7 +302,7 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:6](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tokens/Cosmos.ts#L6)
+[tokens/Cosmos.ts:6](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tokens/Cosmos.ts#L6)
 
 ___
 
@@ -322,7 +324,26 @@ ___
 
 #### Defined in
 
-[chain.ts:1](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/chain.ts#L1)
+[chain.ts:1](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/chain.ts#L1)
+
+___
+
+### DatedViewingKey
+
+Ƭ **DatedViewingKey**: `Object`
+
+ViewingKey with optional birthday
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `birthday` | `number` |
+| `key` | `string` |
+
+#### Defined in
+
+[account.ts:62](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/account.ts#L62)
 
 ___
 
@@ -338,7 +359,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:63](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L63)
+[proposals.ts:63](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L63)
 
 ___
 
@@ -355,7 +376,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:64](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L64)
+[proposals.ts:64](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L64)
 
 ___
 
@@ -365,7 +386,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:92](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L92)
+[proposals.ts:92](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L92)
 
 ___
 
@@ -383,12 +404,15 @@ ___
 | `owner?` | `string` |
 | `parentId?` | `string` |
 | `path` | [`Path`](modules.md#path) |
+| `pseudoExtendedKey?` | `string` |
 | `publicKey?` | `string` |
+| `source?` | ``"imported"`` \| ``"generated"`` |
+| `timestamp?` | `number` |
 | `type` | [`AccountType`](enums/AccountType.md) |
 
 #### Defined in
 
-[account.ts:31](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/account.ts#L31)
+[account.ts:31](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/account.ts#L31)
 
 ___
 
@@ -398,7 +422,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:30](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L30)
+[tx/types.ts:30](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L30)
 
 ___
 
@@ -416,7 +440,7 @@ ___
 
 #### Defined in
 
-[chain.ts:23](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/chain.ts#L23)
+[chain.ts:23](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/chain.ts#L23)
 
 ___
 
@@ -426,7 +450,24 @@ ___
 
 #### Defined in
 
-[chain.ts:18](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/chain.ts#L18)
+[chain.ts:18](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/chain.ts#L18)
+
+___
+
+### GenDisposableSignerResponse
+
+Ƭ **GenDisposableSignerResponse**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `address` | `string` |
+| `publicKey` | `string` |
+
+#### Defined in
+
+[signer.ts:8](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/signer.ts#L8)
 
 ___
 
@@ -436,7 +477,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:31](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L31)
+[tx/types.ts:31](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L31)
 
 ___
 
@@ -446,7 +487,7 @@ ___
 
 #### Defined in
 
-[utils.ts:1](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/utils.ts#L1)
+[utils.ts:1](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/utils.ts#L1)
 
 ___
 
@@ -460,7 +501,7 @@ ___
 
 #### Defined in
 
-[utils.ts:2](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/utils.ts#L2)
+[utils.ts:2](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/utils.ts#L2)
 
 ___
 
@@ -478,7 +519,7 @@ ___
 
 #### Defined in
 
-[account.ts:13](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/account.ts#L13)
+[account.ts:13](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/account.ts#L13)
 
 ___
 
@@ -490,14 +531,14 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `continuous` | \{ `add`: [`PgfTarget`](modules.md#pgftarget)[] ; `remove`: [`PgfTarget`](modules.md#pgftarget)[]  } |
-| `continuous.add` | [`PgfTarget`](modules.md#pgftarget)[] |
-| `continuous.remove` | [`PgfTarget`](modules.md#pgftarget)[] |
+| `continuous` | \{ `add`: ([`PgfTarget`](modules.md#pgftarget) \| [`PgfIbcTarget`](modules.md#pgfibctarget))[] ; `remove`: ([`PgfTarget`](modules.md#pgftarget) \| [`PgfIbcTarget`](modules.md#pgfibctarget))[]  } |
+| `continuous.add` | ([`PgfTarget`](modules.md#pgftarget) \| [`PgfIbcTarget`](modules.md#pgfibctarget))[] |
+| `continuous.remove` | ([`PgfTarget`](modules.md#pgftarget) \| [`PgfIbcTarget`](modules.md#pgfibctarget))[] |
 | `retro` | ([`PgfTarget`](modules.md#pgftarget) \| [`PgfIbcTarget`](modules.md#pgfibctarget))[] |
 
 #### Defined in
 
-[proposals.ts:55](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L55)
+[proposals.ts:55](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L55)
 
 ___
 
@@ -517,7 +558,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:46](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L46)
+[proposals.ts:46](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L46)
 
 ___
 
@@ -534,7 +575,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:66](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L66)
+[proposals.ts:66](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L66)
 
 ___
 
@@ -551,7 +592,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:65](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L65)
+[proposals.ts:65](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L65)
 
 ___
 
@@ -569,7 +610,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:39](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L39)
+[proposals.ts:39](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L39)
 
 ___
 
@@ -579,7 +620,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:15](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L15)
+[proposals.ts:15](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L15)
 
 ___
 
@@ -589,7 +630,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:10](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L10)
+[proposals.ts:10](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L10)
 
 ___
 
@@ -599,7 +640,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:67](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L67)
+[proposals.ts:67](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L67)
 
 ___
 
@@ -609,7 +650,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:69](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L69)
+[proposals.ts:69](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L69)
 
 ___
 
@@ -619,7 +660,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:32](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L32)
+[tx/types.ts:32](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L32)
 
 ___
 
@@ -629,7 +670,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:51](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L51)
+[tx/types.ts:51](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L51)
 
 ___
 
@@ -639,7 +680,7 @@ ___
 
 #### Defined in
 
-[tx/schema/index.ts:47](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/index.ts#L47)
+[tx/schema/index.ts:47](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/index.ts#L47)
 
 ___
 
@@ -649,7 +690,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:35](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L35)
+[tx/types.ts:35](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L35)
 
 ___
 
@@ -659,7 +700,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:34](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L34)
+[tx/types.ts:34](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L34)
 
 ___
 
@@ -669,7 +710,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:37](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L37)
+[tx/types.ts:37](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L37)
 
 ___
 
@@ -679,7 +720,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:36](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L36)
+[tx/types.ts:36](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L36)
 
 ___
 
@@ -696,7 +737,7 @@ ___
 
 #### Defined in
 
-[namada.ts:5](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/namada.ts#L5)
+[namada.ts:9](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/namada.ts#L9)
 
 ___
 
@@ -713,7 +754,7 @@ ___
 
 #### Defined in
 
-[signer.ts:3](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/signer.ts#L3)
+[signer.ts:3](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/signer.ts#L3)
 
 ___
 
@@ -731,7 +772,7 @@ ___
 
 #### Defined in
 
-[namada.ts:10](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/namada.ts#L10)
+[namada.ts:14](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/namada.ts#L14)
 
 ___
 
@@ -741,7 +782,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:33](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L33)
+[tx/types.ts:33](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L33)
 
 ___
 
@@ -751,7 +792,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:45](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L45)
+[tx/types.ts:45](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L45)
 
 ___
 
@@ -761,7 +802,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:53](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L53)
+[tx/types.ts:53](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L53)
 
 ___
 
@@ -771,7 +812,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:108](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L108)
+[proposals.ts:108](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L108)
 
 ___
 
@@ -787,7 +828,7 @@ ___
 
 #### Defined in
 
-[tokens/types.ts:19](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tokens/types.ts#L19)
+[tokens/types.ts:19](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tokens/types.ts#L19)
 
 ___
 
@@ -819,7 +860,7 @@ ___
 
 #### Defined in
 
-[tokens/types.ts:5](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tokens/types.ts#L5)
+[tokens/types.ts:5](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tokens/types.ts#L5)
 
 ___
 
@@ -829,7 +870,7 @@ ___
 
 #### Defined in
 
-[tokens/Namada.ts:21](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tokens/Namada.ts#L21)
+[tokens/Namada.ts:21](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tokens/Namada.ts#L21)
 
 ___
 
@@ -839,7 +880,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:40](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L40)
+[tx/types.ts:40](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L40)
 
 ___
 
@@ -849,7 +890,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:42](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L42)
+[tx/types.ts:42](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L42)
 
 ___
 
@@ -859,7 +900,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:41](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L41)
+[tx/types.ts:41](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L41)
 
 ___
 
@@ -869,7 +910,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:71](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L71)
+[tx/types.ts:71](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L71)
 
 ___
 
@@ -879,7 +920,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:43](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L43)
+[tx/types.ts:43](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L43)
 
 ___
 
@@ -889,7 +930,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:44](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L44)
+[tx/types.ts:44](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L44)
 
 ___
 
@@ -899,7 +940,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:46](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L46)
+[tx/types.ts:46](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L46)
 
 ___
 
@@ -909,7 +950,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:38](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L38)
+[tx/types.ts:38](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L38)
 
 ___
 
@@ -919,7 +960,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:39](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L39)
+[tx/types.ts:39](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L39)
 
 ___
 
@@ -929,7 +970,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:84](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L84)
+[proposals.ts:84](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L84)
 
 ___
 
@@ -947,7 +988,7 @@ ___
 
 #### Defined in
 
-[namada.ts:16](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/namada.ts#L16)
+[namada.ts:20](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/namada.ts#L20)
 
 ___
 
@@ -957,7 +998,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:100](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L100)
+[proposals.ts:100](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L100)
 
 ___
 
@@ -967,7 +1008,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:47](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L47)
+[tx/types.ts:47](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L47)
 
 ___
 
@@ -977,7 +1018,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:72](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L72)
+[proposals.ts:72](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L72)
 
 ___
 
@@ -987,7 +1028,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:77](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L77)
+[proposals.ts:77](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L77)
 
 ___
 
@@ -997,7 +1038,7 @@ ___
 
 #### Defined in
 
-[namada.ts:42](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/namada.ts#L42)
+[namada.ts:47](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/namada.ts#L47)
 
 ___
 
@@ -1007,7 +1048,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:49](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L49)
+[tx/types.ts:49](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L49)
 
 ___
 
@@ -1017,7 +1058,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:50](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/types.ts#L50)
+[tx/types.ts:50](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/types.ts#L50)
 
 ___
 
@@ -1034,7 +1075,7 @@ ___
 
 #### Defined in
 
-[account.ts:7](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/account.ts#L7)
+[account.ts:7](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/account.ts#L7)
 
 ## Variables
 
@@ -1051,7 +1092,7 @@ ___
 
 #### Defined in
 
-[tx/schema/utils.ts:4](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tx/schema/utils.ts#L4)
+[tx/schema/utils.ts:4](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tx/schema/utils.ts#L4)
 
 ___
 
@@ -1061,7 +1102,7 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:5](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tokens/Cosmos.ts#L5)
+[tokens/Cosmos.ts:5](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tokens/Cosmos.ts#L5)
 
 ___
 
@@ -1071,7 +1112,7 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:22](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tokens/Cosmos.ts#L22)
+[tokens/Cosmos.ts:22](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tokens/Cosmos.ts#L22)
 
 ___
 
@@ -1098,7 +1139,7 @@ ___
 
 #### Defined in
 
-[chain.ts:30](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/chain.ts#L30)
+[chain.ts:30](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/chain.ts#L30)
 
 ___
 
@@ -1108,7 +1149,7 @@ ___
 
 #### Defined in
 
-[tokens/Namada.ts:11](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tokens/Namada.ts#L11)
+[tokens/Namada.ts:11](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tokens/Namada.ts#L11)
 
 ___
 
@@ -1118,7 +1159,7 @@ ___
 
 #### Defined in
 
-[tokens/Namada.ts:23](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tokens/Namada.ts#L23)
+[tokens/Namada.ts:23](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tokens/Namada.ts#L23)
 
 ___
 
@@ -1128,7 +1169,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:3](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L3)
+[proposals.ts:3](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L3)
 
 ___
 
@@ -1138,7 +1179,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:102](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L102)
+[proposals.ts:102](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L102)
 
 ___
 
@@ -1148,7 +1189,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:71](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L71)
+[proposals.ts:71](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L71)
 
 ## Functions
 
@@ -1168,7 +1209,7 @@ vote is DelegatorVote
 
 #### Defined in
 
-[proposals.ts:97](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L97)
+[proposals.ts:97](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L97)
 
 ___
 
@@ -1188,7 +1229,7 @@ str is "pending" \| "ongoing" \| "passed" \| "rejected"
 
 #### Defined in
 
-[proposals.ts:12](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L12)
+[proposals.ts:12](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L12)
 
 ___
 
@@ -1208,7 +1249,7 @@ tallyType is "two-fifths" \| "one-half-over-one-third" \| "less-one-half-over-on
 
 #### Defined in
 
-[proposals.ts:110](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L110)
+[proposals.ts:110](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L110)
 
 ___
 
@@ -1228,7 +1269,7 @@ vote is ValidatorVote
 
 #### Defined in
 
-[proposals.ts:89](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L89)
+[proposals.ts:89](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L89)
 
 ___
 
@@ -1248,7 +1289,7 @@ str is "yay" \| "nay" \| "abstain"
 
 #### Defined in
 
-[proposals.ts:74](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/proposals.ts#L74)
+[proposals.ts:74](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/proposals.ts#L74)
 
 ___
 
@@ -1268,7 +1309,7 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:66](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tokens/Cosmos.ts#L66)
+[tokens/Cosmos.ts:66](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tokens/Cosmos.ts#L66)
 
 ___
 
@@ -1288,4 +1329,4 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:48](https://github.com/anoma/namada-interface/blob/be532c799367420fcc6a8d60ac3b6b3a194f2891/packages/types/src/tokens/Cosmos.ts#L48)
+[tokens/Cosmos.ts:48](https://github.com/anoma/namada-interface/blob/9724dc7fb547e95a72df1eb06aecb9fed2c6a05b/packages/types/src/tokens/Cosmos.ts#L48)


### PR DESCRIPTION
This PR updates the docs in `sdk` & `types`, and should be done before releasing v0.14 of the SDK