### PR TITLE
feat: add button to copy shielded address

### DIFF
--- a/apps/namadillo/src/App/Layout/AccountIconButton.tsx
+++ b/apps/namadillo/src/App/Layout/AccountIconButton.tsx
@@ -1,10 +1,12 @@
 import { ButtonHTMLAttributes } from "react";
 
-export const accountIconButtonClassname =
-  "p-1 opacity-80 transition-opacity hover:opacity-100";
-
 export const AccountIconButton = (
   props: ButtonHTMLAttributes<HTMLButtonElement>
 ): JSX.Element => {
-  return <button className={accountIconButtonClassname} {...props} />;
+  return (
+    <button
+      className="p-1 opacity-80 transition-opacity hover:opacity-100"
+      {...props}
+    />
+  );
 };

--- a/apps/namadillo/src/App/Layout/NamadaAccount.tsx
+++ b/apps/namadillo/src/App/Layout/NamadaAccount.tsx
@@ -1,25 +1,69 @@
 import { CopyToClipboardControl, Tooltip } from "@namada/components";
+import { AccountType } from "@namada/types";
+import { shortenAddress } from "@namada/utils";
 import { routes } from "App/routes";
-import { defaultAccountAtom } from "atoms/accounts";
+import { accountsAtom, allDefaultAccountsAtom } from "atoms/accounts";
 import { NamadaKeychain } from "hooks/useNamadaKeychain";
 import { useAtomValue } from "jotai";
 import { useLocation, useNavigate } from "react-router-dom";
-import {
-  AccountIconButton,
-  accountIconButtonClassname,
-} from "./AccountIconButton";
+import { twMerge } from "tailwind-merge";
+import { AccountIconButton } from "./AccountIconButton";
 import { DisconnectAccountIcon } from "./DisconnectAccountIcon";
 import { SwitchAccountIcon } from "./SwitchAccountIcon";
 import NamadaWalletIcon from "./assets/namada-wallet-icon.svg";
 
+const AddressField = ({
+  label,
+  value,
+  isShielded,
+}: {
+  label: string;
+  value?: string;
+  isShielded?: boolean;
+}): JSX.Element => {
+  if (!value) {
+    return <></>;
+  }
+  return (
+    <div>
+      <div className="mb-0.5">{label}</div>
+      <CopyToClipboardControl
+        value={value}
+        className={twMerge(
+          "border rounded-sm font-mono p-2 opacity-80 transition-opacity hover:opacity-100",
+          isShielded && "border-yellow"
+        )}
+      >
+        {shortenAddress(value)}
+      </CopyToClipboardControl>
+    </div>
+  );
+};
+
 export const NamadaAccount = (): JSX.Element => {
-  const { data: account, isFetching } = useAtomValue(defaultAccountAtom);
+  const { data: accounts, isFetching } = useAtomValue(allDefaultAccountsAtom);
+  const allAccounts = useAtomValue(accountsAtom);
+
   const location = useLocation();
   const navigate = useNavigate();
 
-  if (!account || isFetching) {
+  if (isFetching) {
     return <></>;
   }
+
+  const transparentAccount = accounts?.find(
+    (account) => account.type !== AccountType.ShieldedKeys
+  );
+  const shieldedAccount = accounts?.find(
+    (account) => account.type === AccountType.ShieldedKeys
+  );
+
+  const hasDefaultAccount = !!accounts?.length;
+
+  const alias = transparentAccount?.alias ?? shieldedAccount?.alias;
+  const hasMoreThanOneAccount = !!allAccounts.data?.find(
+    (a) => a.alias !== alias
+  );
 
   const onClickDisconnect = async (): Promise<void> => {
     const namada = await new NamadaKeychain().get();
@@ -29,31 +73,52 @@ export const NamadaAccount = (): JSX.Element => {
   };
 
   return (
-    <div className="flex items-center rounded-sm text-sm text-white bg-black px-1">
-      <span className="flex items-center gap-2 relative group/tooltip">
-        <CopyToClipboardControl
-          className={accountIconButtonClassname}
-          value={account.address || ""}
+    <div className="flex items-center rounded-sm text-sm text-white bg-black px-2">
+      {hasDefaultAccount && (
+        <div className="relative group/tooltip">
+          <div className="flex items-center gap-2">
+            <img
+              src={NamadaWalletIcon}
+              alt="Namada Wallet"
+              className="w-6 h-6"
+            />
+            <span className="mr-1">
+              {transparentAccount?.alias ?? shieldedAccount?.alias}
+            </span>
+          </div>
+          <Tooltip position="bottom" className="z-10">
+            <div className="pt-2 pb-3 flex flex-col gap-2">
+              <AddressField
+                label="Transparent address"
+                value={transparentAccount?.address}
+              />
+              <AddressField
+                label="Shielded address"
+                value={shieldedAccount?.address}
+                isShielded
+              />
+            </div>
+          </Tooltip>
+        </div>
+      )}
+
+      {hasMoreThanOneAccount && (
+        <AccountIconButton
+          onClick={() => {
+            navigate(routes.switchAccount, {
+              state: { backgroundLocation: location },
+            });
+          }}
         >
-          <img src={NamadaWalletIcon} alt="Namada Wallet" className="w-6 h-6" />
-          <span className="mr-1">{account.alias}</span>
-        </CopyToClipboardControl>
-        <Tooltip position="left">{account.address}</Tooltip>
-      </span>
+          <SwitchAccountIcon />
+        </AccountIconButton>
+      )}
 
-      <AccountIconButton
-        onClick={() => {
-          navigate(routes.switchAccount, {
-            state: { backgroundLocation: location },
-          });
-        }}
-      >
-        <SwitchAccountIcon />
-      </AccountIconButton>
-
-      <AccountIconButton onClick={onClickDisconnect}>
-        <DisconnectAccountIcon />
-      </AccountIconButton>
+      {hasDefaultAccount && (
+        <AccountIconButton onClick={onClickDisconnect}>
+          <DisconnectAccountIcon />
+        </AccountIconButton>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
On hover the account name, shows the account addresses to be copied

Also, hide the switch button in case the user has only one account (accounts with the same alias)

It also support shielded only accounts imported with spending key

Closes https://github.com/anoma/namada-interface/issues/1589
Closes https://github.com/anoma/namada-interface/issues/1554

![Screenshot 2025-03-08 at 18 27 18](https://github.com/user-attachments/assets/f7bf91ec-ceed-4523-9603-fd9e3e18a209)

![Screenshot 2025-03-08 at 18 27 30](https://github.com/user-attachments/assets/072199ab-c08b-425d-884a-8cdeabc20e37)

