### PR TITLE
chore: bump indexer client to 2.2.0

### DIFF
--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -11,7 +11,7 @@
     "@cosmjs/encoding": "^0.32.3",
     "@keplr-wallet/types": "^0.12.136",
     "@namada/chain-registry": "^1.0.0",
-    "@namada/indexer-client": "2.1.0",
+    "@namada/indexer-client": "2.2.0",
     "@tailwindcss/container-queries": "^0.1.1",
     "@tanstack/query-core": "^5.40.0",
     "@tanstack/react-query": "^5.40.0",

--- a/apps/namadillo/src/atoms/fees/services.ts
+++ b/apps/namadillo/src/atoms/fees/services.ts
@@ -1,29 +1,9 @@
 import {
   DefaultApi,
   GasEstimate,
-  GasLimitTableInnerTxKindEnum,
   GasPriceTableInner,
 } from "@namada/indexer-client";
 import { TxKind } from "types/txKind";
-
-const legacyGasTableMap: Record<GasLimitTableInnerTxKindEnum, TxKind> = {
-  revealPk: "RevealPk",
-  bond: "Bond",
-  unbond: "Unbond",
-  redelegation: "Redelegate",
-  claimRewards: "ClaimRewards",
-  voteProposal: "VoteProposal",
-  transparentTransfer: "TransparentTransfer",
-  shieldingTransfer: "ShieldingTransfer",
-  shieldedTransfer: "ShieldedTransfer",
-  unshieldingTransfer: "UnshieldingTransfer",
-  ibcMsgTransfer: "IbcTransfer",
-  withdraw: "Withdraw",
-  initProposal: "Unknown",
-  changeMetadata: "Unknown",
-  changeCommission: "Unknown",
-  unknown: "Unknown",
-};
 
 export const fetchGasEstimate = async (
   api: DefaultApi,
@@ -52,23 +32,6 @@ export const fetchGasEstimate = async (
     return (await api.apiV1GasEstimateGet(...params)).data;
   } catch (e) {
     console.error("Failed to fetch gas estimate from indexer", e);
-  }
-
-  // if fails, try to fetch from the legacy endpoint
-  try {
-    const legacyValues = (await api.apiV1GasGet()).data;
-    const sum = legacyValues.reduce((sum, item) => {
-      const txKind: TxKind = legacyGasTableMap[item.txKind] ?? "Unknown";
-      return sum + item.gasLimit * (counter(txKind) ?? 0);
-    }, 0);
-    return {
-      min: sum,
-      avg: sum * 1.1,
-      max: sum * 1.2,
-      totalEstimates: 0,
-    };
-  } catch (e) {
-    console.error("Failed to fetch gas table limit from indexer", e);
   }
 
   // otherwise, returns a generic default value

--- a/apps/namadillo/src/compatibility.json
+++ b/apps/namadillo/src/compatibility.json
@@ -1,4 +1,4 @@
 {
   "keychain": "0.4.x",
-  "indexer": "2.1.x"
+  "indexer": "2.2.x"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3831,12 +3831,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@namada/indexer-client@npm:2.1.0":
-  version: 2.1.0
-  resolution: "@namada/indexer-client@npm:2.1.0"
+"@namada/indexer-client@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@namada/indexer-client@npm:2.2.0"
   dependencies:
     axios: "npm:^1.6.1"
-  checksum: 10c0/97c17d4193b2448013c995b4f801d9155efee090f7a9bbf21aa1f50251afea9c61f6d808115c0002ed76aefc16d6b9597ce9f5dca7254833c051d38e8ebe024c
+  checksum: 10c0/146740e9291170e8efad519b83988939a4e86f3506913a3ec25d2a6780281e92775e640782e0554c83e494b444d89909194d68de749b42dfca255712bfcc32e6
   languageName: node
   linkType: hard
 
@@ -3878,7 +3878,7 @@ __metadata:
     "@eslint/js": "npm:^9.9.1"
     "@keplr-wallet/types": "npm:^0.12.136"
     "@namada/chain-registry": "npm:^1.0.0"
-    "@namada/indexer-client": "npm:2.1.0"
+    "@namada/indexer-client": "npm:2.2.0"
     "@playwright/test": "npm:^1.24.1"
     "@svgr/webpack": "npm:^6.5.1"
     "@tailwindcss/container-queries": "npm:^0.1.1"


### PR DESCRIPTION
API was removed
