### PR TITLE
fix: Namadillo - If account is a Ledger, don't show sign arbitrary button

### DIFF
--- a/apps/namadillo/src/App/Layout/TopNavigation.tsx
+++ b/apps/namadillo/src/App/Layout/TopNavigation.tsx
@@ -1,9 +1,11 @@
 import { ActionButton } from "@namada/components";
+import { AccountType } from "@namada/types";
 import { ConnectExtensionButton } from "App/Common/ConnectExtensionButton";
 import { ShieldAssetsModal } from "App/Common/ShieldAssetsModal";
 import { TransactionInProgressSpinner } from "App/Common/TransactionInProgressSpinner";
 import { UnshieldAssetsModal } from "App/Common/UnshieldAssetsModal";
 import { routes } from "App/routes";
+import { defaultAccountAtom } from "atoms/accounts";
 import {
   applicationFeaturesAtom,
   signArbitraryEnabledAtom,
@@ -27,6 +29,7 @@ export const TopNavigation = (): JSX.Element => {
   const { maspEnabled, namTransfersEnabled } = useAtomValue(
     applicationFeaturesAtom
   );
+  const defaultAccount = useAtomValue(defaultAccountAtom);
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -96,19 +99,20 @@ export const TopNavigation = (): JSX.Element => {
       >
         <IoSettingsOutline />
       </button>
-      {signArbitraryEnabled && (
-        <button
-          className="text-2xl text-yellow hover:text-cyan"
-          title="Sign Message"
-          onClick={() =>
-            navigate(routes.signMessages, {
-              state: { backgroundLocation: location },
-            })
-          }
-        >
-          <AiOutlineMessage />
-        </button>
-      )}
+      {defaultAccount.data?.type !== AccountType.Ledger &&
+        signArbitraryEnabled && (
+          <button
+            className="text-2xl text-yellow hover:text-cyan"
+            title="Sign Message"
+            onClick={() =>
+              navigate(routes.signMessages, {
+                state: { backgroundLocation: location },
+              })
+            }
+          >
+            <AiOutlineMessage />
+          </button>
+        )}
 
       <TransactionInProgressSpinner />
       <SyncIndicator />


### PR DESCRIPTION
Resolves #1789 

As Ledger HW Wallet does not have a _sign arbitrary data_ feature, we shouldn't display the sign-arbitrary button.

### Testing

- Enable Sign Arbitrary in Settings
- With a non-Ledger account selected in Keychain, you should see the sign-arbitrary button in the top navigation
- With a Ledger account selected, even with Sign-Arbitrary enabled, you should not see the button