### PR TITLE
feat: invalidate shielded context based on indexer version

### DIFF
--- a/apps/namadillo/src/App/App.tsx
+++ b/apps/namadillo/src/App/App.tsx
@@ -4,6 +4,7 @@ import { createBrowserHistory } from "history";
 import { useExtensionEvents } from "hooks/useExtensionEvents";
 import { useRegistryFeatures } from "hooks/useRegistryFeatures";
 import { useServerSideEvents } from "hooks/useServerSideEvents";
+import { useShouldInvalidateShieldedContext } from "hooks/useShouldInvalidateShieldedContext";
 import { useTransactionCallback } from "hooks/useTransactionCallbacks";
 import { useTransactionNotifications } from "hooks/useTransactionNotifications";
 import { useTransactionWatcher } from "hooks/useTransactionWatcher";
@@ -19,6 +20,7 @@ export function App(): JSX.Element {
   useTransactionWatcher();
   useRegistryFeatures();
   useServerSideEvents();
+  useShouldInvalidateShieldedContext();
 
   return (
     <>

--- a/apps/namadillo/src/App/Settings/SettingsMASP.tsx
+++ b/apps/namadillo/src/App/Settings/SettingsMASP.tsx
@@ -1,29 +1,8 @@
 import { ActionButton, Stack } from "@namada/components";
-import { routes } from "App/routes";
-import {
-  lastCompletedShieldedSyncAtom,
-  storageShieldedBalanceAtom,
-  storageShieldedRewardsAtom,
-} from "atoms/balance/atoms";
-import { clearShieldedContextAtom } from "atoms/settings";
-import { useAtom, useSetAtom } from "jotai";
-import { RESET } from "jotai/utils";
+import { useInvalidateShieldedContext } from "hooks/useInvalidateShieldedContext";
 
 export const SettingsMASP = (): JSX.Element => {
-  const [clearShieldedContext] = useAtom(clearShieldedContextAtom);
-  const setStorageShieldedBalance = useSetAtom(storageShieldedBalanceAtom);
-  const setLastCompletedShieldedSync = useSetAtom(
-    lastCompletedShieldedSyncAtom
-  );
-  const setStorageShieldedRewards = useSetAtom(storageShieldedRewardsAtom);
-
-  const onInvalidateShieldedContext = async (): Promise<void> => {
-    await clearShieldedContext.mutateAsync();
-    setStorageShieldedBalance(RESET);
-    setLastCompletedShieldedSync({});
-    setStorageShieldedRewards(RESET);
-    location.href = routes.root;
-  };
+  const invalidateShieldedContext = useInvalidateShieldedContext();
 
   return (
     <Stack as="footer" className="px-5" gap={3}>
@@ -34,7 +13,7 @@ export const SettingsMASP = (): JSX.Element => {
         minutes to complete.
       </p>
 
-      <ActionButton onClick={onInvalidateShieldedContext} className="shrink-0">
+      <ActionButton onClick={invalidateShieldedContext} className="shrink-0">
         Invalidate Shielded Context
       </ActionButton>
     </Stack>

--- a/apps/namadillo/src/atoms/settings/atoms.ts
+++ b/apps/namadillo/src/atoms/settings/atoms.ts
@@ -234,13 +234,19 @@ export const indexerCrawlersInfoAtom = atomWithQuery((get) => {
 
 export const clearShieldedContextAtom = atomWithMutation((get) => {
   const parameters = get(chainParametersAtom);
+  const chainId = parameters.data?.chainId;
+
   return {
-    mutationKey: ["clear-shielded-context"],
+    mutationKey: ["clear-shielded-context", chainId],
     mutationFn: () => {
-      if (!parameters.data) {
+      if (!chainId) {
         throw new Error("Chain parameters not loaded");
       }
-      return clearShieldedContext(parameters.data.chainId);
+      return clearShieldedContext(chainId);
     },
   };
 });
+
+export const lastInvalidateShieldedContextAtom = atomWithStorage<{
+  [chainId: string]: string | undefined;
+}>("namadillo:last-invalidate-shielded-context", {});

--- a/apps/namadillo/src/hooks/useInvalidateShieldedContext.ts
+++ b/apps/namadillo/src/hooks/useInvalidateShieldedContext.ts
@@ -1,0 +1,39 @@
+import { routes } from "App/routes";
+import {
+  lastCompletedShieldedSyncAtom,
+  storageShieldedBalanceAtom,
+  storageShieldedRewardsAtom,
+} from "atoms/balance/atoms";
+import { chainParametersAtom } from "atoms/chain";
+import {
+  clearShieldedContextAtom,
+  indexerHeartbeatAtom,
+  lastInvalidateShieldedContextAtom,
+} from "atoms/settings";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { RESET } from "jotai/utils";
+
+export const useInvalidateShieldedContext = (): (() => Promise<void>) => {
+  const [clearShieldedContext] = useAtom(clearShieldedContextAtom);
+  const setStorageShieldedBalance = useSetAtom(storageShieldedBalanceAtom);
+  const setLastCompletedShieldedSync = useSetAtom(
+    lastCompletedShieldedSyncAtom
+  );
+  const setStorageShieldedRewards = useSetAtom(storageShieldedRewardsAtom);
+  const setLastInvalidate = useSetAtom(lastInvalidateShieldedContextAtom);
+
+  const chainParameters = useAtomValue(chainParametersAtom);
+  const indexerInfo = useAtomValue(indexerHeartbeatAtom);
+
+  const chainId = chainParameters.data?.chainId ?? "";
+  const indexerVersion = indexerInfo.data?.version ?? "";
+
+  return async () => {
+    await clearShieldedContext.mutateAsync();
+    setStorageShieldedBalance(RESET);
+    setLastCompletedShieldedSync(RESET);
+    setStorageShieldedRewards(RESET);
+    setLastInvalidate((prev) => ({ ...prev, [chainId]: indexerVersion }));
+    location.href = routes.root;
+  };
+};

--- a/apps/namadillo/src/hooks/useSdk.tsx
+++ b/apps/namadillo/src/hooks/useSdk.tsx
@@ -1,5 +1,6 @@
 import { Sdk } from "@namada/sdk/web";
 import { QueryStatus, useQuery } from "@tanstack/react-query";
+import { PageLoader } from "App/Common/PageLoader";
 import { chainParametersAtom, nativeTokenAddressAtom } from "atoms/chain";
 import { useAtomValue } from "jotai";
 import {
@@ -65,6 +66,10 @@ export const SdkProvider: FunctionComponent<PropsWithChildren> = ({
       });
     }
   }, [nativeToken.data]);
+
+  if (!sdk) {
+    return <PageLoader />;
+  }
 
   return (
     <>

--- a/apps/namadillo/src/hooks/useShouldInvalidateShieldedContext.ts
+++ b/apps/namadillo/src/hooks/useShouldInvalidateShieldedContext.ts
@@ -1,0 +1,37 @@
+import { chainParametersAtom } from "atoms/chain/atoms";
+import {
+  indexerHeartbeatAtom,
+  lastInvalidateShieldedContextAtom,
+} from "atoms/settings/atoms";
+import { useAtomValue } from "jotai";
+import { useEffect } from "react";
+import semverSatisfies from "semver/functions/satisfies";
+import { useInvalidateShieldedContext } from "./useInvalidateShieldedContext";
+
+// change this value to the minimun indexer version that demands to clear the context
+const minIndexerVersion = ">=9.9.0";
+
+export const useShouldInvalidateShieldedContext = (): void => {
+  const lastInvalidate = useAtomValue(lastInvalidateShieldedContextAtom);
+  const chainParameters = useAtomValue(chainParametersAtom);
+  const indexerInfo = useAtomValue(indexerHeartbeatAtom);
+
+  const invalidateShieldedContext = useInvalidateShieldedContext();
+
+  const chainId = chainParameters.data?.chainId;
+  const indexerVersion = indexerInfo.data?.version;
+
+  useEffect(() => {
+    if (!chainId || !indexerVersion) {
+      return;
+    }
+    if (
+      // indexer should be updated and satifies the minimum version
+      semverSatisfies(indexerVersion, minIndexerVersion) &&
+      // and the last clear contenxt should be done with an old indexer version
+      !semverSatisfies(lastInvalidate[chainId] ?? "", minIndexerVersion)
+    ) {
+      invalidateShieldedContext();
+    }
+  }, [chainId, indexerVersion]);
+};


### PR DESCRIPTION
Save the indexer version (per chain) when invalidating the shielded context. 

Then uses this saved version to compare with the minimum accepted indexer version:
- in case the saved version is below the minimum accepted
- and the indexer version is greater then the minimum accepted
- execute a new context invalidation saving the new indexer version

Closes: https://github.com/anoma/namada-interface/issues/1845


https://github.com/user-attachments/assets/ad9404d2-b032-4a57-8ce8-420d23cce06d

