### PR TITLE
fix: fix link for ibc asset withdraw

### DIFF
--- a/apps/namadillo/src/App/AccountOverview/TransparentOverviewPanel.tsx
+++ b/apps/namadillo/src/App/AccountOverview/TransparentOverviewPanel.tsx
@@ -101,7 +101,7 @@ const TransparentTokensTable = ({
                   icon: <IoSwapHorizontal className="h-[20px] w-[20px]" />,
                 },
                 {
-                  url: `${routes.ibc}?${params.asset}=${originalAddress}`,
+                  url: `${routes.ibcWithdraw}?${params.asset}=${originalAddress}`,
                   icon: (
                     <TbVectorTriangle className="h-[20px] w-[20px] -mt-1" />
                   ),

--- a/apps/namadillo/src/App/Ibc/IbcTransfer.tsx
+++ b/apps/namadillo/src/App/Ibc/IbcTransfer.tsx
@@ -1,7 +1,7 @@
 import { Chain } from "@chain-registry/types";
 import { AccountType } from "@namada/types";
 import { mapUndefined } from "@namada/utils";
-import { routes } from "App/routes";
+import { params, routes } from "App/routes";
 import {
   OnSubmitTransferParams,
   TransferModule,
@@ -16,6 +16,7 @@ import {
 import BigNumber from "bignumber.js";
 import { useIbcTransaction } from "hooks/useIbcTransaction";
 import { useTransactionActions } from "hooks/useTransactionActions";
+import { useUrlState } from "hooks/useUrlState";
 import { useWalletManager } from "hooks/useWalletManager";
 import { wallets } from "integrations";
 import { KeplrWalletManager } from "integrations/Keplr";
@@ -24,7 +25,7 @@ import { useAtomValue } from "jotai";
 import { useEffect, useMemo, useState } from "react";
 import { generatePath, useNavigate } from "react-router-dom";
 import namadaChain from "registry/namada.json";
-import { Address, AddressWithAssetAndAmountMap } from "types";
+import { AddressWithAssetAndAmountMap } from "types";
 import { useTransactionEventListener } from "utils";
 import { IbcTopHeader } from "./IbcTopHeader";
 
@@ -65,7 +66,9 @@ export const IbcTransfer = (): JSX.Element => {
 
   // Local State
   const [shielded, setShielded] = useState<boolean>(true);
-  const [selectedAssetAddress, setSelectedAssetAddress] = useState<Address>();
+  const [selectedAssetAddress, setSelectedAssetAddress] = useUrlState(
+    params.asset
+  );
   const [amount, setAmount] = useState<BigNumber | undefined>();
   const [generalErrorMessage, setGeneralErrorMessage] = useState("");
   const [sourceChannel, setSourceChannel] = useState("");
@@ -79,10 +82,8 @@ export const IbcTransfer = (): JSX.Element => {
     selectedAssetAddress
   );
 
-  const selectedAsset = mapUndefined(
-    (address) => userAssets?.[address],
-    selectedAssetAddress
-  );
+  const selectedAsset =
+    selectedAssetAddress ? userAssets?.[selectedAssetAddress] : undefined;
 
   const availableAssets = useMemo(() => {
     if (!enabledAssets || !userAssets) return undefined;

--- a/apps/namadillo/src/App/Ibc/IbcWithdraw.tsx
+++ b/apps/namadillo/src/App/Ibc/IbcWithdraw.tsx
@@ -1,7 +1,7 @@
 import { Asset, Chain } from "@chain-registry/types";
 import { IbcTransferMsgValue } from "@namada/types";
 import { mapUndefined } from "@namada/utils";
-import { routes } from "App/routes";
+import { params, routes } from "App/routes";
 import {
   OnSubmitTransferParams,
   TransferModule,
@@ -18,6 +18,7 @@ import {
 import BigNumber from "bignumber.js";
 import { useTransaction } from "hooks/useTransaction";
 import { useTransactionActions } from "hooks/useTransactionActions";
+import { useUrlState } from "hooks/useUrlState";
 import { useWalletManager } from "hooks/useWalletManager";
 import { wallets } from "integrations";
 import { KeplrWalletManager } from "integrations/Keplr";
@@ -27,7 +28,7 @@ import { TransactionPair } from "lib/query";
 import { useEffect, useState } from "react";
 import { generatePath, useNavigate } from "react-router-dom";
 import namadaChainRegistry from "registry/namada.json";
-import { Address, IbcTransferTransactionData, TransferStep } from "types";
+import { IbcTransferTransactionData, TransferStep } from "types";
 import {
   toBaseAmount,
   toDisplayAmount,
@@ -43,7 +44,9 @@ export const IbcWithdraw: React.FC = () => {
   const namadaChain = useAtomValue(chainAtom);
 
   const [generalErrorMessage, setGeneralErrorMessage] = useState("");
-  const [selectedAssetAddress, setSelectedAssetAddress] = useState<Address>();
+  const [selectedAssetAddress, setSelectedAssetAddress] = useUrlState(
+    params.asset
+  );
   const [amount, setAmount] = useState<BigNumber | undefined>();
   const [customAddress, setCustomAddress] = useState<string>("");
   const [sourceChannel, setSourceChannel] = useState("");
@@ -64,10 +67,8 @@ export const IbcWithdraw: React.FC = () => {
     selectedAssetAddress
   );
 
-  const selectedAsset = mapUndefined(
-    (address) => availableAssets?.[address],
-    selectedAssetAddress
-  );
+  const selectedAsset =
+    selectedAssetAddress ? availableAssets?.[selectedAssetAddress] : undefined;
 
   const {
     walletAddress: keplrAddress,

--- a/apps/namadillo/src/App/Masp/MaspShield.tsx
+++ b/apps/namadillo/src/App/Masp/MaspShield.tsx
@@ -15,17 +15,15 @@ import { rpcUrlAtom } from "atoms/settings";
 import BigNumber from "bignumber.js";
 import { useTransactionActions } from "hooks/useTransactionActions";
 import { useTransfer } from "hooks/useTransfer";
+import { useUrlState } from "hooks/useUrlState";
 import { wallets } from "integrations";
 import invariant from "invariant";
 import { useAtom, useAtomValue } from "jotai";
 import { createTransferDataFromNamada } from "lib/transactions";
 import { useState } from "react";
-import { useSearchParams } from "react-router-dom";
 import namadaChain from "registry/namada.json";
-import { Address } from "types";
 
 export const MaspShield: React.FC = () => {
-  const [searchParams, setSearchParams] = useSearchParams();
   const { storeTransaction } = useTransactionActions();
   const [displayAmount, setDisplayAmount] = useState<BigNumber | undefined>();
   const [generalErrorMessage, setGeneralErrorMessage] = useState("");
@@ -51,7 +49,9 @@ export const MaspShield: React.FC = () => {
     (account) => account.type === AccountType.ShieldedKeys
   )?.address;
 
-  const selectedAssetAddress = searchParams.get(params.asset) || undefined;
+  const [selectedAssetAddress, setSelectedAssetAddress] = useUrlState(
+    params.asset
+  );
   const selectedAsset =
     selectedAssetAddress ? availableAssets?.[selectedAssetAddress] : undefined;
 
@@ -86,21 +86,6 @@ export const MaspShield: React.FC = () => {
     },
     asset: selectedAsset?.asset,
   });
-
-  const onChangeSelectedAsset = (address?: Address): void => {
-    setSearchParams(
-      (currentParams) => {
-        const newParams = new URLSearchParams(currentParams);
-        if (address) {
-          newParams.set(params.asset, address);
-        } else {
-          newParams.delete(params.asset);
-        }
-        return newParams;
-      },
-      { replace: true }
-    );
-  };
 
   const onSubmitTransfer = async ({
     memo,
@@ -162,7 +147,7 @@ export const MaspShield: React.FC = () => {
           availableWallets: [wallets.namada],
           wallet: wallets.namada,
           walletAddress: sourceAddress,
-          onChangeSelectedAsset,
+          onChangeSelectedAsset: setSelectedAssetAddress,
           amount: displayAmount,
           onChangeAmount: setDisplayAmount,
           ledgerAccountInfo,

--- a/apps/namadillo/src/App/Masp/MaspUnshield.tsx
+++ b/apps/namadillo/src/App/Masp/MaspUnshield.tsx
@@ -15,17 +15,15 @@ import { rpcUrlAtom } from "atoms/settings";
 import BigNumber from "bignumber.js";
 import { useTransactionActions } from "hooks/useTransactionActions";
 import { useTransfer } from "hooks/useTransfer";
+import { useUrlState } from "hooks/useUrlState";
 import { wallets } from "integrations";
 import invariant from "invariant";
 import { useAtom, useAtomValue } from "jotai";
 import { createTransferDataFromNamada } from "lib/transactions";
 import { useState } from "react";
-import { useSearchParams } from "react-router-dom";
 import namadaChain from "registry/namada.json";
-import { Address } from "types";
 
 export const MaspUnshield: React.FC = () => {
-  const [searchParams, setSearchParams] = useSearchParams();
   const [displayAmount, setDisplayAmount] = useState<BigNumber | undefined>();
   const [generalErrorMessage, setGeneralErrorMessage] = useState("");
   const [currentStatus, setCurrentStatus] = useState("");
@@ -54,7 +52,9 @@ export const MaspUnshield: React.FC = () => {
     (account) => account.type !== AccountType.ShieldedKeys
   )?.address;
 
-  const selectedAssetAddress = searchParams.get(params.asset) || undefined;
+  const [selectedAssetAddress, setSelectedAssetAddress] = useUrlState(
+    params.asset
+  );
   const selectedAsset =
     selectedAssetAddress ? availableAssets?.[selectedAssetAddress] : undefined;
 
@@ -84,21 +84,6 @@ export const MaspUnshield: React.FC = () => {
     },
     asset: selectedAsset?.asset,
   });
-
-  const onChangeSelectedAsset = (address?: Address): void => {
-    setSearchParams(
-      (currentParams) => {
-        const newParams = new URLSearchParams(currentParams);
-        if (address) {
-          newParams.set(params.asset, address);
-        } else {
-          newParams.delete(params.asset);
-        }
-        return newParams;
-      },
-      { replace: true }
-    );
-  };
 
   const onSubmitTransfer = async ({
     memo,
@@ -159,7 +144,7 @@ export const MaspUnshield: React.FC = () => {
           wallet: wallets.namada,
           walletAddress: sourceAddress,
           isShielded: true,
-          onChangeSelectedAsset,
+          onChangeSelectedAsset: setSelectedAssetAddress,
           amount: displayAmount,
           onChangeAmount: setDisplayAmount,
           ledgerAccountInfo,

--- a/apps/namadillo/src/App/NamadaTransfer/NamadaTransfer.tsx
+++ b/apps/namadillo/src/App/NamadaTransfer/NamadaTransfer.tsx
@@ -18,6 +18,7 @@ import { rpcUrlAtom } from "atoms/settings";
 import BigNumber from "bignumber.js";
 import { useTransactionActions } from "hooks/useTransactionActions";
 import { useTransfer } from "hooks/useTransfer";
+import { useUrlState } from "hooks/useUrlState";
 import { wallets } from "integrations";
 import invariant from "invariant";
 import { useAtom, useAtomValue } from "jotai";
@@ -26,7 +27,6 @@ import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import namadaChain from "registry/namada.json";
 import { twMerge } from "tailwind-merge";
-import { Address } from "types";
 import { NamadaTransferTopHeader } from "./NamadaTransferTopHeader";
 
 export const NamadaTransfer: React.FC = () => {
@@ -64,7 +64,9 @@ export const NamadaTransfer: React.FC = () => {
     : account.type !== AccountType.ShieldedKeys
   );
   const sourceAddress = account?.address;
-  const selectedAssetAddress = searchParams.get(params.asset) || undefined;
+  const [selectedAssetAddress, setSelectedAssetAddress] = useUrlState(
+    params.asset
+  );
   const selectedAsset =
     selectedAssetAddress ? availableAssets?.[selectedAssetAddress] : undefined;
   const source = sourceAddress ?? "";
@@ -112,21 +114,6 @@ export const NamadaTransfer: React.FC = () => {
       (currentParams) => {
         const newParams = new URLSearchParams(currentParams);
         newParams.set(params.shielded, isShielded ? "1" : "0");
-        return newParams;
-      },
-      { replace: true }
-    );
-  };
-
-  const onChangeSelectedAsset = (address?: Address): void => {
-    setSearchParams(
-      (currentParams) => {
-        const newParams = new URLSearchParams(currentParams);
-        if (address) {
-          newParams.set(params.asset, address);
-        } else {
-          newParams.delete(params.asset);
-        }
         return newParams;
       },
       { replace: true }
@@ -198,7 +185,7 @@ export const NamadaTransfer: React.FC = () => {
           wallet: wallets.namada,
           walletAddress: sourceAddress,
           selectedAssetAddress,
-          onChangeSelectedAsset,
+          onChangeSelectedAsset: setSelectedAssetAddress,
           isShielded: shielded,
           onChangeShielded,
           amount: displayAmount,

--- a/apps/namadillo/src/hooks/useUrlState.ts
+++ b/apps/namadillo/src/hooks/useUrlState.ts
@@ -1,0 +1,31 @@
+import { params } from "App/routes";
+import { useCallback } from "react";
+import { useSearchParams } from "react-router-dom";
+
+export const useUrlState = (
+  paramName: keyof typeof params
+): [string | undefined, (newValue?: string) => void] => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const value = searchParams.get(paramName) || undefined;
+
+  const setValue = useCallback(
+    (value?: string): void => {
+      setSearchParams(
+        (prev) => {
+          const newParams = new URLSearchParams(prev);
+          if (value === undefined) {
+            newParams.delete(paramName);
+          } else {
+            newParams.set(paramName, value);
+          }
+          return newParams;
+        },
+        { replace: true }
+      );
+    },
+    [paramName, setSearchParams]
+  );
+
+  return [value, setValue];
+};


### PR DESCRIPTION
Fix link for ibc asset withdraw

Create the hook `useUrlState` as a helper to manipulate a state that exists on `URLSearchParams` and apply to all forms related to the transfers

Closes https://github.com/anoma/namada-interface/issues/1846
Closes https://github.com/anoma/namada-interface/issues/1612

https://github.com/user-attachments/assets/9a1ff373-a57d-4a6a-b5ca-fddba581a4c9

