### PR TITLE
feat: limit ibc withdrawal of assets only for the same chain

### DIFF
--- a/apps/namadillo/src/App/Transfer/SelectedChain.tsx
+++ b/apps/namadillo/src/App/Transfer/SelectedChain.tsx
@@ -45,8 +45,11 @@ export const SelectedChain = ({
       {(!wallet || !chain) && (
         <span className={selectorClassList}>
           <EmptyResourceIcon className="w-7" />
-          Select chain
-          <GoChevronDown className="text-sm" />
+          {onClick ?
+            <>
+              Select chain <GoChevronDown className="text-sm" />
+            </>
+          : <span className="bg-neutral-900 w-20 h-7 rounded-sm opacity-30" />}
         </span>
       )}
       {wallet && chain && (

--- a/apps/namadillo/src/App/Transfer/__tests__/TransferDestination.test.tsx
+++ b/apps/namadillo/src/App/Transfer/__tests__/TransferDestination.test.tsx
@@ -16,7 +16,14 @@ import { parseChainInfo } from "../common";
 describe("Component: TransferDestination", () => {
   it("should render the component with the default props", () => {
     render(<TransferDestination />);
-    expect(screen.getByText(/select chain/i)).toBeInTheDocument();
+    const chainButton = screen.queryByText(/select chain/i);
+    expect(chainButton).not.toBeInTheDocument();
+  });
+
+  it("should render the component with chain selectable", () => {
+    render(<TransferDestination openChainSelector={jest.fn()} />);
+    const chainButton = screen.getByText(/select chain/i);
+    expect(chainButton).toBeInTheDocument();
   });
 
   it("should render the TabSelector for shielded/transparent when onChangeShielded is provided", () => {

--- a/apps/namadillo/src/App/Transfer/__tests__/TransferSource.test.tsx
+++ b/apps/namadillo/src/App/Transfer/__tests__/TransferSource.test.tsx
@@ -11,10 +11,22 @@ import { walletMock } from "../__mocks__/providers";
 describe("Component: TransferSource", () => {
   it("should render the component with the default props", () => {
     render(
-      <TransferSource isConnected={false} openProviderSelector={jest.fn()} />
+      <TransferSource
+        isConnected={false}
+        openProviderSelector={jest.fn()}
+        openChainSelector={jest.fn()}
+      />
     );
     expect(screen.getByText("Connect Wallet")).toBeInTheDocument();
     expect(screen.getByText(/select chain/i)).toBeInTheDocument();
+  });
+
+  it("should not render chain selector when openChainSelector is not defined", () => {
+    render(
+      <TransferSource isConnected={false} openProviderSelector={jest.fn()} />
+    );
+    const selectChain = screen.queryByText(/selected chain/i);
+    expect(selectChain).not.toBeInTheDocument();
   });
 
   const setup = (props: Partial<TransferSourceProps> = {}): void => {

--- a/apps/namadillo/src/atoms/integrations/functions.ts
+++ b/apps/namadillo/src/atoms/integrations/functions.ts
@@ -440,3 +440,18 @@ export const addLocalnetToRegistry = (config: LocalnetToml): void => {
 export const getDenomFromIbcTrace = (ibcAddress: string): string => {
   return ibcAddress.replaceAll(/(transfer\/|channel-\d+\/)*/gi, "");
 };
+
+export const chainHasFeeTokenDenom = (chain: Chain, denom: string): boolean => {
+  return !!chain.fees?.fee_tokens?.some(
+    (feeToken) => feeToken.denom.toLowerCase() === denom.toLowerCase()
+  );
+};
+
+export const searchChainByDenom = (denom: string): Chain | undefined => {
+  return getKnownChains(false).find(
+    (chainRegistry: ChainRegistryEntry | undefined) => {
+      if (!chainRegistry) return false;
+      return chainHasFeeTokenDenom(chainRegistry.chain, denom);
+    }
+  )?.chain;
+};


### PR DESCRIPTION
The target chain on Withdrawal should always be the original chain of the selected asset.

Fixes #1747 