### PR TITLE
feat: add masp indexer version

### DIFF
--- a/apps/namadillo/src/App/Common/BugReport.tsx
+++ b/apps/namadillo/src/App/Common/BugReport.tsx
@@ -8,6 +8,7 @@ import { chainStatusAtom } from "atoms/chain";
 import {
   indexerCrawlersInfoAtom,
   indexerHeartbeatAtom,
+  maspIndexerHeartbeatAtom,
   settingsAtom,
 } from "atoms/settings";
 import { useKeychainVersion } from "hooks/useKeychainVersion";
@@ -21,6 +22,7 @@ import { version as namadilloVersion } from "../../../package.json";
 export const BugReport = (): JSX.Element => {
   const keychainVersion = useKeychainVersion();
   const indexerHealth = useAtomValue(indexerHeartbeatAtom);
+  const maspIndexerHealth = useAtomValue(maspIndexerHeartbeatAtom);
   const crawlerInfo = useAtomValue(indexerCrawlersInfoAtom);
   const chainStatus = useAtomValue(chainStatusAtom);
   const currentDate = useRef(new Date().toString());
@@ -44,6 +46,7 @@ Namadillo Version: ${namadilloVersion}
 SDK Version: ${sdkVersion}
 Keychain Version: ${keychainVersion ?? "?"}
 Indexer Version: ${indexerHealth.data?.version}
+Masp Indexer Version: ${maspIndexerHealth.data?.version}
 
 ## MASP Status${sep}
 MASP Indexer URL: ${settings.maspIndexerUrl}

--- a/apps/namadillo/src/App/Settings/SettingsMain.tsx
+++ b/apps/namadillo/src/App/Settings/SettingsMain.tsx
@@ -1,5 +1,5 @@
 import { routes } from "App/routes";
-import { indexerHeartbeatAtom } from "atoms/settings";
+import { indexerHeartbeatAtom, maspIndexerHeartbeatAtom } from "atoms/settings";
 import { useAtomValue } from "jotai";
 import { GoLinkExternal } from "react-icons/go";
 import { version as sdkVersion } from "../../../../../packages/sdk/package.json";
@@ -10,6 +10,7 @@ const { VITE_REVISION: revision = "" } = import.meta.env;
 
 export const SettingsMain = (): JSX.Element => {
   const indexerHealth = useAtomValue(indexerHeartbeatAtom);
+  const maspIndexerHealth = useAtomValue(maspIndexerHeartbeatAtom);
 
   return (
     <div className="flex flex-1 justify-between flex-col w-full">
@@ -25,6 +26,9 @@ export const SettingsMain = (): JSX.Element => {
       <div className="text-xs">
         <div>Namadillo Version: {version}</div>
         <div>Indexer Version: {indexerHealth?.data?.version ?? "-"}</div>
+        <div>
+          Masp Indexer Version: {maspIndexerHealth?.data?.version ?? "-"}
+        </div>
         <div>SDK Version: {sdkVersion}</div>
         <div>
           <span>Revision: </span>

--- a/apps/namadillo/src/atoms/settings/services.ts
+++ b/apps/namadillo/src/atoms/settings/services.ts
@@ -32,15 +32,27 @@ export const getIndexerCrawlerInfo = async (
   }
 };
 
-export const isMaspIndexerAlive = async (url: string): Promise<boolean> => {
-  if (!isUrlValid(url)) {
-    return false;
-  }
+export const getMaspIndexerHealth = async (
+  url: string
+  // TODO replace the `HealthGet200Response` by the type returned from
+  // the package "@namada/masp-indexer-client" when it is published
+): Promise<HealthGet200Response | undefined> => {
   try {
     const response = await fetch(`${url}/health`);
-    return response.ok && response.status === 200;
+    // Former masp indexers returns the commit hash string instead of json,
+    // then we manually check if the returned string is a json-like:
+    // - If yes, we convert to json with `JSON.parse()` and return it.
+    // - If not, it's the commit hash string, then we manually create a json
+    // This is to avoid compatibility issues. We can remove this condition
+    // when all hosts update the masp indexer
+    const text = await response.text();
+    if (text.startsWith("{")) {
+      return JSON.parse(text);
+    } else {
+      return { commit: text, version: "0.0.0" };
+    }
   } catch {
-    return false;
+    return;
   }
 };
 

--- a/apps/namadillo/src/atoms/syncStatus/atoms.ts
+++ b/apps/namadillo/src/atoms/syncStatus/atoms.ts
@@ -5,6 +5,7 @@ import { allProposalsAtom, votedProposalsAtom } from "atoms/proposals";
 import {
   indexerCrawlersInfoAtom,
   indexerHeartbeatAtom,
+  maspIndexerHeartbeatAtom,
   rpcHeartbeatAtom,
 } from "atoms/settings/atoms";
 import { allValidatorsAtom, myValidatorsAtom } from "atoms/validators";
@@ -14,6 +15,7 @@ export const syncStatusAtom = atom((get) => {
   const queries = [
     // Heartbeat
     get(indexerHeartbeatAtom),
+    get(maspIndexerHeartbeatAtom),
     get(rpcHeartbeatAtom),
 
     // Account Overview

--- a/apps/namadillo/src/hooks/useInvalidateShieldedContext.ts
+++ b/apps/namadillo/src/hooks/useInvalidateShieldedContext.ts
@@ -7,8 +7,8 @@ import {
 import { chainParametersAtom } from "atoms/chain";
 import {
   clearShieldedContextAtom,
-  indexerHeartbeatAtom,
   lastInvalidateShieldedContextAtom,
+  maspIndexerHeartbeatAtom,
 } from "atoms/settings";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { RESET } from "jotai/utils";
@@ -23,17 +23,17 @@ export const useInvalidateShieldedContext = (): (() => Promise<void>) => {
   const setLastInvalidate = useSetAtom(lastInvalidateShieldedContextAtom);
 
   const chainParameters = useAtomValue(chainParametersAtom);
-  const indexerInfo = useAtomValue(indexerHeartbeatAtom);
+  const maspIndexerInfo = useAtomValue(maspIndexerHeartbeatAtom);
 
   const chainId = chainParameters.data?.chainId ?? "";
-  const indexerVersion = indexerInfo.data?.version ?? "";
+  const maspIndexerVersion = maspIndexerInfo.data?.version ?? "";
 
   return async () => {
     await clearShieldedContext.mutateAsync();
     setStorageShieldedBalance(RESET);
     setLastCompletedShieldedSync(RESET);
     setStorageShieldedRewards(RESET);
-    setLastInvalidate((prev) => ({ ...prev, [chainId]: indexerVersion }));
+    setLastInvalidate((prev) => ({ ...prev, [chainId]: maspIndexerVersion }));
     location.href = routes.root;
   };
 };

--- a/apps/namadillo/src/hooks/useShouldInvalidateShieldedContext.ts
+++ b/apps/namadillo/src/hooks/useShouldInvalidateShieldedContext.ts
@@ -1,37 +1,37 @@
 import { chainParametersAtom } from "atoms/chain/atoms";
 import {
-  indexerHeartbeatAtom,
   lastInvalidateShieldedContextAtom,
+  maspIndexerHeartbeatAtom,
 } from "atoms/settings/atoms";
 import { useAtomValue } from "jotai";
 import { useEffect } from "react";
 import semverSatisfies from "semver/functions/satisfies";
 import { useInvalidateShieldedContext } from "./useInvalidateShieldedContext";
 
-// change this value to the minimun indexer version that demands to clear the context
-const minIndexerVersion = ">=9.9.0";
+// change this value to the minimun masp indexer version that demands to clear the context
+const minMaspIndexerVersion = ">=9.9.0";
 
 export const useShouldInvalidateShieldedContext = (): void => {
   const lastInvalidate = useAtomValue(lastInvalidateShieldedContextAtom);
   const chainParameters = useAtomValue(chainParametersAtom);
-  const indexerInfo = useAtomValue(indexerHeartbeatAtom);
+  const maspIndexerInfo = useAtomValue(maspIndexerHeartbeatAtom);
 
   const invalidateShieldedContext = useInvalidateShieldedContext();
 
   const chainId = chainParameters.data?.chainId;
-  const indexerVersion = indexerInfo.data?.version;
+  const maspIndexerVersion = maspIndexerInfo.data?.version;
 
   useEffect(() => {
-    if (!chainId || !indexerVersion) {
+    if (!chainId || !maspIndexerVersion) {
       return;
     }
     if (
-      // indexer should be updated and satifies the minimum version
-      semverSatisfies(indexerVersion, minIndexerVersion) &&
-      // and the last clear contenxt should be done with an old indexer version
-      !semverSatisfies(lastInvalidate[chainId] ?? "", minIndexerVersion)
+      // masp indexer should be updated and satifies the minimum version
+      semverSatisfies(maspIndexerVersion, minMaspIndexerVersion) &&
+      // and the last clear context should be done with an old masp indexer version
+      !semverSatisfies(lastInvalidate[chainId] ?? "", minMaspIndexerVersion)
     ) {
       invalidateShieldedContext();
     }
-  }, [chainId, indexerVersion]);
+  }, [chainId, maspIndexerVersion]);
 };


### PR DESCRIPTION
Add masp indexer version and update all places related to it

Also, update the auto invalidate shielded context based on the **masp** indexer version, instead of the indexer version

Closes https://github.com/anoma/namada-interface/issues/1857

![Screenshot 2025-03-08 at 13 50 25](https://github.com/user-attachments/assets/5de8731a-51bb-4cbc-bfbe-baa239749b59)