### PR TITLE
chore: bumping indexer compatibility

### DIFF
--- a/apps/namadillo/src/compatibility.json
+++ b/apps/namadillo/src/compatibility.json
@@ -1,4 +1,4 @@
 {
   "keychain": "0.3.x",
-  "indexer": "1.1.x"
+  "indexer": "2.0.x"
 }


### PR DESCRIPTION
Requires indexer to be on version 2.0.x