### PR TITLE
fix: add fallback for missing gas estimates

### DIFF
--- a/apps/namadillo/src/atoms/fees/atoms.ts
+++ b/apps/namadillo/src/atoms/fees/atoms.ts
@@ -35,23 +35,8 @@ export const gasEstimateFamily = atomFamily(
               totalEstimates: 0,
             };
           }
-          const counter = (kind: TxKind): number | undefined =>
-            txKinds.filter((i) => i === kind).length || undefined;
 
-          const gasEstimate = await fetchGasEstimate(api, [
-            counter("Bond"),
-            counter("ClaimRewards"),
-            counter("Unbond"),
-            counter("TransparentTransfer"),
-            counter("ShieldedTransfer"),
-            counter("ShieldingTransfer"),
-            counter("UnshieldingTransfer"),
-            counter("VoteProposal"),
-            counter("IbcTransfer"),
-            counter("Withdraw"),
-            counter("RevealPk"),
-            counter("Redelegate"),
-          ]);
+          const gasEstimate = await fetchGasEstimate(api, txKinds);
 
           // TODO: we need to improve this estimate API. Currently, gasEstimate.min returns
           // the minimum gas limit ever used for a TX, and avg is failing in most of the transactions.

--- a/apps/namadillo/src/atoms/fees/services.ts
+++ b/apps/namadillo/src/atoms/fees/services.ts
@@ -1,14 +1,95 @@
 import {
   DefaultApi,
   GasEstimate,
+  GasLimitTableInnerTxKindEnum,
   GasPriceTableInner,
 } from "@namada/indexer-client";
+import { TxKind } from "types/txKind";
+
+const convertLegacyGasKind = (kind: GasLimitTableInnerTxKindEnum): TxKind => {
+  switch (kind) {
+    case "revealPk":
+      return "RevealPk";
+    case "bond":
+      return "Bond";
+    case "unbond":
+      return "Unbond";
+    case "redelegation":
+      return "Redelegate";
+    case "claimRewards":
+      return "ClaimRewards";
+    case "voteProposal":
+      return "VoteProposal";
+    case "transparentTransfer":
+      return "TransparentTransfer";
+    case "shieldingTransfer":
+      return "ShieldingTransfer";
+    case "shieldedTransfer":
+      return "ShieldedTransfer";
+    case "unshieldingTransfer":
+      return "UnshieldingTransfer";
+    case "ibcMsgTransfer":
+      return "IbcTransfer";
+    case "withdraw":
+      return "Withdraw";
+    default:
+      return "Unknown";
+  }
+};
 
 export const fetchGasEstimate = async (
   api: DefaultApi,
-  params: Parameters<typeof api.apiV1GasEstimateGet>
+  txKinds: TxKind[]
 ): Promise<GasEstimate> => {
-  return (await api.apiV1GasEstimateGet(...params)).data;
+  const counter = (kind: TxKind): number | undefined =>
+    txKinds.filter((i) => i === kind).length || undefined;
+
+  const params = [
+    counter("Bond"),
+    counter("ClaimRewards"),
+    counter("Unbond"),
+    counter("TransparentTransfer"),
+    counter("ShieldedTransfer"),
+    counter("ShieldingTransfer"),
+    counter("UnshieldingTransfer"),
+    counter("VoteProposal"),
+    counter("IbcTransfer"),
+    counter("Withdraw"),
+    counter("RevealPk"),
+    counter("Redelegate"),
+  ];
+
+  // fetch from the estimate endpoint
+  try {
+    return (await api.apiV1GasEstimateGet(...params)).data;
+  } catch (e) {
+    console.error(e);
+  }
+
+  // if fails, try to fetch from the legacy endpoint
+  try {
+    const legacyValues = (await api.apiV1GasGet()).data;
+    const sum = legacyValues.reduce((sum, item) => {
+      const txKind = convertLegacyGasKind(item.txKind);
+      return sum + item.gasLimit * (counter(txKind) ?? 0);
+    }, 0);
+    return {
+      min: sum,
+      avg: sum,
+      max: sum,
+      totalEstimates: 0,
+    };
+  } catch (e) {
+    console.error(e);
+  }
+
+  // otherwise, returns a generic default value
+  return {
+    min: 50000,
+    avg: 50000,
+    max: 50000,
+    totalEstimates: 0,
+  };
 };
 
 export const fetchTokensGasPrice = async (


### PR DESCRIPTION
Add fallback for missing gas estimates

To test, you can simulate to stake for 15 validator at once with the network tab open, you will see the indexer returning 502, but the fee still increasing

closes https://github.com/anoma/namada-interface/issues/1734

https://github.com/user-attachments/assets/519c364c-af93-454d-b594-c4bc6c4747d1

