### PR TITLE
feat: add version warning banner (anoma#1491)

### DIFF
--- a/apps/namadillo/src/hooks/useCompatibilityErrors.tsx
+++ b/apps/namadillo/src/hooks/useCompatibilityErrors.tsx
@@ -3,6 +3,7 @@ import { useAtomValue } from "jotai";
 import { useEffect, useState } from "react";
 import {
   checkIndexerCompatibilityErrors,
+  checkInterfaceCompatibilityError,
   checkKeychainCompatibilityError,
 } from "utils/compatibility";
 import { useNamadaKeychain } from "./useNamadaKeychain";
@@ -35,6 +36,13 @@ export const useCompatibilityErrors = (): React.ReactNode | undefined => {
     }
   };
 
+  const verifyInterfaceVersion = async (): Promise<void> => {
+    const versionErrorMessage = await checkInterfaceCompatibilityError();
+    if (versionErrorMessage) {
+      setErrorMessage(versionErrorMessage);
+    }
+  };
+
   useEffect(() => {
     verifyKeychainVersion();
   }, [keychain]);
@@ -42,6 +50,10 @@ export const useCompatibilityErrors = (): React.ReactNode | undefined => {
   useEffect(() => {
     indexerHealth.isSuccess && verifyIndexerVersion();
   }, [indexerHealth]);
+
+  useEffect(() => {
+    verifyInterfaceVersion();
+  }, []);
 
   return errorMessage;
 };


### PR DESCRIPTION
This PR introduces a feature to verify the interface version for compatibility by dynamically fetching the required version from the remote package.json file hosted on GitHub.

- Introduced checkInterfaceCompatibilityError to handle interface version validation.
- Enhanced the useCompatibilityErrors hook to include this new check.
- The required interface version is fetched dynamically, ensuring accuracy and up-to-date compatibility.
- Displays a warning banner if the interface version is outdated or incompatible.

This update aligns the interface version check with the existing validations for the indexer and keychain, ensuring consistency across compatibility checks.

by 5ElementsNodes