### PR TITLE
fix: truncate long token names in Select Asset modal

### DIFF
--- a/apps/namadillo/src/App/Transfer/AssetCard.tsx
+++ b/apps/namadillo/src/App/Transfer/AssetCard.tsx
@@ -1,6 +1,8 @@
 import { Asset } from "@chain-registry/types";
+import { shortenAddress } from "@namada/utils";
 import clsx from "clsx";
 import { AssetImage } from "./AssetImage";
+import { isNamadaAddress } from "./common";
 
 type AssetCardProps = {
   asset: Asset;
@@ -15,8 +17,8 @@ export const AssetCard = ({ asset, disabled }: AssetCardProps): JSX.Element => {
       )}
     >
       <AssetImage asset={asset} />
-      <span className="text-left truncate">
-        {asset.name}
+      <span className="text-left">
+        {isNamadaAddress(asset.name) ? shortenAddress(asset.name) : asset.name}
         {disabled && (
           <i className="text-red-500 ml-2">disabled until phase 5</i>
         )}

--- a/apps/namadillo/src/App/Transfer/AssetCard.tsx
+++ b/apps/namadillo/src/App/Transfer/AssetCard.tsx
@@ -15,7 +15,7 @@ export const AssetCard = ({ asset, disabled }: AssetCardProps): JSX.Element => {
       )}
     >
       <AssetImage asset={asset} />
-      <span className="text-left">
+      <span className="text-left truncate">
         {asset.name}
         {disabled && (
           <i className="text-red-500 ml-2">disabled until phase 5</i>

--- a/apps/namadillo/src/hooks/useRegistryFeatures.tsx
+++ b/apps/namadillo/src/hooks/useRegistryFeatures.tsx
@@ -69,16 +69,6 @@ const fetchEnabledFeatures = async (
     switch (enabledFeature) {
       case "claimRewards":
         registryFeatures.claimRewardsEnabled = true;
-        registryFeatures.maspEnabled = true;
-
-        registryFeatures.ibcTransfersEnabled = true;
-
-        registryFeatures.ibcShieldingEnabled = true;
-
-        registryFeatures.namTransfersEnabled = true;
-
-        registryFeatures.shieldingRewardsEnabled = true;
-
         break;
       case "masp":
         registryFeatures.maspEnabled = true;

--- a/apps/namadillo/src/hooks/useRegistryFeatures.tsx
+++ b/apps/namadillo/src/hooks/useRegistryFeatures.tsx
@@ -69,6 +69,16 @@ const fetchEnabledFeatures = async (
     switch (enabledFeature) {
       case "claimRewards":
         registryFeatures.claimRewardsEnabled = true;
+        registryFeatures.maspEnabled = true;
+
+        registryFeatures.ibcTransfersEnabled = true;
+
+        registryFeatures.ibcShieldingEnabled = true;
+
+        registryFeatures.namTransfersEnabled = true;
+
+        registryFeatures.shieldingRewardsEnabled = true;
+
         break;
       case "masp":
         registryFeatures.maspEnabled = true;


### PR DESCRIPTION
<!--

Make sure you have read CONTRIBUTING.md before submitting a pull request!

-->
<img width="539" alt="Screenshot 2025-02-21 at 5 41 37 PM" src="https://github.com/user-attachments/assets/733c851c-5f88-45ba-a303-3a4bddea93a9" />


Closes #1696 
