### PR TITLE
feat: improving masp transactions feedback for users and other gas estimation fixes

### DIFF
--- a/apps/namadillo/src/App/Common/TransactionFeeButton.tsx
+++ b/apps/namadillo/src/App/Common/TransactionFeeButton.tsx
@@ -9,7 +9,6 @@ export const TransactionFeeButton = ({
   feeProps: TransactionFeeProps;
 }): JSX.Element => {
   const [modalOpen, setModalOpen] = useState(false);
-
   return (
     <>
       <button

--- a/apps/namadillo/src/App/Masp/MaspShield.tsx
+++ b/apps/namadillo/src/App/Masp/MaspShield.tsx
@@ -120,7 +120,7 @@ export const MaspShield: React.FC = () => {
   };
 
   return (
-    <Panel className="relative min-h-[600px]">
+    <Panel className="relative min-h-[600px] flex-1">
       <header className="flex flex-col items-center text-center mb-3 gap-6">
         <h1 className="mt-6 text-lg text-yellow">Shield</h1>
         <NamadaTransferTopHeader

--- a/apps/namadillo/src/App/Masp/MaspShield.tsx
+++ b/apps/namadillo/src/App/Masp/MaspShield.tsx
@@ -26,9 +26,10 @@ import { Address, TransferTransactionData } from "types";
 export const MaspShield: React.FC = () => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
+  const { storeTransaction } = useTransactionActions();
   const [displayAmount, setDisplayAmount] = useState<BigNumber | undefined>();
   const [generalErrorMessage, setGeneralErrorMessage] = useState("");
-
+  const [currentStep, setCurrentStep] = useState("");
   const rpcUrl = useAtomValue(rpcUrlAtom);
   const chainParameters = useAtomValue(chainParametersAtom);
   const defaultAccounts = useAtomValue(allDefaultAccountsAtom);
@@ -36,8 +37,6 @@ export const MaspShield: React.FC = () => {
   const { data: availableAssets, isLoading: isLoadingAssets } = useAtomValue(
     namadaTransparentAssetsAtom
   );
-
-  const { storeTransaction } = useTransactionActions();
 
   const chainId = chainParameters.data?.chainId;
   const sourceAddress = defaultAccounts.data?.find(
@@ -61,6 +60,7 @@ export const MaspShield: React.FC = () => {
     target: destinationAddress ?? "",
     token: selectedAsset?.originalAddress ?? "",
     displayAmount: displayAmount ?? new BigNumber(0),
+    onUpdateStatus: setCurrentStep,
   });
 
   const onChangeSelectedAsset = (address?: Address): void => {
@@ -88,6 +88,7 @@ export const MaspShield: React.FC = () => {
   }: OnSubmitTransferParams): Promise<void> => {
     try {
       setGeneralErrorMessage("");
+      setCurrentStep("");
 
       invariant(sourceAddress, "Source address is not defined");
       invariant(chainId, "Chain ID is undefined");
@@ -154,6 +155,7 @@ export const MaspShield: React.FC = () => {
         isSubmitting={isPerformingTransfer}
         errorMessage={generalErrorMessage}
         onSubmitTransfer={onSubmitTransfer}
+        submittingText={isPerformingTransfer ? currentStep : "Shield"}
         buttonTextErrors={{
           NoAmount: "Define an amount to shield",
         }}

--- a/apps/namadillo/src/App/Staking/IncrementBonding.tsx
+++ b/apps/namadillo/src/App/Staking/IncrementBonding.tsx
@@ -80,10 +80,6 @@ const IncrementBonding = (): JSX.Element => {
         </>
       ),
     }),
-    parseErrorTxNotification: () => ({
-      title: "Staking transaction failed",
-      description: "",
-    }),
     onBroadcasted: () => {
       onCloseModal();
     },

--- a/apps/namadillo/src/App/Staking/ReDelegate.tsx
+++ b/apps/namadillo/src/App/Staking/ReDelegate.tsx
@@ -65,10 +65,6 @@ export const ReDelegate = (): JSX.Element => {
       title: "Staking redelegation in progress",
       description: <>Your redelegation transaction is being processed</>,
     }),
-    parseErrorTxNotification: () => ({
-      title: "Staking redelegation failed",
-      description: "",
-    }),
     onBroadcasted: () => {
       onCloseModal();
     },

--- a/apps/namadillo/src/App/Staking/Unstake.tsx
+++ b/apps/namadillo/src/App/Staking/Unstake.tsx
@@ -67,10 +67,6 @@ export const Unstake = (): JSX.Element => {
         </>
       ),
     }),
-    parseErrorTxNotification: () => ({
-      title: "Unstake transaction failed",
-      description: "",
-    }),
     onBroadcasted: () => {
       onCloseModal();
     },

--- a/apps/namadillo/src/App/Transfer/TransferModule.tsx
+++ b/apps/namadillo/src/App/Transfer/TransferModule.tsx
@@ -107,8 +107,6 @@ export const TransferModule = ({
   errorMessage,
   buttonTextErrors = {},
 }: TransferModuleProps): JSX.Element => {
-  const gasConfig = gasConfigProp ?? feeProps?.gasConfig;
-
   const [walletSelectorModalOpen, setWalletSelectorModalOpen] = useState(false);
   const [sourceChainModalOpen, setSourceChainModalOpen] = useState(false);
   const [destinationChainModalOpen, setDestinationChainModalOpen] =
@@ -117,9 +115,9 @@ export const TransferModule = ({
   const [customAddressActive, setCustomAddressActive] = useState(
     destination.enableCustomAddress && !destination.availableWallets
   );
-
   const [memo, setMemo] = useState<undefined | string>();
 
+  const gasConfig = gasConfigProp ?? feeProps?.gasConfig;
   const selectedAsset = mapUndefined(
     (address) => source.availableAssets?.[address],
     source.selectedAssetAddress
@@ -127,7 +125,6 @@ export const TransferModule = ({
 
   const availableAmountMinusFees = useMemo(() => {
     const { selectedAssetAddress, availableAmount } = source;
-
     if (
       typeof selectedAssetAddress === "undefined" ||
       typeof availableAmount === "undefined"

--- a/apps/namadillo/src/atoms/integrations/atoms.ts
+++ b/apps/namadillo/src/atoms/integrations/atoms.ts
@@ -14,7 +14,7 @@ import invariant from "invariant";
 import { atom } from "jotai";
 import { atomWithMutation, atomWithQuery } from "jotai-tanstack-query";
 import { atomFamily, atomWithStorage } from "jotai/utils";
-import { TransactionPair } from "lib/query";
+import { EncodedTxData } from "lib/query";
 import {
   AddressWithAssetAndAmountMap,
   BuildTxAtomParams,
@@ -164,7 +164,7 @@ export const createIbcTxAtom = atomWithMutation((get) => {
       account,
       gasConfig,
     }: BuildTxAtomParams<IbcTransferMsgValue>): Promise<
-      TransactionPair<IbcTransferProps> | undefined
+      EncodedTxData<IbcTransferProps> | undefined
     > => {
       if (typeof account === "undefined") {
         throw new Error("no account");

--- a/apps/namadillo/src/atoms/integrations/functions.ts
+++ b/apps/namadillo/src/atoms/integrations/functions.ts
@@ -17,7 +17,7 @@ import * as elysTestnet from "chain-registry/testnet/elystestnet";
 import * as osmosisTestnet from "chain-registry/testnet/osmosistestnet";
 import * as stargazeTestnet from "chain-registry/testnet/stargazetestnet";
 import { DenomTrace } from "cosmjs-types/ibc/applications/transfer/v1/transfer";
-import { TransactionPair, buildTxPair } from "lib/query";
+import { EncodedTxData, buildTx } from "lib/query";
 import {
   Address,
   AddressWithAssetAndAmount,
@@ -365,9 +365,8 @@ export const createIbcTx = async (
   gasConfig: GasConfig,
   chain: ChainSettings,
   memo?: string
-): Promise<TransactionPair<IbcTransferProps>> => {
-  const { tx } = await getSdkInstance();
-
+): Promise<EncodedTxData<IbcTransferProps>> => {
+  const sdk = await getSdkInstance();
   const ibcTransferProps = {
     source: account.address,
     receiver: destinationAddress,
@@ -377,17 +376,15 @@ export const createIbcTx = async (
     channelId,
     memo,
   };
-
-  const transactionPair = await buildTxPair(
+  return await buildTx(
+    sdk,
     account,
     gasConfig,
     chain,
     [ibcTransferProps],
-    tx.buildIbcTransfer,
-    account.address
+    sdk.tx.buildIbcTransfer,
+    memo
   );
-
-  return transactionPair;
 };
 
 export const namadaLocal = (chainId: string): Chain => {

--- a/apps/namadillo/src/atoms/proposals/functions.ts
+++ b/apps/namadillo/src/atoms/proposals/functions.ts
@@ -27,7 +27,7 @@ import { assertNever, mapUndefined } from "@namada/utils";
 import BigNumber from "bignumber.js";
 import * as E from "fp-ts/Either";
 import * as t from "io-ts";
-import { TransactionPair, buildTxPair } from "lib/query";
+import { TransactionPair, buildTx, signEncodedTx } from "lib/query";
 import { GasConfig } from "types";
 
 import { fromHex } from "@cosmjs/encoding";
@@ -373,23 +373,21 @@ export const createVoteProposalTx = async (
   chain: ChainSettings
 ): Promise<TransactionPair<VoteProposalProps>> => {
   try {
-    const { tx } = await getSdkInstance();
-
+    const sdk = await getSdkInstance();
     const voteProposalProps = {
       signer: account.address,
       proposalId,
       vote,
     };
-
-    const transactionPair = await buildTxPair(
+    const encodedTx = await buildTx(
+      sdk,
       account,
       gasConfig,
       chain,
       [voteProposalProps],
-      tx.buildVoteProposal,
-      account.address
+      sdk.tx.buildVoteProposal
     );
-    return transactionPair;
+    return await signEncodedTx(encodedTx, account.address);
   } catch (err) {
     console.error(err);
     throw err;

--- a/apps/namadillo/src/atoms/transfer/atoms.ts
+++ b/apps/namadillo/src/atoms/transfer/atoms.ts
@@ -6,6 +6,7 @@ import {
 } from "@namada/types";
 import { chainAtom } from "atoms/chain";
 import { rpcUrlAtom } from "atoms/settings";
+import invariant from "invariant";
 import { atomWithMutation } from "jotai-tanstack-query";
 import { BuildTxAtomParams } from "types";
 import {
@@ -25,20 +26,22 @@ export const createTransparentTransferAtom = atomWithMutation((get) => {
       gasConfig,
       account,
       memo,
-    }: BuildTxAtomParams<TransparentTransferMsgValue>) =>
-      createTransparentTransferTx(
+    }: BuildTxAtomParams<TransparentTransferMsgValue>) => {
+      return createTransparentTransferTx(
         chain.data!,
         account,
         params,
         gasConfig,
         memo
-      ),
+      );
+    },
   };
 });
 
 export const createShieldedTransferAtom = atomWithMutation((get) => {
   const chain = get(chainAtom);
   const rpcUrl = get(rpcUrlAtom);
+
   return {
     mutationKey: ["create-shielded-transfer-tx"],
     enabled: chain.isSuccess,
@@ -47,15 +50,19 @@ export const createShieldedTransferAtom = atomWithMutation((get) => {
       gasConfig,
       account,
       memo,
-    }: BuildTxAtomParams<ShieldedTransferMsgValue>) =>
-      createShieldedTransferTx(
+      signer,
+    }: BuildTxAtomParams<ShieldedTransferMsgValue>) => {
+      invariant(signer, "Disposable signer is required for shielded transfers");
+      return createShieldedTransferTx(
         chain.data!,
         account,
         params,
         gasConfig,
         rpcUrl,
+        signer,
         memo
-      ),
+      );
+    },
   };
 });
 
@@ -92,15 +99,22 @@ export const createUnshieldingTransferAtom = atomWithMutation((get) => {
       params,
       gasConfig,
       account,
+      signer,
       memo,
-    }: BuildTxAtomParams<UnshieldingTransferMsgValue>) =>
-      createUnshieldingTransferTx(
+    }: BuildTxAtomParams<UnshieldingTransferMsgValue>) => {
+      invariant(
+        signer,
+        "Disposable signer is required for unshielding transfers"
+      );
+      return createUnshieldingTransferTx(
         chain.data!,
         account,
         params,
         gasConfig,
         rpcUrl,
+        signer,
         memo
-      ),
+      );
+    },
   };
 });

--- a/apps/namadillo/src/hooks/useTransaction.tsx
+++ b/apps/namadillo/src/hooks/useTransaction.tsx
@@ -82,23 +82,16 @@ export const useTransaction = <T,>({
 }: UseTransactionProps<T>): UseTransactionOutput<T> => {
   const { data: account } = useAtomValue(defaultAccountAtom);
   const dispatchNotification = useSetAtom(dispatchToastNotificationAtom);
-  const txKinds = new Array(params.length).fill(eventType);
-  const feeProps = useTransactionFee(txKinds);
   const {
     mutateAsync: performBuildTx,
     isPending,
     isSuccess,
   } = useAtomValue(createTxAtom);
 
-<<<<<<< HEAD
-  const dispatchNotification = useSetAtom(dispatchToastNotificationAtom);
-
   // We don't want to display zeroed value when params are not set yet.
   const txKinds = new Array(Math.max(1, params.length)).fill(eventType);
   const feeProps = useTransactionFee(txKinds);
 
-=======
->>>>>>> a38dcd75 (feat: adding more stages to transaction button)
   const dispatchPendingTxNotification = (
     tx: TransactionPair<T>,
     notification: PartialNotification

--- a/apps/namadillo/src/hooks/useTransactionFee.ts
+++ b/apps/namadillo/src/hooks/useTransactionFee.ts
@@ -24,23 +24,22 @@ export type TransactionFeeProps = {
 export const useTransactionFee = (txKinds: TxKind[]): TransactionFeeProps => {
   const [gasLimitValue, setGasLimitValue] = useState<BigNumber | undefined>();
   const [gasTokenValue, setGasTokenValue] = useState<string | undefined>();
-
   const isPublicKeyRevealed = useAtomValue(isPublicKeyRevealedAtom);
 
   const { data: nativeToken, isLoading: isLoadingNativeToken } = useAtomValue(
     nativeTokenAddressAtom
   );
+
   const { data: gasEstimate, isLoading: isLoadingGasEstimate } = useAtomValue(
     gasEstimateFamily(isPublicKeyRevealed ? txKinds : ["RevealPk", ...txKinds])
   );
+
   const { data: gasPriceTable, isLoading: isLoadingGasPriceTable } =
     useAtomValue(gasPriceTableAtom);
 
   const averageGasLimit = gasEstimate && BigNumber(gasEstimate.avg);
   const gasLimit = gasLimitValue ?? averageGasLimit ?? BigNumber(0);
-
   const gasToken = gasTokenValue ?? nativeToken ?? "";
-
   const gasPrice =
     gasPriceTable?.find((i) => i.token === gasToken)?.gasPrice ?? BigNumber(0);
 

--- a/apps/namadillo/src/hooks/useTransfer.ts
+++ b/apps/namadillo/src/hooks/useTransfer.ts
@@ -14,7 +14,7 @@ import {
   createUnshieldingTransferAtom,
 } from "atoms/transfer/atoms";
 import BigNumber from "bignumber.js";
-import { useTransaction, useTransactionOutput } from "hooks/useTransaction";
+import { useTransaction, UseTransactionOutput } from "hooks/useTransaction";
 import { useAtomValue } from "jotai";
 import { Address, NamadaTransferTxKind } from "types";
 
@@ -27,10 +27,10 @@ type useTransferParams = {
 };
 
 type useTransferOutput = (
-  | useTransactionOutput<TransparentTransferMsgValue>
-  | useTransactionOutput<ShieldedTransferMsgValue>
-  | useTransactionOutput<ShieldingTransferMsgValue>
-  | useTransactionOutput<UnshieldingTransferMsgValue>
+  | UseTransactionOutput<TransparentTransferMsgValue>
+  | UseTransactionOutput<ShieldedTransferMsgValue>
+  | UseTransactionOutput<ShieldingTransferMsgValue>
+  | UseTransactionOutput<UnshieldingTransferMsgValue>
 ) & {
   txKind: NamadaTransferTxKind;
 };
@@ -40,6 +40,7 @@ export const useTransfer = ({
   target,
   token,
   displayAmount: amount,
+  onUpdateStatus,
 }: useTransferParams): useTransferOutput => {
   const defaultAccounts = useAtomValue(allDefaultAccountsAtom);
   const shieldedAccount = defaultAccounts.data?.find(
@@ -77,6 +78,12 @@ export const useTransfer = ({
     eventType: "ShieldingTransfer",
     createTxAtom: createShieldingTransferAtom,
     params: [{ target, data: [{ source, token, amount }] }],
+    onBeforeCreateDisposableSigner: () =>
+      onUpdateStatus?.("Creating new disposable signer..."),
+    onBeforeBuildTx: () =>
+      onUpdateStatus?.("Generating MASP params and building transaction..."),
+    onBeforeSign: () => onUpdateStatus?.("Waiting for signature..."),
+    onBeforeBroadcast: () => onUpdateStatus?.("Broadcasting transaction..."),
     ...commomProps,
   });
 

--- a/apps/namadillo/src/hooks/useTransfer.ts
+++ b/apps/namadillo/src/hooks/useTransfer.ts
@@ -23,6 +23,7 @@ type useTransferParams = {
   target: Address;
   token: Address;
   displayAmount: BigNumber;
+  onUpdateStatus?: (status: string) => void;
 };
 
 type useTransferOutput = (
@@ -68,6 +69,7 @@ export const useTransfer = ({
     eventType: "ShieldedTransfer",
     createTxAtom: createShieldedTransferAtom,
     params: [{ data: [{ source: pseudoExtendedKey, target, token, amount }] }],
+    useDisposableSigner: true,
     ...commomProps,
   });
 
@@ -82,6 +84,7 @@ export const useTransfer = ({
     eventType: "UnshieldingTransfer",
     createTxAtom: createUnshieldingTransferAtom,
     params: [{ source: pseudoExtendedKey, data: [{ target, token, amount }] }],
+    useDisposableSigner: true,
     ...commomProps,
   });
 

--- a/apps/namadillo/src/lib/query.ts
+++ b/apps/namadillo/src/lib/query.ts
@@ -97,14 +97,14 @@ export const buildTx = async <T>(
   queryProps: T[],
   txFn: (wrapperTxProps: WrapperTxProps, props: T) => Promise<TxMsgValue>,
   memo?: string,
-  skipRevealPk?: boolean
+  shouldRevealPk: boolean = true
 ): Promise<EncodedTxData<T>> => {
   const wrapperTxProps = getTxProps(account, gasConfig, chain, memo);
   const txs: TxMsgValue[] = [];
   const txProps: TxProps[] = [];
 
   // Determine if RevealPK is needed:
-  if (!skipRevealPk) {
+  if (shouldRevealPk) {
     const publicKeyRevealed = await isPublicKeyRevealed(account.address);
     if (!publicKeyRevealed) {
       const revealPkTx = await sdk.tx.buildRevealPk(wrapperTxProps);

--- a/apps/namadillo/src/types.ts
+++ b/apps/namadillo/src/types.ts
@@ -157,11 +157,17 @@ export type ClaimRewardsProps = {
   gasConfig: GasConfig;
 };
 
+export type Signer = {
+  publicKey: string;
+  address: string;
+};
+
 export type BuildTxAtomParams<T> = {
   account: Account;
   params: T[];
   gasConfig: GasConfig;
   memo?: string;
+  signer?: Signer;
 };
 
 export type SortOptions = "asc" | "desc" | undefined;

--- a/apps/namadillo/src/workers/MaspTxWorker.ts
+++ b/apps/namadillo/src/workers/MaspTxWorker.ts
@@ -108,7 +108,7 @@ async function shield(
     shieldingProps,
     sdk.tx.buildShieldingTransfer,
     memo,
-    publicKeyRevealed
+    !publicKeyRevealed
   );
 
   return encodedTxData;
@@ -128,7 +128,7 @@ async function unshield(
     props,
     sdk.tx.buildUnshieldingTransfer,
     undefined,
-    true
+    false
   );
 
   return encodedTxData;
@@ -148,7 +148,7 @@ async function shieldedTransfer(
     props,
     sdk.tx.buildShieldedTransfer,
     undefined,
-    true
+    false
   );
 
   return encodedTxData;

--- a/apps/namadillo/src/workers/MaspTxWorker.ts
+++ b/apps/namadillo/src/workers/MaspTxWorker.ts
@@ -107,8 +107,8 @@ async function shield(
     chain,
     shieldingProps,
     sdk.tx.buildShieldingTransfer,
-    Boolean(publicKeyRevealed),
-    memo
+    memo,
+    publicKeyRevealed
   );
 
   return encodedTxData;
@@ -119,9 +119,7 @@ async function unshield(
   payload: Unshield["payload"]
 ): Promise<EncodedTxData<UnshieldingTransferMsgValue>> {
   const { account, gasConfig, chain, props } = payload;
-
   await sdk.masp.loadMaspParams("", chain.chainId);
-
   const encodedTxData = await buildTx<UnshieldingTransferMsgValue>(
     sdk,
     account,
@@ -129,6 +127,7 @@ async function unshield(
     chain,
     props,
     sdk.tx.buildUnshieldingTransfer,
+    undefined,
     true
   );
 
@@ -140,9 +139,7 @@ async function shieldedTransfer(
   payload: ShieldedTransfer["payload"]
 ): Promise<EncodedTxData<ShieldedTransferMsgValue>> {
   const { account, gasConfig, chain, props } = payload;
-
   await sdk.masp.loadMaspParams("", chain.chainId);
-
   const encodedTxData = await buildTx<ShieldedTransferMsgValue>(
     sdk,
     account,
@@ -150,6 +147,7 @@ async function shieldedTransfer(
     chain,
     props,
     sdk.tx.buildShieldedTransfer,
+    undefined,
     true
   );
 


### PR DESCRIPTION
This PR refactors all the transactions logic separating the build step from the signing step. With this we will be able to improve user experience while waiting for long steps, like the generation of masp params. I've only implemented multiple status on Shielding because we're going to change a few things on the UI in the next PRs.

It also creates a quick workaround to increase gas fees while we improve the indexer api for estimate. The reason behind it is that many transactions were frequently failing because of gas (ex: unstake, re-delegate, etc)