### PR TITLE
fix - Keychain login prompt on connect shouldn't flash approve domain components

### DIFF
--- a/apps/extension/src/Approvals/ApproveConnection.tsx
+++ b/apps/extension/src/Approvals/ApproveConnection.tsx
@@ -6,7 +6,7 @@ import {
 } from "background/approvals";
 import { useQuery } from "hooks";
 import { useRequester } from "hooks/useRequester";
-import { useContext, useEffect } from "react";
+import { useContext, useEffect, useState } from "react";
 import { Ports } from "router";
 import { closeCurrentTab } from "utils";
 import { ExtensionLockContext } from "./Approvals";
@@ -17,6 +17,7 @@ export const ApproveConnection: React.FC = () => {
   const interfaceOrigin = params.get("interfaceOrigin")!;
   const chainId = params.get("chainId")!;
   const { isUnlocked } = useContext(ExtensionLockContext);
+  const [isApproved, setIsApproved] = useState<boolean>();
 
   const checkIsApproved = async (): Promise<void> => {
     requester
@@ -25,6 +26,7 @@ export const ApproveConnection: React.FC = () => {
         new CheckIsApprovedSiteMsg(interfaceOrigin, chainId)
       )
       .then((isApproved) => {
+        setIsApproved(isApproved);
         if (isApproved) {
           // Go ahead and connect as this domain is already approved
           void handleResponse(true);
@@ -43,45 +45,47 @@ export const ApproveConnection: React.FC = () => {
   }, [isUnlocked]);
 
   const handleResponse = async (allowConnection: boolean): Promise<void> => {
-    if (interfaceOrigin) {
-      await requester.sendMessage(
-        Ports.Background,
-        new ConnectInterfaceResponseMsg(
-          interfaceOrigin,
-          allowConnection,
-          chainId || undefined
-        )
-      );
-      await closeCurrentTab();
-    }
+    await requester.sendMessage(
+      Ports.Background,
+      new ConnectInterfaceResponseMsg(
+        interfaceOrigin,
+        allowConnection,
+        chainId || undefined
+      )
+    );
+    await closeCurrentTab();
   };
 
   return (
     <Stack full gap={GapPatterns.TitleContent} className="pt-4 pb-8">
-      <PageHeader title="Approve Request" />
-      <Stack full className="justify-between" gap={12}>
-        <Alert type="warning">
-          Approve connection for <strong>{interfaceOrigin}</strong>
-          {chainId && (
-            <>
-              {" "}
-              and enable signing for <strong>{chainId}</strong>
-            </>
-          )}
-          ?
-        </Alert>
-        <Stack gap={2}>
-          <ActionButton onClick={() => handleResponse(true)}>
-            Approve
-          </ActionButton>
-          <ActionButton
-            outlineColor="yellow"
-            onClick={() => handleResponse(false)}
-          >
-            Reject
-          </ActionButton>
-        </Stack>
-      </Stack>
+      {typeof isApproved !== "undefined" && !isApproved && (
+        <>
+          <PageHeader title="Approve Request" />
+          <Stack full className="justify-between" gap={12}>
+            <Alert type="warning">
+              Approve connection for <strong>{interfaceOrigin}</strong>
+              {chainId && (
+                <>
+                  {" "}
+                  and enable signing for <strong>{chainId}</strong>
+                </>
+              )}
+              ?
+            </Alert>
+            <Stack gap={2}>
+              <ActionButton onClick={() => handleResponse(true)}>
+                Approve
+              </ActionButton>
+              <ActionButton
+                outlineColor="yellow"
+                onClick={() => handleResponse(false)}
+              >
+                Reject
+              </ActionButton>
+            </Stack>
+          </Stack>
+        </>
+      )}
     </Stack>
   );
 };


### PR DESCRIPTION
Relates to #1791 

- [x] Fix issue where `Approve Connection` form displays briefly even though domain/chain ID are already approved
  - To test - Lock keychain, and _from Namadillo_, from an approved domain/chain ID, click `Connect Keychain` - upon successful authentication, you shouldn't see the `Approve Connection` form flash before popup closes (this now displays only if the check approved site has happened before determining if anything should be displayed)
  - Remove Site in keychain (unapprove it), lock keychain, then connect again from Namadillo - should see the form as expected
