### PR TITLE
fix: SDK: Enable panic hook in SDK Rust for debugging

### DIFF
--- a/packages/shared/lib/src/utils.rs
+++ b/packages/shared/lib/src/utils.rs
@@ -40,11 +40,7 @@ where
     }
 }
 
-#[cfg(feature = "dev")]
 pub fn set_panic_hook() {
     web_sys::console::log_1(&"Set panic hook".into());
     console_error_panic_hook::set_once();
 }
-
-#[cfg(not(feature = "dev"))]
-pub fn set_panic_hook() {}


### PR DESCRIPTION
Enable panic hook in Rust in the event of panics/unreachable so we can determine what is happening in SDK.