### PR TITLE
fix: empty reward storage

### DIFF
--- a/apps/namadillo/src/atoms/balance/atoms.ts
+++ b/apps/namadillo/src/atoms/balance/atoms.ts
@@ -326,6 +326,10 @@ export const cachedShieldedRewardsAtom = atom((get) => {
   const rewards = get(shieldRewardsAtom);
   const data = rewards.isSuccess ? rewards.data : storage[viewingKey.key];
 
+  if (!data) {
+    return { amount: BigNumber(0) };
+  }
+
   return {
     amount: toDisplayAmount(namadaAsset(), BigNumber(data.minDenomAmount)),
   };


### PR DESCRIPTION
Fix race condition when the user has empty value for rewards

![Screenshot 2025-01-31 at 12 22 02](https://github.com/user-attachments/assets/ace1184a-7bd8-46a2-8550-c84f5c2b2522)
