### PR TITLE
bug: Keychain - Disable shielded key import for nano S

### DIFF
--- a/apps/extension/src/Setup/Ledger/LedgerConnect.tsx
+++ b/apps/extension/src/Setup/Ledger/LedgerConnect.tsx
@@ -59,8 +59,8 @@ export const LedgerConnect: React.FC<Props> = ({
       if (returnCode !== LedgerError.NoErrors) {
         throw new Error(errorMessage);
       }
-      const canImportShielded = await ledger?.isZip32Supported();
-      setIsZip32Supported(canImportShielded);
+      const isMaspSupported = await ledger?.isZip32Supported();
+      setIsZip32Supported(isMaspSupported);
 
       setIsLedgerConnecting(true);
       setCurrentApprovalStep(1);
@@ -68,7 +68,7 @@ export const LedgerConnect: React.FC<Props> = ({
         makeBip44Path(chains.namada.bip44.coinType, bip44Path)
       );
 
-      if (canImportShielded) {
+      if (isMaspSupported) {
         // Import Shielded Keys
         const path = makeSaplingPath(chains.namada.bip44.coinType, {
           account: zip32Path.account,
@@ -157,8 +157,8 @@ export const LedgerConnect: React.FC<Props> = ({
 
         {isLedgerConnecting && !isZip32Supported && (
           <Alert type="warning">
-            Shielded key import will be enabled in NamadaApp v
-            {LEDGER_MIN_VERSION_ZIP32}
+            Shielded key import is not available for the Nano S or on versions
+            below {LEDGER_MIN_VERSION_ZIP32}
           </Alert>
         )}
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,5 +1,6 @@
 // Make Ledger available for direct-import as it is not dependent on Sdk initialization
 export {
+  LEDGER_MASP_BLACKLISTED,
   LEDGER_MIN_VERSION_ZIP32,
   Ledger,
   initLedgerUSBTransport,

--- a/packages/sdk/src/tests/ledger.test.ts
+++ b/packages/sdk/src/tests/ledger.test.ts
@@ -100,9 +100,15 @@ describe("ledger", () => {
     it("should return the status of the ledger", async () => {
       const version = { version: "1.0.0" };
       const info = { info: "info" };
+      const deviceId = "nanoSP";
+      const deviceName = "Ledger Nano S+";
+
       const namadaApp = {
         getVersion: jest.fn().mockReturnValue(version),
         getAppInfo: jest.fn().mockReturnValue(info),
+        transport: {
+          deviceModel: { id: deviceId, productName: deviceName },
+        },
       };
       const ledger: Ledger = new (Ledger as any)(namadaApp as any);
 
@@ -110,7 +116,7 @@ describe("ledger", () => {
 
       expect(namadaApp.getVersion).toHaveBeenCalled();
       expect(namadaApp.getAppInfo).toHaveBeenCalled();
-      expect(res).toEqual({ version, info });
+      expect(res).toEqual({ version, info, deviceId, deviceName });
     });
   });
 


### PR DESCRIPTION
Resolves #1952 



- [x] If device is a Nano S, disable shielded key import
- [x] Update Ledger validation to also check against this (zip32 or masp functions only work if both device and version is correct)
- [x] Update warning copy on import

### Testing

Build/install extension from this branch, then, assuming you are on > v3.0.0 of the Namada App:

Nano S:
- In setup, import your Ledger
- You should see the warning in the screenshot below
- You should be able to successfully import just the transparent keys

Not-Nano S:
- In setup, import your Ledger
- You should not see any warning
- You are guided through 3 steps: Transparent import, Viewing key import, Proof Gen / Auth key import

### Notes

See: https://github.com/LedgerHQ/ledger-live/blob/06cfbf04e2d99e4e7916ace7a10cff8d37c5c38a/libs/ledgerjs/packages/types-devices/src/index.ts#L4

Ledger Live has enumerated the available device IDs here:
```typescript
/**
 * DeviceModelId is a unique identifier to identify the model of a Ledger hardware wallet.
 */
export enum DeviceModelId {
  blue = "blue",
  nanoS = "nanoS",
  nanoSP = "nanoSP",
  nanoX = "nanoX",
  stax = "stax",
  europa = "europa",
}
```

### Screenshots

**NOTE** I forced this message by setting the blacklisted device as `nanoSP` -  this should be only be displayed for the `nanoS`:

![image](https://github.com/user-attachments/assets/9db7d927-95c0-4c0f-82c0-e5770177e2a9)


