### PR TITLE
feat: update shield/unshield navigation flow

### DIFF
--- a/apps/namadillo/src/App/Common/ConnectPanel.tsx
+++ b/apps/namadillo/src/App/Common/ConnectPanel.tsx
@@ -25,7 +25,7 @@ export const ConnectPanel = ({
       <Image styleOverrides={{ width: "203px" }} imageName="LogoMinimal" />
       <h2
         className={
-          "max-w-[500px] uppercase text-center font-medium text-yellow leading-10 text-4xl"
+          "max-w-[500px] uppercase text-center font-medium text-yellow selection:bg-yellow selection:text-black leading-10 text-4xl"
         }
       >
         {children}

--- a/apps/namadillo/src/App/Common/UnshieldAssetsModal.tsx
+++ b/apps/namadillo/src/App/Common/UnshieldAssetsModal.tsx
@@ -1,22 +1,34 @@
 import { routes } from "App/routes";
 import { wallets } from "integrations";
 import { getAssetImageUrl } from "integrations/utils";
+import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { namadaAsset } from "utils";
 import { SelectOptionModal } from "./SelectOptionModal";
 
 type UnshieldAssetsModal = {
+  assetAddress?: string;
   onClose: () => void;
 };
 
 export const UnshieldAssetsModal = ({
+  assetAddress,
   onClose,
 }: UnshieldAssetsModal): JSX.Element => {
   const navigate = useNavigate();
   const goTo = (url: string): void => {
-    navigate(url);
+    const search = assetAddress ? `asset=${assetAddress}` : undefined;
+    navigate({ pathname: url, search });
     onClose();
   };
+
+  // TODO
+  // We are auto-selecting the `Internal Unshield` option
+  // while the unshield from Shielded Pool is not implemented.
+  // https://github.com/anoma/namada-interface/issues/1638
+  useEffect(() => {
+    goTo(routes.maspUnshield);
+  }, []);
 
   return (
     <SelectOptionModal

--- a/apps/namadillo/src/App/Masp/MaspLayout.tsx
+++ b/apps/namadillo/src/App/Masp/MaspLayout.tsx
@@ -2,17 +2,15 @@ import { ConnectPanel } from "App/Common/ConnectPanel";
 import { MaspContainer } from "App/Common/MaspContainer";
 import { PageWithSidebar } from "App/Common/PageWithSidebar";
 import { Sidebar } from "App/Layout/Sidebar";
-import { routes } from "App/routes";
 import { ShieldAllBanner } from "App/Sidebars/ShieldAllBanner";
 import { shieldedBalanceAtom } from "atoms/balance";
 import { useUserHasAccount } from "hooks/useIsAuthenticated";
 import { useAtomValue } from "jotai";
 import { useEffect } from "react";
-import { Outlet, useLocation } from "react-router-dom";
+import { Outlet } from "react-router-dom";
 
 export const MaspLayout: React.FC = () => {
   const userHasAccount = useUserHasAccount();
-  const location = useLocation();
 
   const { refetch: refetchShieldedBalance } = useAtomValue(shieldedBalanceAtom);
 
@@ -20,7 +18,7 @@ export const MaspLayout: React.FC = () => {
     refetchShieldedBalance();
   }, []);
 
-  if (!userHasAccount && location.pathname !== routes.masp) {
+  if (!userHasAccount) {
     return <ConnectPanel actionText="To shield assets" />;
   }
 

--- a/apps/namadillo/src/App/Masp/ShieldedFungibleTable.tsx
+++ b/apps/namadillo/src/App/Masp/ShieldedFungibleTable.tsx
@@ -3,7 +3,7 @@ import { formatPercentage } from "@namada/utils";
 import { FiatCurrency } from "App/Common/FiatCurrency";
 import { TableWithPaginator } from "App/Common/TableWithPaginator";
 import { TokenCurrency } from "App/Common/TokenCurrency";
-import { params, routes } from "App/routes";
+import { UnshieldAssetsModal } from "App/Common/UnshieldAssetsModal";
 import { TokenBalance } from "atoms/balance/atoms";
 import { getAssetImageUrl } from "integrations/utils";
 import { useEffect, useState } from "react";
@@ -18,6 +18,8 @@ export const ShieldedFungibleTable = ({
   data: TokenBalance[];
 }): JSX.Element => {
   const [page, setPage] = useState(initialPage);
+  const [unshieldingModalOpen, setUnshieldingModalOpen] = useState(false);
+  const [assetAddress, setAssetAddress] = useState("");
 
   const headers = [
     "Token",
@@ -72,7 +74,10 @@ export const ShieldedFungibleTable = ({
           size="xs"
           outlineColor="white"
           className="w-fit mx-auto"
-          href={`${routes.maspUnshield}?${params.asset}=${originalAddress}`}
+          onClick={() => {
+            setUnshieldingModalOpen(true);
+            setAssetAddress(originalAddress);
+          }}
         >
           Unshield
         </ActionButton>,
@@ -115,6 +120,12 @@ export const ShieldedFungibleTable = ({
         }}
         headProps={{ className: "text-neutral-500" }}
       />
+      {unshieldingModalOpen && (
+        <UnshieldAssetsModal
+          assetAddress={assetAddress}
+          onClose={() => setUnshieldingModalOpen(false)}
+        />
+      )}
     </>
   );
 };

--- a/apps/namadillo/src/App/Masp/ShieldedOverviewPanel.tsx
+++ b/apps/namadillo/src/App/Masp/ShieldedOverviewPanel.tsx
@@ -1,8 +1,7 @@
 import { ActionButton, Panel, SkeletonLoading } from "@namada/components";
 import { AtomErrorBoundary } from "App/Common/AtomErrorBoundary";
-import { routes } from "App/routes";
+import { ShieldAssetsModal } from "App/Common/ShieldAssetsModal";
 import { shieldedTokensAtom } from "atoms/balance/atoms";
-import { useUserHasAccount } from "hooks/useIsAuthenticated";
 import { useAtomValue } from "jotai";
 import { useState } from "react";
 import { ShieldedFungibleTable } from "./ShieldedFungibleTable";
@@ -11,12 +10,22 @@ import { ShieldedNFTTable } from "./ShieldedNFTTable";
 const tabs = ["Fungible", "NFT"];
 
 const ShieldAssetCta = (): JSX.Element => {
+  const [shieldingModalOpen, setShieldingModalOpen] = useState(false);
+
   return (
-    <div className="flex-1 flex items-center justify-center">
-      <ActionButton href={routes.maspShield} className="w-fit uppercase">
-        Shield your first assets
-      </ActionButton>
-    </div>
+    <>
+      <div className="flex-1 flex items-center justify-center">
+        <ActionButton
+          onClick={() => setShieldingModalOpen(true)}
+          className="w-fit uppercase"
+        >
+          Shield your first assets
+        </ActionButton>
+      </div>
+      {shieldingModalOpen && (
+        <ShieldAssetsModal onClose={() => setShieldingModalOpen(false)} />
+      )}
+    </>
   );
 };
 
@@ -76,16 +85,12 @@ const AssetTable = (): JSX.Element => {
 };
 
 export const ShieldedOverviewPanel: React.FC = () => {
-  const userHasAccount = useUserHasAccount();
-
   return (
     <Panel
       className="relative pb-6 border border-yellow min-h-[500px] flex flex-col"
-      title={userHasAccount ? "Shielded Overview" : undefined}
+      title="Shielded Overview"
     >
-      {userHasAccount ?
-        <AssetTable />
-      : <ShieldAssetCta />}
+      <AssetTable />
     </Panel>
   );
 };


### PR DESCRIPTION
Update masp transfer flow 

- Add the missing modals for Shield/Unshield like we have on TopNavigation
- Temporally removes the IBC Unshield from Shielded Pool while it's not implemented
- Also, add the full banner of extension connect if it's not yet, so we don't show a eternal loading state which confuses the user 

closes https://github.com/anoma/namada-interface/issues/1494
closes https://github.com/anoma/namada-interface/issues/1631


https://github.com/user-attachments/assets/b7fff28d-e664-44af-9581-8dcf3193a194





