### PR TITLE
chore: bump namada_sdk to current main and indexer client to 1.1.6

### DIFF
--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -10,7 +10,7 @@
     "@chain-registry/client": "^1.53.5",
     "@cosmjs/encoding": "^0.32.3",
     "@keplr-wallet/types": "^0.12.136",
-    "@namada/indexer-client": "1.1.4",
+    "@namada/indexer-client": "1.1.6",
     "@tailwindcss/container-queries": "^0.1.1",
     "@tanstack/query-core": "^5.40.0",
     "@tanstack/react-query": "^5.40.0",

--- a/apps/namadillo/src/App/Governance/LiveGovernanceProposals.tsx
+++ b/apps/namadillo/src/App/Governance/LiveGovernanceProposals.tsx
@@ -1,5 +1,5 @@
 import { SegmentedBar, Stack } from "@namada/components";
-import { Proposal, VoteType, voteTypes } from "@namada/types";
+import { Proposal, UnknownVoteType, VoteType, voteTypes } from "@namada/types";
 import { routes } from "App/routes";
 import BigNumber from "bignumber.js";
 import clsx from "clsx";
@@ -14,7 +14,7 @@ import { colors } from "./types";
 
 const ProposalListItem: React.FC<{
   proposal: Proposal;
-  vote?: VoteType;
+  vote?: VoteType | UnknownVoteType;
 }> = ({ proposal, vote }) => {
   const { status } = proposal;
 
@@ -84,7 +84,7 @@ const ProposalListItem: React.FC<{
 
 type LiveGovernanceProposalsProps = {
   proposals: Proposal[];
-  votedProposals: { proposalId: bigint; vote: VoteType }[];
+  votedProposals: { proposalId: bigint; vote: VoteType | UnknownVoteType }[];
 };
 
 export const LiveGovernanceProposals: React.FC<

--- a/apps/namadillo/src/App/Governance/ProposalHeader.tsx
+++ b/apps/namadillo/src/App/Governance/ProposalHeader.tsx
@@ -3,7 +3,7 @@ import {
   ProgressBar as ProgressBarComponent,
   Stack,
 } from "@namada/components";
-import { Proposal, VoteType } from "@namada/types";
+import { Proposal, UnknownVoteType, VoteType } from "@namada/types";
 import { routes } from "App/routes";
 import {
   canVoteAtom,
@@ -303,7 +303,7 @@ const ProgressBar: React.FC<{
 
 const VoteButton: React.FC<{
   proposal: AtomWithQueryResult<Proposal>;
-  vote: AtomWithQueryResult<VoteType | null>;
+  vote: AtomWithQueryResult<VoteType | UnknownVoteType | null>;
   proposalId: bigint;
 }> = ({ proposal, vote, proposalId }) => {
   const navigate = useNavigate();
@@ -360,7 +360,7 @@ const VoteButton: React.FC<{
 };
 
 const VotedLabel: React.FC<{
-  vote: AtomWithQueryResult<VoteType | null>;
+  vote: AtomWithQueryResult<VoteType | UnknownVoteType | null>;
 }> = ({ vote }) => {
   if (vote.isSuccess && vote.data !== null) {
     return (

--- a/apps/namadillo/src/App/Governance/ProposalLabels.tsx
+++ b/apps/namadillo/src/App/Governance/ProposalLabels.tsx
@@ -1,6 +1,12 @@
 import { InsetLabel, RoundedLabel } from "@namada/components";
-import { ProposalStatus, ProposalType, VoteType } from "@namada/types";
+import {
+  ProposalStatus,
+  ProposalType,
+  UnknownVoteType,
+  VoteType,
+} from "@namada/types";
 import { assertNever } from "@namada/utils";
+import { BsQuestionCircleFill } from "react-icons/bs";
 import { GoCheckCircleFill, GoSkipFill, GoXCircleFill } from "react-icons/go";
 import { twMerge } from "tailwind-merge";
 import { proposalStatusToString, proposalTypeStringToString } from "utils";
@@ -25,7 +31,7 @@ export const StatusLabel: React.FC<
 };
 
 type VotedLabelProps = {
-  vote: VoteType;
+  vote: VoteType | UnknownVoteType;
 } & React.ComponentProps<"div">;
 
 export const VotedLabel: React.FC<VotedLabelProps> = ({
@@ -35,13 +41,19 @@ export const VotedLabel: React.FC<VotedLabelProps> = ({
 }) => {
   const { icon, label, color } =
     vote === "yay" ?
-      { icon: <GoCheckCircleFill />, label: "yes", color: "text-yay" }
+      { icon: <GoCheckCircleFill />, label: "Voted yes", color: "text-yay" }
     : vote === "nay" ?
-      { icon: <GoXCircleFill />, label: "no", color: "text-nay" }
+      { icon: <GoXCircleFill />, label: "Voted no", color: "text-nay" }
     : vote === "abstain" ?
       {
         icon: <GoSkipFill className="rotate-45" />,
-        label: "abstain",
+        label: "Voted abstain",
+        color: "text-abstain",
+      }
+    : vote === "unknown" ?
+      {
+        icon: <BsQuestionCircleFill />,
+        label: "Vote unknown",
         color: "text-abstain",
       }
     : assertNever(vote);
@@ -51,7 +63,7 @@ export const VotedLabel: React.FC<VotedLabelProps> = ({
       {...props}
       className={twMerge("flex gap-1 py-1 px-2 items-center", color, className)}
     >
-      <div className="grow">Voted {label}</div>
+      <div className="grow">{label}</div>
       <i className="inline-flex text-lg">{icon}</i>
     </RoundedLabel>
   );

--- a/apps/namadillo/src/App/WorkerTest.tsx
+++ b/apps/namadillo/src/App/WorkerTest.tsx
@@ -12,10 +12,10 @@ import {
   disposableSignerAtom,
 } from "atoms/accounts";
 import { chainAtom, nativeTokenAddressAtom } from "atoms/chain";
-import { indexerUrlAtom, maspIndexerUrlAtom, rpcUrlAtom } from "atoms/settings";
+import { maspIndexerUrlAtom, rpcUrlAtom } from "atoms/settings";
 import BigNumber from "bignumber.js";
 import { useAtom, useAtomValue } from "jotai";
-import { signTx } from "lib/query";
+import { isPublicKeyRevealed, signTx } from "lib/query";
 import { Shield, ShieldedTransfer, Unshield } from "workers/MaspTxMessages";
 import {
   Worker as MaspTxWorkerApi,
@@ -33,7 +33,6 @@ export function WorkerTest(): JSX.Element {
   const { data: accounts } = useAtomValue(accountsAtom);
   const { data: chain } = useAtomValue(chainAtom);
   const { data: token } = useAtomValue(nativeTokenAddressAtom);
-  const indexerUrl = useAtomValue(indexerUrlAtom);
   const maspIndexerUrl = useAtomValue(maspIndexerUrlAtom);
   const shieldedAccount = accounts?.find(
     (a) => a.type === AccountType.ShieldedKeys && a.alias === account?.alias
@@ -87,9 +86,11 @@ export function WorkerTest(): JSX.Element {
       ],
     });
 
+    const publicKeyRevealed = await isPublicKeyRevealed(account!.address);
     const msg: Shield = {
       type: "shield",
       payload: {
+        publicKeyRevealed,
         account: account!,
         gasConfig: {
           gasLimit: BigNumber(50000),
@@ -97,7 +98,6 @@ export function WorkerTest(): JSX.Element {
           gasToken: "tnam1",
         },
         props: [shieldingMsgValue],
-        indexerUrl,
         chain: chain!,
       },
     };

--- a/apps/namadillo/src/atoms/api.ts
+++ b/apps/namadillo/src/atoms/api.ts
@@ -2,6 +2,8 @@ import { Configuration, DefaultApi } from "@namada/indexer-client";
 import { Atom, atom, getDefaultStore } from "jotai";
 import { indexerUrlAtom } from "./settings";
 
+const BASE_OPTIONS = { headers: {} };
+
 export const indexerApiAtom = atom<DefaultApi>((get) => {
   return getApi(get);
 });
@@ -14,7 +16,20 @@ export const getIndexerApi = (): DefaultApi => {
 // Helper function to use outside of hooks
 const getApi = (get: <Value>(atom: Atom<Value>) => Value): DefaultApi => {
   const indexerUrl = get(indexerUrlAtom);
-  const configuration = new Configuration({ basePath: indexerUrl });
+  const configuration = new Configuration({
+    basePath: indexerUrl,
+    baseOptions: BASE_OPTIONS,
+  });
+
+  return new DefaultApi(configuration);
+};
+
+// This function is used to get the custom indexer API - used in the settings page
+export const getCustomIndexerApi = (indexerUrl: string): DefaultApi => {
+  const configuration = new Configuration({
+    basePath: indexerUrl,
+    baseOptions: BASE_OPTIONS,
+  });
 
   return new DefaultApi(configuration);
 };

--- a/apps/namadillo/src/atoms/balance/atoms.ts
+++ b/apps/namadillo/src/atoms/balance/atoms.ts
@@ -134,8 +134,7 @@ export const shieldedBalanceAtom = atomWithQuery((get) => {
         !chainTokens ||
         !chainId ||
         !namTokenAddress ||
-        !rpcUrl ||
-        !maspIndexerUrl
+        !rpcUrl
       ) {
         return [];
       }

--- a/apps/namadillo/src/atoms/balance/atoms.ts
+++ b/apps/namadillo/src/atoms/balance/atoms.ts
@@ -2,7 +2,7 @@ import { DefaultApi } from "@namada/indexer-client";
 import { Account, AccountType, DatedViewingKey } from "@namada/types";
 import {
   accountsAtom,
-  defaultAccountAtom,
+  allDefaultAccountsAtom,
   transparentBalanceAtom,
 } from "atoms/accounts/atoms";
 import { indexerApiAtom } from "atoms/api";
@@ -74,17 +74,17 @@ export const viewingKeysAtom = atomWithQuery<
   [DatedViewingKey, DatedViewingKey[]]
 >((get) => {
   const accountsQuery = get(accountsAtom);
-  const defaultAccountQuery = get(defaultAccountAtom);
+  const defaultAccountsQuery = get(allDefaultAccountsAtom);
   const api = get(indexerApiAtom);
 
   return {
-    queryKey: ["viewing-keys", accountsQuery.data, defaultAccountQuery.data],
+    queryKey: ["viewing-keys", accountsQuery.data, defaultAccountsQuery.data],
     ...queryDependentFn(async () => {
       const shieldedAccounts = accountsQuery.data!.filter(
         (a) => a.type === AccountType.ShieldedKeys
       );
-      const defaultShieldedAccount = shieldedAccounts.find(
-        (a) => a.alias === defaultAccountQuery.data?.alias
+      const defaultShieldedAccount = defaultAccountsQuery.data?.find(
+        (account) => account.type === AccountType.ShieldedKeys
       );
 
       if (!defaultShieldedAccount) {
@@ -100,7 +100,7 @@ export const viewingKeysAtom = atomWithQuery<
       );
 
       return [defaultViewingKey, viewingKeys];
-    }, [accountsQuery, defaultAccountQuery]),
+    }, [accountsQuery, defaultAccountsQuery]),
   };
 });
 

--- a/apps/namadillo/src/atoms/integrations/services.ts
+++ b/apps/namadillo/src/atoms/integrations/services.ts
@@ -207,7 +207,6 @@ export const updateIbcWithdrawalStatus = async (
   if (!tx.hash) throw "Transaction hash not defined";
   const response = await api.apiV1IbcTxIdStatusGet(tx.hash);
 
-  //@ts-expect-error Indexer not providing correct type
   const { status } = response.data;
 
   if (status === "success") {

--- a/apps/namadillo/src/atoms/proposals/atoms.ts
+++ b/apps/namadillo/src/atoms/proposals/atoms.ts
@@ -1,6 +1,7 @@
 import {
   ProposalStatus,
   ProposalTypeString,
+  UnknownVoteType,
   VoteProposalProps,
   VoteType,
 } from "@namada/types";
@@ -38,7 +39,7 @@ export const proposalFamily = atomFamily((id: bigint) =>
 );
 
 export const proposalVoteFamily = atomFamily((id: bigint) =>
-  atomWithQuery<VoteType | null>((get) => {
+  atomWithQuery<VoteType | UnknownVoteType | null>((get) => {
     const votedProposals = get(votedProposalsAtom);
     const enablePolling = get(shouldUpdateProposalAtom);
 

--- a/apps/namadillo/src/atoms/proposals/functions.ts
+++ b/apps/namadillo/src/atoms/proposals/functions.ts
@@ -19,7 +19,7 @@ import {
   ProposalType,
   ProposalTypeString,
   TallyType,
-  Vote,
+  UnknownVoteType,
   VoteProposalProps,
   VoteType,
 } from "@namada/types";
@@ -353,31 +353,10 @@ export const fetchPaginatedProposals = async (
   };
 };
 
-export const fetchProposalVotes = async (
-  api: DefaultApi,
-  id: bigint
-): Promise<Vote[]> => {
-  const response = await api.apiV1GovProposalIdVotesGet(Number(id));
-
-  // TODO: This is only needed for votes breakdown, check if it's still relevant
-  const votingPower: [string, BigNumber][] = [
-    ["_", BigNumber(0)], // TODO: return voting power
-  ];
-
-  const votes: Vote[] = response.data.results.map((vote) => ({
-    address: vote.voterAddress,
-    voteType: vote.vote,
-    votingPower,
-    isValidator: false,
-  }));
-
-  return votes;
-};
-
 export const fetchVotedProposalsByAccount = async (
   api: DefaultApi,
   account: Account
-): Promise<{ proposalId: bigint; vote: VoteType }[]> => {
+): Promise<{ proposalId: bigint; vote: VoteType | UnknownVoteType }[]> => {
   const response = await api.apiV1GovVoterAddressVotesGet(account.address);
 
   return response.data.map(({ proposalId, vote }) => ({

--- a/apps/namadillo/src/atoms/settings/atoms.ts
+++ b/apps/namadillo/src/atoms/settings/atoms.ts
@@ -1,4 +1,5 @@
 import { isUrlValid, sanitizeUrl } from "@namada/utils";
+import { getCustomIndexerApi, indexerApiAtom } from "atoms/api";
 import { chainParametersAtom, indexerRpcUrlAtom } from "atoms/chain";
 import { Getter, Setter, atom, getDefaultStore } from "jotai";
 import { atomWithMutation, atomWithQuery } from "jotai-tanstack-query";
@@ -178,7 +179,8 @@ export const updateIndexerUrlAtom = atomWithMutation(() => {
     mutationKey: ["update-indexer-url"],
     mutationFn: changeSettingsUrl(
       "indexerUrl",
-      async (url: string): Promise<boolean> => !!(await getIndexerHealth(url))
+      async (url: string): Promise<boolean> =>
+        !!(await getIndexerHealth(getCustomIndexerApi(url)))
     ),
   };
 });
@@ -197,6 +199,7 @@ export const signArbitraryEnabledAtom = atom(
 
 export const indexerHeartbeatAtom = atomWithQuery((get) => {
   const indexerUrl = get(indexerUrlAtom);
+  const api = get(indexerApiAtom);
   return {
     queryKey: ["indexer-heartbeat", indexerUrl],
     enabled: !!indexerUrl,
@@ -204,7 +207,7 @@ export const indexerHeartbeatAtom = atomWithQuery((get) => {
     refetchOnWindowFocus: true,
     refetchInterval: 10_000,
     queryFn: async () => {
-      const indexerInfo = await getIndexerHealth(indexerUrl);
+      const indexerInfo = await getIndexerHealth(api);
       if (!indexerInfo) throw "Unable to verify indexer heartbeat";
       return indexerInfo;
     },

--- a/apps/namadillo/src/atoms/settings/services.ts
+++ b/apps/namadillo/src/atoms/settings/services.ts
@@ -1,23 +1,13 @@
-import {
-  Configuration,
-  DefaultApi,
-  HealthGet200Response,
-} from "@namada/indexer-client";
+import { DefaultApi, HealthGet200Response } from "@namada/indexer-client";
 import { isUrlValid } from "@namada/utils";
 import toml from "toml";
 import { SettingsTomlOptions } from "types";
 import { getSdkInstance } from "utils/sdk";
 
 export const getIndexerHealth = async (
-  url: string
+  api: DefaultApi
 ): Promise<HealthGet200Response | undefined> => {
-  if (!isUrlValid(url)) {
-    return;
-  }
-
   try {
-    const configuration = new Configuration({ basePath: url });
-    const api = new DefaultApi(configuration);
     const response = await api.healthGet();
 
     return response.data;

--- a/apps/namadillo/src/atoms/settings/services.ts
+++ b/apps/namadillo/src/atoms/settings/services.ts
@@ -1,12 +1,16 @@
-import { Configuration, DefaultApi } from "@namada/indexer-client";
+import {
+  Configuration,
+  DefaultApi,
+  HealthGet200Response,
+} from "@namada/indexer-client";
 import { isUrlValid } from "@namada/utils";
 import toml from "toml";
-import { SettingsTomlOptions, TempIndexerHealthType } from "types";
+import { SettingsTomlOptions } from "types";
 import { getSdkInstance } from "utils/sdk";
 
 export const getIndexerHealth = async (
   url: string
-): Promise<TempIndexerHealthType | undefined> => {
+): Promise<HealthGet200Response | undefined> => {
   if (!isUrlValid(url)) {
     return;
   }
@@ -16,9 +20,7 @@ export const getIndexerHealth = async (
     const api = new DefaultApi(configuration);
     const response = await api.healthGet();
 
-    // TODO:update when indexer swagger is fixed
-    // @ts-expect-error Indexer swagger is out of date
-    return response.data as TempIndexerHealthType;
+    return response.data;
   } catch {
     return;
   }

--- a/apps/namadillo/src/atoms/transfer/atoms.ts
+++ b/apps/namadillo/src/atoms/transfer/atoms.ts
@@ -5,7 +5,7 @@ import {
   UnshieldingTransferMsgValue,
 } from "@namada/types";
 import { chainAtom } from "atoms/chain";
-import { indexerUrlAtom, rpcUrlAtom } from "atoms/settings";
+import { rpcUrlAtom } from "atoms/settings";
 import { atomWithMutation } from "jotai-tanstack-query";
 import { BuildTxAtomParams } from "types";
 import {
@@ -62,7 +62,6 @@ export const createShieldedTransferAtom = atomWithMutation((get) => {
 export const createShieldingTransferAtom = atomWithMutation((get) => {
   const chain = get(chainAtom);
   const rpcUrl = get(rpcUrlAtom);
-  const indexerUrl = get(indexerUrlAtom);
   return {
     mutationKey: ["create-shielding-transfer-tx"],
     enabled: chain.isSuccess,
@@ -78,7 +77,6 @@ export const createShieldingTransferAtom = atomWithMutation((get) => {
         params,
         gasConfig,
         rpcUrl,
-        indexerUrl,
         memo
       ),
   };

--- a/apps/namadillo/src/types.ts
+++ b/apps/namadillo/src/types.ts
@@ -376,9 +376,3 @@ export type LocalnetToml = {
   chain_1_channel: string;
   chain_2_channel: string;
 };
-
-// TODO: remove this after indexer swagger gets fixed
-export type TempIndexerHealthType = {
-  version: string;
-  commit: string;
-};

--- a/apps/namadillo/src/workers/MaspTxMessages.ts
+++ b/apps/namadillo/src/workers/MaspTxMessages.ts
@@ -23,7 +23,7 @@ type ShieldPayload = {
   gasConfig: GasConfig;
   props: ShieldingTransferMsgValue[];
   chain: ChainSettings;
-  indexerUrl: string;
+  publicKeyRevealed: boolean;
   memo?: string;
 };
 export type Shield = WebWorkerMessage<"shield", ShieldPayload>;

--- a/apps/namadillo/src/workers/MaspTxWorker.ts
+++ b/apps/namadillo/src/workers/MaspTxWorker.ts
@@ -1,4 +1,3 @@
-import { Configuration, DefaultApi } from "@namada/indexer-client";
 import { initMulticore } from "@namada/sdk/inline-init";
 import { getSdk, Sdk } from "@namada/sdk/web";
 import {
@@ -78,19 +77,13 @@ async function shield(
   payload: Shield["payload"]
 ): Promise<EncodedTxData<ShieldingTransferMsgValue>> {
   const {
-    indexerUrl,
+    publicKeyRevealed,
     account,
     gasConfig,
     chain,
     props: shieldingProps,
     memo,
   } = payload;
-
-  const configuration = new Configuration({ basePath: indexerUrl });
-  const api = new DefaultApi(configuration);
-  const publicKeyRevealed = (
-    await api.apiV1RevealedPublicKeyAddressGet(account.address)
-  ).data.publicKey;
 
   await sdk.masp.loadMaspParams("", chain.chainId);
   const encodedTxData = await buildTx<ShieldingTransferMsgValue>(

--- a/packages/shared/lib/Cargo.lock
+++ b/packages/shared/lib/Cargo.lock
@@ -464,14 +464,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "borsh-ext"
-version = "1.2.0"
-source = "git+https://github.com/heliaxdev/borsh-ext?tag=v1.2.0#a62fee3e847e512cad9ac0f1fd5a900e5db9ba37"
-dependencies = [
- "borsh",
-]
-
-[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,8 +644,9 @@ checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "clru"
-version = "0.5.0"
-source = "git+https://github.com/marmeladema/clru-rs.git?rev=71ca566#71ca566915f21f3c308091ca7756a91b0f8b5afc"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
 
 [[package]]
 name = "coins-bip32"
@@ -1169,8 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-contract"
-version = "0.24.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.24.0#d66708bb8a734111988b9eaf08c7473bd7020c00"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccec11776e279f18dcef377c95932ac7e558358477870c972e3b5eba0f1cc661"
 dependencies = [
  "ethbridge-bridge-events",
  "ethbridge-structs",
@@ -1180,8 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-bridge-events"
-version = "0.24.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.24.0#d66708bb8a734111988b9eaf08c7473bd7020c00"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f862616190f541d733357e234d65ba73fec0ddacd62e91abb26a0258048a6bb1"
 dependencies = [
  "ethabi",
  "ethbridge-structs",
@@ -1191,8 +1186,9 @@ dependencies = [
 
 [[package]]
 name = "ethbridge-structs"
-version = "0.24.0"
-source = "git+https://github.com/heliaxdev/ethbridge-rs?tag=v0.24.0#d66708bb8a734111988b9eaf08c7473bd7020c00"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7b3e89a2332887bf096cd589ac5781a6664b4fb0881506aa99b2be32e8e086"
 dependencies = [
  "ethabi",
  "ethers",
@@ -2500,15 +2496,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
-name = "index-set"
-version = "0.8.0"
-source = "git+https://github.com/heliaxdev/index-set?tag=v0.8.1#b0d928f83cf0d465ccda299d131e8df2859b5184"
-dependencies = [
- "borsh",
- "serde",
-]
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2885,8 +2872,8 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "namada_account"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2897,8 +2884,8 @@ dependencies = [
 
 [[package]]
 name = "namada_controller"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "namada_core",
  "smooth-operator",
@@ -2907,12 +2894,11 @@ dependencies = [
 
 [[package]]
 name = "namada_core"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "bech32 0.8.1",
  "borsh",
- "borsh-ext",
  "chrono",
  "data-encoding",
  "ed25519-consensus",
@@ -2922,7 +2908,6 @@ dependencies = [
  "ibc",
  "ics23",
  "impl-num-traits",
- "index-set",
  "indexmap 2.2.4",
  "k256",
  "lazy_static",
@@ -2951,14 +2936,15 @@ dependencies = [
  "tokio",
  "tracing",
  "uint",
+ "usize-set",
  "wasmtimer",
  "zeroize",
 ]
 
 [[package]]
 name = "namada_ethereum_bridge"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "borsh",
  "ethers",
@@ -2985,8 +2971,8 @@ dependencies = [
 
 [[package]]
 name = "namada_events"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "borsh",
  "namada_core",
@@ -2999,8 +2985,8 @@ dependencies = [
 
 [[package]]
 name = "namada_gas"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3012,8 +2998,8 @@ dependencies = [
 
 [[package]]
 name = "namada_governance"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3035,8 +3021,8 @@ dependencies = [
 
 [[package]]
 name = "namada_ibc"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "borsh",
  "data-encoding",
@@ -3065,8 +3051,8 @@ dependencies = [
 
 [[package]]
 name = "namada_io"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "async-trait",
  "kdam",
@@ -3078,8 +3064,8 @@ dependencies = [
 
 [[package]]
 name = "namada_macros"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "data-encoding",
  "proc-macro2",
@@ -3090,8 +3076,8 @@ dependencies = [
 
 [[package]]
 name = "namada_merkle_tree"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "borsh",
  "eyre",
@@ -3105,8 +3091,8 @@ dependencies = [
 
 [[package]]
 name = "namada_parameters"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "namada_core",
  "namada_macros",
@@ -3120,8 +3106,8 @@ dependencies = [
 
 [[package]]
 name = "namada_proof_of_stake"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3144,21 +3130,20 @@ dependencies = [
 
 [[package]]
 name = "namada_replay_protection"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "namada_core",
 ]
 
 [[package]]
 name = "namada_sdk"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "async-trait",
  "bimap",
  "borsh",
- "borsh-ext",
  "circular-queue",
  "clap",
  "data-encoding",
@@ -3221,8 +3206,8 @@ dependencies = [
 
 [[package]]
 name = "namada_shielded_token"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "async-trait",
  "borsh",
@@ -3262,8 +3247,8 @@ dependencies = [
 
 [[package]]
 name = "namada_state"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "borsh",
  "clru",
@@ -3285,8 +3270,8 @@ dependencies = [
 
 [[package]]
 name = "namada_storage"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
@@ -3304,8 +3289,8 @@ dependencies = [
 
 [[package]]
 name = "namada_systems"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -3314,8 +3299,8 @@ dependencies = [
 
 [[package]]
 name = "namada_token"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3332,8 +3317,8 @@ dependencies = [
 
 [[package]]
 name = "namada_trans_token"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "konst",
  "namada_core",
@@ -3349,8 +3334,8 @@ dependencies = [
 
 [[package]]
 name = "namada_tx"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "ark-bls12-381",
  "bitflags 2.5.0",
@@ -3378,8 +3363,8 @@ dependencies = [
 
 [[package]]
 name = "namada_tx_env"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -3388,8 +3373,8 @@ dependencies = [
 
 [[package]]
 name = "namada_vm"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "borsh",
  "clru",
@@ -3410,8 +3395,8 @@ dependencies = [
 
 [[package]]
 name = "namada_vote_ext"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "borsh",
  "namada_core",
@@ -3422,8 +3407,8 @@ dependencies = [
 
 [[package]]
 name = "namada_vp"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "namada_core",
  "namada_events",
@@ -3438,8 +3423,8 @@ dependencies = [
 
 [[package]]
 name = "namada_vp_env"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "derivative",
  "masp_primitives",
@@ -3453,12 +3438,11 @@ dependencies = [
 
 [[package]]
 name = "namada_wallet"
-version = "0.46.0"
-source = "git+https://github.com/anoma/namada?rev=49a4a5d3260423df19ead14df82d18a51fa9b157#49a4a5d3260423df19ead14df82d18a51fa9b157"
+version = "0.46.1"
+source = "git+https://github.com/anoma/namada?rev=9eb747ce145d622fda5296475c1d35eb4c3e86a4#9eb747ce145d622fda5296475c1d35eb4c3e86a4"
 dependencies = [
  "bimap",
  "borsh",
- "borsh-ext",
  "data-encoding",
  "derivation-path",
  "itertools 0.12.1",
@@ -5007,16 +4991,18 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smooth-operator"
-version = "0.7.0"
-source = "git+https://github.com/heliaxdev/smooth-operator?tag=v0.7.0#0e182707f5e5bb9c6e0efa2d235dc9efd715d0a1"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6dece39b9b4d19edc6399498b056d1511135b70b5adf7822affdedf5715598"
 dependencies = [
  "smooth-operator-impl",
 ]
 
 [[package]]
 name = "smooth-operator-impl"
-version = "0.7.0"
-source = "git+https://github.com/heliaxdev/smooth-operator?tag=v0.7.0#0e182707f5e5bb9c6e0efa2d235dc9efd715d0a1"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "867851a695e22b0d1fc85f2f84dba29fef7e5d571f12fb23253e0b213bf190f7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5786,6 +5772,16 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+]
+
+[[package]]
+name = "usize-set"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12fbfdf92a2a7f550e532818381f9e8367cac2115671edb024120836f33985e9"
+dependencies = [
+ "borsh",
+ "serde",
 ]
 
 [[package]]

--- a/packages/shared/lib/Cargo.toml
+++ b/packages/shared/lib/Cargo.toml
@@ -18,7 +18,7 @@ nodejs = []
 web = []
 
 [build-dependencies]
-namada_tx = { git = "https://github.com/anoma/namada", rev = "49a4a5d3260423df19ead14df82d18a51fa9b157" }
+namada_tx = { git = "https://github.com/anoma/namada", rev = "9eb747ce145d622fda5296475c1d35eb4c3e86a4" }
 
 [dependencies]
 async-trait = {version = "0.1.51"}
@@ -27,7 +27,7 @@ chrono = "0.4.22"
 getrandom = { version = "0.2.7", features = ["js"] }
 gloo-utils = { version = "0.1.5", features = ["serde"] }
 js-sys = "0.3.60"
-namada_sdk = { git = "https://github.com/anoma/namada", rev="49a4a5d3260423df19ead14df82d18a51fa9b157", default-features = false }
+namada_sdk = { git = "https://github.com/anoma/namada", rev="9eb747ce145d622fda5296475c1d35eb4c3e86a4", default-features = false }
 rand = "0.8.5"
 rayon = { version = "1.5.3", optional = true }
 rexie = "0.5"

--- a/packages/types/src/proposals.ts
+++ b/packages/types/src/proposals.ts
@@ -70,6 +70,7 @@ export type ProposalTypeString = ProposalType["type"];
 
 export const voteTypes = ["yay", "nay", "abstain"] as const;
 export type VoteType = (typeof voteTypes)[number];
+export type UnknownVoteType = "unknown";
 
 export const isVoteType = (str: string): str is VoteType =>
   voteTypes.includes(str as VoteType);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3568,12 +3568,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@namada/indexer-client@npm:1.1.4":
-  version: 1.1.4
-  resolution: "@namada/indexer-client@npm:1.1.4"
+"@namada/indexer-client@npm:1.1.6":
+  version: 1.1.6
+  resolution: "@namada/indexer-client@npm:1.1.6"
   dependencies:
     axios: "npm:^1.6.1"
-  checksum: 10c0/47a420251658c634bc3874a8e3cb27a91e9f2a5b6b7eb40ab4591595f2f7b866a60ed27fd5ac12fee1d869f5ec6e0827ffdab521860bf428ec64dbc8c47604df
+  checksum: 10c0/15eb7355f400c8c8724d828d1647423b01af420c83b1203d8900b271d092f8b65ca63a3bef299a52e82011d870c9b068535a0ff93f17cc4fd95c23f5e84b2f33
   languageName: node
   linkType: hard
 
@@ -3614,7 +3614,7 @@ __metadata:
     "@cosmjs/encoding": "npm:^0.32.3"
     "@eslint/js": "npm:^9.9.1"
     "@keplr-wallet/types": "npm:^0.12.136"
-    "@namada/indexer-client": "npm:1.1.4"
+    "@namada/indexer-client": "npm:1.1.6"
     "@playwright/test": "npm:^1.24.1"
     "@svgr/webpack": "npm:^6.5.1"
     "@tailwindcss/container-queries": "npm:^0.1.1"


### PR DESCRIPTION
- bumps namada_sdk to the latest commit from main
- bumps namada indexer client to 1.1.6
- fixes types errors
- adds "voted unknown" label - this happens when someone voted then redelegated then voted again, this should not happen too often
- unified api configuration - sth changed and we have to override default headers produced by indexer client 
- fixed small problem with shielded sync not running when masp indexer url is not present
- fixed small issue in viewing keys atom which was checking shielded account by alias

![obraz](https://github.com/user-attachments/assets/4081bdf6-0ecb-47b7-abda-77801032fc22)
