### PR TITLE
fix: fix claim and stake NaN issue

### DIFF
--- a/apps/namadillo/src/App/Staking/ClaimRewardsSubmitModalStage.tsx
+++ b/apps/namadillo/src/App/Staking/ClaimRewardsSubmitModalStage.tsx
@@ -36,7 +36,7 @@ export const ClaimRewardsSubmitModalStage = ({
 }: ClaimRewardsPanelProps): JSX.Element => {
   const validators = useAtomValue(allValidatorsAtom);
   const availableRewards = sumBigNumberArray(
-    rewardsToClaim.map((r) => rewards[r.validator])
+    rewardsToClaim.map((r) => rewards[r.validator]).filter(Boolean)
   );
   const allRewards = rewardsToClaim.length === Object.keys(rewards).length;
   const image = isClaimAndStake ? claimAndStakeImage : claimImage;


### PR DESCRIPTION
Fix claim and stake NaN issue.

Closes https://github.com/anoma/namada-interface/issues/1907

This is happening in case the transaction returns an error because the stake didn't applied, but the claim succeed. This causes the return the error message, but the validator rewards is empty: `rewards[r.validator] === undefined`

To simulate this, you can:
1 - Replace the validator address for anything else `rewards['something-else']` on `ClaimRewardsSubmitModalStage.tsx:39`
2 - In case you want to submit the transaction, you can simulate an error by adding `throw new Error(`Broadcast Tx failed! Mock timeout error`);` on `src/lib/query.ts:233`

![Screenshot 2025-04-02 at 20 47 40](https://github.com/user-attachments/assets/7e45708c-508a-463d-bb84-37c38716da3c)


