### PR TITLE
feat: add shielded balance pulse animation

### DIFF
--- a/apps/namadillo/src/App/AccountOverview/MaspBanner.tsx
+++ b/apps/namadillo/src/App/AccountOverview/MaspBanner.tsx
@@ -1,13 +1,14 @@
-import { ActionButton, Panel } from "@namada/components";
+import { ActionButton, Panel, SkeletonLoading } from "@namada/components";
 import { FiatCurrency } from "App/Common/FiatCurrency";
 import { routes } from "App/routes";
-import { shieldedTokensAtom } from "atoms/balance/atoms";
+import { shieldedBalanceAtom, shieldedTokensAtom } from "atoms/balance/atoms";
 import { getTotalDollar } from "atoms/balance/functions";
 import { useAtomValue } from "jotai";
 import { twMerge } from "tailwind-merge";
 import maspBg from "./assets/masp-bg.png";
 
 export const MaspBanner = (): JSX.Element => {
+  const { isFetching: isShieldSyncing } = useAtomValue(shieldedBalanceAtom);
   const shieldedTokensQuery = useAtomValue(shieldedTokensAtom);
   const total = getTotalDollar(shieldedTokensQuery.data);
 
@@ -24,12 +25,13 @@ export const MaspBanner = (): JSX.Element => {
         <div className="col-start-1 row-start-1 text-4xl">MASP</div>
       </div>
       <div className="flex-1">
-        {total && total.gt(0) && (
-          <>
-            <div className="text-sm">Total shielded balance</div>
-            <FiatCurrency className="text-4xl" amount={total} />
-          </>
-        )}
+        <div className="text-sm">Total shielded balance</div>
+        {total ?
+          <FiatCurrency
+            className={twMerge("text-4xl", isShieldSyncing && "animate-pulse")}
+            amount={total}
+          />
+        : <SkeletonLoading height="54px" width="120px" />}
       </div>
       <ActionButton
         size="md"

--- a/apps/namadillo/src/App/AccountOverview/NamBalanceContainer.tsx
+++ b/apps/namadillo/src/App/AccountOverview/NamBalanceContainer.tsx
@@ -2,7 +2,7 @@ import { Heading, SkeletonLoading, Stack } from "@namada/components";
 import { AtomErrorBoundary } from "App/Common/AtomErrorBoundary";
 import { NamCurrency } from "App/Common/NamCurrency";
 import { ShieldedRewardsBox } from "App/Masp/ShieldedRewardsBox";
-import { cachedShieldedRewardsAtom } from "atoms/balance";
+import { cachedShieldedRewardsAtom, shieldedBalanceAtom } from "atoms/balance";
 import { applicationFeaturesAtom } from "atoms/settings";
 import BigNumber from "bignumber.js";
 import clsx from "clsx";
@@ -16,6 +16,7 @@ type NamBalanceListItemProps = {
   color: string;
   amount: BigNumber;
   isLoading: boolean;
+  isSyncing?: boolean;
   isEnabled?: boolean;
 };
 
@@ -52,6 +53,7 @@ const NamBalanceListItem = ({
   color,
   amount,
   isLoading,
+  isSyncing,
   isEnabled = true,
 }: NamBalanceListItemProps): JSX.Element => {
   return (
@@ -70,7 +72,10 @@ const NamBalanceListItem = ({
         <SkeletonLoading height="22px" width="100px" />
       : <NamCurrency
           amount={amount}
-          className="text-2xl pl-5 font-light"
+          className={twMerge(
+            "text-2xl pl-5 font-light",
+            isSyncing && "animate-pulse"
+          )}
           currencySymbolClassName="hidden"
           decimalPlaces={2}
         />
@@ -83,6 +88,7 @@ export const NamBalanceContainer = (): JSX.Element => {
   const { maspEnabled, shieldingRewardsEnabled } = useAtomValue(
     applicationFeaturesAtom
   );
+  const { isFetching: isShieldSyncing } = useAtomValue(shieldedBalanceAtom);
   const shieldedRewards = useAtomValue(cachedShieldedRewardsAtom);
 
   const {
@@ -121,18 +127,21 @@ export const NamBalanceContainer = (): JSX.Element => {
               color={colors.balance}
               amount={availableAmount}
               isLoading={isLoading}
+              isSyncing={balanceQuery.isFetching}
             />
             <NamBalanceListItem
               title="Staked NAM"
               color={colors.bond}
               amount={bondedAmount}
               isLoading={isLoading}
+              isSyncing={stakeQuery.isFetching}
             />
             <NamBalanceListItem
               title="Unbonded NAM"
               color={colors.unbond}
               amount={unbondedAmount.plus(withdrawableAmount)}
               isLoading={isLoading}
+              isSyncing={stakeQuery.isFetching}
             />
           </Stack>
           <Stack className="w-full" gap={2}>
@@ -141,6 +150,7 @@ export const NamBalanceContainer = (): JSX.Element => {
               color={colors.shielded}
               amount={maspEnabled ? shieldedNamAmount : new BigNumber(0)}
               isLoading={shieldedAmountQuery.isLoading}
+              isSyncing={isShieldSyncing}
               isEnabled={maspEnabled}
             />
             <ListItemContainer

--- a/apps/namadillo/src/App/AccountOverview/__tests__/NamBalanceContainer.test.tsx
+++ b/apps/namadillo/src/App/AccountOverview/__tests__/NamBalanceContainer.test.tsx
@@ -11,6 +11,7 @@ jest.mock("hooks/useBalances", () => ({
 
 jest.mock("atoms/balance", () => ({
   cachedShieldedRewardsAtom: atom({ data: undefined }),
+  shieldedBalanceAtom: atom({ isFetching: false }),
 }));
 
 describe("Component: NamBalanceContainer", () => {

--- a/apps/namadillo/src/App/Masp/ShieldedBalanceChart.tsx
+++ b/apps/namadillo/src/App/Masp/ShieldedBalanceChart.tsx
@@ -1,7 +1,7 @@
 import { Heading, PieChart, SkeletonLoading } from "@namada/components";
 import { AtomErrorBoundary } from "App/Common/AtomErrorBoundary";
 import { FiatCurrency } from "App/Common/FiatCurrency";
-import { shieldedTokensAtom } from "atoms/balance/atoms";
+import { shieldedBalanceAtom, shieldedTokensAtom } from "atoms/balance/atoms";
 import { getTotalDollar } from "atoms/balance/functions";
 import { applicationFeaturesAtom } from "atoms/settings";
 import clsx from "clsx";
@@ -10,6 +10,7 @@ import { twMerge } from "tailwind-merge";
 import { colors } from "theme";
 
 export const ShieldedBalanceChart = (): JSX.Element => {
+  const { isFetching: isShieldSyncing } = useAtomValue(shieldedBalanceAtom);
   const { namTransfersEnabled } = useAtomValue(applicationFeaturesAtom);
   const shieldedTokensQuery = useAtomValue(shieldedTokensAtom);
 
@@ -53,7 +54,8 @@ export const ShieldedBalanceChart = (): JSX.Element => {
                       <FiatCurrency
                         className={twMerge(
                           "text-2xl sm:text-3xl whitespace-nowrap",
-                          !namTransfersEnabled && "after:content-['*']"
+                          !namTransfersEnabled && "after:content-['*']",
+                          isShieldSyncing && "animate-pulse"
                         )}
                         amount={shieldedDollars}
                       />

--- a/apps/namadillo/src/App/Masp/ShieldedNamBalance.tsx
+++ b/apps/namadillo/src/App/Masp/ShieldedNamBalance.tsx
@@ -3,6 +3,7 @@ import { AtomErrorBoundary } from "App/Common/AtomErrorBoundary";
 import { NamCurrency } from "App/Common/NamCurrency";
 import {
   cachedShieldedRewardsAtom,
+  shieldedBalanceAtom,
   shieldedTokensAtom,
 } from "atoms/balance/atoms";
 import { getTotalNam } from "atoms/balance/functions";
@@ -16,9 +17,11 @@ import namadaShieldedSvg from "./assets/namada-shielded.svg";
 
 const AsyncNamCurrency = ({
   amount,
+  syncing,
   className = "",
 }: {
   amount?: BigNumber;
+  syncing?: boolean;
   className?: string;
 }): JSX.Element => {
   if (amount === undefined) {
@@ -33,13 +36,18 @@ const AsyncNamCurrency = ({
   return (
     <NamCurrency
       amount={amount}
-      className={twMerge("block text-center text-3xl leading-none", className)}
+      className={twMerge(
+        "block text-center text-3xl leading-none",
+        syncing && "animate-pulse",
+        className
+      )}
       currencySymbolClassName="block text-xs mt-1"
     />
   );
 };
 
 export const ShieldedNamBalance = (): JSX.Element => {
+  const { isFetching: isShieldSyncing } = useAtomValue(shieldedBalanceAtom);
   const shieldedTokensQuery = useAtomValue(shieldedTokensAtom);
   const { shieldingRewardsEnabled } = useAtomValue(applicationFeaturesAtom);
   const shieldedRewards = useAtomValue(cachedShieldedRewardsAtom);
@@ -75,7 +83,7 @@ export const ShieldedNamBalance = (): JSX.Element => {
               />
             </div>
           </div>
-          <AsyncNamCurrency amount={shieldedNam} />
+          <AsyncNamCurrency amount={shieldedNam} syncing={isShieldSyncing} />
           <div
             className={twMerge(
               "py-2 max-w-[160px] mx-auto mt-4 mb-3",


### PR DESCRIPTION
Add the pulse animation on balances when shield sync is running

closes #1602
closes #1564


https://github.com/user-attachments/assets/6cd06cb5-9947-4e69-904f-94a58e078111

