### PR TITLE
fix: allow predefining transparent source for transfers

### DIFF
--- a/apps/namadillo/src/App/AccountOverview/TransparentOverviewPanel.tsx
+++ b/apps/namadillo/src/App/AccountOverview/TransparentOverviewPanel.tsx
@@ -97,7 +97,7 @@ const TransparentTokensTable = ({
               <span className="text-xs">NAM Transfer Locked</span>
             : [
                 {
-                  url: `${routes.transfer}?${params.asset}=${originalAddress}`,
+                  url: `${routes.transfer}?${params.asset}=${originalAddress}&${params.shielded}=0`,
                   icon: <IoSwapHorizontal className="h-[20px] w-[20px]" />,
                 },
                 {

--- a/apps/namadillo/src/App/Masp/MaspShield.tsx
+++ b/apps/namadillo/src/App/Masp/MaspShield.tsx
@@ -94,7 +94,7 @@ export const MaspShield: React.FC = () => {
         }
         return newParams;
       },
-      { replace: false }
+      { replace: true }
     );
   };
 

--- a/apps/namadillo/src/App/Masp/MaspUnshield.tsx
+++ b/apps/namadillo/src/App/Masp/MaspUnshield.tsx
@@ -91,7 +91,7 @@ export const MaspUnshield: React.FC = () => {
         }
         return newParams;
       },
-      { replace: false }
+      { replace: true }
     );
   };
 

--- a/apps/namadillo/src/App/NamadaTransfer/NamadaTransfer.tsx
+++ b/apps/namadillo/src/App/NamadaTransfer/NamadaTransfer.tsx
@@ -31,12 +31,14 @@ import { NamadaTransferTopHeader } from "./NamadaTransferTopHeader";
 export const NamadaTransfer: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [displayAmount, setDisplayAmount] = useState<BigNumber | undefined>();
-  const [shielded, setShielded] = useState<boolean>(true);
   const [customAddress, setCustomAddress] = useState<string>("");
   const [generalErrorMessage, setGeneralErrorMessage] = useState("");
   const [currentStatus, setCurrentStatus] = useState("");
   const [currentStatusExplanation, setCurrentStatusExplanation] = useState("");
   const [completedAt, setCompletedAt] = useState<Date | undefined>();
+
+  const shieldedParam = searchParams.get(params.shielded);
+  const shielded = shieldedParam ? shieldedParam === "1" : true;
 
   const rpcUrl = useAtomValue(rpcUrlAtom);
   const chainParameters = useAtomValue(chainParametersAtom);
@@ -98,6 +100,17 @@ export const NamadaTransfer: React.FC = () => {
   const isSourceShielded = isShieldedAddress(source);
   const isTargetShielded = isShieldedAddress(target);
 
+  const onChangeShielded = (isShielded: boolean): void => {
+    setSearchParams(
+      (currentParams) => {
+        const newParams = new URLSearchParams(currentParams);
+        newParams.set(params.shielded, isShielded ? "1" : "0");
+        return newParams;
+      },
+      { replace: true }
+    );
+  };
+
   const onChangeSelectedAsset = (address?: Address): void => {
     setSearchParams(
       (currentParams) => {
@@ -109,7 +122,7 @@ export const NamadaTransfer: React.FC = () => {
         }
         return newParams;
       },
-      { replace: false }
+      { replace: true }
     );
   };
 
@@ -177,7 +190,7 @@ export const NamadaTransfer: React.FC = () => {
           selectedAssetAddress,
           onChangeSelectedAsset,
           isShielded: shielded,
-          onChangeShielded: setShielded,
+          onChangeShielded,
           amount: displayAmount,
           onChangeAmount: setDisplayAmount,
         }}

--- a/apps/namadillo/src/App/routes.ts
+++ b/apps/namadillo/src/App/routes.ts
@@ -43,4 +43,5 @@ export const routes = {
 
 export const params = {
   asset: "asset",
+  shielded: "shielded",
 } as const;


### PR DESCRIPTION
Allow predefining transparent source for transfers

It fixes the transfer button on Overview

ref: https://github.com/anoma/namada-interface/issues/1612

![Screenshot 2025-02-26 at 11 21 21](https://github.com/user-attachments/assets/baf81d92-d9be-427a-b563-a4f7d919e811)
