### PR TITLE
fix: tokens sometimes not rendering correctly after refreshing masp page

### DIFF
--- a/apps/namadillo/src/atoms/balance/atoms.ts
+++ b/apps/namadillo/src/atoms/balance/atoms.ts
@@ -205,6 +205,7 @@ export const shieldedBalanceAtom = atomWithQuery((get) => {
 export const namadaShieldedAssetsAtom = atomWithQuery((get) => {
   const storageShieldedBalance = get(storageShieldedBalanceAtom);
   const viewingKeysQuery = get(viewingKeysAtom);
+  const chainTokensQuery = get(chainTokensAtom);
   const chainAssetsMap = get(chainAssetsMapAtom);
 
   const [viewingKey] = viewingKeysQuery.data ?? [];
@@ -219,7 +220,7 @@ export const namadaShieldedAssetsAtom = atomWithQuery((get) => {
             [],
           chainAssetsMap
         ),
-      [viewingKeysQuery]
+      [viewingKeysQuery, chainTokensQuery]
     ),
   };
 });


### PR DESCRIPTION
To reproduce this issue you need to go to the masp list of tokens and refresh the page. Sometimes tokens are not loaded correctly. 