### PR TITLE
chore: fix clippy warnings

### DIFF
--- a/packages/crypto/lib/.cargo/config.toml
+++ b/packages/crypto/lib/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-unknown-unknown"

--- a/packages/crypto/lib/src/crypto/aes.rs
+++ b/packages/crypto/lib/src/crypto/aes.rs
@@ -32,7 +32,7 @@ impl AES {
                 key.length
             ));
         }
-        let mut key = GenericArray::from_iter(key.vec.clone().into_iter());
+        let mut key = GenericArray::from_iter(key.vec.clone());
         let iv: [u8; 12] = match iv.try_into() {
             Ok(iv) => iv,
             Err(_) => {

--- a/packages/crypto/lib/src/crypto/bip32.rs
+++ b/packages/crypto/lib/src/crypto/bip32.rs
@@ -40,7 +40,7 @@ impl Key {
 
     pub fn to_hex(&self) -> StringPointer {
         let bytes: &[u8] = &self.bytes;
-        let string = hex::encode(&bytes);
+        let string = hex::encode(bytes);
         StringPointer::new(string)
     }
 }

--- a/packages/crypto/lib/src/crypto/pointer_types.rs
+++ b/packages/crypto/lib/src/crypto/pointer_types.rs
@@ -30,8 +30,10 @@ impl VecU8Pointer {
             vec,
         }
     }
+}
 
-    pub fn clone(&self) -> VecU8Pointer {
+impl Clone for VecU8Pointer {
+    fn clone(&self) -> Self {
         VecU8Pointer::new(self.vec.clone())
     }
 }
@@ -57,8 +59,10 @@ impl StringPointer {
             string,
         }
     }
+}
 
