### PR TITLE
feat: tnam znam address validation in the transfer module

### DIFF
--- a/apps/namadillo/src/App/NamadaTransfer/NamadaTransfer.tsx
+++ b/apps/namadillo/src/App/NamadaTransfer/NamadaTransfer.tsx
@@ -130,6 +130,10 @@ export const NamadaTransfer: React.FC = () => {
         sourceAddress !== customAddress,
         "The recipient address must differ from the sender address"
       );
+      invariant(
+        customAddress.startsWith("tnam") || customAddress.startsWith("znam"),
+        "The recipient address must be a Namada address"
+      );
 
       const txResponse = await performTransfer({ memo });
       if (txResponse) {


### PR DESCRIPTION
We do not want to allow ibc inside transfer tab(at least for now :))
From this:
![image](https://github.com/user-attachments/assets/e49210ef-631c-42ae-b371-02c499321873)
to this:
![image](https://github.com/user-attachments/assets/6981ed3a-0da0-4803-99a6-0547b996c15f)
