### PR TITLE
feat: Extension - Add view and import Spending Key

### DIFF
--- a/apps/extension/src/App/Accounts/ParentAccounts.tsx
+++ b/apps/extension/src/App/Accounts/ParentAccounts.tsx
@@ -11,7 +11,6 @@ import { AccountType, DerivedAccount } from "@namada/types";
 import { ParentAccountsFooter } from "App/Accounts/ParentAccountsFooter";
 import { PageHeader } from "App/Common";
 import routes from "App/routes";
-import { ParentAccount } from "background/keyring";
 import { AccountContext } from "context";
 import { isOutdatedShieldedAccount, openSetupTab } from "utils";
 
@@ -117,7 +116,7 @@ export const ParentAccounts = (): JSX.Element => {
                 onSelectAccount={() => {
                   changeActiveAccountId(
                     account.id,
-                    account.type as ParentAccount
+                    account.type as AccountType
                   );
                 }}
               />

--- a/apps/extension/src/App/Accounts/SpendingKey.tsx
+++ b/apps/extension/src/App/Accounts/SpendingKey.tsx
@@ -1,0 +1,117 @@
+import {
+  ActionButton,
+  Alert,
+  GapPatterns,
+  Input,
+  Stack,
+} from "@namada/components";
+import { PageHeader } from "App/Common";
+import { RevealSpendingKeyMsg } from "background/keyring";
+import { useVaultContext } from "context";
+import { useRequester } from "hooks/useRequester";
+import { useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Ports } from "router";
+
+type SpendingKeyParams = {
+  accountId: string;
+};
+
+export const SpendingKey = (): JSX.Element => {
+  const navigate = useNavigate();
+  const requester = useRequester();
+  const { checkPassword } = useVaultContext();
+  const { accountId } = useParams<SpendingKeyParams>();
+  const [password, setPassword] = useState<string>();
+  const [passwordChecked, setPasswordChecked] = useState(false);
+  const [passwordError, setPasswordError] = useState<string>();
+  const [spendingKey, setSpendingKey] = useState<string>();
+
+  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+
+    if (!password) {
+      return;
+    }
+
+    const isValidPassword = await checkPassword(password);
+
+    if (!accountId) {
+      throw new Error("Invalid account id");
+    }
+
+    setPasswordChecked(isValidPassword);
+
+    if (isValidPassword) {
+      const response = await requester.sendMessage(
+        Ports.Background,
+        new RevealSpendingKeyMsg(accountId)
+      );
+      if (response) {
+        setSpendingKey(response);
+      }
+      return;
+    }
+
+    setPasswordError("Invalid password");
+  };
+
+  return (
+    <>
+      <Stack
+        full
+        as="form"
+        gap={GapPatterns.TitleContent}
+        onSubmit={handleSubmit}
+      >
+        <PageHeader title="Spending Key" />
+        {!passwordChecked && (
+          <>
+            <Stack className="mt-12" full gap={GapPatterns.FormFields}>
+              <Alert type="info">
+                Please provide your password in order to view your spending key
+              </Alert>
+              <Input
+                autoFocus
+                variant="Password"
+                label="Password"
+                placeholder="Password"
+                error={passwordError}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+            </Stack>
+            <ActionButton type="submit" size="md" disabled={!password}>
+              Proceed
+            </ActionButton>
+          </>
+        )}
+
+        {passwordChecked && (
+          <>
+            <Stack className="flex-1 justify-center" full gap={1}>
+              <div className="text-sm -mt-1.5"></div>
+              <p className="text-white">
+                Your spending key grants the holder the ability to spend funds
+                from your shielded account. This must be kept secret!
+              </p>
+              <Input
+                label="Spending Key"
+                variant="ReadOnlyCopyText"
+                readOnly={true}
+                rows={10}
+                valueToDisplay={spendingKey}
+                value={spendingKey}
+                theme="secondary"
+                className="pb-20 [&_textarea]:py-2"
+              />{" "}
+            </Stack>
+            <ActionButton size="md" onClick={() => navigate(-1)}>
+              Close
+            </ActionButton>
+          </>
+        )}
+      </Stack>
+    </>
+  );
+};

