### PR TITLE
fix: Updating docker & nginx configs for multicore

### DIFF
--- a/apps/namadillo/README.md
+++ b/apps/namadillo/README.md
@@ -84,7 +84,19 @@ It's possible to run the Docker container using the following command:
 
 `docker run -p 80:80 namadillo`
 
-In order to change your `config.toml`, please copy the file `/docker/.namadillo.config.toml` to `/docker/namadillo.config.toml` and change the parameters accordingly, before building the image.
+In order to change your `config.toml`, please copy the file `/docker/namadillo/.config.toml` to `/docker/namadillo/config.toml` and change the parameters accordingly, before building the image.
+
+**Note:** If you are using an Arch-based Linux distribution, and encounter the following error:
+
+```bash
+the --chmod option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled
+```
+
+you can install it via:
+
+```bash
+sudo pacman -S docker-buildx
+```
 
 #### Self Hosting
 

--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -49,7 +49,7 @@
     "dev": "VITE_REVISION=$(git rev-parse HEAD) vite",
     "dev:local": "NODE_ENV=development NAMADA_INTERFACE_LOCAL=\"true\" yarn dev",
     "dev:proxy": "VITE_PROXY=true && ./scripts/start-proxies.sh && yarn dev:local",
-    "build": "NODE_ENV=production && yarn wasm:build && VITE_REVISION=$(git rev-parse HEAD) vite build",
+    "build": "NODE_ENV=production && yarn wasm:build:multicore && VITE_REVISION=$(git rev-parse HEAD) vite build",
     "build:only": "NODE_ENV=production && VITE_REVISION=$(git rev-parse HEAD) vite build",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "yarn lint -- --fix",

--- a/apps/namadillo/vite.config.mjs
+++ b/apps/namadillo/vite.config.mjs
@@ -11,7 +11,7 @@ export default defineConfig(() => {
     server: {
       headers: {
         "Cross-Origin-Opener-Policy": "same-origin",
-        "Cross-Origin-Embedder-Policy": "require-corp",
+        "Cross-Origin-Embedder-Policy": "credentialless",
       },
     },
     plugins: [

--- a/docker/namadillo/.gitignore
+++ b/docker/namadillo/.gitignore
@@ -1,0 +1,1 @@
+config.toml

--- a/docker/namadillo/Dockerfile
+++ b/docker/namadillo/Dockerfile
@@ -7,7 +7,7 @@ RUN npm install -g yarn
 RUN rustup target add wasm32-unknown-unknown
 RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -y
 
-COPY .yarnrc.yml tsconfig.base.json package.json yarn.lock .
+COPY .yarnrc.yml tsconfig.base.json package.json yarn.lock ./
 COPY ./.yarn ./.yarn
 COPY ./packages ./packages
 COPY ./scripts ./scripts

--- a/docker/namadillo/Dockerfile
+++ b/docker/namadillo/Dockerfile
@@ -18,10 +18,10 @@ RUN yarn
 WORKDIR /app/apps/namadillo
 COPY ./apps/namadillo/scripts ./scripts
 
-RUN yarn wasm:build
+RUN yarn wasm:build:multicore
 
 COPY ./apps/namadillo .
-RUN yarn && yarn build
+RUN yarn && yarn build:only
 
 FROM nginx:alpine
 WORKDIR /app

--- a/docker/namadillo/nginx.conf
+++ b/docker/namadillo/nginx.conf
@@ -5,8 +5,8 @@ server {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         try_files $uri $uri/ $uri.html /index.html;
-        add_header Cross-Origin-Opener-Policy same-origin
-        add_header Cross-Origin-Embedder-Policy require-corp
+        add_header Cross-Origin-Opener-Policy same-origin;
+        add_header Cross-Origin-Embedder-Policy require-corp;
     }
     gzip off;
 }

--- a/docker/namadillo/nginx.conf
+++ b/docker/namadillo/nginx.conf
@@ -5,8 +5,11 @@ server {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         try_files $uri $uri/ $uri.html /index.html;
-        add_header Cross-Origin-Opener-Policy same-origin;
-        add_header Cross-Origin-Embedder-Policy require-corp;
+
+        location ~* (.+\.(js|html))$ {
+            add_header Cross-Origin-Opener-Policy same-origin;
+            add_header Cross-Origin-Embedder-Policy require-corp;
+        }
     }
     gzip off;
 }

--- a/docker/namadillo/nginx.conf
+++ b/docker/namadillo/nginx.conf
@@ -5,11 +5,8 @@ server {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         try_files $uri $uri/ $uri.html /index.html;
-
-        location ~* (.+\.(js|html))$ {
-            add_header Cross-Origin-Opener-Policy same-origin;
-            add_header Cross-Origin-Embedder-Policy require-corp;
-        }
+        add_header Cross-Origin-Embedder-Policy "credentialless";
+        add_header Cross-Origin-Opener-Policy "same-origin";
     }
     gzip off;
 }

--- a/docker/namadillo/nginx.conf
+++ b/docker/namadillo/nginx.conf
@@ -5,6 +5,8 @@ server {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         try_files $uri $uri/ $uri.html /index.html;
+        add_header Cross-Origin-Opener-Policy same-origin
+        add_header Cross-Origin-Embedder-Policy require-corp
     }
     gzip off;
 }


### PR DESCRIPTION
Resolves #1598 

See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy#credentialless

For an example of how to get multicore working locally with a production build, one can use the following Python script to host the `dist` folder locally (copy into `/dist` after building, then run `python server.py`

```python
from http.server import HTTPServer, SimpleHTTPRequestHandler


class CustomHandler(SimpleHTTPRequestHandler):
    def end_headers(self):
        # Add the cross-origin headers to every response
        self.send_header("Cross-Origin-Opener-Policy", "same-origin")
        self.send_header("Cross-Origin-Embedder-Policy", "require-corp")

        # Call the base class's end_headers method
        super().end_headers()


# Run the server
server_address = ("", 8000)
httpd = HTTPServer(server_address, CustomHandler)
print("Serving on http://localhost:8000")
httpd.serve_forever()
```


### TESTING

This seems to be fixed in this PR. To test locally, use `docker`:

```bash
# Update `config.toml`, not necessary, but convenient

# Build
docker build . -f docker/namadillo/Dockerfile -t namadillo

# Run locally
docker run -p 80:80 namadillo
```
