### PR TITLE
feat: add dollar support for multiple channels

### DIFF
--- a/apps/namadillo/src/atoms/balance/functions.ts
+++ b/apps/namadillo/src/atoms/balance/functions.ts
@@ -1,42 +1,16 @@
 import { IbcToken, NativeToken } from "@namada/indexer-client";
-import { nativeTokenAddressAtom } from "atoms/chain";
 import { mapCoinsToAssets } from "atoms/integrations";
 import BigNumber from "bignumber.js";
 import { DenomTrace } from "cosmjs-types/ibc/applications/transfer/v1/transfer";
-import { getDefaultStore } from "jotai";
 import { AddressWithAssetAndAmountMap } from "types";
 import { isNamadaAsset } from "utils";
 import { TokenBalance } from "./atoms";
 
-const getNativeTokenAddress = (): string | undefined => {
-  const { get } = getDefaultStore();
-  return get(nativeTokenAddressAtom).data;
-};
-
-/**
- * Sum the dollar amount of a list of tokens
- * @param tokens
- * @returns The total of dollars, or `undefined` if at least one token has `dollar: undefined`
- */
-export const sumDollars = (tokens: TokenBalance[]): BigNumber | undefined => {
-  let sum = new BigNumber(0);
-  for (let i = 0; i < tokens.length; i++) {
-    const { dollar, originalAddress } = tokens[i];
-    if (!dollar) {
-      // create an exception for native token while we don't have a market price for it
-      // we can safely delete this condition when osmosis api returns a native token price
-      if (originalAddress === getNativeTokenAddress()) {
-        continue;
-      }
-      return undefined;
-    }
-    sum = sum.plus(dollar);
-  }
-  return sum;
-};
-
-export const getTotalDollar = (list?: TokenBalance[]): BigNumber | undefined =>
-  sumDollars(list ?? []);
+export const getTotalDollar = (list?: TokenBalance[]): BigNumber =>
+  (list ?? []).reduce(
+    (sum, { dollar }) => (dollar ? sum.plus(dollar) : sum),
+    new BigNumber(0)
+  );
 
 export const getTotalNam = (list?: TokenBalance[]): BigNumber =>
   list?.find((i) => isNamadaAsset(i.asset))?.amount ?? new BigNumber(0);

--- a/apps/namadillo/src/atoms/prices/functions.ts
+++ b/apps/namadillo/src/atoms/prices/functions.ts
@@ -1,22 +1,26 @@
 import { IbcToken, NativeToken } from "@namada/indexer-client";
 import BigNumber from "bignumber.js";
 import * as osmosis from "chain-registry/mainnet/osmosis";
-import { Address } from "types";
+import { Address, BaseDenom } from "types";
 import { findAssetByToken } from "utils/assets";
 import { fetchCoinPrices } from "./services";
 
 export const fetchTokenPrices = async (
   tokenAddressToFetch: Address[],
-  apiTokens: (NativeToken | IbcToken)[]
+  chainTokens: (NativeToken | IbcToken)[]
 ): Promise<Record<Address, BigNumber>> => {
-  const baseMap: Record<string, string> = {};
+  const baseMap: Record<BaseDenom, Address[]> = {};
   tokenAddressToFetch.forEach((address) => {
-    const token = apiTokens?.find((t) => t.address === address);
+    const token = chainTokens?.find((t) => t.address === address);
     if (token) {
       // searching only on osmosis because these are the assets supported by fetchCoinPrices
       const asset = findAssetByToken(token, osmosis.assets.assets);
       if (asset) {
-        baseMap[asset.base] = address;
+        if (baseMap[asset.base]) {
+          baseMap[asset.base].push(address);
+        } else {
+          baseMap[asset.base] = [address];
+        }
       }
     }
   });
@@ -25,10 +29,11 @@ export const fetchTokenPrices = async (
 
   const tokenPrices: Record<string, BigNumber> = {};
   Object.entries(apiResponse).forEach(([base, value]) => {
-    const address = baseMap[base];
     const dollar = Object.values(value)[0];
     if (dollar) {
-      tokenPrices[address] = new BigNumber(dollar);
+      baseMap[base].forEach((address) => {
+        tokenPrices[address] = new BigNumber(dollar);
+      });
     }
   });
   return tokenPrices;

--- a/apps/namadillo/src/types.ts
+++ b/apps/namadillo/src/types.ts
@@ -25,6 +25,8 @@ export type PublicKey = string;
 
 export type Address = string;
 
+export type BaseDenom = string;
+
 export type ChainId = string;
 
 export type GasLimit = BigNumber;
@@ -32,7 +34,7 @@ export type GasLimit = BigNumber;
 export type GasPrice = BigNumber;
 
 // For Namada chain, it should be the address. For Ibc, it should be the base denom
-export type GasToken = Address | string;
+export type GasToken = Address | BaseDenom;
 
 export type AddressBalance = Record<Address, BigNumber>;
 


### PR DESCRIPTION
We can have more than one channel for the same base denom

For these cases, we need to fetch and map all dollar values to all possible addresses

We also removed the `N/A` in case it's missing a token dollar value for whatever reason. It simplifies how user understand these values and don't looks like buggy

closes #1608

![Screenshot 2025-02-05 at 11 52 46](https://github.com/user-attachments/assets/b5505c8c-1ed2-4441-b525-708822a25926)

![Screenshot 2025-02-05 at 13 04 44](https://github.com/user-attachments/assets/0013c86f-e64a-43a4-be86-84e95f74ef1d)

