### PR TITLE
feat: SDK - Add lookup for TxResponse result codes

### DIFF
--- a/apps/namadillo/src/lib/query.ts
+++ b/apps/namadillo/src/lib/query.ts
@@ -234,8 +234,7 @@ export const broadcastTxWithEvents = async <T>(
       if (result.status === "fulfilled") {
         return result.value.commitments;
       } else {
-        // Throw wrapper error if encountered
-        throw new Error(`Broadcast Tx failed! ${result.reason}`);
+        throw new Error(result.reason.toString());
       }
     });
 

--- a/packages/sdk/src/rpc/rpc.ts
+++ b/packages/sdk/src/rpc/rpc.ts
@@ -6,6 +6,7 @@ import {
   TransferToEthereum,
 } from "@namada/shared";
 import {
+  BroadcastTxError,
   DatedViewingKey,
   TxResponseMsgValue,
   TxResponseProps,
@@ -229,7 +230,11 @@ export class Rpc {
     signedTxBytes: Uint8Array,
     deadline: bigint = BigInt(60)
   ): Promise<TxResponseProps> {
-    const response = await this.sdk.broadcast_tx(signedTxBytes, deadline);
+    const response = await this.sdk
+      .broadcast_tx(signedTxBytes, deadline)
+      .catch((e) => {
+        throw new BroadcastTxError(e);
+      });
     return deserialize(Buffer.from(response), TxResponseMsgValue);
   }
 

--- a/packages/sdk/src/tx/tx.ts
+++ b/packages/sdk/src/tx/tx.ts
@@ -17,6 +17,8 @@ import {
   Message,
   RedelegateMsgValue,
   RedelegateProps,
+  ResultCode,
+  ResultCodes,
   RevealPkMsgValue,
   ShieldedTransferMsgValue,
   ShieldedTransferProps,
@@ -528,5 +530,14 @@ export class Tx {
    */
   getInnerTxHashes(bytes: Uint8Array): string[] {
     return get_inner_tx_hashes(bytes);
+  }
+
+  /**
+   * Return text from TxResponse code
+   * @param code - ResultCode enum value
+   * @returns text string
+   */
+  resultCodeToText(code: ResultCode): string {
+    return ResultCodes[code];
   }
 }

--- a/packages/sdk/src/tx/tx.ts
+++ b/packages/sdk/src/tx/tx.ts
@@ -17,8 +17,6 @@ import {
   Message,
   RedelegateMsgValue,
   RedelegateProps,
-  ResultCode,
-  ResultCodes,
   RevealPkMsgValue,
   ShieldedTransferMsgValue,
   ShieldedTransferProps,
@@ -530,14 +528,5 @@ export class Tx {
    */
   getInnerTxHashes(bytes: Uint8Array): string[] {
     return get_inner_tx_hashes(bytes);
-  }
-
-  /**
-   * Return text from TxResponse code
-   * @param code - ResultCode enum value
-   * @returns text string
-   */
-  resultCodeToText(code: ResultCode): string {
-    return ResultCodes[code];
   }
 }

--- a/packages/shared/lib/src/sdk/mod.rs
+++ b/packages/shared/lib/src/sdk/mod.rs
@@ -22,11 +22,12 @@ use namada_sdk::args::{
 };
 use namada_sdk::borsh::{self, BorshDeserialize};
 use namada_sdk::collections::HashMap;
+use namada_sdk::control_flow::time;
 use namada_sdk::eth_bridge::bridge_pool::build_bridge_pool_tx;
 use namada_sdk::hash::Hash;
 use namada_sdk::ibc::convert_masp_tx_to_ibc_memo;
 use namada_sdk::ibc::core::host::types::identifiers::{ChannelId, PortId};
-use namada_sdk::io::NamadaIo;
+use namada_sdk::io::{Client, NamadaIo};
 use namada_sdk::key::{common, ed25519, RefTo, SigScheme};
 use namada_sdk::masp::shielded_wallet::ShieldedApi;
 use namada_sdk::masp::ShieldedContext;
@@ -35,21 +36,19 @@ use namada_sdk::masp_primitives::transaction::components::{
     amount::I128Sum, sapling::builder::StoredBuildParams, sapling::fees::InputView,
 };
 use namada_sdk::masp_primitives::zip32::{ExtendedFullViewingKey, ExtendedKey};
-use namada_sdk::rpc::{self, query_denom, query_epoch, InnerTxResult, TxBroadcastData, TxResponse};
+use namada_sdk::rpc::{self, query_denom, query_epoch, InnerTxResult, TxResponse};
 use namada_sdk::signing::SigningTxData;
 use namada_sdk::string_encoding::Format;
 use namada_sdk::tendermint_rpc::Url;
-use namada_sdk::control_flow::time;
 use namada_sdk::token::{Amount, DenominatedAmount, MaspEpoch};
 use namada_sdk::token::{MaspTxId, OptionExt};
 use namada_sdk::tx::data::TxType;
 use namada_sdk::tx::Section;
 use namada_sdk::tx::{
-    broadcast_tx, build_batch, build_bond, build_claim_rewards, build_ibc_transfer,
-    build_redelegation, build_reveal_pk, build_shielded_transfer, build_shielding_transfer,
-    build_transparent_transfer, build_unbond, build_unshielding_transfer, build_vote_proposal,
-    build_withdraw, data::compute_inner_tx_hash, either::Either, gen_ibc_shielding_transfer,
-    Tx,
+    build_batch, build_bond, build_claim_rewards, build_ibc_transfer, build_redelegation,
+    build_reveal_pk, build_shielded_transfer, build_shielding_transfer, build_transparent_transfer,
+    build_unbond, build_unshielding_transfer, build_vote_proposal, build_withdraw,
+    data::compute_inner_tx_hash, either::Either, gen_ibc_shielding_transfer, Tx,
 };
 use namada_sdk::wallet::{Store, Wallet};
 use namada_sdk::{ExtendedViewingKey, Namada, NamadaImpl, PaymentAddress, TransferTarget};
@@ -338,49 +337,63 @@ impl Sdk {
         to_js_result(borsh::to_vec(&namada_tx)?)
     }
 
-    pub async fn broadcast_tx(&self, tx_bytes: &[u8], deadline: u64) -> Result<JsValue, JsError> {
-        let tx = Tx::try_from_slice(tx_bytes)?;
+    pub async fn broadcast_tx(&self, tx_bytes: &[u8], deadline: u64) -> Result<JsValue, JsValue> {
+        let tx = Tx::try_from_slice(tx_bytes).expect("Should be able to deserialize a Tx");
         let cmts = tx.commitments().clone();
         let wrapper_hash = tx.wrapper_hash();
         let tx_hash = tx.header_hash().to_string();
-        // TODO: Do we want to support dryrun here?
-        let tx_data = TxBroadcastData::Live { tx: tx.clone(), tx_hash: tx_hash.clone() };
-        broadcast_tx(&self.namada, &tx_data).await?;
 
-        let deadline = time::Instant::now()
-            + time::Duration::from_secs(deadline);
+        let response = self.namada.client().broadcast_tx_sync(tx.to_bytes()).await;
 
-        let tx_query = rpc::TxEventQuery::Applied(tx_hash.as_str());
-        let event = rpc::query_tx_status(&self.namada, tx_query, deadline).await?;
-        let tx_response = TxResponse::from_event(event);
+        match response {
+            Ok(res) => {
+                if res.clone().code != 0.into() {
+                    return Err(JsValue::from(
+                        &serde_json::to_string(&res)
+                            .map_err(|e| JsValue::from_str(&e.to_string()))?,
+                    ));
+                }
 
-        let mut batch_tx_results: Vec<tx::BatchTxResult> = vec![];
-        let code =  u8::try_from(tx_response.code.to_usize())?;
-        let gas_used = tx_response.gas_used.to_string();
-        let height = tx_response.height.to_string();
-        let info = tx_response.info.to_string();
-        let log = tx_response.log.to_string();
+                let deadline = time::Instant::now() + time::Duration::from_secs(deadline);
+                let tx_query = rpc::TxEventQuery::Applied(tx_hash.as_str());
+                let event = rpc::query_tx_status(&self.namada, tx_query, deadline)
+                    .await
+                    .map_err(|e| JsValue::from_str(&e.to_string()))?;
+                let tx_response = TxResponse::from_event(event);
 
-        for cmt in cmts {
-            let hash = compute_inner_tx_hash(wrapper_hash.as_ref(), Either::Right(&cmt));
+                let mut batch_tx_results: Vec<tx::BatchTxResult> = vec![];
+                let code =
+                    u8::try_from(tx_response.code.to_usize()).expect("Code should fit in u8");
+                let gas_used = tx_response.gas_used.to_string();
+                let height = tx_response.height.to_string();
+                let info = tx_response.info.to_string();
+                let log = tx_response.log.to_string();
 
-            if let Some(InnerTxResult::Success(_)) = tx_response.batch_result().get(&hash) {
-                batch_tx_results.push(tx::BatchTxResult::new(hash.to_string(), true));
-            } else {
-                batch_tx_results.push(tx::BatchTxResult::new(hash.to_string(), false));
+                for cmt in cmts {
+                    let hash = compute_inner_tx_hash(wrapper_hash.as_ref(), Either::Right(&cmt));
+
+                    if let Some(InnerTxResult::Success(_)) = tx_response.batch_result().get(&hash) {
+                        batch_tx_results.push(tx::BatchTxResult::new(hash.to_string(), true));
+                    } else {
+                        batch_tx_results.push(tx::BatchTxResult::new(hash.to_string(), false));
+                    }
+                }
+
+                let tx_response = tx::TxResponse::new(
+                    code,
+                    batch_tx_results,
+                    gas_used,
+                    wrapper_hash.unwrap().to_string(),
+                    height,
+                    info,
+                    log,
+                );
+                Ok(JsValue::from(
+                    borsh::to_vec(&tx_response).map_err(|e| JsValue::from_str(&e.to_string()))?,
+                ))
             }
+            Err(e) => Err(JsValue::from(e.to_string())),
         }
-
-        let response = tx::TxResponse::new(
-            code,
-            batch_tx_results,
-            gas_used,
-            wrapper_hash.unwrap().to_string(),
-            height,
-            info,
-            log,
-        );
-        to_js_result(borsh::to_vec(&response)?)
     }
 
     /// Build a batch Tx from built transactions and return the bytes

--- a/packages/shared/lib/src/sdk/mod.rs
+++ b/packages/shared/lib/src/sdk/mod.rs
@@ -355,7 +355,7 @@ impl Sdk {
         let tx_response = TxResponse::from_event(event);
 
         let mut batch_tx_results: Vec<tx::BatchTxResult> = vec![];
-        let code = tx_response.code.to_string();
+        let code =  u8::try_from(tx_response.code.to_usize())?;
         let gas_used = tx_response.gas_used.to_string();
         let height = tx_response.height.to_string();
         let info = tx_response.info.to_string();

--- a/packages/shared/lib/src/sdk/tx.rs
+++ b/packages/shared/lib/src/sdk/tx.rs
@@ -452,7 +452,7 @@ impl BatchTxResult {
 #[derive(BorshSerialize, BorshDeserialize)]
 #[borsh(crate = "namada_sdk::borsh")]
 pub struct TxResponse {
-    code: String,
+    code: u8,
     commitments: Vec<BatchTxResult>,
     gas_used: String,
     hash: String,
@@ -463,7 +463,7 @@ pub struct TxResponse {
 
 impl TxResponse {
     pub fn new(
-        code: String,
+        code: u8,
         commitments: Vec<BatchTxResult>,
         gas_used: String,
         hash: String,

--- a/packages/types/src/errors.ts
+++ b/packages/types/src/errors.ts
@@ -1,0 +1,43 @@
+import { ResultCode, ResultCodes, TxResponseProps } from "./tx";
+
+/**
+ * Custom error for Broadcast Tx
+ */
+export class BroadcastTxError extends Error {
+  /**
+   * @param message - string
+   * @returns BroadcastTxError
+   */
+  constructor(message: string) {
+    super(message);
+    this.name = "BroadcastTxError";
+  }
+
+  /**
+   * @returns string
+   */
+  toString(): string {
+    try {
+      const { code } = this.toProps();
+      const message = ResultCodes[code as ResultCode];
+      return message;
+      // eslint-disable-next-line
+    } catch (_) {
+      // If not able to be parsed as JSON, return
+      // original error message
+      return this.message;
+    }
+  }
+
+  /**
+   * @returns TxResponseProps
+   */
+  toProps(): TxResponseProps {
+    try {
+      const props = JSON.parse(this.message) as TxResponseProps;
+      return props;
+    } catch (e) {
+      throw new Error(`${e}`);
+    }
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./account";
 export * from "./chain";
+export * from "./errors";
 export * from "./events";
 export * from "./namada";
 export * from "./proposals";

--- a/packages/types/src/tx/schema/txResponse.ts
+++ b/packages/types/src/tx/schema/txResponse.ts
@@ -4,8 +4,8 @@ import { TxResponseProps } from "../types";
 import { BatchTxResultMsgValue } from "./batchTxResult";
 
 export class TxResponseMsgValue {
-  @field({ type: "string" })
-  code!: string;
+  @field({ type: "u8" })
+  code!: number;
 
   @field({ type: vec(BatchTxResultMsgValue) })
   commitments!: BatchTxResultMsgValue[];

--- a/packages/types/src/tx/types.ts
+++ b/packages/types/src/tx/types.ts
@@ -82,3 +82,35 @@ export type TxDetails = WrapperTxProps & {
   // We override wrapperFeePayer to be a string because it should always be defined at this point
   wrapperFeePayer: string;
 };
+
+export enum ResultCode {
+  Ok = 0,
+  WasmRuntimeError = 1,
+  InvalidTx = 2,
+  InvalidSig = 3,
+  AllocationError = 4,
+  ReplayTx = 5,
+  InvalidChainId = 6,
+  ExpiredTx = 7,
+  TxGasLimit = 8,
+  FeeError = 9,
+  InvalidVoteExtension = 10,
+  TooLarge = 11,
+  TxNotAllowlisted = 12,
+}
+
+export const ResultCodes: Record<ResultCode, string> = {
+  [ResultCode.Ok]: "",
+  [ResultCode.WasmRuntimeError]: "Error in WASM tx execution",
+  [ResultCode.InvalidTx]: "Invalid tx",
+  [ResultCode.InvalidSig]: "Invalid signature",
+  [ResultCode.AllocationError]: "The block is full",
+  [ResultCode.ReplayTx]: "Replayed tx",
+  [ResultCode.InvalidChainId]: "Invalid chain ID",
+  [ResultCode.ExpiredTx]: "Expired tx",
+  [ResultCode.TxGasLimit]: "Exceeded gas limit",
+  [ResultCode.FeeError]: "Error in paying tx fee",
+  [ResultCode.InvalidVoteExtension]: "Invalid vote extension",
+  [ResultCode.TooLarge]: "Tx is too large",
+  [ResultCode.TxNotAllowlisted]: "Tx code is not allowlisted",
+};


### PR DESCRIPTION
Resolves #1898 

See `ResultCode` definition at:

https://github.com/anoma/namada/blob/427a57cab8c93a18f293b00e9f54e6e9da5ac147/crates/tx/src/data/mod.rs#L42-L90

- [x] Provide `ResultCode` definitions in `@namada/types`
- [x] Provide result code text lookup in SDK
- [x] Hook up to Namadillo when a `TxResponse` is returned from chain

To update these error messages, we simply need to make the change here: https://github.com/anoma/namada-interface/blob/1f1962bd14f7134c25a8bd6739f53937eae79ac1/packages/types/src/tx/types.ts#L102-L116

Broadcast error messages returned from Namada SDK can now be parsed as JSON. The response before was being formatted in `broadcast_tx` in Namada SDK, so we'd end up with an error like this:

```
Encountered error while broadcasting transaction: StringTracer: server error: {"codespace":"","code":8,"data":"","log":"Mempool validation failed: Wrapper transaction exceeds its gas limit","hash":"11AE6D481A56ABB762509198DE7F5088EF1772A281F0FFCEDD86E6273F813AC7"}
```

Deadline timeout should return a normal, non-JSON string.

Introduced a custom error `BroadcastTxError` that can parse a `TxResponse` from the SDK, otherwise will return the original error string for non-TxResponse results.

### Testing

- Trigger a gas error by decreasing gas limit to an unreasonable amount - should get appropriate message
- Trigger a deadline error by updating `deadline` to `BigInt(1)`, should get appropriate message in notification

Tested with normal accounts (batch tx) and Ledger (with multiple Txs)

### Screenshots

Gas limit exceeded:
![image](https://github.com/user-attachments/assets/1ad7c688-2236-4a2d-8a04-a9f3cd1b17a8)


Deadline timeout:
![image](https://github.com/user-attachments/assets/7859ef1f-2363-4757-bd93-662a8141161a)
