### PR TITLE
fix: dispatching Docker workflow when a new release is published

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,8 +25,6 @@ jobs:
         images:
           - path: "docker/namadillo/Dockerfile"
             tag: "namadillo-main"
-          - path: "docker/faucet/Dockerfile"
-            tag: "faucet-interface-main"
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This fixes Docker workflow dispatch after a new release is published