--- a/apps/extension/src/App/Accounts/ViewAccount.tsx
+++ b/apps/extension/src/App/Accounts/ViewAccount.tsx
@@ -97,13 +97,30 @@ export const ViewAccount = (): JSX.Element => {
               trimCharacters={21}
             />
             {viewingKey && (
-              <ActionButton
-                outlineColor="yellow"
-                size="sm"
-                onClick={() => navigate(routes.viewViewingKey(viewingKey))}
-              >
-                Access Viewing Key
-              </ActionButton>
+              <>
+                {parentAccount.type !== AccountType.Ledger && (
+                  <ActionButton
+                    outlineColor="yellow"
+                    size="sm"
+                    onClick={() =>
+                      navigate(
+                        routes.viewSpendingKey(
+                          searchShieldedKey(accountId)?.id || ""
+                        )
+                      )
+                    }
+                  >
+                    Access Spending Key
+                  </ActionButton>
+                )}
+                <ActionButton
+                  outlineColor="yellow"
+                  size="sm"
+                  onClick={() => navigate(routes.viewViewingKey(viewingKey))}
+                >
+                  Access Viewing Key
+                </ActionButton>
+              </>
             )}
           </Stack>
           <ActionButton size="md" onClick={() => navigate(-1)}>

--- a/apps/extension/src/App/Accounts/ViewAccount.tsx
+++ b/apps/extension/src/App/Accounts/ViewAccount.tsx
@@ -44,20 +44,37 @@ export const ViewAccount = (): JSX.Element => {
     const parentAccount = searchParentAccount(accountId);
     if (parentAccount) {
       setParentAccount(parentAccount);
-      setTransparentAddress(parentAccount.address);
-      setTransparentPath(
-        isCustomPath(parentAccount.path) ?
-          makeBip44Path(
-            chains.namada.bip44.coinType,
-            {
-              ...parentAccount.path,
-              change: parentAccount.path.change || 0,
-              index: parentAccount.path.index || 0,
-            },
-            false
-          )
-        : undefined
-      );
+
+      if (parentAccount.type === AccountType.ShieldedKeys) {
+        setShieldedAddress(parentAccount.address);
+        setShieldedPath(
+          isCustomPath(parentAccount.path) ?
+            makeSaplingPath(
+              chains.namada.bip44.coinType,
+              parentAccount.path,
+              false
+            )
+          : undefined
+        );
+        if (parentAccount.owner) {
+          setViewingKey(parentAccount.owner);
+        }
+      } else {
+        setTransparentAddress(parentAccount.address);
+        setTransparentPath(
+          isCustomPath(parentAccount.path) ?
+            makeBip44Path(
+              chains.namada.bip44.coinType,
+              {
+                ...parentAccount.path,
+                change: parentAccount.path.change || 0,
+                index: parentAccount.path.index || 0,
+              },
+              false
+            )
+          : undefined
+        );
+      }
     }
 
     const shieldedAccount = searchShieldedKey(accountId);
@@ -102,13 +119,17 @@ export const ViewAccount = (): JSX.Element => {
                   <ActionButton
                     outlineColor="yellow"
                     size="sm"
-                    onClick={() =>
-                      navigate(
-                        routes.viewSpendingKey(
-                          searchShieldedKey(accountId)?.id || ""
-                        )
-                      )
-                    }
+                    onClick={() => {
+                      if (parentAccount.type === AccountType.ShieldedKeys) {
+                        navigate(routes.viewSpendingKey(parentAccount.id));
+                      } else {
+                        navigate(
+                          routes.viewSpendingKey(
+                            searchShieldedKey(accountId)?.id || ""
+                          )
+                        );
+                      }
+                    }}
                   >
                     Access Spending Key
                   </ActionButton>

--- a/apps/extension/src/App/AppContent.tsx
+++ b/apps/extension/src/App/AppContent.tsx
@@ -14,6 +14,7 @@ import {
   ViewMnemonic,
 } from "./Accounts";
 import { ParentAccounts } from "./Accounts/ParentAccounts";
+import { SpendingKey } from "./Accounts/SpendingKey";
 import { ViewingKey } from "./Accounts/ViewingKey";
 import { ChangePassword, ConnectedSites, Network } from "./Settings";
 import { Warnings } from "./Settings/Warnings";
@@ -82,6 +83,7 @@ export const AppContent = ({ warnings }: Props): JSX.Element => {
             <Route path={routes.deleteAccount()} element={<DeleteAccount />} />
             <Route path={routes.viewAccount()} element={<ViewAccount />} />
             <Route path={routes.viewViewingKey()} element={<ViewingKey />} />
+            <Route path={routes.viewSpendingKey()} element={<SpendingKey />} />
             <Route path={routes.renameAccount()} element={<RenameAccount />} />
             <Route
               path={routes.viewAccountMnemonic()}

--- a/apps/extension/src/App/routes.ts
+++ b/apps/extension/src/App/routes.ts
@@ -15,6 +15,8 @@ export default {
     `/accounts/view/${accountId}`,
   viewViewingKey: (viewingKey: string = ":viewingKey") =>
     `/accounts/view/viewingKey/${viewingKey}`,
+  viewSpendingKey: (accountId: string = ":accountId") =>
+    `/accounts/view/spendingKey/${accountId}`,
   deleteAccount: (accountId: string = ":accountId") =>
     `/accounts/delete/${accountId}`,
   renameAccount: (accountId: string = ":accountId") =>

--- a/apps/extension/src/Setup/Setup.tsx
+++ b/apps/extension/src/Setup/Setup.tsx
@@ -114,6 +114,7 @@ export const Setup: React.FC = () => {
       const prettyAccountSecret =
         accountSecret.t === "Mnemonic" ? "mnemonic"
         : accountSecret.t === "PrivateKey" ? "private key"
+        : accountSecret.t === "ShieldedKeys" ? "spending key"
         : assertNever(accountSecret);
       setCompletionStatusInfo(`Encrypting and storing ${prettyAccountSecret}.`);
 

--- a/apps/extension/src/Setup/Setup.tsx
+++ b/apps/extension/src/Setup/Setup.tsx
@@ -11,7 +11,12 @@ import {
   Container,
   LifecycleExecutionWrapper as Wrapper,
 } from "@namada/components";
-import { Bip44Path, DerivedAccount, Zip32Path } from "@namada/types";
+import {
+  AccountType,
+  Bip44Path,
+  DerivedAccount,
+  Zip32Path,
+} from "@namada/types";
 import { assertNever } from "@namada/utils";
 import { AccountSecret, AccountStore } from "background/keyring";
 import { AnimatePresence, motion } from "framer-motion";
@@ -123,15 +128,19 @@ export const Setup: React.FC = () => {
       if (!parentAccount) {
         throw new Error("Background returned failure when creating account");
       }
-      setParentAccountStore(parentAccount);
 
-      // Create shielded account
-      setCompletionStatusInfo("Generating Shielded Account");
-      const shieldedAccount = await accountManager.saveShieldedAccount(
-        details,
-        parentAccount
-      );
-      setShieldedAccount(shieldedAccount);
+      if (parentAccount.type !== AccountType.ShieldedKeys) {
+        setParentAccountStore(parentAccount);
+        // Create shielded account
+        setCompletionStatusInfo("Generating Shielded Account");
+        const shieldedAccount = await accountManager.saveShieldedAccount(
+          details,
+          parentAccount
+        );
+        setShieldedAccount(shieldedAccount);
+      } else {
+        setShieldedAccount(parentAccount);
+      }
       setCompletionStatus(CompletionStatus.Completed);
       setCompletionStatusInfo("Done!");
     } catch (e) {

--- a/apps/extension/src/background/keyring/handler.ts
+++ b/apps/extension/src/background/keyring/handler.ts
@@ -189,7 +189,7 @@ const handleQueryAccountsMsg: (
     const output =
       query && query.accountId ?
         await service.queryAccountsByParentId(query.accountId)
-        : await service.queryAccounts();
+      : await service.queryAccounts();
 
     return output;
   };

--- a/apps/extension/src/background/keyring/handler.ts
+++ b/apps/extension/src/background/keyring/handler.ts
@@ -16,6 +16,7 @@ import {
   QueryParentAccountsMsg,
   RenameAccountMsg,
   RevealAccountMnemonicMsg,
+  RevealSpendingKeyMsg,
   SaveAccountSecretMsg,
   SetActiveAccountMsg,
   ValidateMnemonicMsg,
@@ -98,6 +99,12 @@ export const getHandler: (service: KeyRingService) => Handler = (service) => {
           env,
           msg as GenDisposableSignerMsg
         );
+      case RevealSpendingKeyMsg:
+        return handleRevealSpendingKeyMsg(service)(
+          env,
+          msg as RevealSpendingKeyMsg
+        );
+
       default:
         throw new Error("Unknown msg type");
     }
@@ -182,7 +189,7 @@ const handleQueryAccountsMsg: (
     const output =
       query && query.accountId ?
         await service.queryAccountsByParentId(query.accountId)
-      : await service.queryAccounts();
+        : await service.queryAccounts();
 
     return output;
   };
@@ -258,5 +265,13 @@ const handleGenDisposableSignerMsg: (
 ) => InternalHandler<GenDisposableSignerMsg> = (service) => {
   return async (_, _msg) => {
     return await service.genDisposableSigner();
+  };
+};
+
+const handleRevealSpendingKeyMsg: (
+  service: KeyRingService
+) => InternalHandler<RevealSpendingKeyMsg> = (service) => {
+  return async (_, msg) => {
+    return await service.revealSpendingKey(msg.accountId);
   };
 };

--- a/apps/extension/src/background/keyring/init.ts
+++ b/apps/extension/src/background/keyring/init.ts
@@ -18,6 +18,7 @@ import {
   QueryParentAccountsMsg,
   RenameAccountMsg,
   RevealAccountMnemonicMsg,
+  RevealSpendingKeyMsg,
   SaveAccountSecretMsg,
   SetActiveAccountMsg,
   ValidateMnemonicMsg,
@@ -39,6 +40,7 @@ export function init(router: Router, service: KeyRingService): void {
   router.registerMessage(CheckDurabilityMsg);
   router.registerMessage(AddLedgerAccountMsg);
   router.registerMessage(RevealAccountMnemonicMsg);
+  router.registerMessage(RevealSpendingKeyMsg);
   router.registerMessage(RenameAccountMsg);
   router.registerMessage(VerifyArbitraryMsg);
   router.registerMessage(GenDisposableSignerMsg);

--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -527,9 +527,6 @@ export class KeyRing {
     if (!account) {
       throw new Error(`Account with address ${address} not found.`);
     }
-    if (account.type === AccountType.ShieldedKeys) {
-      throw new Error(`Cannot use this account type: ${account.type}`);
-    }
     const { id, type } = account;
     await this.setActiveAccount(id, type);
   }

--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -180,7 +180,7 @@ export class KeyRing {
     return JSON.parse(sensitiveData.text).spendingKey;
   }
 
-  // Store validated mnemonic or private key
+  // Store validated mnemonic, private key, or spending key
   public async storeAccountSecret(
     accountSecret: AccountSecret,
     alias: string,

--- a/apps/extension/src/background/keyring/messages.ts
+++ b/apps/extension/src/background/keyring/messages.ts
@@ -29,6 +29,7 @@ enum MessageType {
   ValidateMnemonic = "validate-mnemonic",
   AddLedgerAccount = "add-ledger-account",
   RevealAccountMnemonic = "reveal-account-mnemonic",
+  RevealSpendingKey = "reveal-spending-key",
   RenameAccount = "rename-account",
   QueryAccountDetails = "query-account-details",
   AppendLedgerSignature = "append-ledger-signature",
@@ -75,6 +76,28 @@ export class RevealAccountMnemonicMsg extends Message<string> {
 
   type(): string {
     return RevealAccountMnemonicMsg.type();
+  }
+}
+
+export class RevealSpendingKeyMsg extends Message<string> {
+  public static type(): MessageType {
+    return MessageType.RevealSpendingKey;
+  }
+
+  constructor(public readonly accountId: string) {
+    super();
+  }
+
+  validate(): void {
+    return;
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return RevealSpendingKeyMsg.type();
   }
 }
 

--- a/apps/extension/src/background/keyring/messages.ts
+++ b/apps/extension/src/background/keyring/messages.ts
@@ -8,14 +8,13 @@ import {
 import { Result } from "@namada/utils";
 import { ResponseSign } from "@zondax/ledger-namada";
 import { Message } from "router";
-import { validatePrivateKey, validateProps } from "utils";
+import { validatePrivateKey, validateProps, validateSpendingKey } from "utils";
 import { ROUTE } from "./constants";
 import {
   AccountSecret,
   AccountStore,
   DeleteAccountError,
   MnemonicValidationResponse,
-  ParentAccount,
 } from "./types";
 
 enum MessageType {
@@ -189,6 +188,12 @@ export class SaveAccountSecretMsg extends Message<AccountStore | false> {
         }
         break;
 
+      case "ShieldedKeys":
+        if (!validateSpendingKey(this.accountSecret.spendingKey).ok) {
+          throw new Error("Invalid spending key!");
+        }
+        break;
+
       default:
         throw new Error("Unknown account secret type");
     }
@@ -286,7 +291,7 @@ export class SetActiveAccountMsg extends Message<void> {
 
   constructor(
     public readonly accountId: string,
-    public readonly accountType: ParentAccount
+    public readonly accountType: AccountType
   ) {
     super();
   }
@@ -311,7 +316,7 @@ export class SetActiveAccountMsg extends Message<void> {
 }
 
 export class GetActiveAccountMsg extends Message<
-  { id: string; type: ParentAccount } | undefined
+  { id: string; type: AccountType } | undefined
 > {
   public static type(): MessageType {
     return MessageType.GetActiveAccount;

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -24,7 +24,6 @@ import {
   ActiveAccountStore,
   DeleteAccountError,
   MnemonicValidationResponse,
-  ParentAccount,
   UtilityStore,
 } from "./types";
 
@@ -184,7 +183,7 @@ export class KeyRingService {
     return account?.public ?? null;
   }
 
-  async setActiveAccount(id: string, type: ParentAccount): Promise<void> {
+  async setActiveAccount(id: string, type: AccountType): Promise<void> {
     await this._keyRing.setActiveAccount(id, type);
     await this.broadcaster.updateAccounts();
   }

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -62,6 +62,10 @@ export class KeyRingService {
     return await this._keyRing.revealMnemonic(accountId);
   }
 
+  async revealSpendingKey(accountId: string): Promise<string> {
+    return await this._keyRing.revealSpendingKey(accountId);
+  }
+
   async saveAccountSecret(
     accountSecret: AccountSecret,
     alias: string,

--- a/apps/extension/src/background/keyring/types.ts
+++ b/apps/extension/src/background/keyring/types.ts
@@ -59,7 +59,8 @@ export enum DeleteAccountError {
 
 type Mnemonic = { t: "Mnemonic"; seedPhrase: string[]; passphrase: string };
 type PrivateKey = { t: "PrivateKey"; privateKey: string };
-export type AccountSecret = Mnemonic | PrivateKey;
+type SpendingKey = { t: "ShieldedKeys"; spendingKey: string };
+export type AccountSecret = Mnemonic | PrivateKey | SpendingKey;
 
 export type MnemonicValidationResponse = {
   isValid: boolean;

--- a/apps/extension/src/background/keyring/types.ts
+++ b/apps/extension/src/background/keyring/types.ts
@@ -2,6 +2,8 @@ import { CryptoRecord } from "@namada/sdk/web";
 import { StoredRecord } from "@namada/storage";
 import { AccountType, DerivedAccount, Path } from "@namada/types";
 
+export type AccountSource = "imported" | "generated";
+
 export interface AccountStore extends StoredRecord {
   alias: string;
   address: string;
@@ -12,7 +14,7 @@ export interface AccountStore extends StoredRecord {
   parentId?: string;
   pseudoExtendedKey?: string;
   type: AccountType;
-  source: "imported" | "generated";
+  source: AccountSource;
   timestamp: number;
 }
 
@@ -34,14 +36,9 @@ export type TabStore = {
   timestamp: number;
 };
 
-export type ParentAccount =
-  | AccountType.Mnemonic
-  | AccountType.Ledger
-  | AccountType.PrivateKey;
-
 export type ActiveAccountStore = {
   id: string;
-  type: ParentAccount;
+  type: AccountType;
 };
 
 export type DurablityStore = {

--- a/apps/extension/src/context/AccountContext.tsx
+++ b/apps/extension/src/context/AccountContext.tsx
@@ -1,9 +1,8 @@
-import { DerivedAccount } from "@namada/types";
+import { AccountType, DerivedAccount } from "@namada/types";
 import { LoadingStatus } from "App/types";
 import {
   DeleteAccountMsg,
   GetActiveAccountMsg,
-  ParentAccount,
   RenameAccountMsg,
   RevealAccountMnemonicMsg,
   SetActiveAccountMsg,
@@ -32,10 +31,7 @@ type AccountContextType = {
   fetchAll: () => Promise<DerivedAccount[]>;
   getById: (accountId: string) => DerivedAccount | undefined;
   revealMnemonic: (accountId: string) => Promise<string>;
-  changeActiveAccountId: (
-    accountId: string,
-    accountType: ParentAccount
-  ) => void;
+  changeActiveAccountId: (accountId: string, accountType: AccountType) => void;
 };
 
 // This initializer
@@ -50,10 +46,7 @@ const createAccountContext = (): AccountContextType => ({
   remove: async (_accountId: string) => {},
   rename: async (_id: string, _alias: string) => undefined,
   fetchAll: async () => [],
-  changeActiveAccountId: (
-    _accountId: string,
-    _accountType: ParentAccount
-  ) => {},
+  changeActiveAccountId: (_accountId: string, _accountType: AccountType) => {},
 });
 
 export const AccountContext = createContext<AccountContextType>(
@@ -109,7 +102,7 @@ export const AccountContextWrapper = ({
     if (accountId === activeAccountId && parentAccounts.length > 1) {
       await changeActiveAccountId(
         parentAccounts[0].id,
-        parentAccounts[0].type as ParentAccount
+        parentAccounts[0].type as AccountType
       );
     }
 
@@ -144,7 +137,7 @@ export const AccountContextWrapper = ({
 
   const changeActiveAccountId = async (
     accountId: string,
-    accountType: ParentAccount
+    accountType: AccountType
   ): Promise<void> => {
     setActiveAccountId(accountId);
     await requester.sendMessage(

--- a/apps/extension/src/provider/InjectedNamada.ts
+++ b/apps/extension/src/provider/InjectedNamada.ts
@@ -1,8 +1,8 @@
 import {
-  Account,
   GenDisposableSignerResponse,
   Namada as INamada,
   Signer as ISigner,
+  NamadaKeychainAccount,
   SignArbitraryProps,
   SignArbitraryResponse,
   SignProps,
@@ -32,12 +32,16 @@ export class InjectedNamada implements INamada {
     );
   }
 
-  public async accounts(): Promise<Account[]> {
-    return await InjectedProxy.requestMethod<string, Account[]>("accounts");
+  public async accounts(): Promise<NamadaKeychainAccount[]> {
+    return await InjectedProxy.requestMethod<string, NamadaKeychainAccount[]>(
+      "accounts"
+    );
   }
 
-  public async defaultAccount(): Promise<Account> {
-    return await InjectedProxy.requestMethod<string, Account>("defaultAccount");
+  public async defaultAccount(): Promise<NamadaKeychainAccount> {
+    return await InjectedProxy.requestMethod<string, NamadaKeychainAccount>(
+      "defaultAccount"
+    );
   }
 
   public async updateDefaultAccount(address: string): Promise<void> {

--- a/apps/extension/src/provider/Namada.ts
+++ b/apps/extension/src/provider/Namada.ts
@@ -1,9 +1,9 @@
 import {
-  Account,
   AccountType,
   DerivedAccount,
   GenDisposableSignerResponse,
   Namada as INamada,
+  NamadaKeychainAccount,
   SignArbitraryProps,
   SignArbitraryResponse,
   SignProps,
@@ -57,7 +57,7 @@ export class Namada implements INamada {
     );
   }
 
-  public async accounts(): Promise<Account[] | undefined> {
+  public async accounts(): Promise<NamadaKeychainAccount[] | undefined> {
     const accounts: DerivedAccount[] = [];
     const allAccounts = await this.requester?.sendMessage(
       Ports.Background,
@@ -82,7 +82,7 @@ export class Namada implements INamada {
     return accounts?.map(toPublicAccount);
   }
 
-  public async defaultAccount(): Promise<Account | undefined> {
+  public async defaultAccount(): Promise<NamadaKeychainAccount | undefined> {
     return await this.requester
       ?.sendMessage(Ports.Background, new QueryDefaultAccountMsg())
       .then((defaultAccount) => {

--- a/apps/extension/src/utils/index.ts
+++ b/apps/extension/src/utils/index.ts
@@ -80,6 +80,23 @@ export const filterPrivateKeyPrefix = (privateKey: string): string =>
     privateKey.replace(/^00/, "")
   : privateKey;
 
+const SPENDING_KEY_MAX_LENGTH = 284;
+const SPENDING_KEY_BECH32M_PREFIX = "zsknam1";
+export type SpendingKeyError =
+  | { t: "IncorrectLength"; length: number }
+  | { t: "BadPrefix"; prefix: string };
+
+// Spending key basic validation, ignore empty field
+export const validateSpendingKey = (
+  spendingKey: string
+): Result<null, SpendingKeyError> =>
+  spendingKey.length === 0 ? Result.ok(null)
+  : spendingKey.length !== SPENDING_KEY_MAX_LENGTH ?
+    Result.err({ t: "IncorrectLength", length: 284 })
+  : !/^zsknam1/.test(spendingKey) ?
+    Result.err({ t: "BadPrefix", prefix: SPENDING_KEY_BECH32M_PREFIX })
+  : Result.ok(null);
+
 // Convert any Uint8Arrays in TxProps to string, and construct EncodedTxData
 export const toEncodedTx = (txProps: TxProps): EncodedTxData => ({
   ...txProps,

--- a/apps/extension/src/utils/index.ts
+++ b/apps/extension/src/utils/index.ts
@@ -1,8 +1,8 @@
 import { fromBase64, toBase64 } from "@cosmjs/encoding";
 import {
-  Account,
   AccountType,
   DerivedAccount,
+  NamadaKeychainAccount,
   Path,
   TransferProps,
   TxProps,
@@ -200,11 +200,15 @@ export const parseTransferType = (
  * @param derivedAccount - Derived account type returned from keyring
  * @returns Account type for public API
  */
-export const toPublicAccount = (derivedAccount: DerivedAccount): Account => {
+export const toPublicAccount = (
+  derivedAccount: DerivedAccount
+): NamadaKeychainAccount => {
   const {
+    id,
     alias,
     address,
     type,
+    parentId,
     publicKey,
     owner,
     pseudoExtendedKey,
@@ -212,9 +216,11 @@ export const toPublicAccount = (derivedAccount: DerivedAccount): Account => {
     timestamp,
   } = derivedAccount;
   const isShielded = type === AccountType.ShieldedKeys;
-  const account: Account = {
+  const account: NamadaKeychainAccount = {
+    id,
     alias,
     address,
+    parentId,
     type,
   };
   if (isShielded) {

--- a/apps/namadillo/src/App/SwitchAccount/SwitchAccountPanel.tsx
+++ b/apps/namadillo/src/App/SwitchAccount/SwitchAccountPanel.tsx
@@ -44,7 +44,6 @@ export const SwitchAccountPanel = (): JSX.Element => {
           </header>
           <div className="overflow-auto dark-scrollbar pb-5">
             {data
-              // TODO: How can this be fixed?
               ?.filter((i) => !i.parentId)
               .map(({ alias, address }) => (
                 <button

--- a/apps/namadillo/src/App/SwitchAccount/SwitchAccountPanel.tsx
+++ b/apps/namadillo/src/App/SwitchAccount/SwitchAccountPanel.tsx
@@ -1,5 +1,4 @@
 import { Checkbox, Modal } from "@namada/components";
-import { AccountType } from "@namada/types";
 import { ModalTransition } from "App/Common/ModalTransition";
 import {
   accountsAtom,
@@ -45,7 +44,8 @@ export const SwitchAccountPanel = (): JSX.Element => {
           </header>
           <div className="overflow-auto dark-scrollbar pb-5">
             {data
-              ?.filter((i) => i.type !== AccountType.ShieldedKeys)
+              // TODO: How can this be fixed?
+              ?.filter((i) => !i.parentId)
               .map(({ alias, address }) => (
                 <button
                   key={alias}

--- a/apps/namadillo/src/atoms/accounts/services.ts
+++ b/apps/namadillo/src/atoms/accounts/services.ts
@@ -1,21 +1,25 @@
 import { Balance, DefaultApi } from "@namada/indexer-client";
-import { Account } from "@namada/types";
+import { NamadaKeychainAccount } from "@namada/types";
 import { NamadaKeychain } from "hooks/useNamadaKeychain";
 
-export const fetchAccounts = async (): Promise<readonly Account[]> => {
+export const fetchAccounts = async (): Promise<
+  readonly NamadaKeychainAccount[]
+> => {
   const namada = await new NamadaKeychain().get();
   const result = await namada?.accounts();
   return result || [];
 };
 
-export const fetchDefaultAccount = async (): Promise<Account | undefined> => {
+export const fetchDefaultAccount = async (): Promise<
+  NamadaKeychainAccount | undefined
+> => {
   const namada = await new NamadaKeychain().get();
   return await namada?.defaultAccount();
 };
 
 export const fetchAccountBalance = async (
   api: DefaultApi,
-  account: Account
+  account: NamadaKeychainAccount
 ): Promise<Balance[]> => {
   return (await api.apiV1AccountAddressGet(account.address)).data;
 };

--- a/packages/components/src/RadioGroup.tsx
+++ b/packages/components/src/RadioGroup.tsx
@@ -7,9 +7,9 @@ const radioGroup = tv({
     wrapper:
       "inline-flex bg-black rounded-[60px] p-0.5 overflow-hidden mx-auto",
     fieldset: "flex relative w-full h-full",
-    container: "flex text-neutral-600 min-w-30 text-center",
+    container: "flex text-neutral-600 min-w-28 text-center",
     label:
-      "cursor-pointer text-xs font-bold px-6 py-1.5 relative w-full select-none active:top-px",
+      "cursor-pointer text-xs font-bold px-0 py-1.5 relative w-full select-none active:top-px",
     input: "unset [&:checked+span]:text-white",
     text: "relative transition-color duration-100 ease-out z-10 select-none",
     indicator: clsx(
@@ -86,9 +86,9 @@ export const RadioGroup = ({
                 value={option.value.toString()}
                 checked={value ? option.value === value : idx === 0}
                 ref={(ref) =>
-                  option.value === value || (!value && idx === 0)
-                    ? (initialSelectedRadio.current = ref)
-                    : null
+                  option.value === value || (!value && idx === 0) ?
+                    (initialSelectedRadio.current = ref)
+                  : null
                 }
                 onChange={(e) =>
                   _onChange(e.currentTarget, option.value.toString())

--- a/packages/sdk/src/keys/keys.ts
+++ b/packages/sdk/src/keys/keys.ts
@@ -216,6 +216,27 @@ export class Keys {
   }
 
   /**
+   * Given a bech32m-encoded extended spending key, return viewing and proof-gen keys
+   * @param spendingKey - string
+   * @returns ShieldedKeys
+   */
+  shieldedKeysFromSpendingKey(spendingKey: string): ShieldedKeys {
+    const extendedSpendingKey = ExtendedSpendingKey.from_string(spendingKey);
+    const pseudoExtendedKey = extendedSpendingKey
+      .to_pseudo_extended_key()
+      .encode();
+    const viewingKey = extendedSpendingKey.to_viewing_key().encode();
+    const address = extendedSpendingKey.to_default_address().encode();
+
+    return {
+      address,
+      viewingKey,
+      pseudoExtendedKey,
+      spendingKey,
+    };
+  }
+
+  /**
    * Generate a disposable transparent keypair
    * @returns Keys and address
    */

--- a/packages/shared/lib/src/types/masp.rs
+++ b/packages/shared/lib/src/types/masp.rs
@@ -107,6 +107,22 @@ impl ExtendedSpendingKey {
         Ok(ExtendedSpendingKey(xsk))
     }
 
+    pub fn from_string(xsk: String) -> Result<ExtendedSpendingKey, String> {
+        let xsk= NamadaExtendedSpendingKey::from_str(&xsk).map_err(|err| err.to_string())?;
+
+        Ok(ExtendedSpendingKey(xsk))
+    }
+
+    pub fn to_viewing_key(&self) -> Result<ExtendedViewingKey, String> {
+        ExtendedViewingKey::new(&self.0.to_viewing_key().to_bytes())
+    }
+
+    pub fn to_default_address(&self) -> PaymentAddress {
+        let xsk = zip32::ExtendedSpendingKey::from(self.0);
+        let xfvk = zip32::ExtendedFullViewingKey::from(&xsk);
+        PaymentAddress(NamadaPaymentAddress::from(xfvk.default_address().1))
+    }
+
     pub fn to_proof_generation_key(&self) -> ProofGenerationKey {
         let xsk = zip32::ExtendedSpendingKey::from(self.0);
         let pgk = xsk

--- a/packages/types/src/account.ts
+++ b/packages/types/src/account.ts
@@ -57,6 +57,11 @@ export type Account = Pick<
   viewingKey?: string;
 };
 
+export type NamadaKeychainAccount = Account & {
+  id: string;
+  parentId?: string;
+};
+
 /**
  * ViewingKey with optional birthday
  */

--- a/packages/types/src/namada.ts
+++ b/packages/types/src/namada.ts
@@ -1,4 +1,4 @@
-import { Account } from "./account";
+import { NamadaKeychainAccount } from "./account";
 import {
   GenDisposableSignerResponse,
   SignArbitraryResponse,
@@ -29,11 +29,11 @@ export type BalancesProps = {
 };
 
 export interface Namada {
-  accounts(): Promise<readonly Account[] | undefined>;
+  accounts(): Promise<readonly NamadaKeychainAccount[] | undefined>;
   connect(chainId?: string): Promise<void>;
   disconnect(chainId?: string): Promise<void>;
   isConnected(chainId?: string): Promise<boolean | undefined>;
-  defaultAccount(): Promise<Account | undefined>;
+  defaultAccount(): Promise<NamadaKeychainAccount | undefined>;
   updateDefaultAccount(address: string): Promise<void>;
   sign(props: SignProps): Promise<Uint8Array[] | undefined>;
   signArbitrary(


### PR DESCRIPTION
Resolves #1720

- [x] User can import Spending Key (similar to Private Key import)
- [x] User can view Spending Key
- [x] User is prompted to authenticate to view Spending Key (similar to View Seed Phrase)

### Testing

__NOTE__ I think it's a good idea while running this locally, to take an existing dev extension installation based on `main` (or older), then loading it with this branch, just to simulate an upgrade. I didn't change any values in storage for this branch, but I think it's good to confirm the logic in place is correct for all existing accounts! That's a good practice for any Keychain update.

We want to make sure that the viewing key (and default address) we _derived_ from a mnemonic matches what is imported when we import the spending key directly. Also, and most critically, we need to ensure that this works with previous extension data in place, and doesn't affect the normal account flows in any way!

Since the PR introduces "Access Spending Key", we can test with any mnemonic import:

1. Import mnemonic
2. In Keychain popup -> View Keys -> `Access Spending Key` - copy this value and make note of Viewing key and payment address (default address)
3. Delete this account from keychain (avoiding duplicates)
4. Import Spending Key
5. Verify that Viewing Key & Payment address are the same (since we are using deterministic payment addresses for now)

#### Testing accounts

Here are a few accounts we can test with:
```
Mnemonic code: equip will roof matter pink blind book anxiety banner elbow sun young
```

- Using HD derivation path `m/32'/877'/0'`
  - Viewing key: `zvknam1q080khy2qqqqpqp3qmymr4d28kgmwy0frpv89csgpd0azueh2deuu6t97cztywgh3mgkp4zhvjfxy2zjuk6y7j5w45f2mk94cnd4kqsndjtp6e7ezv59rm8czavrwjpw0dqtmmq6lrfnvrj57qspy2vlrv7gkmw3zktr5yyplmmp5hsf3reqnnuyfdt30zpkxzjdkq9t3d79z2cwx7y99dtdtrr48n9q7wphhwqxg9lxnass4njj6v09j48atd49kfj589ej5rk0gpswcm8qf`
  - Spending key: `zsknam1q080khy2qqqqpqp3qmymr4d28kgmwy0frpv89csgpd0azueh2deuu6t97cztywgh36uz5vhuw5wg5en4vlprudwkshg9t435c9stne4dvt64n02z2susqewexquafzcsplgd37d5wzta4ypmfamx43vxsde2p63r2y34xngflmmp5hsf3reqnnuyfdt30zpkxzjdkq9t3d79z2cwx7y99dtdtrr48n9q7wphhwqxg9lxnass4njj6v09j48atd49kfj589ej5rk0gpsc8tuen`
- Using HD derivation path `m/32'/877'/1'`
  - Viewing key: `zvknam1q080khy2qyqqpqr5w2asdwt4knzw92c5zenpz0ccj2f6m8u4t670wgja23hh38xwc07qjt96pze42mhyw3wrxglj2anjwffafl3ggkuutpwde7rftp7ekkzdznm577wdrkheacgglrqpfasnyw7ecknqpqzzcack0ng6vny33nt7z0hyw647g8gw9sr2585732d7cnfvmvkwqsd3efw96haa4k2pnmfmyh2rf9uknstm6dzwe97nkqw3nxltzj9pwrm06zmzqxlwt3g45ts0e`
  - Spending key: `zsknam1q080khy2qyqqpqr5w2asdwt4knzw92c5zenpz0ccj2f6m8u4t670wgja23hh38xwcw08c7cp64hauuf8uv44d3uy4gh6zwr9c6cegsy66exmgah2rlqseydkzl5rydtz3sr6dtm0yxhd4eagmre8vjrpyppzjpcm98ynx6gz3nt7z0hyw647g8gw9sr2585732d7cnfvmvkwqsd3efw96haa4k2pnmfmyh2rf9uknstm6dzwe97nkqw3nxltzj9pwrm06zmzqxlwt3g47ty63`
- Using HD derivation path `m/32'/877'/2'`
  - Viewing key: `zvknam1q080khy2qgqqpqrp6vhyc2d39vpn5rty473yzycelycdlmlzxkj6jyevtw4x4ycm2jujg3463hx2nlgwuw45yfgl2dr86te7u4t4s6p57fzuvsxmkumk8mwpafv8cfdqcalrt9h2vngqag3q2hae0mp6ptv3zdgyjh0ycv38j07f0ckn9mkszd4kc6t3lpn37engast5lct67ef6dg3uezqzmxpmps43xlvgfjkxhlhd07k8c5klqhl0ymxpk0wlvr22wnshnqvuc0crg6tme`
  - Spending key: `zsknam1q080khy2qgqqpqrp6vhyc2d39vpn5rty473yzycelycdlmlzxkj6jyevtw4x4ycm2smstj8dh97jssumgnz6zx9me40fz4yvfgv26jp20anf0yct2p3smjaqtydk6zd3u96c5v4y95e4dplygxzywn8m8nknfu52kjcf6lqgj07f0ckn9mkszd4kc6t3lpn37engast5lct67ef6dg3uezqzmxpmps43xlvgfjkxhlhd07k8c5klqhl0ymxpk0wlvr22wnshnqvuc0cd753f6`

### Screenshots

Spending Key auth prompt:
![image](https://github.com/user-attachments/assets/85f6cca5-0fd9-4ad9-87f5-c99d0bc5a812)

Spending Key view (Pending final copy):
![image](https://github.com/user-attachments/assets/8161f30d-3f98-45b9-9b04-6786b2800b56)

Button appears before `Viewing Key` and should only display on non-Ledger shielded accounts:
![image](https://github.com/user-attachments/assets/c84a9b7f-0b7e-4c10-9909-d58e5ed684ff)

Spending Key Import - New Tab:
![image](https://github.com/user-attachments/assets/92d70763-c9e8-463c-b0f5-29acabc7a0d9)
