### PR TITLE
Check Ledger app version before enabling zip32

### DIFF
--- a/apps/extension/src/Setup/Common/LedgerApprovalStep.tsx
+++ b/apps/extension/src/Setup/Common/LedgerApprovalStep.tsx
@@ -2,10 +2,12 @@ import { Heading, ProgressIndicator, Stack } from "@namada/components";
 
 type LedgerApprovalStepProps = {
   currentApprovalStep: number;
+  isZip32Supported: boolean;
 };
 
 export const LedgerApprovalStep = ({
   currentApprovalStep,
+  isZip32Supported,
 }: LedgerApprovalStepProps): JSX.Element => {
   const stepText = [
     "Deriving Bip44 public key...",
@@ -21,14 +23,20 @@ export const LedgerApprovalStep = ({
     <Stack gap={1} className="bg-black w-full p-4 rounded-md min-h-[240px]">
       <Stack direction="horizontal" className="flex">
         <span className="flex-none">
-          <ProgressIndicator
-            keyName="ledger-import"
-            totalSteps={totalSteps}
-            currentStep={currentStep}
-          />
+          {isZip32Supported && (
+            <ProgressIndicator
+              keyName="ledger-import"
+              totalSteps={totalSteps}
+              currentStep={currentStep}
+            />
+          )}
         </span>
         <span className="flex-1 text-white font-medium text-right">
-          Approval {currentStep}/{totalSteps}
+          {isZip32Supported && (
+            <>
+              Approval {currentStep}/{totalSteps}
+            </>
+          )}
         </span>
       </Stack>
       <Heading

--- a/apps/extension/src/Setup/query.ts
+++ b/apps/extension/src/Setup/query.ts
@@ -92,6 +92,7 @@ export class AccountManager {
       address,
       publicKey,
       bip44Path,
+      zip32Path,
       extendedViewingKey,
       pseudoExtendedKey,
       paymentAddress,
@@ -103,6 +104,7 @@ export class AccountManager {
         address,
         publicKey,
         bip44Path,
+        zip32Path,
         extendedViewingKey,
         pseudoExtendedKey,
         paymentAddress

--- a/apps/extension/src/background/keyring/handler.ts
+++ b/apps/extension/src/background/keyring/handler.ts
@@ -113,6 +113,7 @@ const handleAddLedgerAccountMsg: (
       address,
       publicKey,
       bip44Path,
+      zip32Path,
       extendedViewingKey,
       pseudoExtendedKey,
       paymentAddress,
@@ -122,6 +123,7 @@ const handleAddLedgerAccountMsg: (
       address,
       publicKey,
       bip44Path,
+      zip32Path,
       extendedViewingKey,
       pseudoExtendedKey,
       paymentAddress

--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -109,9 +109,10 @@ export class KeyRing {
     address: string,
     publicKey: string,
     bip44Path: Bip44Path,
-    pseudoExtendedKey: string,
-    extendedViewingKey: string,
-    paymentAddress: string
+    zip32Path?: Zip32Path,
+    pseudoExtendedKey?: string,
+    extendedViewingKey?: string,
+    paymentAddress?: string
   ): Promise<AccountStore | false> {
     const id = generateId(UUID_NAMESPACE, alias, address);
     const accountStore: AccountStore = {
@@ -135,29 +136,36 @@ export class KeyRing {
       sensitive,
     });
 
-    const shieldedId = generateId(UUID_NAMESPACE, alias, paymentAddress);
-    const shieldedAccountStore: AccountStore = {
-      id: shieldedId,
-      alias,
-      address: paymentAddress,
-      publicKey,
-      owner: extendedViewingKey,
-      path: bip44Path,
-      pseudoExtendedKey,
-      parentId: id,
-      type: AccountType.ShieldedKeys,
-      source: "imported",
-      timestamp: 0,
-    };
+    if (
+      zip32Path &&
+      pseudoExtendedKey &&
+      extendedViewingKey &&
+      paymentAddress
+    ) {
+      const shieldedId = generateId(UUID_NAMESPACE, alias, paymentAddress);
+      const shieldedAccountStore: AccountStore = {
+        id: shieldedId,
+        alias,
+        address: paymentAddress,
+        publicKey,
+        owner: extendedViewingKey,
+        path: zip32Path,
+        pseudoExtendedKey,
+        parentId: id,
+        type: AccountType.ShieldedKeys,
+        source: "imported",
+        timestamp: 0,
+      };
 
-    const shieldedSensitive = await this.vaultService.encryptSensitiveData({
-      text: "",
-      passphrase: "",
-    });
-    await this.vaultStorage.add(KeyStore, {
-      public: shieldedAccountStore,
-      sensitive: shieldedSensitive,
-    });
+      const shieldedSensitive = await this.vaultService.encryptSensitiveData({
+        text: "",
+        passphrase: "",
+      });
+      await this.vaultStorage.add(KeyStore, {
+        public: shieldedAccountStore,
+        sensitive: shieldedSensitive,
+      });
+    }
 
     await this.setActiveAccount(id, AccountType.Ledger);
     return accountStore;

--- a/apps/extension/src/background/keyring/messages.ts
+++ b/apps/extension/src/background/keyring/messages.ts
@@ -190,23 +190,16 @@ export class AddLedgerAccountMsg extends Message<AccountStore | false> {
     public readonly address: string,
     public readonly publicKey: string,
     public readonly bip44Path: Bip44Path,
-    public readonly extendedViewingKey: string,
-    public readonly pseudoExtendedKey: string,
-    public readonly paymentAddress: string
+    public readonly zip32Path?: Zip32Path,
+    public readonly extendedViewingKey?: string,
+    public readonly pseudoExtendedKey?: string,
+    public readonly paymentAddress?: string
   ) {
     super();
   }
 
   validate(): void {
-    validateProps(this, [
-      "alias",
-      "address",
-      "publicKey",
-      "bip44Path",
-      "extendedViewingKey",
-      "pseudoExtendedKey",
-      "paymentAddress",
-    ]);
+    validateProps(this, ["alias", "address", "publicKey", "bip44Path"]);
   }
 
   route(): string {

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -83,9 +83,10 @@ export class KeyRingService {
     address: string,
     publicKey: string,
     bip44Path: Bip44Path,
-    extendedViewingKey: string,
-    pseudoExtendedKey: string,
-    paymentAddress: string
+    zip32Path?: Zip32Path,
+    extendedViewingKey?: string,
+    pseudoExtendedKey?: string,
+    paymentAddress?: string
   ): Promise<AccountStore | false> {
     const account = await this._keyRing.queryAccountByAddress(address);
     if (account) {
@@ -99,6 +100,7 @@ export class KeyRingService {
       address,
       publicKey,
       bip44Path,
+      zip32Path,
       pseudoExtendedKey,
       extendedViewingKey,
       paymentAddress

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,5 +1,10 @@
 // Make Ledger available for direct-import as it is not dependent on Sdk initialization
-export { Ledger, initLedgerUSBTransport, ledgerUSBList } from "./ledger";
+export {
+  LEDGER_MIN_VERSION_ZIP32,
+  Ledger,
+  initLedgerUSBTransport,
+  ledgerUSBList,
+} from "./ledger";
 export type {
   LedgerAddressAndPublicKey,
   LedgerProofGenerationKey,

--- a/packages/sdk/src/ledger.ts
+++ b/packages/sdk/src/ledger.ts
@@ -30,7 +30,7 @@ export type LedgerStatus = {
   info: ResponseAppInfo;
 };
 
-export const LEDGER_MIN_VERSION_ZIP32 = "3.0.1";
+export const LEDGER_MIN_VERSION_ZIP32 = "3.0.0";
 
 export type Bparams = {
   spend: {

--- a/packages/sdk/src/ledger.ts
+++ b/packages/sdk/src/ledger.ts
@@ -30,7 +30,7 @@ export type LedgerStatus = {
   info: ResponseAppInfo;
 };
 
-const LEDGER_MIN_VERSION_ZIP32 = "2.0.0";
+export const LEDGER_MIN_VERSION_ZIP32 = "3.0.1";
 
 export type Bparams = {
   spend: {
@@ -80,7 +80,7 @@ export class Ledger {
   /**
    * @param namadaApp - Inititalized NamadaApp class from Zondax package
    */
-  private constructor(public readonly namadaApp: NamadaApp) { }
+  private constructor(public readonly namadaApp: NamadaApp) {}
 
   /**
    * Initialize and return Ledger class instance with initialized Transport
@@ -350,7 +350,7 @@ export class Ledger {
       } = await this.status();
       throw new Error(
         `This method requires Zip32 and is unsupported in ${appVersion}! ` +
-        `Please update to at least ${LEDGER_MIN_VERSION_ZIP32}!`
+          `Please update to at least ${LEDGER_MIN_VERSION_ZIP32}!`
       );
     }
   }


### PR DESCRIPTION
Resolves #1698 

- [x] If zip32 is supported on this Ledger app version, allow specifying custom path
- [x] If zip32 supported, include shielded import steps
- [x] If zip32 isn't supported, display warning and skip shielded import steps
- [x] Store correct zip32 path in Ledger account storage
  - Custom paths should be correct in `View Keys` - this is the only view where paths are seen, and only when they are non-default!

### TODO
- [ ] Improve custom path form and approval steps UI


### TESTING

- Use 3.0.0+ version of Ledger (latest is `v3.0.1`) - flows should be identical to before with shielded accounts in place
  - Custom zip32 paths are now correct (UI to be improved after this PR)
- Downgrade to version in Ledger Live (1.0.5) and go through import flows: You'll see a message that shielded accounts will be enabled in 3.0.0, and it will only import transparent
  - Non-shielded Tx work as before