### PR TITLE
feat: use indexer services timestamps in status check

### DIFF
--- a/apps/namadillo/src/App/Layout/SyncIndicator.tsx
+++ b/apps/namadillo/src/App/Layout/SyncIndicator.tsx
@@ -1,12 +1,20 @@
 import { Tooltip } from "@namada/components";
 import { chainStatusAtom } from "atoms/chain";
-import { syncStatusAtom } from "atoms/syncStatus/atoms";
+import {
+  indexerServicesSyncStatusAtom,
+  syncStatusAtom,
+} from "atoms/syncStatus/atoms";
 import { useAtomValue } from "jotai";
 import { twMerge } from "tailwind-merge";
 
 export const SyncIndicator = (): JSX.Element => {
   const syncStatus = useAtomValue(syncStatusAtom);
+  const indexerServicesSyncStatus = useAtomValue(indexerServicesSyncStatusAtom);
   const chainStatus = useAtomValue(chainStatusAtom);
+
+  const isError = syncStatus.isError || indexerServicesSyncStatus.isError;
+  const isSyncing = syncStatus.isSyncing || indexerServicesSyncStatus.isSyncing;
+  const { services } = indexerServicesSyncStatus;
 
   return (
     <div className="relative group/tooltip p-1">
@@ -14,15 +22,15 @@ export const SyncIndicator = (): JSX.Element => {
         className={twMerge(
           "w-2 h-2 rounded-full",
           "bg-green-500",
-          syncStatus.isSyncing && "bg-yellow-500 animate-pulse",
-          syncStatus.isError && "bg-red-500"
+          isSyncing && "bg-yellow-500 animate-pulse",
+          isError && !isSyncing && "bg-red-500"
         )}
       />
       <Tooltip className="whitespace-nowrap">
-        {syncStatus.isSyncing ?
+        {isSyncing ?
           "Syncing"
-        : syncStatus.isError ?
-          "Error syncing"
+        : isError ?
+          `Error syncing ${services.length ? `. Lagging services: ${services.join(", ")}.` : ""}`
         : `Fully synced: height ${chainStatus?.height}, epoch ${chainStatus?.epoch}`
         }
       </Tooltip>

--- a/apps/namadillo/src/atoms/chain/atoms.ts
+++ b/apps/namadillo/src/atoms/chain/atoms.ts
@@ -134,6 +134,7 @@ export const chainParametersAtom = atomWithQuery<ChainParameters>((get) => {
         ...parameters,
         apr: BigNumber(parameters.apr),
         unbondingPeriod: calculateUnbondingPeriod(parameters),
+        maxBlockTime: Number(parameters.maxBlockTime),
       };
     },
   };

--- a/apps/namadillo/src/atoms/settings/services.ts
+++ b/apps/namadillo/src/atoms/settings/services.ts
@@ -1,5 +1,6 @@
 import {
   ApiV1CrawlersTimestampsGet200ResponseInner,
+  ApiV1CrawlersTimestampsGetCrawlerNamesEnum,
   DefaultApi,
   HealthGet200Response,
 } from "@namada/indexer-client";
@@ -20,10 +21,11 @@ export const getIndexerHealth = async (
 };
 
 export const getIndexerCrawlerInfo = async (
-  api: DefaultApi
+  api: DefaultApi,
+  services?: ApiV1CrawlersTimestampsGetCrawlerNamesEnum[]
 ): Promise<ApiV1CrawlersTimestampsGet200ResponseInner[] | undefined> => {
   try {
-    const response = await api.apiV1CrawlersTimestampsGet();
+    const response = await api.apiV1CrawlersTimestampsGet(services);
     return response.data;
   } catch {
     return;

--- a/apps/namadillo/src/atoms/syncStatus/atoms.ts
+++ b/apps/namadillo/src/atoms/syncStatus/atoms.ts
@@ -1,7 +1,12 @@
 import { accountBalanceAtom, transparentBalanceAtom } from "atoms/accounts";
 import { shieldedBalanceAtom } from "atoms/balance";
+import { chainParametersAtom } from "atoms/chain";
 import { allProposalsAtom, votedProposalsAtom } from "atoms/proposals";
-import { indexerHeartbeatAtom, rpcHeartbeatAtom } from "atoms/settings/atoms";
+import {
+  indexerCrawlersInfoAtom,
+  indexerHeartbeatAtom,
+  rpcHeartbeatAtom,
+} from "atoms/settings/atoms";
 import { allValidatorsAtom, myValidatorsAtom } from "atoms/validators";
 import { atom } from "jotai";
 
@@ -27,11 +32,62 @@ export const syncStatusAtom = atom((get) => {
 
   const isSyncing = queries.some((q) => q.isFetching);
   const isError = queries.some((q) => q.isError);
-  const error = queries.find((q) => q.error)?.error || undefined;
 
   return {
     isSyncing,
     isError,
-    error,
+  };
+});
+
+export const indexerServicesSyncStatusAtom = atom((get) => {
+  const servicesTimestamps = get(indexerCrawlersInfoAtom);
+  const chainParams = get(chainParametersAtom);
+
+  if (servicesTimestamps.isSuccess && chainParams.isSuccess) {
+    const { maxBlockTime } = chainParams.data;
+    // Milliseconds to seconds
+    const timeNow = Date.now() / 1000;
+
+    const { isError, services } = servicesTimestamps.data
+      // We ignore the following services: ["rewards", "governance"]
+      // The reason is that processing that these service do takes a long time,
+      // during which we are not updating the timestamps.
+      // TODO: change this after implementing additional logic in the indexer
+      .filter((s) => !["rewards", "governance"].includes(s.name))
+      .map((s) => {
+        // We leave some margin for error
+        const inSync = s.timestamp > timeNow - 3 * maxBlockTime;
+
+        return {
+          name: s.name,
+          inSync,
+        };
+      })
+      .reduce(
+        (acc, curr) => {
+          const isError = acc.isError || !curr.inSync;
+          return {
+            isError,
+            services:
+              !curr.inSync ? [...acc.services, curr.name] : acc.services,
+          };
+        },
+        { isError: false, services: [] } as {
+          isError: boolean;
+          services: string[];
+        }
+      );
+
+    return {
+      isSyncing: false,
+      isError,
+      services,
+    };
+  }
+
+  return {
+    isSyncing: servicesTimestamps.isFetching || chainParams.isFetching,
+    isError: servicesTimestamps.isError || chainParams.isError,
+    services: [],
   };
 });

--- a/apps/namadillo/src/types.ts
+++ b/apps/namadillo/src/types.ts
@@ -76,6 +76,7 @@ export type ChainParameters = {
   nativeTokenAddress: Address;
   unbondingPeriod: string;
   checksums: Record<string, string>;
+  maxBlockTime: number;
 };
 
 export type SettingsStorage = {


### PR DESCRIPTION
With this change the "status dot" will turn red if one of indexers services - chain, pos, parameters or transactions lags behind.
This skips checks for rewards and governance as they do not update timestamps fast enough(computation can take a while). I plan to change this but first we need to update the indexer.

I think the best way to test it is to use different indexers and see if dot is turning red :D 
![image](https://github.com/user-attachments/assets/7d8e0d72-895f-4aa8-8564-fed4dc43fad8)

