### PR TITLE
fix: load shielded context before generating ibc shielding memo

### DIFF
--- a/packages/shared/lib/src/sdk/mod.rs
+++ b/packages/shared/lib/src/sdk/mod.rs
@@ -733,6 +733,8 @@ impl Sdk {
         amount: &str,
         channel_id: &str,
     ) -> Result<JsValue, JsError> {
+        let _ = &self.namada.shielded_mut().await.load().await?;
+
         let ledger_address = Url::from_str(&self.rpc_url).expect("RPC URL is a valid URL");
         let target = TransferTarget::PaymentAddress(
             PaymentAddress::from_str(target).expect("target is a valid shielded address"),


### PR DESCRIPTION
Resolves #1664 