### PR TITLE
feat: fetching known ibc channels from github chain-registry repository

### DIFF
--- a/apps/namadillo/public/config.toml
+++ b/apps/namadillo/public/config.toml
@@ -3,3 +3,6 @@
 #rpc_url = ""
 #masp_indexer_url = ""
 #localnet_enabled = false
+
+github_chain_registry_base_url = "https://raw.githubusercontent.com/anoma/namada-chain-registry/refs/heads/main"
+github_namada_interface_url = "https://raw.githubusercontent.com/anoma/namada-interface/refs/heads/main"

--- a/apps/namadillo/src/App/Ibc/IbcTransfer.tsx
+++ b/apps/namadillo/src/App/Ibc/IbcTransfer.tsx
@@ -44,9 +44,11 @@ export const IbcTransfer = (): JSX.Element => {
   } = useWalletManager(keplr);
 
   // IBC Channels & Balances
-  const { data: ibcChannels } = useAtomValue(
-    ibcChannelsFamily(registry?.chain.chain_name)
-  );
+  const {
+    data: ibcChannels,
+    isError: unknownIbcChannels,
+    isLoading: isLoadingIbcChannels,
+  } = useAtomValue(ibcChannelsFamily(registry?.chain.chain_name));
 
   const { data: userAssets, isLoading: isLoadingBalances } = useAtomValue(
     assetBalanceAtomFamily({
@@ -101,16 +103,18 @@ export const IbcTransfer = (): JSX.Element => {
     );
   }, [defaultAccounts, shielded]);
 
-  const requiresIbcChannels =
-    !ibcChannels?.cosmosChannelId ||
-    (shielded && !ibcChannels?.namadaChannelId);
+  const requiresIbcChannels = Boolean(
+    !isLoadingIbcChannels &&
+      (unknownIbcChannels ||
+        (shielded && ibcChannels && !ibcChannels?.namadaChannel))
+  );
 
   useEffect(() => setSelectedAssetAddress(undefined), [registry]);
 
   // Set source and destination channels based on IBC channels data
   useEffect(() => {
-    setSourceChannel(ibcChannels?.cosmosChannelId || "");
-    setDestinationChannel(ibcChannels?.namadaChannelId || "");
+    setSourceChannel(ibcChannels?.ibcChannel || "");
+    setDestinationChannel(ibcChannels?.namadaChannel || "");
   }, [ibcChannels]);
 
   const onSubmitTransfer = async ({

--- a/apps/namadillo/src/App/Ibc/IbcWithdraw.tsx
+++ b/apps/namadillo/src/App/Ibc/IbcWithdraw.tsx
@@ -80,12 +80,14 @@ export const IbcWithdraw: React.FC = () => {
     connectToChainId(chain.chain_id);
   };
 
-  const { data: ibcChannels } = useAtomValue(
-    ibcChannelsFamily(registry?.chain.chain_name)
-  );
+  const {
+    data: ibcChannels,
+    isError: unknownIbcChannels,
+    isLoading: isLoadingIbcChannels,
+  } = useAtomValue(ibcChannelsFamily(registry?.chain.chain_name));
 
   useEffect(() => {
-    setSourceChannel(ibcChannels?.namadaChannelId || "");
+    setSourceChannel(ibcChannels?.namadaChannel || "");
   }, [ibcChannels]);
 
   const { execute: performWithdraw, isPending } = useTransaction({
@@ -190,7 +192,8 @@ export const IbcWithdraw: React.FC = () => {
     }
   };
 
-  const requiresIbcChannels = !ibcChannels?.cosmosChannelId;
+  const requiresIbcChannels = !isLoadingIbcChannels && unknownIbcChannels;
+
   return (
     <div className="relative min-h-[600px]">
       <header className="flex flex-col items-center text-center mb-3 gap-6">

--- a/apps/namadillo/src/atoms/integrations/functions.ts
+++ b/apps/namadillo/src/atoms/integrations/functions.ts
@@ -57,7 +57,7 @@ export const namadaTestnetChainList = [
   housefireOldChain,
 ] as Chain[];
 
-cosmosRegistry.chains.push(...namadaTestnetChainList, namadaChain);
+cosmosRegistry.chains.push(namadaChain, ...namadaTestnetChainList);
 
 cosmosRegistry.assets.push(
   internalDevnetAssets,

--- a/apps/namadillo/src/lib/chain.ts
+++ b/apps/namadillo/src/lib/chain.ts
@@ -1,0 +1,8 @@
+import { Chain } from "@chain-registry/types";
+import { namadaTestnetChainList } from "atoms/integrations";
+
+export const searchNamadaTestnetByChainId = (
+  chainId: string
+): Chain | undefined => {
+  return namadaTestnetChainList.find((chain) => chain.chain_id === chainId);
+};

--- a/apps/namadillo/src/types.ts
+++ b/apps/namadillo/src/types.ts
@@ -62,6 +62,8 @@ export type SettingsTomlOptions = {
   masp_indexer_url?: string;
   rpc_url?: string;
   localnet_enabled?: boolean;
+  github_chain_registry_base_url?: string;
+  github_namada_interface_url?: string;
 };
 
 export type ChainParameters = {


### PR DESCRIPTION
Tries to fetch known IBC channels from namada-chain-registry repository, instead of relying on the ibc channels added to Namadillo build. Maybe in the future we can revert these changes, but now we'll need a more dynamic way to fetch the latest changes and info from relayers.

This PR also introduce new config.toml entries:

github_chain_registry_base_url = "https://raw.githubusercontent.com/anoma/namada-chain-registry/refs/heads/main"
github_namada_interface_url = "https://raw.githubusercontent.com/anoma/namada-interface/refs/heads/main"
