### PR TITLE
Namadillo: querying next rpc if the previous one fails

### DIFF
--- a/apps/namadillo/src/App/Common/QueryProvider.tsx
+++ b/apps/namadillo/src/App/Common/QueryProvider.tsx
@@ -1,8 +1,4 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { getDefaultStore } from "jotai";
-import { queryClientAtom } from "jotai-tanstack-query";
-import { Provider as JotaiProvider } from "jotai/react";
-import { useHydrateAtoms } from "jotai/utils";
 
 type ErrorWithResponse = Error & {
   response?: {
@@ -11,7 +7,6 @@ type ErrorWithResponse = Error & {
 };
 
 const MAX_RETRIES = 3;
-
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -31,21 +26,12 @@ export const queryClient = new QueryClient({
   },
 });
 
-const HydrateAtoms = (props: { children: JSX.Element }): JSX.Element => {
-  useHydrateAtoms([[queryClientAtom, queryClient]]);
-  return props.children;
-};
-
 export const QueryProvider = ({
   children,
 }: {
   children: JSX.Element;
 }): JSX.Element => {
   return (
-    <QueryClientProvider client={queryClient}>
-      <JotaiProvider store={getDefaultStore()}>
-        <HydrateAtoms>{children}</HydrateAtoms>
-      </JotaiProvider>
-    </QueryClientProvider>
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
 };

--- a/apps/namadillo/src/App/Common/StorageProvider.tsx
+++ b/apps/namadillo/src/App/Common/StorageProvider.tsx
@@ -1,0 +1,24 @@
+import { queryClient } from "App/Common/QueryProvider";
+import { getDefaultStore } from "jotai";
+import { queryClientAtom } from "jotai-tanstack-query";
+import { Provider as JotaiProvider } from "jotai/react";
+import { useHydrateAtoms } from "jotai/utils";
+
+type StorageProviderProps = { children: JSX.Element };
+
+const HydrateAtoms = (props: { children: JSX.Element }): JSX.Element => {
+  useHydrateAtoms([[queryClientAtom, queryClient]]);
+  return props.children;
+};
+
+export const defaultStore = getDefaultStore();
+
+export const StorageProvider = ({
+  children,
+}: StorageProviderProps): JSX.Element => {
+  return (
+    <JotaiProvider store={defaultStore}>
+      <HydrateAtoms>{children}</HydrateAtoms>
+    </JotaiProvider>
+  );
+};

--- a/apps/namadillo/src/atoms/integrations/atoms.ts
+++ b/apps/namadillo/src/atoms/integrations/atoms.ts
@@ -18,6 +18,7 @@ import {
   BuildTxAtomParams,
   ChainId,
   ChainRegistryEntry,
+  RpcStorage,
   TransferStep,
   TransferTransactionData,
 } from "types";
@@ -64,10 +65,9 @@ export const selectedIBCChainAtom = atomWithStorage<string | undefined>(
   undefined
 );
 
-export const workingRpcsAtom = atomWithStorage<Record<string, string>>(
-  "namadillo:rpcs",
-  {}
-);
+export const rpcByChainAtom = atomWithStorage<
+  Record<string, RpcStorage> | undefined
+>("namadillo:rpc:active", undefined);
 
 export const ibcTransferAtom = atomWithMutation(() => {
   return {

--- a/apps/namadillo/src/atoms/integrations/functions.ts
+++ b/apps/namadillo/src/atoms/integrations/functions.ts
@@ -26,6 +26,7 @@ import {
   Coin,
   GasConfig,
   LocalnetToml,
+  RpcStorage,
 } from "types";
 import { toDisplayAmount } from "utils";
 import { unknownAsset } from "utils/assets";
@@ -299,13 +300,17 @@ export const mapCoinsToAssets = async (
   );
 };
 
-export const getRpcByIndex = (chain: Chain, index = 0): string => {
+export const getRpcByIndex = (chain: Chain, index = 0): RpcStorage => {
   const availableRpcs = chain.apis?.rpc;
   if (!availableRpcs) {
     throw new Error("There are no available RPCs for " + chain.chain_name);
   }
-  const randomRpc = availableRpcs[Math.min(index, availableRpcs.length - 1)];
-  return randomRpc.address;
+
+  const rpc = availableRpcs[Math.min(index, availableRpcs.length - 1)];
+  return {
+    address: rpc.address,
+    index,
+  };
 };
 
 export const getRestApiAddressByIndex = (chain: Chain, index = 0): string => {

--- a/apps/namadillo/src/index.tsx
+++ b/apps/namadillo/src/index.tsx
@@ -8,6 +8,7 @@ import { getRouter } from "./App/AppRoutes";
 
 import "@namada/components/src/base.css";
 import "@namada/utils/bigint-to-json-polyfill";
+import { StorageProvider } from "App/Common/StorageProvider";
 import { ExtensionLoader } from "App/Setup/ExtensionLoader";
 import { IndexerLoader } from "App/Setup/IndexerLoader";
 import { TomlConfigLoader } from "App/Setup/TomlConfigLoader";
@@ -23,15 +24,17 @@ if (container) {
     root.render(
       <React.StrictMode>
         <QueryProvider>
-          <TomlConfigLoader>
-            <IndexerLoader>
-              <ExtensionLoader>
-                <SdkProvider>
-                  <RouterProvider router={router} />
-                </SdkProvider>
-              </ExtensionLoader>
-            </IndexerLoader>
-          </TomlConfigLoader>
+          <StorageProvider>
+            <TomlConfigLoader>
+              <IndexerLoader>
+                <ExtensionLoader>
+                  <SdkProvider>
+                    <RouterProvider router={router} />
+                  </SdkProvider>
+                </ExtensionLoader>
+              </IndexerLoader>
+            </TomlConfigLoader>
+          </StorageProvider>
         </QueryProvider>
       </React.StrictMode>
     );

--- a/apps/namadillo/src/integrations/utils.ts
+++ b/apps/namadillo/src/integrations/utils.ts
@@ -154,7 +154,7 @@ export const basicConvertToKeplrChain = (
   return {
     chainId: chain.chain_id,
     chainName: chain.chain_name,
-    rpc,
+    rpc: rpc.address,
     rest,
     bip44: { coinType: chain.slip44 },
     bech32Config: generateBech32Config(chain.bech32_prefix),

--- a/apps/namadillo/src/types.ts
+++ b/apps/namadillo/src/types.ts
@@ -81,6 +81,11 @@ export type SettingsStorage = {
   enableTestnets?: boolean;
 };
 
+export type RpcStorage = {
+  address: string;
+  index: number;
+};
+
 export type Validator = Unique & {
   alias?: string;
   address: Address;


### PR DESCRIPTION
If we query an RPC endpoint and it fails for whatever reason (timeout, CORS, etc), we should query the next one in the list. 

Closes #1464 