### PR TITLE
feat: starting the advanced mode feature on Namadillo

### DIFF
--- a/apps/namadillo/src/App/Settings/Advanced.tsx
+++ b/apps/namadillo/src/App/Settings/Advanced.tsx
@@ -29,8 +29,8 @@ export const Advanced = (): JSX.Element => {
 
   const [rpc, setRpc] = useState(currentRpcUrl);
   const [indexer, setIndexer] = useState(currentIndexerUrl);
-  const [enableTestnets, setTestnetsEnabled] = useState<boolean>(
-    settings.enableTestnets || false
+  const [enableAdvancedMode, setAdvancedMode] = useState<boolean>(
+    settings.advancedMode || false
   );
   const [maspIndexer, setMaspIndexer] = useState(currentMaspIndexer);
 
@@ -41,8 +41,8 @@ export const Advanced = (): JSX.Element => {
         rpcMutation.mutateAsync(rpc),
         indexerMutation.mutateAsync(indexer),
         settingsMutation.mutateAsync({
-          key: "enableTestnets",
-          value: enableTestnets,
+          key: "advancedMode",
+          value: enableAdvancedMode,
         }),
         maspIndexerMutation.mutateAsync(maspIndexer),
       ]);
@@ -116,12 +116,12 @@ export const Advanced = (): JSX.Element => {
         />
         <div className="flex gap-3 items-center">
           <Checkbox
-            id="testnets-enabled"
-            checked={enableTestnets}
-            onChange={(e) => setTestnetsEnabled(e.target.checked)}
+            id="advanced-mode-enabled"
+            checked={enableAdvancedMode}
+            onChange={(e) => setAdvancedMode(e.target.checked)}
           />
-          <label htmlFor="testnets-enabled" className="cursor-pointer">
-            Enable Testnets
+          <label htmlFor="advanced-mode-enabled" className="cursor-pointer">
+            Advanced mode
           </label>
         </div>
       </Stack>

--- a/apps/namadillo/src/App/Sidebars/EpochInformation.tsx
+++ b/apps/namadillo/src/App/Sidebars/EpochInformation.tsx
@@ -1,11 +1,14 @@
 import { Panel } from "@namada/components";
 import { chainStatusAtom } from "atoms/chain";
+import { settingsAtom } from "atoms/settings";
 import { useAtomValue } from "jotai";
 import { TbClockStop } from "react-icons/tb";
 
 export const EpochInformation = (): JSX.Element => {
   const chainStatus = useAtomValue(chainStatusAtom);
-  if (!chainStatus) {
+  const settings = useAtomValue(settingsAtom);
+
+  if (!chainStatus || !settings.advancedMode) {
     return <></>;
   }
 

--- a/apps/namadillo/src/atoms/integrations/atoms.ts
+++ b/apps/namadillo/src/atoms/integrations/atoms.ts
@@ -114,7 +114,7 @@ export const assetBalanceAtomFamily = atomFamily(
 export const chainRegistryAtom = atom<Record<ChainId, ChainRegistryEntry>>(
   (get) => {
     const settings = get(settingsAtom);
-    const knownChains = getKnownChains(settings.enableTestnets);
+    const knownChains = getKnownChains(settings.advancedMode);
     const map: Record<ChainId, ChainRegistryEntry> = {};
     knownChains.forEach((chain) => {
       map[chain.chain.chain_id] = chain;
@@ -126,13 +126,13 @@ export const chainRegistryAtom = atom<Record<ChainId, ChainRegistryEntry>>(
 // Lists only the available chain list
 export const availableChainsAtom = atom((get) => {
   const settings = get(settingsAtom);
-  return getKnownChains(settings.enableTestnets).map(({ chain }) => chain);
+  return getKnownChains(settings.advancedMode).map(({ chain }) => chain);
 });
 
 // Lists only the available assets list
 export const availableAssetsAtom = atom((get) => {
   const settings = get(settingsAtom);
-  return getKnownChains(settings.enableTestnets).map(({ assets }) => assets);
+  return getKnownChains(settings.advancedMode).map(({ assets }) => assets);
 });
 
 export const ibcRateLimitAtom = atomWithQuery((get) => {

--- a/apps/namadillo/src/types.ts
+++ b/apps/namadillo/src/types.ts
@@ -85,7 +85,7 @@ export type SettingsStorage = {
   indexerUrl: string;
   maspIndexerUrl?: string;
   signArbitraryEnabled: boolean;
-  enableTestnets?: boolean;
+  advancedMode?: boolean;
 };
 
 export type RpcStorage = {


### PR DESCRIPTION
This PR introduces an "advanced mode" for Namadillo. For version 2 of the interface, we're planning to hide a few features to make UX more clean and straightforward for regular users. As a starting point, this PR also hides Epoch info and closes #1851 . 