### PR TITLE
feat: adding masp asset rewards panel info

### DIFF
--- a/apps/namadillo/src/App/Masp/MaspLayout.tsx
+++ b/apps/namadillo/src/App/Masp/MaspLayout.tsx
@@ -2,8 +2,10 @@ import { ConnectPanel } from "App/Common/ConnectPanel";
 import { MaspContainer } from "App/Common/MaspContainer";
 import { PageWithSidebar } from "App/Common/PageWithSidebar";
 import { Sidebar } from "App/Layout/Sidebar";
+import { MaspAssetRewards } from "App/Sidebars/MaspAssetRewards";
 import { ShieldAllBanner } from "App/Sidebars/ShieldAllBanner";
 import { shieldedBalanceAtom } from "atoms/balance";
+import { applicationFeaturesAtom } from "atoms/settings";
 import { useUserHasAccount } from "hooks/useIsAuthenticated";
 import { useAtomValue } from "jotai";
 import { useEffect } from "react";
@@ -12,6 +14,7 @@ import { LearnAboutMasp } from "./LearnAboutMasp";
 
 export const MaspLayout: React.FC = () => {
   const userHasAccount = useUserHasAccount();
+  const features = useAtomValue(applicationFeaturesAtom);
 
   const { refetch: refetchShieldedBalance } = useAtomValue(shieldedBalanceAtom);
 
@@ -29,6 +32,7 @@ export const MaspLayout: React.FC = () => {
         <Outlet />
       </MaspContainer>
       <Sidebar>
+        {features.shieldingRewardsEnabled && <MaspAssetRewards />}
         <ShieldAllBanner />
         <LearnAboutMasp />
       </Sidebar>

--- a/apps/namadillo/src/App/Sidebars/MaspAssetRewards.tsx
+++ b/apps/namadillo/src/App/Sidebars/MaspAssetRewards.tsx
@@ -1,0 +1,65 @@
+import { Asset } from "@chain-registry/types";
+import { Panel, SkeletonLoading } from "@namada/components";
+import { formatPercentage } from "@namada/utils";
+import { AssetImage } from "App/Transfer/AssetImage";
+import { maspRewardsAtom } from "atoms/chain";
+import BigNumber from "bignumber.js";
+import clsx from "clsx";
+import { useAtomValue } from "jotai";
+
+type MaspAssetRewardsItemProps = {
+  asset: Asset;
+  percentage: BigNumber;
+};
+
+const MaspAssetRewardsItem = ({
+  asset,
+  percentage,
+}: MaspAssetRewardsItemProps): JSX.Element => {
+  return (
+    <div
+      className={clsx(
+        "bg-neutral-800 rounded-sm py-2 px-2.5 flex items-center justify-between text-yellow"
+      )}
+    >
+      <span className="flex gap-4 items-center">
+        <i className="w-6">
+          <AssetImage asset={asset} />
+        </i>
+        {asset.symbol}
+      </span>
+      <span>{formatPercentage(percentage)}</span>
+    </div>
+  );
+};
+
+export const MaspAssetRewards = (): JSX.Element => {
+  const rewards = useAtomValue(maspRewardsAtom);
+  return (
+    <Panel className={clsx("flex flex-col pt-2 pb-5 px-2")}>
+      <h2 className="uppercase text-sm text-yellow text-center">
+        MASP Asset Rewards
+      </h2>
+      <div className="flex-1 mt-3">
+        {rewards.isLoading && (
+          <div className="flex flex-col gap-1">
+            <SkeletonLoading height="40px" width="100%" />
+            <SkeletonLoading height="40px" width="100%" />
+            <SkeletonLoading height="40px" width="100%" />
+          </div>
+        )}
+        <ul className="flex flex-col gap-1">
+          {rewards.data &&
+            rewards.data.map((reward) => (
+              <li key={reward.asset.base}>
+                <MaspAssetRewardsItem
+                  asset={reward.asset}
+                  percentage={reward.maxRewardRate}
+                />
+              </li>
+            ))}
+        </ul>
+      </div>
+    </Panel>
+  );
+};

--- a/apps/namadillo/src/atoms/chain/atoms.ts
+++ b/apps/namadillo/src/atoms/chain/atoms.ts
@@ -3,7 +3,6 @@ import namadaAssets from "@namada/chain-registry/namada/assetlist.json";
 import namada from "@namada/chains/chains/namada";
 import { IbcToken, NativeToken } from "@namada/indexer-client";
 import { indexerApiAtom } from "atoms/api";
-import { getDenomFromIbcTrace } from "atoms/integrations";
 import {
   defaultServerConfigAtom,
   indexerUrlAtom,
@@ -12,7 +11,6 @@ import {
 import { queryDependentFn } from "atoms/utils";
 import BigNumber from "bignumber.js";
 import * as osmosis from "chain-registry/mainnet/osmosis";
-import { findAssetByDenom } from "integrations/utils";
 import { atom } from "jotai";
 import { atomWithQuery } from "jotai-tanstack-query";
 import {
@@ -22,7 +20,7 @@ import {
   ChainStatus,
   MaspAssetRewards,
 } from "types";
-import { findAssetByToken, unknownAsset } from "utils/assets";
+import { findAssetByToken } from "utils/assets";
 import { calculateUnbondingPeriod } from "./functions";
 import {
   fetchChainParameters,
@@ -148,21 +146,7 @@ export const maspRewardsAtom = atomWithQuery((get) => {
   return {
     queryKey: ["masp-rewards", chain],
     ...queryDependentFn(async (): Promise<MaspAssetRewards[]> => {
-      const rewards = await fetchMaspRewards();
-      const existingRewards: MaspAssetRewards[] = rewards
-        .filter((r) => r.max_reward_rate > 0)
-        .map((r) => {
-          const denom = getDenomFromIbcTrace(r.name);
-          const asset = findAssetByDenom(denom) ?? unknownAsset(denom);
-          return {
-            asset,
-            kdGain: new BigNumber(r.kd_gain),
-            kpGain: new BigNumber(r.kp_gain),
-            lockedAmountTarget: new BigNumber(r.locked_amount_target),
-            maxRewardRate: new BigNumber(r.max_reward_rate),
-          };
-        });
-      return existingRewards;
+      return await fetchMaspRewards();
     }, [chain]),
   };
 });

--- a/apps/namadillo/src/atoms/chain/services.ts
+++ b/apps/namadillo/src/atoms/chain/services.ts
@@ -5,6 +5,7 @@ import {
   Parameters,
 } from "@namada/indexer-client";
 import { getSdkInstance } from "utils/sdk";
+import { MaspTokenRewards } from "../../../../../packages/sdk/src/rpc";
 
 export const fetchRpcUrlFromIndexer = async (
   api: DefaultApi
@@ -29,4 +30,9 @@ export const fetchChainTokens = async (
 export const clearShieldedContext = async (chainId: string): Promise<void> => {
   const sdk = await getSdkInstance();
   await sdk.getMasp().clearShieldedContext(chainId);
+};
+
+export const fetchMaspRewards = async (): Promise<MaspTokenRewards[]> => {
+  const sdk = await getSdkInstance();
+  return await sdk.rpc.globalShieldedRewardForTokens();
 };

--- a/apps/namadillo/src/atoms/chain/services.ts
+++ b/apps/namadillo/src/atoms/chain/services.ts
@@ -40,16 +40,16 @@ export const fetchMaspRewards = async (): Promise<MaspAssetRewards[]> => {
   const sdk = await getSdkInstance();
   const rewards = await sdk.rpc.globalShieldedRewardForTokens();
   const existingRewards: MaspAssetRewards[] = rewards
-    .filter((r) => r.max_reward_rate > 0)
+    .filter((r) => r.maxRewardRate > 0)
     .map((r) => {
       const denom = getDenomFromIbcTrace(r.name);
       const asset = findAssetByDenom(denom) ?? unknownAsset(denom);
       return {
         asset,
-        kdGain: new BigNumber(r.kd_gain),
-        kpGain: new BigNumber(r.kp_gain),
-        lockedAmountTarget: new BigNumber(r.locked_amount_target),
-        maxRewardRate: new BigNumber(r.max_reward_rate),
+        kdGain: new BigNumber(r.kdGain),
+        kpGain: new BigNumber(r.kpGain),
+        lockedAmountTarget: new BigNumber(r.lockedAmountTarget),
+        maxRewardRate: new BigNumber(r.maxRewardRate),
       };
     });
   return existingRewards;

--- a/apps/namadillo/src/types.ts
+++ b/apps/namadillo/src/types.ts
@@ -398,3 +398,11 @@ export type LedgerAccountInfo = {
   deviceConnected: boolean;
   errorMessage: string;
 };
+
+export type MaspAssetRewards = {
+  asset: Asset;
+  kdGain: BigNumber;
+  kpGain: BigNumber;
+  lockedAmountTarget: BigNumber;
+  maxRewardRate: BigNumber;
+};

--- a/packages/sdk/src/rpc/rpc.ts
+++ b/packages/sdk/src/rpc/rpc.ts
@@ -20,6 +20,7 @@ import {
   DelegationTotals,
   DelegatorsVotes,
   GasCosts,
+  MaspTokenRewards,
   StakingPositions,
   StakingTotals,
   StakingTotalsResponse,
@@ -263,6 +264,15 @@ export class Rpc {
    */
   async shieldedRewards(owner: string, chainId: string): Promise<string> {
     return await this.sdk.shielded_rewards(owner, chainId);
+  }
+
+  /**
+   * Return global shielded rewards per token
+   * @async
+   * @returns Array of MaspTokenRewards
+   */
+  async globalShieldedRewardForTokens(): Promise<MaspTokenRewards[]> {
+    return await this.query.masp_reward_tokens();
   }
 
   /**

--- a/packages/sdk/src/rpc/rpc.ts
+++ b/packages/sdk/src/rpc/rpc.ts
@@ -272,7 +272,33 @@ export class Rpc {
    * @returns Array of MaspTokenRewards
    */
   async globalShieldedRewardForTokens(): Promise<MaspTokenRewards[]> {
-    return await this.query.masp_reward_tokens();
+    return (await this.query.masp_reward_tokens()).map(
+      (rewardToken: {
+        name: string;
+        address: string;
+        max_reward_rate: number;
+        kp_gain: number;
+        kd_gain: number;
+        locked_amount_target: number;
+      }) => {
+        const {
+          name,
+          address,
+          max_reward_rate: maxRewardRate,
+          kp_gain: kpGain,
+          kd_gain: kdGain,
+          locked_amount_target: lockedAmountTarget,
+        } = rewardToken;
+        return {
+          name,
+          address,
+          maxRewardRate,
+          kpGain,
+          kdGain,
+          lockedAmountTarget,
+        };
+      }
+    );
   }
 
   /**

--- a/packages/sdk/src/rpc/types.ts
+++ b/packages/sdk/src/rpc/types.ts
@@ -44,6 +44,15 @@ export type StakingPositions = {
   unbonds: Unbonds[];
 };
 
+export type MaspTokenRewards = {
+  name: string;
+  address: string;
+  max_reward_rate: number;
+  kp_gain: number;
+  kd_gain: number;
+  locked_amount_target: number;
+};
+
 /**
  * DelegationTotals
  * Record<address, totalDelegations>

--- a/packages/sdk/src/rpc/types.ts
+++ b/packages/sdk/src/rpc/types.ts
@@ -47,10 +47,10 @@ export type StakingPositions = {
 export type MaspTokenRewards = {
   name: string;
   address: string;
-  max_reward_rate: number;
-  kp_gain: number;
-  kd_gain: number;
-  locked_amount_target: number;
+  maxRewardRate: number;
+  kpGain: number;
+  kdGain: number;
+  lockedAmountTarget: number;
 };
 
 /**

--- a/packages/shared/lib/src/query.rs
+++ b/packages/shared/lib/src/query.rs
@@ -26,7 +26,7 @@ use namada_sdk::queries::RPC;
 use namada_sdk::rpc::{
     self, get_public_key_at, get_token_balance, get_total_staked_tokens, is_steward, query_epoch,
     query_masp_epoch, query_native_token, query_proposal_by_id, query_proposal_votes,
-    query_storage_value,
+    query_storage_value, query_masp_reward_tokens
 };
 use namada_sdk::state::Key;
 use namada_sdk::token;
@@ -49,7 +49,7 @@ use crate::sdk::{
     masp::{sync, JSShieldedUtils},
 };
 use crate::types::masp::DatedViewingKey;
-use crate::types::query::{ProposalInfo, WasmHash};
+use crate::types::query::{ProposalInfo, WasmHash, MaspTokenRewardData};
 use crate::utils::{set_panic_hook, to_js_result};
 
 /// Progress bar names
@@ -689,6 +689,21 @@ impl Query {
         }
 
         to_js_result(delegations)
+    }
+
+    pub async fn masp_reward_tokens(&self) -> Result<JsValue, JsError> {
+        let rewards = query_masp_reward_tokens(&self.client).await?;
+        let serializable_rewards: Vec<MaspTokenRewardData> = rewards.iter().map(|reward| {
+            MaspTokenRewardData {
+                name: reward.name.clone(),
+                address: reward.address.clone(),
+                max_reward_rate: reward.max_reward_rate,
+                kp_gain: reward.kp_gain,
+                kd_gain: reward.kd_gain,
+                locked_amount_target: reward.locked_amount_target,
+            }
+        }).collect();
+        to_js_result(serializable_rewards)
     }
 
     /// Returns list of delegators that already voted on a proposal

--- a/packages/shared/lib/src/types/query.rs
+++ b/packages/shared/lib/src/types/query.rs
@@ -1,4 +1,7 @@
 use namada_sdk::borsh::BorshSerialize;
+use namada_sdk::address::Address;
+use namada_sdk::uint::Uint;
+use namada_sdk::dec::Dec;
 use serde::{Deserialize, Serialize};
 
 #[derive(BorshSerialize)]
@@ -13,6 +16,16 @@ pub struct ProposalInfo {
     pub tally_type: String,
     pub proposal_type: String,
     pub data: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MaspTokenRewardData {
+    pub name: String,
+    pub address: Address,
+    pub max_reward_rate: Dec,
+    pub kp_gain: Dec,
+    pub kd_gain: Dec,
+    pub locked_amount_target: Uint,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
This PR adds the related methods to the sdk and shared packages to load global masp asset rewards from the RPC, and also implements the sidebar panel enumerating the rewards.

Closes #1334