### PR TITLE
fix: bumping namada keychain version (0.4.0) and fixing required indexer version (2.0.x)

### DIFF
--- a/apps/namadillo/src/compatibility.json
+++ b/apps/namadillo/src/compatibility.json
@@ -1,4 +1,4 @@
 {
-  "keychain": "0.3.x",
-  "indexer": ">=2.0.0"
+  "keychain": "0.4.x",
+  "indexer": "2.0.x"
 }


### PR DESCRIPTION
In order to complete last rollout of different releases, we're finally setting the keychain to 0.4.0 and indexer to 2.0.x