### PR TITLE
WIP: fix: update mismatched data hashes

### DIFF
--- a/apps/namadillo/src/App/Governance/VoteInfoCards.tsx
+++ b/apps/namadillo/src/App/Governance/VoteInfoCards.tsx
@@ -10,11 +10,9 @@ import {
   Proposal,
 } from "@namada/types";
 
-import { sha256Hash } from "@namada/utils";
 import { proposalFamily } from "atoms/proposals";
 import BigNumber from "bignumber.js";
 import { useAtomValue } from "jotai";
-import { useEffect, useState } from "react";
 import { namadaAsset, toDisplayAmount } from "utils";
 import {
   secondsToDateTimeString,
@@ -172,19 +170,6 @@ const DateTimeEpoch: React.FC<{ date: bigint; epoch: bigint }> = ({
 const Loaded: React.FC<{
   proposal: Proposal;
 }> = ({ proposal }) => {
-  const [dataHash, setDataHash] = useState<string>();
-
-  useEffect(() => {
-    if (
-      proposal.proposalType.type === "default_with_wasm" &&
-      proposal.proposalType.data.length > 0
-    ) {
-      sha256Hash(proposal.proposalType.data).then((hash) =>
-        setDataHash(hash.toUpperCase())
-      );
-    }
-  }, [proposal.proposalType]);
-
   return (
     <>
       <InfoCard
@@ -219,10 +204,10 @@ const Loaded: React.FC<{
         content={proposal.author}
         className="col-span-full"
       />
-      {dataHash && (
+      {proposal.dataHash && (
         <InfoCard
           title="Data Hash"
-          content={dataHash}
+          content={proposal.dataHash}
           className="col-span-full"
         />
       )}

--- a/apps/namadillo/src/atoms/proposals/functions.ts
+++ b/apps/namadillo/src/atoms/proposals/functions.ts
@@ -223,6 +223,7 @@ const toProposal = (
   return {
     id: BigInt(proposal.id),
     author: proposal.author,
+    dataHash: proposal.data ?? "",
     content: contentDecoded.right,
     startEpoch: BigInt(proposal.startEpoch),
     endEpoch: BigInt(proposal.endEpoch),
@@ -246,6 +247,7 @@ export const fetchProposalById = async (
   id: bigint
 ): Promise<Proposal> => {
   const proposalPromise = api.apiV1GovProposalIdGet(Number(id));
+  console.log("proposalPromise", proposalPromise);
   const totalVotingPowerPromise = api.apiV1PosVotingPowerGet();
   const [proposalResponse, votingPowerResponse] = await Promise.all([
     proposalPromise,


### PR DESCRIPTION
<!--

Make sure you have read CONTRIBUTING.md before submitting a pull request!

-->
<img width="888" alt="Screenshot 2025-02-23 at 9 36 54 PM" src="https://github.com/user-attachments/assets/9fde5919-675d-4366-903a-765867ae701f" />

```
namadac query-proposal --proposal-id 10 --node $RPC 
 
Last committed epoch: 324
Proposal Id: 10
Type: Default with Wasm
Author: tnam1qqgll8x8rz9fvtdv8q6n985za0vjvgyu0udxh7fp
Content: {"details": "In anticipation of updating the claim-rewards tx wasm in the Namada on-chain storage, we first must increase the maximum allowed gas in a block. This must be done because the tx to initialize that proposal consumes about 4.3M gas units, whereas the current block maximum is 3M. This proposal increases the block maximum from 3M to 5M.\n\nThe code used to produce the attached WASM can be viewed here: https://github.com/anoma/namada-governance-upgrades/blob/b26aff300654a791b91d8ff40483d7d2f0bf9d5f/max_block_gas/src/lib.rs", "discussions-to": "https://forum.namada.net/t/two-proposals-to-update-the-claim-rewards-wasm-tx-on-chain/1548", "title": "Increase max block gas to 5M gas units"}
Start Epoch: 318
End Epoch: 330
Activation Epoch: 331
Status: on-going
Data: Hash: DB27ADA6B1F734008E4A3AF440F0666A441FDDAF2D8FF44CBC9B6D187949ECD1
```

Closes #1713 