### PR TITLE
fix: fix duplicated broadcast

### DIFF
--- a/apps/namadillo/src/hooks/useTransaction.tsx
+++ b/apps/namadillo/src/hooks/useTransaction.tsx
@@ -10,7 +10,6 @@ import invariant from "invariant";
 import { Atom, useAtomValue, useSetAtom } from "jotai";
 import { AtomWithMutationResult } from "jotai-tanstack-query";
 import {
-  broadcastTransaction,
   broadcastTxWithEvents,
   EncodedTxData,
   signTx,
@@ -169,10 +168,6 @@ export const useTransaction = <T,>({
       }
 
       onBeforeBroadcast?.(transactionPair);
-      broadcastTransaction(
-        transactionPair.encodedTxData,
-        transactionPair.signedTxs
-      );
       broadcastTxWithEvents(
         transactionPair.encodedTxData,
         transactionPair.signedTxs,


### PR DESCRIPTION
Fix `broadcast` being called twice

![Screenshot 2025-02-04 at 12 14 43](https://github.com/user-attachments/assets/297b1c7e-6a7b-4963-932e-06abba282c40)
