### PR TITLE
fix: rewards fee race condition

### DIFF
--- a/apps/namadillo/src/atoms/chain/atoms.ts
+++ b/apps/namadillo/src/atoms/chain/atoms.ts
@@ -74,27 +74,32 @@ export const chainTokensAtom = atomWithQuery<(NativeToken | IbcToken)[]>(
   }
 );
 
-export const chainAssetsMapAtom = atom<Record<Address, Asset>>((get) => {
-  const nativeTokenAddress = get(nativeTokenAddressAtom);
-  const chainTokensQuery = get(chainTokensAtom);
+export const chainAssetsMapAtom = atom<Record<Address, Asset | undefined>>(
+  (get) => {
+    const nativeTokenAddress = get(nativeTokenAddressAtom);
+    const chainTokensQuery = get(chainTokensAtom);
 
-  const chainAssetsMap: Record<Address, Asset> = {};
-  if (nativeTokenAddress.data) {
-    // the first asset is the native token asset
-    chainAssetsMap[nativeTokenAddress.data] = namadaAssets.assets[0];
-  }
-  // TODO
-  // while we don't have all assets listed on namada-chain-registry,
-  // merge the osmosis assets to guarantee the most common ones to be available
-  const assetList: Asset[] = [...namadaAssets.assets, ...osmosis.assets.assets];
-  chainTokensQuery.data?.forEach((token) => {
-    const asset = findAssetByToken(token, assetList);
-    if (asset) {
-      chainAssetsMap[token.address] = asset;
+    const chainAssetsMap: Record<Address, Asset> = {};
+    if (nativeTokenAddress.data) {
+      // the first asset is the native token asset
+      chainAssetsMap[nativeTokenAddress.data] = namadaAssets.assets[0];
     }
-  });
-  return chainAssetsMap;
-});
+    // TODO
+    // while we don't have all assets listed on namada-chain-registry,
+    // merge the osmosis assets to guarantee the most common ones to be available
+    const assetList: Asset[] = [
+      ...namadaAssets.assets,
+      ...osmosis.assets.assets,
+    ];
+    chainTokensQuery.data?.forEach((token) => {
+      const asset = findAssetByToken(token, assetList);
+      if (asset) {
+        chainAssetsMap[token.address] = asset;
+      }
+    });
+    return chainAssetsMap;
+  }
+);
 
 // Prefer calling settings@rpcUrlAtom instead, because default rpc url might be
 // overrided by the user

--- a/apps/namadillo/src/atoms/fees/atoms.ts
+++ b/apps/namadillo/src/atoms/fees/atoms.ts
@@ -75,7 +75,7 @@ export const gasPriceTableAtom = atomWithQuery<GasPriceTable>((get) => {
   const chainAssetsMap = get(chainAssetsMapAtom);
 
   return {
-    queryKey: ["gas-price-table"],
+    queryKey: ["gas-price-table", chainAssetsMap],
     ...queryDependentFn(async () => {
       const response = await fetchTokensGasPrice(api);
       return response.map(({ token, minDenomAmount }) => {

--- a/apps/namadillo/src/utils/gas.ts
+++ b/apps/namadillo/src/utils/gas.ts
@@ -14,7 +14,7 @@ export const calculateGasFee = (gasConfig: GasConfig): BigNumber => {
 
 export const getDisplayGasFee = (
   gasConfig: GasConfig,
-  chainAssetsMap?: Record<Address, Asset>
+  chainAssetsMap?: Record<Address, Asset | undefined>
 ): GasConfigToDisplay => {
   const { gasToken } = gasConfig;
   let asset: Asset;

--- a/apps/namadillo/src/utils/index.ts
+++ b/apps/namadillo/src/utils/index.ts
@@ -80,8 +80,8 @@ export const namadaAsset = (): Asset => {
   return asset satisfies Asset;
 };
 
-export const isNamadaAsset = (asset: Asset): boolean =>
-  asset.symbol === namadaAsset().symbol;
+export const isNamadaAsset = (asset?: Asset): boolean =>
+  asset?.symbol === namadaAsset().symbol;
 
 export const toDisplayAmount = (
   asset: Asset,


### PR DESCRIPTION
When loading the interface directly on http://localhost:5173/staking/claim-rewards or if you is too fast clicking on the 'Claim' button, the native token asset is not found and the gas is not used as displayAmount, so there is an error

The solution was to add `chainAssetsMap` on the `queryKey` plus changing the type of `chainTokensQuery` to `Record<Address, Asset | undefined>` with the undefined piece, so we can map similar cases better

https://github.com/user-attachments/assets/79f82092-f212-4a82-9419-b964e7c2f100

