### PR TITLE
fix: Signing without shielded account present

### DIFF
--- a/apps/extension/src/Approvals/Approvals.tsx
+++ b/apps/extension/src/Approvals/Approvals.tsx
@@ -37,6 +37,7 @@ export type ApprovalDetails = {
   accountType: AccountType;
   msgId: string;
   txDetails: TxDetails[];
+  txType?: string;
 };
 
 export type SignArbitraryDetails = {

--- a/apps/extension/src/Approvals/ConfirmSignTx.tsx
+++ b/apps/extension/src/Approvals/ConfirmSignTx.tsx
@@ -16,7 +16,7 @@ type Props = {
 };
 
 export const ConfirmSignTx: React.FC<Props> = ({ details }) => {
-  const { msgId, signer } = details;
+  const { msgId, signer, txType } = details;
 
   const navigate = useNavigate();
   const requester = useRequester();
@@ -41,12 +41,12 @@ export const ConfirmSignTx: React.FC<Props> = ({ details }) => {
           throw new Error("Invalid password!");
         }
 
-        // TODO: ideally we should only calling this for Unshielding and Shielded Transfers,
-        // it should not break anything it's just unnecessary computation
-        await requester.sendMessage(
-          Ports.Background,
-          new SignMaspMsg(msgId, signer)
-        );
+        if (txType === "Unshielding" || txType === "Shielded") {
+          await requester.sendMessage(
+            Ports.Background,
+            new SignMaspMsg(msgId, signer)
+          );
+        }
 
         await requester.sendMessage(
           Ports.Background,


### PR DESCRIPTION
If user has a "stranded" transparent account (for example, they imported a mnemonic, but did not specify a unique zip32 path and detection prevented the duplicate shielded account from being saved), it fails to sign, as it _always_ sends a `SignMaspMsg`.

- Perform detection of commitment type (if it's a `TxType.Transfer`), and check before invoking masp signing.
  - Enable only for `Unshielding` and `Shielded` transfers