### PR TITLE
fix: fix missing nam asset on balances

### DIFF
--- a/apps/namadillo/src/atoms/balance/atoms.ts
+++ b/apps/namadillo/src/atoms/balance/atoms.ts
@@ -8,6 +8,7 @@ import {
 } from "atoms/accounts/atoms";
 import { indexerApiAtom } from "atoms/api";
 import {
+  chainAssetsMapAtom,
   chainParametersAtom,
   chainTokensAtom,
   nativeTokenAddressAtom,
@@ -203,54 +204,39 @@ export const shieldedBalanceAtom = atomWithQuery((get) => {
 export const namadaShieldedAssetsAtom = atomWithQuery((get) => {
   const storageShieldedBalance = get(storageShieldedBalanceAtom);
   const viewingKeysQuery = get(viewingKeysAtom);
-  const chainTokensQuery = get(chainTokensAtom);
-  const chainParameters = get(chainParametersAtom);
+  const chainAssetsMap = get(chainAssetsMapAtom);
 
   const [viewingKey] = viewingKeysQuery.data ?? [];
   const shieldedBalance = viewingKey && storageShieldedBalance[viewingKey.key];
 
   return {
-    queryKey: [
-      "namada-shielded-assets",
-      shieldedBalance,
-      chainTokensQuery.data,
-      chainParameters.data!.chainId,
-    ],
+    queryKey: ["namada-shielded-assets", shieldedBalance],
     ...queryDependentFn(
       async () =>
-        await mapNamadaAddressesToAssets(
+        mapNamadaAddressesToAssets(
           shieldedBalance?.map((i) => ({
             ...i,
             minDenomAmount: BigNumber(i.minDenomAmount),
           })) ?? [],
-          chainTokensQuery.data!,
-          chainParameters.data!.chainId
+          chainAssetsMap
         ),
-      [chainTokensQuery, chainParameters, viewingKeysQuery]
+      [viewingKeysQuery]
     ),
   };
 });
 
 export const namadaTransparentAssetsAtom = atomWithQuery((get) => {
   const transparentBalances = get(transparentBalanceAtom);
-  const chainTokensQuery = get(chainTokensAtom);
-  const chainParameters = get(chainParametersAtom);
+  const chainAssetsMap = get(chainAssetsMapAtom);
+
+  const transparentBalance = transparentBalances.data;
 
   return {
-    queryKey: [
-      "namada-transparent-assets",
-      transparentBalances.data,
-      chainTokensQuery.data,
-      chainParameters.data!.chainId,
-    ],
+    queryKey: ["namada-transparent-assets", transparentBalance, chainAssetsMap],
     ...queryDependentFn(
       async () =>
-        await mapNamadaAddressesToAssets(
-          transparentBalances.data!,
-          chainTokensQuery.data!,
-          chainParameters.data!.chainId
-        ),
-      [transparentBalances, chainTokensQuery, chainParameters]
+        mapNamadaAddressesToAssets(transparentBalance ?? [], chainAssetsMap),
+      [transparentBalances]
     ),
   };
 });


### PR DESCRIPTION
Fix missing nam asset on balances

Solution: use the `chainAssetsMapAtom` to map the tokens. This is more reliable because the previous implementation was using the integration search, that is focused on `denom` and `ibc/...` addresses, that is not the reality of how we handle balances based on `tnam...` address. 

This is happening on mainnet only because the `denom` and `ibc/...` addresses use the [chain-registry](https://github.com/cosmos/chain-registry/blob/master/namada/assetlist.json) instead of [namada-chain-resigry](https://github.com/anoma/namada-chain-registry/blob/main/namada/assetlist.json), which is missing the `address` field. We don't have housefire on `chain-registry`

![Screenshot 2025-02-24 at 18 16 19](https://github.com/user-attachments/assets/60e31fb7-603b-411c-a813-a2637492c465)
