### PR TITLE
Revert change to SwitchAccountPanel filter

### DIFF
--- a/apps/namadillo/src/App/SwitchAccount/SwitchAccountPanel.tsx
+++ b/apps/namadillo/src/App/SwitchAccount/SwitchAccountPanel.tsx
@@ -1,5 +1,4 @@
 import { Checkbox, Modal } from "@namada/components";
-import { AccountType } from "@namada/types";
 import { ModalTransition } from "App/Common/ModalTransition";
 import {
   accountsAtom,
@@ -45,7 +44,7 @@ export const SwitchAccountPanel = (): JSX.Element => {
           </header>
           <div className="overflow-auto dark-scrollbar pb-5">
             {data
-              ?.filter((i) => i.type !== AccountType.ShieldedKeys)
+              ?.filter((i) => !i.parentId)
               .map(({ alias, address }) => (
                 <button
                   key={alias}


### PR DESCRIPTION
This PR simply reverts the change to the `SwitchAccountPanel` filter used on latest Namadillo release.

- Spending key imports should display and able to be switched to in Namadillo