### PR TITLE
fix: removing Github configs overrides to avoid upgrade issues

### DIFF
--- a/apps/namadillo/public/config.toml
+++ b/apps/namadillo/public/config.toml
@@ -4,5 +4,3 @@
 #masp_indexer_url = ""
 #localnet_enabled = false
 
-github_chain_registry_base_url = "https://raw.githubusercontent.com/anoma/namada-chain-registry/refs/heads/main"
-github_namada_interface_url = "https://raw.githubusercontent.com/anoma/namada-interface/refs/heads/main"

--- a/apps/namadillo/src/atoms/integrations/atoms.ts
+++ b/apps/namadillo/src/atoms/integrations/atoms.ts
@@ -22,6 +22,7 @@ import {
   ChainRegistryEntry,
   RpcStorage,
 } from "types";
+import { githubNamadaChainRegistryBaseUrl } from "urls";
 import {
   addLocalnetToRegistry,
   createIbcTx,
@@ -141,21 +142,12 @@ export const ibcChannelsFamily = atomFamily((ibcChainName?: string) =>
       ...queryDependentFn(async () => {
         invariant(chainSettings.data, "No chain settings");
         invariant(ibcChainName, "No IBC chain name");
-        invariant(
-          config.data?.github_chain_registry_base_url,
-          "No github_chain_registry_base_url was provided on config.toml"
-        );
         return fetchIbcChannelFromRegistry(
           chainSettings.data.chainId,
           ibcChainName,
-          config.data?.github_chain_registry_base_url
+          githubNamadaChainRegistryBaseUrl
         );
-      }, [
-        chainSettings,
-        config,
-        !!ibcChainName,
-        !!config.data?.github_chain_registry_base_url,
-      ]),
+      }, [chainSettings, config, !!ibcChainName]),
     };
   })
 );

--- a/apps/namadillo/src/types.ts
+++ b/apps/namadillo/src/types.ts
@@ -62,8 +62,6 @@ export type SettingsTomlOptions = {
   masp_indexer_url?: string;
   rpc_url?: string;
   localnet_enabled?: boolean;
-  github_chain_registry_base_url?: string;
-  github_namada_interface_url?: string;
 };
 
 export type ChainParameters = {

--- a/apps/namadillo/src/urls.ts
+++ b/apps/namadillo/src/urls.ts
@@ -1,2 +1,8 @@
 export const DISCORD_URL = "https://discord.com/invite/namada";
 export const TWITTER_URL = "https://twitter.com/namada";
+
+export const githubNamadaChainRegistryBaseUrl =
+  "https://raw.githubusercontent.com/anoma/namada-chain-registry/refs/heads/main";
+
+export const githubNamadaInterfaceBaseUrl =
+  "https://raw.githubusercontent.com/anoma/namada-interface/refs/heads/main";


### PR DESCRIPTION
We introduced two different entries on config.toml that won't be super useful and are causing issues when providers don't upgrade the config.toml after a new Namadillo release. So we're removing this variables and setting them as constants in /url.ts 