### PR TITLE
fix: pending transactions

### DIFF
--- a/apps/namadillo/src/hooks/useTransactionWatcher.tsx
+++ b/apps/namadillo/src/hooks/useTransactionWatcher.tsx
@@ -28,9 +28,7 @@ export const useTransactionWatcher = (): void => {
             case "TransparentToShielded":
             case "ShieldedToTransparent":
             case "ShieldedToShielded": {
-              const hash = tx.hash ?? "";
-              const response = await fetchTransaction(hash);
-              const newTx = handleStandardTransfer(tx, response);
+              const newTx = await handleStandardTransfer(tx, fetchTransaction);
               dispatchTransferEvent(transactionTypeToEventName(tx), newTx);
               break;
             }


### PR DESCRIPTION
Fix pending transactions because the promise for 404 status wasn't handled inside the `switch...case`, then we move it to `handleStandardTransfer` 

Also, update the timeout to 30 minutes to avoid having the spinner for a long time