### PR TITLE
feat: adding multicore as default option for Namadillo and publishing sdk packages automatically to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,11 @@ jobs:
           tag: ${{ needs.release-please.outputs.sdk_tag }}
           bundle_filename: namada-${{ needs.release-please.outputs.sdk_tag }}.zip
           working_dir: ./packages/sdk
+      - name: Publish to NPM repository
+        working_dir: ./packages/sdk
+        run: yarn npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
   build-types:
     needs: [release-please]

--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -48,7 +48,7 @@
     "dev": "VITE_REVISION=$(git rev-parse HEAD) vite",
     "dev:local": "NODE_ENV=development NAMADA_INTERFACE_LOCAL=\"true\" yarn dev",
     "dev:proxy": "VITE_PROXY=true && ./scripts/start-proxies.sh && yarn dev:local",
-    "build": "NODE_ENV=production && yarn wasm:build && VITE_REVISION=$(git rev-parse HEAD) vite build",
+    "build": "NODE_ENV=production && yarn wasm:build:multicore && VITE_REVISION=$(git rev-parse HEAD) vite build",
     "build:only": "NODE_ENV=production && VITE_REVISION=$(git rev-parse HEAD) vite build",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "yarn lint -- --fix",


### PR DESCRIPTION
- Adding multicore to Namadillo build
- Publishing SDK to NPM repository 