### PR TITLE
fix(docker): temporarily remove concurrency

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,10 +4,6 @@ on:
   release:
     types: [published]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
 env:
   GIT_LFS_SKIP_SMUDGE: 1
 


### PR DESCRIPTION
Docker release is not being triggered by the CI on a new release is published. This PR removes concurrency that might be conflicting with the triggering