-    pub fn clone(&self) -> StringPointer {
+impl Clone for StringPointer {
+    fn clone(&self) -> Self {
         StringPointer::new(self.string.clone())
     }
 }

--- a/packages/crypto/lib/src/crypto/zip32.rs
+++ b/packages/crypto/lib/src/crypto/zip32.rs
@@ -1,7 +1,9 @@
-//! ShieldedHDWallet - Provide wasm_bindgen bindings for zip32 HD wallets
-//! Imports from masp_primitives::zip32, instead of zcash_primitives::zip32, as
-//! the value for constant ZIP32_SAPLING_MASTER_PERSONALIZATION is different!
-//! Otherwise, these implementations should be equivalent.
+/*!
+ShieldedHDWallet - Provide wasm_bindgen bindings for zip32 HD wallets
+Imports from masp_primitives::zip32, instead of zcash_primitives::zip32, as
+the value for constant ZIP32_SAPLING_MASTER_PERSONALIZATION is different!
+Otherwise, these implementations should be equivalent.
+*/
 use borsh::BorshDeserialize;
 use borsh_ext::BorshSerializeExt;
 use masp_primitives::{

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "prepublish": "yarn && yarn build",
     "build": "yarn wasm:build && tsc --build",
+    "wasm:check": "cd ./lib && cargo check && cargo clippy",
     "wasm:build": "./scripts/build.sh --release",
     "wasm:build:dev": "./scripts/build.sh",
     "wasm:build:node": "./scripts/build-node.sh --release",

--- a/packages/shared/lib/.cargo/config.toml
+++ b/packages/shared/lib/.cargo/config.toml
@@ -1,2 +1,6 @@
 [build]
 target = "wasm32-unknown-unknown"
+
+# It's recommended to set the flag on a per-target basis:
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/packages/shared/lib/Cargo.toml
+++ b/packages/shared/lib/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = []
+default = ["web"]
 dev = []
 multicore = ["rayon", "wasm-bindgen-rayon", "namada_sdk/multicore"]
 nodejs = []

--- a/packages/shared/lib/src/sdk/args.rs
+++ b/packages/shared/lib/src/sdk/args.rs
@@ -62,6 +62,7 @@ pub struct WrapperTxMsg {
 }
 
 impl WrapperTxMsg {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         token: String,
         fee_amount: String,

--- a/packages/shared/lib/src/sdk/mod.rs
+++ b/packages/shared/lib/src/sdk/mod.rs
@@ -228,7 +228,7 @@ impl Sdk {
     pub fn sign_masp_ledger(
         &self,
         tx: Vec<u8>,
-        signing_data: Box<[Uint8Array]>,
+        signing_data: Vec<Uint8Array>,
         signature: Vec<u8>,
     ) -> Result<JsValue, JsError> {
         let mut namada_tx: Tx = borsh::from_slice(&tx)?;
@@ -306,16 +306,14 @@ impl Sdk {
                 common::SecretKey::Ed25519(ed25519::SecretKey::from_str(&private_key)?);
             signing_keys.push(signing_key.clone());
 
-            if !wrapper_signing_key.is_some() {
+            if wrapper_signing_key.is_none() {
                 // Check address against wrapper_fee_payer
                 let wrapper_fee_payer = wrapper_fee_payer.clone();
                 let public = common::PublicKey::from(signing_key.ref_to());
                 let implicit = Address::Implicit(ImplicitAddress::from(&public));
 
-                if wrapper_fee_payer.is_some() {
-                    if implicit == wrapper_fee_payer.unwrap() {
-                        wrapper_signing_key = Some(signing_key)
-                    }
+                if wrapper_fee_payer.is_some() && implicit == wrapper_fee_payer.unwrap() {
+                    wrapper_signing_key = Some(signing_key)
                 }
             }
         }
@@ -902,7 +900,7 @@ impl Sdk {
             .await
             .ok_or(JsError::new(&format!(
                 "Denom for token {} not found",
-                token.to_string()
+                token
             )))?;
         let amount = DenominatedAmount::new(Amount::from_str(amount, denom)?, denom);
 

--- a/packages/shared/lib/src/sdk/tx.rs
+++ b/packages/shared/lib/src/sdk/tx.rs
@@ -304,10 +304,7 @@ impl TxDetails {
                 let token = wrapper.fee.token.to_string();
                 let wrapper_fee_payer = wrapper.fee_payer();
 
-                let expiration: Option<u64> = match expiration {
-                    Some(exp) => Some(exp.to_unix_timestamp() as u64),
-                    None => None,
-                };
+                let expiration: Option<u64> = expiration.map(|exp| exp.to_unix_timestamp() as u64);
 
                 let wrapper_tx = WrapperTxMsg::new(
                     token,

--- a/packages/shared/lib/src/types/masp.rs
+++ b/packages/shared/lib/src/types/masp.rs
@@ -137,7 +137,7 @@ impl ExtendedSpendingKey {
     }
 
     pub fn from_string(xsk: String) -> Result<ExtendedSpendingKey, String> {
-        let xsk= NamadaExtendedSpendingKey::from_str(&xsk).map_err(|err| err.to_string())?;
+        let xsk = NamadaExtendedSpendingKey::from_str(&xsk).map_err(|err| err.to_string())?;
 
         Ok(ExtendedSpendingKey(xsk))
     }

--- a/packages/shared/lib/src/types/query.rs
+++ b/packages/shared/lib/src/types/query.rs
@@ -1,7 +1,7 @@
-use namada_sdk::borsh::BorshSerialize;
 use namada_sdk::address::Address;
-use namada_sdk::uint::Uint;
+use namada_sdk::borsh::BorshSerialize;
 use namada_sdk::dec::Dec;
+use namada_sdk::uint::Uint;
 use serde::{Deserialize, Serialize};
 
 #[derive(BorshSerialize)]

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -17,7 +17,7 @@
     "wasm:build:dev": "yarn wasm:ts:web && node ./scripts/build.js",
     "wasm:build:dev:multicore": "yarn wasm:ts:web && node ./scripts/build.js --multicore",
     "wasm:build:node": "yarn wasm:ts:node && node ./scripts/build.js --target nodejs --release",
-    "test-wasm:ci": "yarn wasm:ts:node && cd ./lib && RUSTFLAGS='--cfg getrandom_backend=\"wasm_js\"' wasm-pack test --node -- --features nodejs",
+    "test-wasm:ci": "yarn wasm:ts:node && cd ./lib && RUSTFLAGS='--cfg getrandom_backend=\"wasm_js\"' wasm-pack test --node -- --features nodejs --no-default-features",
     "wasm:build:node:multicore": "yarn wasm:ts:node && node ./scripts/build.js --target nodejs --release --multicore",
     "wasm:build:node:dev": "yarn wasm:ts:node && node ./scripts/build.js --target nodejs",
     "wasm:build:node:dev:multicore": "yarn wasm:ts:node && node ./scripts/build.js --target nodejs --multicore"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,6 +9,7 @@
   "license": "MIT",
   "scripts": {
     "prepublish": "yarn wasm:build && tsc --build",
+    "wasm:check": "cd ./lib && cargo check && cargo clippy",
     "wasm:ts:node": "tsc -p tsconfig.node.json",
     "wasm:ts:web": "tsc -p tsconfig.web.json",
     "wasm:build": "yarn wasm:ts:web && node ./scripts/build.js --release",

--- a/packages/shared/scripts/build.js
+++ b/packages/shared/scripts/build.js
@@ -62,6 +62,7 @@ const { status } = spawnSync(
     `--out-dir`,
     outDir,
     `--`,
+    `--no-default-features`,
     ["--features", features.join(",")].flat(),
     multicore ? [`-Z`, `build-std=panic_abort,std`] : [],
   ].flat(),


### PR DESCRIPTION
- fixed clippy warnings
- added build target to `.cargo/config.toml`
- set `"web"` as default feature and added `--no-default-features` in build script, because of that:
  - LSP correctly displays clippy warnings in code
  - I had to add `--no-default-features` so we do not build both web and node at the same time
  - for developing node features we can temporarily replace "web" with "node" in `Cargo.toml` - this only affects LSP code highlighting/checking
