### PR TITLE
feat: filter only enabled assets

### DIFF
--- a/apps/namadillo/src/atoms/integrations/functions.ts
+++ b/apps/namadillo/src/atoms/integrations/functions.ts
@@ -436,3 +436,7 @@ export const addLocalnetToRegistry = (config: LocalnetToml): void => {
 
   mainnetChains.push(localChain);
 };
+
+export const getDenomFromIbcTrace = (ibcAddress: string): string => {
+  return ibcAddress.replaceAll(/(transfer\/|channel-\d\/)*/gi, "");
+};

--- a/apps/namadillo/src/atoms/integrations/services.ts
+++ b/apps/namadillo/src/atoms/integrations/services.ts
@@ -10,6 +10,7 @@ import {
   StdFee,
 } from "@cosmjs/stargate";
 import {
+  IbcRateLimit,
   WrapperTransaction,
   WrapperTransactionExitCodeEnum,
 } from "@namada/indexer-client";
@@ -400,4 +401,10 @@ export const transactionTypeToEventName = (
     case "IbcToTransparent":
       return "IbcTransfer";
   }
+};
+
+export const fetchIbcRateLimits = async (): Promise<IbcRateLimit[]> => {
+  const api = getIndexerApi();
+  const response = await api.apiV1IbcRateLimitsGet();
+  return response.data;
 };


### PR DESCRIPTION
This PR filters all the available assets of a user to a list of enabled tokens. This list is fetched from `api/v1/ibc/rate-limits` endpoint that provides all the rate limits for enabled tokens. 