### PR TITLE
feat: Keychain signing - only require password on session timeout

### DIFF
--- a/apps/extension/src/Approvals/Approvals.tsx
+++ b/apps/extension/src/Approvals/Approvals.tsx
@@ -19,12 +19,6 @@ import { ConfirmSignLedgerTx } from "./ConfirmSignLedgerTx";
 import { ConfirmSignTx } from "./ConfirmSignTx";
 import { WithAuth } from "./WithAuth";
 
-export enum Status {
-  Completed,
-  Pending,
-  Failed,
-}
-
 export type ExtensionLockContextType = {
   isUnlocked?: boolean;
   setIsUnlocked?: Dispatch<SetStateAction<boolean>>;

--- a/apps/extension/src/Approvals/ConfirmSignArbitrary.tsx
+++ b/apps/extension/src/Approvals/ConfirmSignArbitrary.tsx
@@ -10,11 +10,13 @@ import {
 } from "@namada/components";
 import { shortenAddress } from "@namada/utils";
 import { PageHeader } from "App/Common";
-import { SignArbitraryDetails, Status } from "Approvals/Approvals";
+import { SignArbitraryDetails } from "Approvals/Approvals";
 import { SubmitApprovedSignArbitraryMsg } from "background/approvals";
+import { CheckPasswordMsg, CheckRequiresAuthMsg } from "background/vault";
 import { useRequester } from "hooks/useRequester";
 import { Ports } from "router";
 import { closeCurrentTab } from "utils";
+import { Status } from "./types";
 
 type Props = {
   details: SignArbitraryDetails;
@@ -25,20 +27,16 @@ export const ConfirmSignature: React.FC<Props> = ({ details }) => {
 
   const navigate = useNavigate();
   const requester = useRequester();
-  const [requiresAuth, setRequiresAuth] = useState(false);
-  const [_password, setPassword] = useState("");
+  const [requiresAuth, setRequiresAuth] = useState<boolean>();
+  const [password, setPassword] = useState("");
   const [error, setError] = useState<string>();
   const [status, setStatus] = useState<Status>();
   const [statusInfo, setStatusInfo] = useState("");
 
-  const handleApproveSignature = useCallback(async (): Promise<void> => {
-    const address = shortenAddress(signer, 24);
-
-    setStatus(Status.Pending);
-    setStatusInfo(`Decrypting keys for ${address}`);
-
+  const signArbitrary = async (): Promise<void> => {
     try {
-      setStatusInfo(`Signing keys with ${address}`);
+      setStatus(Status.Pending);
+      setStatusInfo(`Signing keys with ${shortenAddress(signer, 24)}`);
       await requester
         .sendMessage(
           Ports.Background,
@@ -49,19 +47,56 @@ export const ConfirmSignature: React.FC<Props> = ({ details }) => {
         });
       setStatus(Status.Completed);
     } catch (e) {
-      console.info(e);
+      throw new Error(`${e}`);
+    }
+  };
+
+  const handleApproveSignature = useCallback(async (): Promise<void> => {
+    try {
+      if (requiresAuth) {
+        setStatusInfo(`Decrypting keys and signing data...`);
+        const isAuthenticated = await requester.sendMessage(
+          Ports.Background,
+          new CheckPasswordMsg(password)
+        );
+
+        if (!isAuthenticated) {
+          throw new Error("Invalid password!");
+        }
+      }
+
+      await signArbitrary();
+      setStatus(Status.Completed);
+    } catch (e) {
       setError(`${e}`);
       setStatus(Status.Failed);
     }
-  }, []);
+  }, [requiresAuth, password]);
 
   useEffect(() => {
+    if (!status && typeof requiresAuth === "undefined") {
+      requester
+        .sendMessage(Ports.Background, new CheckRequiresAuthMsg())
+        .then((isAuthRequired) => {
+          setRequiresAuth(isAuthRequired);
+        })
+        .catch((e) => console.error(e));
+    }
+
+    if (typeof requiresAuth !== "undefined" && !requiresAuth) {
+      // User is authenticated with a valid session, so submit signed data
+      signArbitrary()
+        .then(() => setStatus(Status.Completed))
+        .catch((e) => {
+          setError(`${e}`);
+          setStatus(Status.Failed);
+        });
+    }
+
     if (status === Status.Completed) {
       void closeCurrentTab();
     }
-    // TODO:
-    setRequiresAuth(false);
-  }, [status]);
+  }, [status, requiresAuth]);
 
   const onSubmit = async (e: React.FormEvent): Promise<void> => {
     e.preventDefault();
@@ -76,7 +111,9 @@ export const ConfirmSignature: React.FC<Props> = ({ details }) => {
       gap={GapPatterns.TitleContent}
       className="pt-4 pb-8"
     >
-      <PageHeader title="Confirm Signature" />
+      <PageHeader
+        title={requiresAuth ? "Confirm Signature" : "Submitting signature"}
+      />
       {status === Status.Pending && <Alert type="info">{statusInfo}</Alert>}
       {status === Status.Failed && (
         <Alert type="error">
@@ -103,12 +140,17 @@ export const ConfirmSignature: React.FC<Props> = ({ details }) => {
             )}
           </Stack>
           <Stack gap={3}>
-            <ActionButton type="submit" disabled={requiresAuth}>
-              Authenticate
-            </ActionButton>
-            <ActionButton outlineColor="yellow" onClick={() => navigate(-1)}>
-              Back
-            </ActionButton>
+            {requiresAuth && (
+              <>
+                <ActionButton disabled={!password}>Authenticate</ActionButton>
+                <ActionButton
+                  outlineColor="yellow"
+                  onClick={() => navigate(-1)}
+                >
+                  Back
+                </ActionButton>
+              </>
+            )}
           </Stack>
         </>
       )}

--- a/apps/extension/src/Approvals/ConfirmSignLedgerTx.tsx
+++ b/apps/extension/src/Approvals/ConfirmSignLedgerTx.tsx
@@ -14,7 +14,7 @@ import { fromBase64, toBase64 } from "@cosmjs/encoding";
 import { chains } from "@namada/chains";
 import { TransferProps } from "@namada/types";
 import { PageHeader } from "App/Common";
-import { ApprovalDetails, Status } from "Approvals/Approvals";
+import { ApprovalDetails } from "Approvals/Approvals";
 import {
   QueryPendingTxBytesMsg,
   ReplaceMaspSignaturesMsg,
@@ -28,6 +28,7 @@ import { closeCurrentTab, parseTransferType } from "utils";
 import { ApproveIcon } from "./ApproveIcon";
 import { LedgerIcon } from "./LedgerIcon";
 import { StatusBox } from "./StatusBox";
+import { Status } from "./types";
 
 type Props = {
   details: ApprovalDetails;

--- a/apps/extension/src/Approvals/ConfirmSignTx.tsx
+++ b/apps/extension/src/Approvals/ConfirmSignTx.tsx
@@ -3,13 +3,14 @@ import { useNavigate } from "react-router-dom";
 
 import { ActionButton, Alert, Input, Stack } from "@namada/components";
 import { PageHeader } from "App/Common";
-import { ApprovalDetails, Status } from "Approvals/Approvals";
+import { ApprovalDetails } from "Approvals/Approvals";
 import { SignMaspMsg, SubmitApprovedSignTxMsg } from "background/approvals";
 import { CheckPasswordMsg, CheckRequiresAuthMsg } from "background/vault";
 import { useRequester } from "hooks/useRequester";
 import { Ports } from "router";
 import { closeCurrentTab } from "utils";
 import { StatusBox } from "./StatusBox";
+import { Status } from "./types";
 
 type Props = {
   details: ApprovalDetails;
@@ -70,7 +71,7 @@ export const ConfirmSignTx: React.FC<Props> = ({ details }) => {
         setStatus(Status.Failed);
       }
     },
-    [password]
+    [requiresAuth, password]
   );
 
   useEffect(() => {
@@ -79,7 +80,6 @@ export const ConfirmSignTx: React.FC<Props> = ({ details }) => {
         .sendMessage(Ports.Background, new CheckRequiresAuthMsg())
         .then((isAuthRequired) => {
           setRequiresAuth(isAuthRequired);
-          console.log({ isAuthRequired });
         })
         .catch((e) => console.error(e));
     }
@@ -123,7 +123,7 @@ export const ConfirmSignTx: React.FC<Props> = ({ details }) => {
         <Stack gap={2}>
           {requiresAuth && (
             <>
-              <ActionButton disabled={status === Status.Pending}>
+              <ActionButton disabled={!password || status === Status.Pending}>
                 Authenticate
               </ActionButton>
               <ActionButton

--- a/apps/extension/src/Approvals/StatusBox.tsx
+++ b/apps/extension/src/Approvals/StatusBox.tsx
@@ -1,5 +1,5 @@
 import { Alert } from "@namada/components";
-import { Status } from "Approvals/Approvals";
+import { Status } from "./types";
 
 type Props = {
   status?: Status;

--- a/apps/extension/src/Approvals/types.ts
+++ b/apps/extension/src/Approvals/types.ts
@@ -33,3 +33,9 @@ export type TransferType =
   | "Shielded"
   | "Unshielding"
   | "Unknown";
+
+export enum Status {
+  Completed,
+  Pending,
+  Failed,
+}

--- a/apps/extension/src/background/vault/handler.ts
+++ b/apps/extension/src/background/vault/handler.ts
@@ -1,13 +1,14 @@
 import { Env, Handler, InternalHandler, Message } from "router";
 import {
   CheckIsLockedMsg,
+  CheckPasswordInitializedMsg,
   CheckPasswordMsg,
+  CheckRequiresAuthMsg,
+  CreatePasswordMsg,
   LockVaultMsg,
+  LogoutMsg,
   ResetPasswordMsg,
   UnlockVaultMsg,
-  CheckPasswordInitializedMsg,
-  CreatePasswordMsg,
-  LogoutMsg,
 } from "./messages";
 
 import { VaultService } from "./service";
@@ -37,6 +38,12 @@ export const getHandler: (service: VaultService) => Handler = (service) => {
         return handleCheckPasswordInitializedMsg(service)(
           env,
           msg as CheckPasswordInitializedMsg
+        );
+
+      case CheckRequiresAuthMsg:
+        return handleCheckRequiresAuthMsg(service)(
+          env,
+          msg as CheckRequiresAuthMsg
         );
 
       case CreatePasswordMsg:
@@ -109,5 +116,13 @@ const handleCreatePasswordMsg: (
 ) => InternalHandler<CreatePasswordMsg> = (service) => {
   return async (_, msg) => {
     return await service.createPassword(msg.password);
+  };
+};
+
+const handleCheckRequiresAuthMsg: (
+  service: VaultService
+) => InternalHandler<CheckRequiresAuthMsg> = (service) => {
+  return async (_, _msg) => {
+    return await service.requiresAuth();
   };
 };

--- a/apps/extension/src/background/vault/init.ts
+++ b/apps/extension/src/background/vault/init.ts
@@ -3,13 +3,14 @@ import { ROUTE } from "./constants";
 import { getHandler } from "./handler";
 import {
   CheckIsLockedMsg,
+  CheckPasswordInitializedMsg,
   CheckPasswordMsg,
+  CheckRequiresAuthMsg,
+  CreatePasswordMsg,
   LockVaultMsg,
+  LogoutMsg,
   ResetPasswordMsg,
   UnlockVaultMsg,
-  CheckPasswordInitializedMsg,
-  CreatePasswordMsg,
-  LogoutMsg,
 } from "./messages";
 import { VaultService } from "./service";
 
@@ -20,6 +21,7 @@ export function init(router: Router, service: VaultService): void {
   router.registerMessage(ResetPasswordMsg);
   router.registerMessage(UnlockVaultMsg);
   router.registerMessage(CheckPasswordInitializedMsg);
+  router.registerMessage(CheckRequiresAuthMsg);
   router.registerMessage(CreatePasswordMsg);
   router.registerMessage(LogoutMsg);
   router.addHandler(ROUTE, getHandler(service));

--- a/apps/extension/src/background/vault/messages.ts
+++ b/apps/extension/src/background/vault/messages.ts
@@ -6,6 +6,7 @@ import { ResetPasswordError } from "./types";
 enum MessageType {
   CheckIsLocked = "check-is-locked",
   CheckPassword = "check-password",
+  CheckRequiresAuth = "check-requires-auth",
   LockKeyRing = "lock-keyring",
   ResetPassword = "reset-password",
   UnlockKeyRing = "unlock-keyring",
@@ -77,6 +78,28 @@ export class CheckIsLockedMsg extends Message<boolean> {
 
   type(): string {
     return CheckIsLockedMsg.type();
+  }
+}
+
+export class CheckRequiresAuthMsg extends Message<boolean> {
+  public static type(): MessageType {
+    return MessageType.CheckRequiresAuth;
+  }
+
+  constructor() {
+    super();
+  }
+
+  validate(): void {
+    return;
+  }
+
+  route(): string {
+    return ROUTE;
+  }
+
+  type(): string {
+    return CheckRequiresAuthMsg.type();
   }
 }
 

--- a/apps/extension/src/background/vault/tests/service.test.ts
+++ b/apps/extension/src/background/vault/tests/service.test.ts
@@ -5,7 +5,7 @@ import { KVPrefix } from "router";
 import { KeyStore, KeyStoreType, VaultStorage } from "storage";
 import { KVStoreMock } from "test/init";
 import { VaultService } from "../service";
-import { SessionPassword } from "../types";
+import { SessionValues } from "../types";
 
 jest.mock("webextension-polyfill", () => ({}));
 
@@ -43,7 +43,7 @@ describe("Testing untouched Vault Service", () => {
 
   beforeEach(async () => {
     storage = new VaultStorage(new KVStoreMock(KVPrefix.IndexedDB));
-    const sessionStore = new KVStoreMock<SessionPassword>(
+    const sessionStore = new KVStoreMock<SessionValues>(
       KVPrefix.SessionStorage
     );
 

--- a/apps/extension/src/background/vault/types.ts
+++ b/apps/extension/src/background/vault/types.ts
@@ -12,4 +12,4 @@ export type Vault<T = unknown> = {
 
 export type VaultStoreData = Record<string, Vault[]>;
 
-export type SessionPassword = string;
+export type SessionValues = string | number;

--- a/apps/extension/src/test/init.ts
+++ b/apps/extension/src/test/init.ts
@@ -14,7 +14,7 @@ import {
   init as initKeyRing,
 } from "../background/keyring";
 
-import { SessionPassword, VaultService } from "background/vault";
+import { SessionValues, VaultService } from "background/vault";
 
 import {
   ApprovalsService,
@@ -56,9 +56,7 @@ export const init = async (): Promise<{
   vaultService: VaultService;
 }> => {
   const messenger = new ExtensionMessengerMock();
-  const sessionStore = new KVStoreMock<SessionPassword>(
-    KVPrefix.SessionStorage
-  );
+  const sessionStore = new KVStoreMock<SessionValues>(KVPrefix.SessionStorage);
   const extStore = new KVStoreMock<number>(KVPrefix.IndexedDB);
   const utilityStore = new KVStoreMock<UtilityStore>(KVPrefix.Utility);
   const localStorage = new LocalStorage(new KVStoreMock(KVPrefix.LocalStorage));

--- a/packages/storage/src/store/SessionKVStore.ts
+++ b/packages/storage/src/store/SessionKVStore.ts
@@ -1,5 +1,5 @@
-import { KVStore } from "./types";
 import browser from "webextension-polyfill";
+import { KVStore } from "./types";
 
 export class SessionKVStore<T> implements KVStore<T[]> {
   constructor(private readonly _prefix: string) {}
@@ -13,7 +13,10 @@ export class SessionKVStore<T> implements KVStore<T[]> {
   }
 
   public async set<T = unknown>(key: string, data: T | null): Promise<void> {
-    await browser.storage.session.set({ [this.prefix()]: { [key]: data } });
+    const obj = await browser.storage.session.get(this.prefix());
+    await browser.storage.session.set({
+      [this.prefix()]: { ...obj[this.prefix()], [key]: data },
+    });
   }
 
   public prefix(): string {


### PR DESCRIPTION
Resolves #1411

**NOTE** The timeout period is set to 5 minutes.

- [x] Extension can sign _without_ entering password every time
- [x] Track session start time (times out after 5 minutes), able to query background to determine if session has expired
- [x] Require auth if session is timed-out, otherwise, it is not needed
  - [x] If session is valid, clicking `Approve` submits the signature
  - [x] If session is invalid, user must enter password (like before), then clicking `Authenticate` submits the signature
- [x] Implement for `ConfirmSignTx`
- [x] Implement for `ConfirmSignArbitrary`

### Testing

- With this Keychain, unlock and submit a transaction
  - You should not need to enter your password
- Check Chrome service worker (if testing on Chrome) - wait for it to go `Inactive`, then submit another Tx (~1 minute, make sure you don't have service worker dev tools open! This causes the service worker to stay running)
  - If it's been under 5 minutes since you last entered your password, you should not be prompted for it when signing
  - This test is just to demonstrate that an inactive Chrome service worker preserves the existing session and shouldn't have any effect on this feature
- After 5 minutes since you last entered your password, submit a Tx (you can change this line to like one minute if it's too annoying to wait): https://github.com/anoma/namada-interface/blob/7a30b9a173ee4ab40b1433331d78fbd7fcefb349/apps/extension/src/background/vault/service.ts#L81
  - At this point, you need to enter password.
  - Any Tx within the next 5 minutes will not need a password  