### PR TITLE
fix: adding back Docker build on release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,6 +2,8 @@ name: Docker 🐳
 
 on:
   workflow_dispatch:
+    release:
+      types: [published]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION
Simple PR to trigger Docker build after a release is made