### PR TITLE
chore: Update docs for SDK & Types packages

### DIFF
--- a/packages/sdk/docs/classes/Crypto.md
+++ b/packages/sdk/docs/classes/Crypto.md
@@ -40,7 +40,7 @@ Class Crypto handles AES encryption tasks
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/crypto/crypto.ts#L20)
+[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/crypto/crypto.ts#L20)
 
 ## Properties
 
@@ -52,7 +52,7 @@ WebAssembly Memory for crypto
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/crypto/crypto.ts#L20)
+[sdk/src/crypto/crypto.ts:20](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/crypto/crypto.ts#L20)
 
 ## Methods
 
@@ -75,7 +75,7 @@ decrypted text
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:115](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/crypto/crypto.ts#L115)
+[sdk/src/crypto/crypto.ts:115](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/crypto/crypto.ts#L115)
 
 ___
 
@@ -100,7 +100,7 @@ crypto record
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:61](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/crypto/crypto.ts#L61)
+[sdk/src/crypto/crypto.ts:61](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/crypto/crypto.ts#L61)
 
 ___
 
@@ -126,7 +126,7 @@ array of encrypted bytes
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:98](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/crypto/crypto.ts#L98)
+[sdk/src/crypto/crypto.ts:98](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/crypto/crypto.ts#L98)
 
 ___
 
@@ -153,7 +153,7 @@ crypto record used for storage
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:30](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/crypto/crypto.ts#L30)
+[sdk/src/crypto/crypto.ts:30](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/crypto/crypto.ts#L30)
 
 ___
 
@@ -178,4 +178,4 @@ encryption parameters
 
 #### Defined in
 
-[sdk/src/crypto/crypto.ts:73](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/crypto/crypto.ts#L73)
+[sdk/src/crypto/crypto.ts:73](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/crypto/crypto.ts#L73)

--- a/packages/sdk/docs/classes/ExtendedViewingKey.md
+++ b/packages/sdk/docs/classes/ExtendedViewingKey.md
@@ -36,21 +36,21 @@ Instantiate ExtendedViewingKey from serialized vector
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:135
+shared/src/shared/shared.d.ts:81
 
 ## Methods
 
 ### default\_payment\_address
 
-▸ **default_payment_address**(): `PaymentAddress`
+▸ **default_payment_address**(): `any`
 
 #### Returns
 
-`PaymentAddress`
+`any`
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:144
+shared/src/shared/shared.d.ts:86
 
 ___
 
@@ -66,7 +66,7 @@ Return ExtendedViewingKey as Bech32-encoded String
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:140
+shared/src/shared/shared.d.ts:85
 
 ___
 
@@ -80,4 +80,4 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:130
+shared/src/shared/shared.d.ts:77

--- a/packages/sdk/docs/classes/Ledger.md
+++ b/packages/sdk/docs/classes/Ledger.md
@@ -26,7 +26,7 @@ Functionality for interacting with NamadaApp for Ledger Hardware Wallets
 - [showAddressAndPublicKey](Ledger.md#showaddressandpublickey)
 - [sign](Ledger.md#sign)
 - [status](Ledger.md#status)
-- [validateVersionForZip32](Ledger.md#validateversionforzip32)
+- [validateZip32Support](Ledger.md#validatezip32support)
 - [init](Ledger.md#init)
 
 ## Constructors
@@ -47,7 +47,7 @@ Functionality for interacting with NamadaApp for Ledger Hardware Wallets
 
 #### Defined in
 
-[sdk/src/ledger.ts:93](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/ledger.ts#L93)
+[sdk/src/ledger.ts:96](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/ledger.ts#L96)
 
 ## Properties
 
@@ -59,7 +59,7 @@ Inititalized NamadaApp class from Zondax package
 
 #### Defined in
 
-[sdk/src/ledger.ts:93](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/ledger.ts#L93)
+[sdk/src/ledger.ts:96](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/ledger.ts#L96)
 
 ## Methods
 
@@ -80,7 +80,7 @@ void
 
 #### Defined in
 
-[sdk/src/ledger.ts:333](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/ledger.ts#L333)
+[sdk/src/ledger.ts:339](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/ledger.ts#L339)
 
 ___
 
@@ -107,7 +107,7 @@ Address and public key
 
 #### Defined in
 
-[sdk/src/ledger.ts:136](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/ledger.ts#L136)
+[sdk/src/ledger.ts:142](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/ledger.ts#L142)
 
 ___
 
@@ -127,7 +127,7 @@ bparams
 
 #### Defined in
 
-[sdk/src/ledger.ts:179](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/ledger.ts#L179)
+[sdk/src/ledger.ts:185](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/ledger.ts#L185)
 
 ___
 
@@ -155,7 +155,7 @@ ShieldedKeys
 
 #### Defined in
 
-[sdk/src/ledger.ts:266](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/ledger.ts#L266)
+[sdk/src/ledger.ts:272](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/ledger.ts#L272)
 
 ___
 
@@ -183,7 +183,7 @@ ShieldedKeys
 
 #### Defined in
 
-[sdk/src/ledger.ts:233](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/ledger.ts#L233)
+[sdk/src/ledger.ts:239](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/ledger.ts#L239)
 
 ___
 
@@ -204,7 +204,7 @@ boolean
 
 #### Defined in
 
-[sdk/src/ledger.ts:343](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/ledger.ts#L343)
+[sdk/src/ledger.ts:349](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/ledger.ts#L349)
 
 ___
 
@@ -225,7 +225,7 @@ Error message if error is found
 
 #### Defined in
 
-[sdk/src/ledger.ts:316](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/ledger.ts#L316)
+[sdk/src/ledger.ts:322](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/ledger.ts#L322)
 
 ___
 
@@ -252,7 +252,7 @@ Address and public key
 
 #### Defined in
 
-[sdk/src/ledger.ts:156](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/ledger.ts#L156)
+[sdk/src/ledger.ts:162](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/ledger.ts#L162)
 
 ___
 
@@ -280,7 +280,7 @@ Response signature
 
 #### Defined in
 
-[sdk/src/ledger.ts:301](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/ledger.ts#L301)
+[sdk/src/ledger.ts:307](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/ledger.ts#L307)
 
 ___
 
@@ -301,15 +301,16 @@ Version and info of NamadaApp
 
 #### Defined in
 
-[sdk/src/ledger.ts:119](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/ledger.ts#L119)
+[sdk/src/ledger.ts:122](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/ledger.ts#L122)
 
 ___
 
-### validateVersionForZip32
+### validateZip32Support
 
-▸ **validateVersionForZip32**(): `Promise`\<`void`\>
+▸ **validateZip32Support**(): `Promise`\<`void`\>
 
-Validate the version against the minimum required version for Zip32 functionality.
+Validate the version against the minimum required version and
+device type for Zip32 functionality.
 Throw error if it is unsupported or app is not initialized.
 
 #### Returns
@@ -322,7 +323,7 @@ void
 
 #### Defined in
 
-[sdk/src/ledger.ts:356](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/ledger.ts#L356)
+[sdk/src/ledger.ts:367](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/ledger.ts#L367)
 
 ___
 
@@ -348,4 +349,4 @@ Ledger class instance
 
 #### Defined in
 
-[sdk/src/ledger.ts:101](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/ledger.ts#L101)
+[sdk/src/ledger.ts:104](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/ledger.ts#L104)

--- a/packages/sdk/docs/classes/Masp.md
+++ b/packages/sdk/docs/classes/Masp.md
@@ -43,7 +43,7 @@ Class representing utilities related to MASP
 
 #### Defined in
 
-[sdk/src/masp/masp.ts:10](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/masp/masp.ts#L10)
+[sdk/src/masp/masp.ts:10](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/masp/masp.ts#L10)
 
 ## Properties
 
@@ -55,7 +55,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/masp/masp.ts:10](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/masp/masp.ts#L10)
+[sdk/src/masp/masp.ts:10](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/masp/masp.ts#L10)
 
 ## Methods
 
@@ -82,7 +82,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp/masp.ts:71](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/masp/masp.ts#L71)
+[sdk/src/masp/masp.ts:71](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/masp/masp.ts#L71)
 
 ___
 
@@ -109,7 +109,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp/masp.ts:49](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/masp/masp.ts#L49)
+[sdk/src/masp/masp.ts:49](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/masp/masp.ts#L49)
 
 ___
 
@@ -136,7 +136,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp/masp.ts:60](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/masp/masp.ts#L60)
+[sdk/src/masp/masp.ts:60](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/masp/masp.ts#L60)
 
 ___
 
@@ -160,7 +160,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp/masp.ts:89](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/masp/masp.ts#L89)
+[sdk/src/masp/masp.ts:89](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/masp/masp.ts#L89)
 
 ___
 
@@ -186,7 +186,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp/masp.ts:27](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/masp/masp.ts#L27)
+[sdk/src/masp/masp.ts:27](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/masp/masp.ts#L27)
 
 ___
 
@@ -206,7 +206,7 @@ True if MASP parameters are loaded
 
 #### Defined in
 
-[sdk/src/masp/masp.ts:17](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/masp/masp.ts#L17)
+[sdk/src/masp/masp.ts:17](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/masp/masp.ts#L17)
 
 ___
 
@@ -233,7 +233,7 @@ void
 
 #### Defined in
 
-[sdk/src/masp/masp.ts:38](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/masp/masp.ts#L38)
+[sdk/src/masp/masp.ts:38](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/masp/masp.ts#L38)
 
 ___
 
@@ -252,4 +252,4 @@ the MASP address
 
 #### Defined in
 
-[sdk/src/masp/masp.ts:80](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/masp/masp.ts#L80)
+[sdk/src/masp/masp.ts:80](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/masp/masp.ts#L80)

--- a/packages/sdk/docs/classes/Mnemonic.md
+++ b/packages/sdk/docs/classes/Mnemonic.md
@@ -38,7 +38,7 @@ Class for accessing mnemonic functionality from wasm
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:20](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/mnemonic.ts#L20)
+[sdk/src/mnemonic.ts:20](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/mnemonic.ts#L20)
 
 ## Properties
 
@@ -50,7 +50,7 @@ Memory accessor for crypto lib
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:20](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/mnemonic.ts#L20)
+[sdk/src/mnemonic.ts:20](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/mnemonic.ts#L20)
 
 ## Methods
 
@@ -74,7 +74,7 @@ An array of words
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:27](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/mnemonic.ts#L27)
+[sdk/src/mnemonic.ts:27](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/mnemonic.ts#L27)
 
 ___
 
@@ -99,7 +99,7 @@ Seed bytes
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:45](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/mnemonic.ts#L45)
+[sdk/src/mnemonic.ts:45](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/mnemonic.ts#L45)
 
 ___
 
@@ -129,4 +129,4 @@ Object with validation result and error message if invalid
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:63](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/mnemonic.ts#L63)
+[sdk/src/mnemonic.ts:63](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/mnemonic.ts#L63)

--- a/packages/sdk/docs/classes/ProgressBarNames.md
+++ b/packages/sdk/docs/classes/ProgressBarNames.md
@@ -28,6 +28,10 @@
 
 [`ProgressBarNames`](ProgressBarNames.md)
 
+#### Defined in
+
+shared/src/shared/shared.d.ts:107
+
 ## Properties
 
 ### Applied
@@ -36,7 +40,7 @@
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:173
+shared/src/shared/shared.d.ts:111
 
 ___
 
@@ -46,7 +50,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:176
+shared/src/shared/shared.d.ts:110
 
 ___
 
@@ -56,7 +60,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:179
+shared/src/shared/shared.d.ts:109
 
 ## Methods
 
@@ -70,4 +74,4 @@ shared/src/shared/shared.d.ts:179
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:170
+shared/src/shared/shared.d.ts:108

--- a/packages/sdk/docs/classes/ProofGenerationKey.md
+++ b/packages/sdk/docs/classes/ProofGenerationKey.md
@@ -25,6 +25,10 @@
 
 [`ProofGenerationKey`](ProofGenerationKey.md)
 
+#### Defined in
+
+shared/src/shared/shared.d.ts:126
+
 ## Methods
 
 ### encode
@@ -37,7 +41,7 @@
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:209
+shared/src/shared/shared.d.ts:129
 
 ___
 
@@ -51,7 +55,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:199
+shared/src/shared/shared.d.ts:127
 
 ___
 
@@ -71,7 +75,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:214
+shared/src/shared/shared.d.ts:130
 
 ___
 
@@ -92,4 +96,4 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:205
+shared/src/shared/shared.d.ts:128

--- a/packages/sdk/docs/classes/PseudoExtendedKey.md
+++ b/packages/sdk/docs/classes/PseudoExtendedKey.md
@@ -27,6 +27,10 @@ Wrap ExtendedSpendingKey
 
 [`PseudoExtendedKey`](PseudoExtendedKey.md)
 
+#### Defined in
+
+shared/src/shared/shared.d.ts:136
+
 ## Methods
 
 ### encode
@@ -39,7 +43,7 @@ Wrap ExtendedSpendingKey
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:224
+shared/src/shared/shared.d.ts:138
 
 ___
 
@@ -53,7 +57,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:220
+shared/src/shared/shared.d.ts:137
 
 ___
 
@@ -73,7 +77,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:229
+shared/src/shared/shared.d.ts:139
 
 ___
 
@@ -94,4 +98,4 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:235
+shared/src/shared/shared.d.ts:140

--- a/packages/sdk/docs/classes/Rpc.md
+++ b/packages/sdk/docs/classes/Rpc.md
@@ -18,6 +18,7 @@ API for executing RPC requests with Namada
 ### Methods
 
 - [broadcastTx](Rpc.md#broadcasttx)
+- [globalShieldedRewardForTokens](Rpc.md#globalshieldedrewardfortokens)
 - [queryAllValidators](Rpc.md#queryallvalidators)
 - [queryBalance](Rpc.md#querybalance)
 - [queryChecksums](Rpc.md#querychecksums)
@@ -31,6 +32,7 @@ API for executing RPC requests with Namada
 - [queryTotalBonds](Rpc.md#querytotalbonds)
 - [queryTotalDelegations](Rpc.md#querytotaldelegations)
 - [shieldedRewards](Rpc.md#shieldedrewards)
+- [shieldedRewardsPerToken](Rpc.md#shieldedrewardspertoken)
 - [shieldedSync](Rpc.md#shieldedsync)
 - [simulateShieldedRewards](Rpc.md#simulateshieldedrewards)
 
@@ -53,7 +55,7 @@ API for executing RPC requests with Namada
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:38](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/rpc.ts#L38)
+[sdk/src/rpc/rpc.ts:37](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/rpc.ts#L37)
 
 ## Properties
 
@@ -65,7 +67,7 @@ Instance of Query struct from wasm lib
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:40](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/rpc.ts#L40)
+[sdk/src/rpc/rpc.ts:39](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/rpc.ts#L39)
 
 ___
 
@@ -77,13 +79,13 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:39](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/rpc.ts#L39)
+[sdk/src/rpc/rpc.ts:38](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/rpc.ts#L38)
 
 ## Methods
 
 ### broadcastTx
 
-▸ **broadcastTx**(`signedTxBytes`, `args`): `Promise`\<`TxResponseMsgValue`\>
+▸ **broadcastTx**(`signedTxBytes`, `deadline?`): `Promise`\<`TxResponseMsgValue`\>
 
 Broadcast a Tx to the ledger
 
@@ -92,7 +94,7 @@ Broadcast a Tx to the ledger
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `signedTxBytes` | `Uint8Array` | Transaction with signature |
-| `args` | `WrapperTxMsgValue` | WrapperTxProps |
+| `deadline?` | `bigint` | timeout deadline in seconds, defaults to 60 seconds |
 
 #### Returns
 
@@ -104,7 +106,27 @@ TxResponseProps object
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:230](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/rpc.ts#L230)
+[sdk/src/rpc/rpc.ts:229](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/rpc.ts#L229)
+
+___
+
+### globalShieldedRewardForTokens
+
+▸ **globalShieldedRewardForTokens**(): `Promise`\<`MaspTokenRewards`[]\>
+
+Return global shielded rewards per token
+
+#### Returns
+
+`Promise`\<`MaspTokenRewards`[]\>
+
+Array of MaspTokenRewards
+
+**`Async`**
+
+#### Defined in
+
+[sdk/src/rpc/rpc.ts:272](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/rpc.ts#L272)
 
 ___
 
@@ -124,7 +146,7 @@ Array of all validator addresses
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:85](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/rpc.ts#L85)
+[sdk/src/rpc/rpc.ts:84](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/rpc.ts#L84)
 
 ___
 
@@ -152,7 +174,7 @@ Query balances from chain
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:51](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/rpc.ts#L51)
+[sdk/src/rpc/rpc.ts:50](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/rpc.ts#L50)
 
 ___
 
@@ -172,7 +194,7 @@ Object
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:210](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/rpc.ts#L210)
+[sdk/src/rpc/rpc.ts:209](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/rpc.ts#L209)
 
 ___
 
@@ -198,7 +220,7 @@ Promise resolving to delegators votes
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:109](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/rpc.ts#L109)
+[sdk/src/rpc/rpc.ts:108](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/rpc.ts#L108)
 
 ___
 
@@ -218,7 +240,7 @@ Query gas costs
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:201](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/rpc.ts#L201)
+[sdk/src/rpc/rpc.ts:200](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/rpc.ts#L200)
 
 ___
 
@@ -238,7 +260,7 @@ Address of native token
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:64](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/rpc.ts#L64)
+[sdk/src/rpc/rpc.ts:63](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/rpc.ts#L63)
 
 ___
 
@@ -265,7 +287,7 @@ String of public key if found
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:75](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/rpc.ts#L75)
+[sdk/src/rpc/rpc.ts:74](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/rpc.ts#L74)
 
 ___
 
@@ -291,7 +313,7 @@ Promise resolving to pending ethereum transfers
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:192](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/rpc.ts#L192)
+[sdk/src/rpc/rpc.ts:191](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/rpc.ts#L191)
 
 ___
 
@@ -317,7 +339,7 @@ Promise resolving to staking positions
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:146](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/rpc.ts#L146)
+[sdk/src/rpc/rpc.ts:145](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/rpc.ts#L145)
 
 ___
 
@@ -343,7 +365,7 @@ Promise resolving to staking totals
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:119](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/rpc.ts#L119)
+[sdk/src/rpc/rpc.ts:118](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/rpc.ts#L118)
 
 ___
 
@@ -367,7 +389,7 @@ Total bonds amount
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:182](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/rpc.ts#L182)
+[sdk/src/rpc/rpc.ts:181](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/rpc.ts#L181)
 
 ___
 
@@ -394,7 +416,7 @@ Promise resolving to total delegations
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:96](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/rpc.ts#L96)
+[sdk/src/rpc/rpc.ts:95](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/rpc.ts#L95)
 
 ___
 
@@ -402,7 +424,7 @@ ___
 
 ▸ **shieldedRewards**(`owner`, `chainId`): `Promise`\<`string`\>
 
-Return shielded rewards for specific owner for next epoch
+Return shielded rewards for specific owner for the next masp epoch
 
 #### Parameters
 
@@ -421,7 +443,35 @@ amount in base units
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:264](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/rpc.ts#L264)
+[sdk/src/rpc/rpc.ts:263](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/rpc.ts#L263)
+
+___
+
+### shieldedRewardsPerToken
+
+▸ **shieldedRewardsPerToken**(`owner`, `token`, `chainId`): `Promise`\<`string`\>
+
+Return shielded rewards for specific owner and token for the next masp epoch
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `owner` | `string` | Viewing key of an owner |
+| `token` | `string` | Token address |
+| `chainId` | `string` | Chain ID to load the context for |
+
+#### Returns
+
+`Promise`\<`string`\>
+
+amount in base units
+
+**`Async`**
+
+#### Defined in
+
+[sdk/src/rpc/rpc.ts:310](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/rpc.ts#L310)
 
 ___
 
@@ -446,7 +496,7 @@ Sync the shielded context
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:249](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/rpc.ts#L249)
+[sdk/src/rpc/rpc.ts:248](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/rpc.ts#L248)
 
 ___
 
@@ -472,4 +522,4 @@ amount in base units
 
 #### Defined in
 
-[sdk/src/rpc/rpc.ts:275](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/rpc.ts#L275)
+[sdk/src/rpc/rpc.ts:325](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/rpc.ts#L325)

--- a/packages/sdk/docs/classes/Sdk.md
+++ b/packages/sdk/docs/classes/Sdk.md
@@ -64,7 +64,7 @@ API for interacting with Namada SDK
 
 #### Defined in
 
-[sdk/src/sdk.ts:26](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L26)
+[sdk/src/sdk.ts:26](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L26)
 
 ## Properties
 
@@ -76,7 +76,7 @@ Memory accessor for crypto lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:29](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L29)
+[sdk/src/sdk.ts:29](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L29)
 
 ___
 
@@ -88,7 +88,7 @@ Address of chain's native token
 
 #### Defined in
 
-[sdk/src/sdk.ts:31](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L31)
+[sdk/src/sdk.ts:31](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L31)
 
 ___
 
@@ -100,7 +100,7 @@ Instance of Query struct from wasm lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:28](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L28)
+[sdk/src/sdk.ts:28](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L28)
 
 ___
 
@@ -112,7 +112,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/sdk.ts:27](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L27)
+[sdk/src/sdk.ts:27](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L27)
 
 ___
 
@@ -124,7 +124,7 @@ RPC url
 
 #### Defined in
 
-[sdk/src/sdk.ts:30](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L30)
+[sdk/src/sdk.ts:30](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L30)
 
 ## Accessors
 
@@ -142,7 +142,7 @@ Utilities for encrypting and decrypting data
 
 #### Defined in
 
-[sdk/src/sdk.ts:177](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L177)
+[sdk/src/sdk.ts:177](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L177)
 
 ___
 
@@ -160,7 +160,7 @@ key-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:153](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L153)
+[sdk/src/sdk.ts:153](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L153)
 
 ___
 
@@ -178,7 +178,7 @@ Masp utilities for handling params
 
 #### Defined in
 
-[sdk/src/sdk.ts:169](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L169)
+[sdk/src/sdk.ts:169](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L169)
 
 ___
 
@@ -196,7 +196,7 @@ mnemonic-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:145](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L145)
+[sdk/src/sdk.ts:145](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L145)
 
 ___
 
@@ -214,7 +214,7 @@ rpc client
 
 #### Defined in
 
-[sdk/src/sdk.ts:129](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L129)
+[sdk/src/sdk.ts:129](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L129)
 
 ___
 
@@ -232,7 +232,7 @@ Non-Tx signing functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:161](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L161)
+[sdk/src/sdk.ts:161](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L161)
 
 ___
 
@@ -250,7 +250,7 @@ tx-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:137](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L137)
+[sdk/src/sdk.ts:137](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L137)
 
 ___
 
@@ -268,7 +268,7 @@ Version from package.json
 
 #### Defined in
 
-[sdk/src/sdk.ts:185](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L185)
+[sdk/src/sdk.ts:185](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L185)
 
 ## Methods
 
@@ -286,7 +286,7 @@ Utilities for encrypting and decrypting data
 
 #### Defined in
 
-[sdk/src/sdk.ts:103](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L103)
+[sdk/src/sdk.ts:103](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L103)
 
 ___
 
@@ -304,7 +304,7 @@ key-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:79](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L79)
+[sdk/src/sdk.ts:79](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L79)
 
 ___
 
@@ -322,7 +322,7 @@ Masp utilities for handling params
 
 #### Defined in
 
-[sdk/src/sdk.ts:95](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L95)
+[sdk/src/sdk.ts:95](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L95)
 
 ___
 
@@ -340,7 +340,7 @@ mnemonic-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:71](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L71)
+[sdk/src/sdk.ts:71](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L71)
 
 ___
 
@@ -358,7 +358,7 @@ Namada RPC client
 
 #### Defined in
 
-[sdk/src/sdk.ts:55](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L55)
+[sdk/src/sdk.ts:55](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L55)
 
 ___
 
@@ -376,7 +376,7 @@ Non-Tx signing functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:87](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L87)
+[sdk/src/sdk.ts:87](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L87)
 
 ___
 
@@ -394,7 +394,7 @@ Tx-related functionality
 
 #### Defined in
 
-[sdk/src/sdk.ts:63](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L63)
+[sdk/src/sdk.ts:63](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L63)
 
 ___
 
@@ -412,7 +412,7 @@ SDK version
 
 #### Defined in
 
-[sdk/src/sdk.ts:121](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L121)
+[sdk/src/sdk.ts:121](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L121)
 
 ___
 
@@ -438,7 +438,7 @@ Class for interacting with NamadaApp for Ledger Hardware Wallets
 
 #### Defined in
 
-[sdk/src/sdk.ts:113](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L113)
+[sdk/src/sdk.ts:113](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L113)
 
 ___
 
@@ -463,4 +463,4 @@ this instance of Sdk
 
 #### Defined in
 
-[sdk/src/sdk.ts:40](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/sdk.ts#L40)
+[sdk/src/sdk.ts:40](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/sdk.ts#L40)

--- a/packages/sdk/docs/classes/Signing.md
+++ b/packages/sdk/docs/classes/Signing.md
@@ -41,7 +41,7 @@ Signing constructor
 
 #### Defined in
 
-[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/signing.ts#L14)
+[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/signing.ts#L14)
 
 ## Properties
 
@@ -53,7 +53,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/signing.ts#L14)
+[sdk/src/signing.ts:14](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/signing.ts#L14)
 
 ## Methods
 
@@ -79,7 +79,7 @@ signed tx bytes - Promise resolving to Uint8Array
 
 #### Defined in
 
-[sdk/src/signing.ts:23](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/signing.ts#L23)
+[sdk/src/signing.ts:23](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/signing.ts#L23)
 
 ___
 
@@ -104,7 +104,7 @@ hash and signature
 
 #### Defined in
 
-[sdk/src/signing.ts:62](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/signing.ts#L62)
+[sdk/src/signing.ts:62](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/signing.ts#L62)
 
 ___
 
@@ -129,7 +129,7 @@ tx with masp spends signed - Promise resolving to Uint8Array
 
 #### Defined in
 
-[sdk/src/signing.ts:48](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/signing.ts#L48)
+[sdk/src/signing.ts:48](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/signing.ts#L48)
 
 ___
 
@@ -155,4 +155,4 @@ void
 
 #### Defined in
 
-[sdk/src/signing.ts:73](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/signing.ts#L73)
+[sdk/src/signing.ts:73](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/signing.ts#L73)

--- a/packages/sdk/docs/classes/Tx.md
+++ b/packages/sdk/docs/classes/Tx.md
@@ -55,7 +55,7 @@ SDK functionality related to transactions
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:56](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/tx/tx.ts#L56)
+[sdk/src/tx/tx.ts:56](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/tx/tx.ts#L56)
 
 ## Properties
 
@@ -67,7 +67,7 @@ Instance of Sdk struct from wasm lib
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:56](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/tx/tx.ts#L56)
+[sdk/src/tx/tx.ts:56](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/tx/tx.ts#L56)
 
 ## Methods
 
@@ -93,7 +93,7 @@ transaction bytes with signature appended
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:376](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/tx/tx.ts#L376)
+[sdk/src/tx/tx.ts:376](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/tx/tx.ts#L376)
 
 ___
 
@@ -118,7 +118,7 @@ Append signature for transactions signed by Ledger Hardware Wallet
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:390](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/tx/tx.ts#L390)
+[sdk/src/tx/tx.ts:390](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/tx/tx.ts#L390)
 
 ___
 
@@ -142,7 +142,7 @@ a serialized TxMsgValue type
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:358](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/tx/tx.ts#L358)
+[sdk/src/tx/tx.ts:358](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/tx/tx.ts#L358)
 
 ___
 
@@ -169,7 +169,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:178](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/tx/tx.ts#L178)
+[sdk/src/tx/tx.ts:178](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/tx/tx.ts#L178)
 
 ___
 
@@ -196,7 +196,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:337](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/tx/tx.ts#L337)
+[sdk/src/tx/tx.ts:337](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/tx/tx.ts#L337)
 
 ___
 
@@ -223,7 +223,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:290](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/tx/tx.ts#L290)
+[sdk/src/tx/tx.ts:290](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/tx/tx.ts#L290)
 
 ___
 
@@ -252,7 +252,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:267](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/tx/tx.ts#L267)
+[sdk/src/tx/tx.ts:267](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/tx/tx.ts#L267)
 
 ___
 
@@ -279,7 +279,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:242](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/tx/tx.ts#L242)
+[sdk/src/tx/tx.ts:242](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/tx/tx.ts#L242)
 
 ___
 
@@ -305,7 +305,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:165](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/tx/tx.ts#L165)
+[sdk/src/tx/tx.ts:165](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/tx/tx.ts#L165)
 
 ___
 
@@ -332,7 +332,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:90](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/tx/tx.ts#L90)
+[sdk/src/tx/tx.ts:90](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/tx/tx.ts#L90)
 
 ___
 
@@ -359,7 +359,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:115](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/tx/tx.ts#L115)
+[sdk/src/tx/tx.ts:115](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/tx/tx.ts#L115)
 
 ___
 
@@ -386,7 +386,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:65](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/tx/tx.ts#L65)
+[sdk/src/tx/tx.ts:65](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/tx/tx.ts#L65)
 
 ___
 
@@ -413,7 +413,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:199](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/tx/tx.ts#L199)
+[sdk/src/tx/tx.ts:199](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/tx/tx.ts#L199)
 
 ___
 
@@ -440,7 +440,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:141](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/tx/tx.ts#L141)
+[sdk/src/tx/tx.ts:141](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/tx/tx.ts#L141)
 
 ___
 
@@ -467,7 +467,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:313](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/tx/tx.ts#L313)
+[sdk/src/tx/tx.ts:313](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/tx/tx.ts#L313)
 
 ___
 
@@ -494,7 +494,7 @@ promise that resolves to an TxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:221](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/tx/tx.ts#L221)
+[sdk/src/tx/tx.ts:221](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/tx/tx.ts#L221)
 
 ___
 
@@ -519,7 +519,7 @@ a TxDetails object
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:443](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/tx/tx.ts#L443)
+[sdk/src/tx/tx.ts:443](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/tx/tx.ts#L443)
 
 ___
 
@@ -543,7 +543,7 @@ Serialized WrapperTxMsgValue
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:431](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/tx/tx.ts#L431)
+[sdk/src/tx/tx.ts:431](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/tx/tx.ts#L431)
 
 ___
 
@@ -573,7 +573,7 @@ promise that resolves to the shielding memo
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:510](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/tx/tx.ts#L510)
+[sdk/src/tx/tx.ts:510](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/tx/tx.ts#L510)
 
 ___
 
@@ -597,4 +597,4 @@ array of inner Tx hashes
 
 #### Defined in
 
-[sdk/src/tx/tx.ts:529](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/tx/tx.ts#L529)
+[sdk/src/tx/tx.ts:529](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/tx/tx.ts#L529)

--- a/packages/sdk/docs/enums/KdfType.md
+++ b/packages/sdk/docs/enums/KdfType.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:38](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/crypto/types.ts#L38)
+[sdk/src/crypto/types.ts:38](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/crypto/types.ts#L38)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:39](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/crypto/types.ts#L39)
+[sdk/src/crypto/types.ts:39](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/crypto/types.ts#L39)

--- a/packages/sdk/docs/enums/PhraseSize.md
+++ b/packages/sdk/docs/enums/PhraseSize.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:9](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/mnemonic.ts#L9)
+[sdk/src/mnemonic.ts:9](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/mnemonic.ts#L9)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[sdk/src/mnemonic.ts:10](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/mnemonic.ts#L10)
+[sdk/src/mnemonic.ts:10](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/mnemonic.ts#L10)

--- a/packages/sdk/docs/enums/SdkEvents.md
+++ b/packages/sdk/docs/enums/SdkEvents.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:48
+shared/src/shared/shared.d.ts:32
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:47
+shared/src/shared/shared.d.ts:31
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:46
+shared/src/shared/shared.d.ts:30

--- a/packages/sdk/docs/enums/TxType.md
+++ b/packages/sdk/docs/enums/TxType.md
@@ -26,7 +26,7 @@
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:41
+shared/src/shared/shared.d.ts:25
 
 ___
 
@@ -36,7 +36,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:32
+shared/src/shared/shared.d.ts:16
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:42
+shared/src/shared/shared.d.ts:26
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:37
+shared/src/shared/shared.d.ts:21
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:36
+shared/src/shared/shared.d.ts:20
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:40
+shared/src/shared/shared.d.ts:24
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:38
+shared/src/shared/shared.d.ts:22
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:35
+shared/src/shared/shared.d.ts:19
 
 ___
 
@@ -106,7 +106,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:33
+shared/src/shared/shared.d.ts:17
 
 ___
 
@@ -116,7 +116,7 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:39
+shared/src/shared/shared.d.ts:23
 
 ___
 
@@ -126,4 +126,4 @@ ___
 
 #### Defined in
 
-shared/src/shared/shared.d.ts:34
+shared/src/shared/shared.d.ts:18

--- a/packages/sdk/docs/modules.md
+++ b/packages/sdk/docs/modules.md
@@ -36,6 +36,7 @@
 - [DelegationTotals](modules.md#delegationtotals)
 - [DelegatorsVotes](modules.md#delegatorsvotes)
 - [EncryptionParams](modules.md#encryptionparams)
+- [GeneratedPaymentAddress](modules.md#generatedpaymentaddress)
 - [LedgerAddressAndPublicKey](modules.md#ledgeraddressandpublickey)
 - [LedgerProofGenerationKey](modules.md#ledgerproofgenerationkey)
 - [LedgerStatus](modules.md#ledgerstatus)
@@ -52,6 +53,7 @@
 - [Argon2Config](modules.md#argon2config)
 - [DEFAULT\_BIP44\_PATH](modules.md#default_bip44_path)
 - [DEFAULT\_ZIP32\_PATH](modules.md#default_zip32_path)
+- [LEDGER\_MASP\_BLACKLISTED](modules.md#ledger_masp_blacklisted)
 - [LEDGER\_MIN\_VERSION\_ZIP32](modules.md#ledger_min_version_zip32)
 - [MODIFIED\_ZIP32\_PATH](modules.md#modified_zip32_path)
 - [TxTypeLabel](modules.md#txtypelabel)
@@ -80,7 +82,7 @@ Address and public key type
 
 #### Defined in
 
-[sdk/src/keys/types.ts:6](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/keys/types.ts#L6)
+[sdk/src/keys/types.ts:6](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/keys/types.ts#L6)
 
 ___
 
@@ -90,7 +92,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:23](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/crypto/types.ts#L23)
+[sdk/src/crypto/types.ts:23](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/crypto/types.ts#L23)
 
 ___
 
@@ -103,7 +105,7 @@ Balance
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:69](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/types.ts#L69)
+[sdk/src/rpc/types.ts:78](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/types.ts#L78)
 
 ___
 
@@ -122,7 +124,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:27](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/types.ts#L27)
+[sdk/src/rpc/types.ts:27](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/types.ts#L27)
 
 ___
 
@@ -150,7 +152,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:42](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/crypto/types.ts#L42)
+[sdk/src/crypto/types.ts:42](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/crypto/types.ts#L42)
 
 ___
 
@@ -163,7 +165,7 @@ Record<address, totalDelegations>
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:51](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/types.ts#L51)
+[sdk/src/rpc/types.ts:60](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/types.ts#L60)
 
 ___
 
@@ -176,7 +178,7 @@ Record<address, boolean>
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:57](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/types.ts#L57)
+[sdk/src/rpc/types.ts:66](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/types.ts#L66)
 
 ___
 
@@ -195,7 +197,26 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:30](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/crypto/types.ts#L30)
+[sdk/src/crypto/types.ts:30](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/crypto/types.ts#L30)
+
+___
+
+### GeneratedPaymentAddress
+
+Ƭ **GeneratedPaymentAddress**: `Object`
+
+Result of generating next payment address
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `address` | `string` |
+| `diversifierIndex` | `number` |
+
+#### Defined in
+
+[sdk/src/keys/types.ts:32](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/keys/types.ts#L32)
 
 ___
 
@@ -212,7 +233,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:19](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/ledger.ts#L19)
+[sdk/src/ledger.ts:19](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/ledger.ts#L19)
 
 ___
 
@@ -229,7 +250,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:23](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/ledger.ts#L23)
+[sdk/src/ledger.ts:23](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/ledger.ts#L23)
 
 ___
 
@@ -241,12 +262,14 @@ ___
 
 | Name | Type |
 | :------ | :------ |
+| `deviceId?` | `string` |
+| `deviceName?` | `string` |
 | `info` | `ResponseAppInfo` |
 | `version` | `ResponseVersion` |
 
 #### Defined in
 
-[sdk/src/ledger.ts:28](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/ledger.ts#L28)
+[sdk/src/ledger.ts:28](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/ledger.ts#L28)
 
 ___
 
@@ -262,7 +285,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:20](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/ledger.ts#L20)
+[sdk/src/ledger.ts:20](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/ledger.ts#L20)
 
 ___
 
@@ -277,13 +300,14 @@ Shielded keys and address
 | Name | Type |
 | :------ | :------ |
 | `address` | `string` |
+| `diversifierIndex` | `number` |
 | `pseudoExtendedKey` | `string` |
 | `spendingKey` | `string` |
 | `viewingKey` | `string` |
 
 #### Defined in
 
-[sdk/src/keys/types.ts:21](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/keys/types.ts#L21)
+[sdk/src/keys/types.ts:21](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/keys/types.ts#L21)
 
 ___
 
@@ -300,7 +324,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:42](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/types.ts#L42)
+[sdk/src/rpc/types.ts:42](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/types.ts#L42)
 
 ___
 
@@ -320,7 +344,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:19](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/types.ts#L19)
+[sdk/src/rpc/types.ts:19](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/types.ts#L19)
 
 ___
 
@@ -330,7 +354,7 @@ ___
 
 #### Defined in
 
-[shared/src/types.ts:3](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/shared/src/types.ts#L3)
+[shared/src/types.ts:3](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/shared/src/types.ts#L3)
 
 ___
 
@@ -342,7 +366,7 @@ Public and private keypair with address
 
 #### Defined in
 
-[sdk/src/keys/types.ts:14](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/keys/types.ts#L14)
+[sdk/src/keys/types.ts:14](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/keys/types.ts#L14)
 
 ___
 
@@ -362,7 +386,7 @@ ___
 
 #### Defined in
 
-[sdk/src/rpc/types.ts:34](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/rpc/types.ts#L34)
+[sdk/src/rpc/types.ts:34](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/rpc/types.ts#L34)
 
 ## Variables
 
@@ -380,7 +404,7 @@ ___
 
 #### Defined in
 
-[sdk/src/crypto/types.ts:3](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/crypto/types.ts#L3)
+[sdk/src/crypto/types.ts:3](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/crypto/types.ts#L3)
 
 ___
 
@@ -390,7 +414,7 @@ ___
 
 #### Defined in
 
-[sdk/src/keys/types.ts:28](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/keys/types.ts#L28)
+[sdk/src/keys/types.ts:37](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/keys/types.ts#L37)
 
 ___
 
@@ -400,7 +424,17 @@ ___
 
 #### Defined in
 
-[sdk/src/keys/types.ts:40](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/keys/types.ts#L40)
+[sdk/src/keys/types.ts:49](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/keys/types.ts#L49)
+
+___
+
+### LEDGER\_MASP\_BLACKLISTED
+
+• `Const` **LEDGER\_MASP\_BLACKLISTED**: ``"nanoS"``
+
+#### Defined in
+
+[sdk/src/ledger.ts:36](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/ledger.ts#L36)
 
 ___
 
@@ -410,7 +444,7 @@ ___
 
 #### Defined in
 
-[sdk/src/ledger.ts:33](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/ledger.ts#L33)
+[sdk/src/ledger.ts:35](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/ledger.ts#L35)
 
 ___
 
@@ -420,7 +454,7 @@ ___
 
 #### Defined in
 
-[sdk/src/keys/types.ts:34](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/keys/types.ts#L34)
+[sdk/src/keys/types.ts:43](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/keys/types.ts#L43)
 
 ___
 
@@ -430,7 +464,7 @@ ___
 
 #### Defined in
 
-[shared/src/types.ts:28](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/shared/src/types.ts#L28)
+[shared/src/types.ts:28](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/shared/src/types.ts#L28)
 
 ## Functions
 
@@ -450,7 +484,7 @@ Transport object
 
 #### Defined in
 
-[sdk/src/ledger.ts:54](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/ledger.ts#L54)
+[sdk/src/ledger.ts:57](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/ledger.ts#L57)
 
 ___
 
@@ -470,7 +504,7 @@ List of USB devices
 
 #### Defined in
 
-[sdk/src/ledger.ts:63](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/ledger.ts#L63)
+[sdk/src/ledger.ts:66](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/ledger.ts#L66)
 
 ___
 
@@ -490,7 +524,7 @@ ___
 
 #### Defined in
 
-[sdk/src/keys/keys.ts:262](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/keys/keys.ts#L262)
+[sdk/src/keys/keys.ts:281](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/keys/keys.ts#L281)
 
 ___
 
@@ -510,4 +544,4 @@ Transport object
 
 #### Defined in
 
-[sdk/src/ledger.ts:72](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/sdk/src/ledger.ts#L72)
+[sdk/src/ledger.ts:75](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/sdk/src/ledger.ts#L75)

--- a/packages/sdk/examples/submitTransfer.ts
+++ b/packages/sdk/examples/submitTransfer.ts
@@ -45,7 +45,9 @@ export const submitTransfer = async (
 
     const signedTx = await sdk.signing.sign(encodedTx, signingKey);
 
-    await sdk.rpc.broadcastTx(signedTx, wrapperTxProps);
+    await sdk.rpc
+      .broadcastTx(signedTx)
+      .then((txReponse) => console.log(txReponse));
     process.exit(0);
   } catch (error) {
     console.error("Error:", error);

--- a/packages/types/docs/classes/BatchTxResultMsgValue.md
+++ b/packages/types/docs/classes/BatchTxResultMsgValue.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[tx/schema/batchTxResult.ts:12](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/batchTxResult.ts#L12)
+[packages/types/src/tx/schema/batchTxResult.ts:12](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/batchTxResult.ts#L12)
 
 ## Properties
 
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[tx/schema/batchTxResult.ts:7](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/batchTxResult.ts#L7)
+[packages/types/src/tx/schema/batchTxResult.ts:7](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/batchTxResult.ts#L7)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[tx/schema/batchTxResult.ts:10](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/batchTxResult.ts#L10)
+[packages/types/src/tx/schema/batchTxResult.ts:10](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/batchTxResult.ts#L10)

--- a/packages/types/docs/classes/BondMsgValue.md
+++ b/packages/types/docs/classes/BondMsgValue.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[tx/schema/bond.ts:17](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/bond.ts#L17)
+[packages/types/src/tx/schema/bond.ts:17](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/bond.ts#L17)
 
 ## Properties
 
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[tx/schema/bond.ts:15](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/bond.ts#L15)
+[packages/types/src/tx/schema/bond.ts:15](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/bond.ts#L15)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[tx/schema/bond.ts:9](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/bond.ts#L9)
+[packages/types/src/tx/schema/bond.ts:9](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/bond.ts#L9)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[tx/schema/bond.ts:12](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/bond.ts#L12)
+[packages/types/src/tx/schema/bond.ts:12](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/bond.ts#L12)

--- a/packages/types/docs/classes/BparamsConvertMsgValue.md
+++ b/packages/types/docs/classes/BparamsConvertMsgValue.md
@@ -30,7 +30,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:78](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L78)
+[packages/types/src/tx/schema/transfer.ts:78](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L78)
 
 ## Properties
 
@@ -40,4 +40,4 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:76](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L76)
+[packages/types/src/tx/schema/transfer.ts:76](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L76)

--- a/packages/types/docs/classes/BparamsMsgValue.md
+++ b/packages/types/docs/classes/BparamsMsgValue.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:93](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L93)
+[packages/types/src/tx/schema/transfer.ts:93](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L93)
 
 ## Properties
 
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:91](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L91)
+[packages/types/src/tx/schema/transfer.ts:91](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L91)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:88](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L88)
+[packages/types/src/tx/schema/transfer.ts:88](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L88)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:85](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L85)
+[packages/types/src/tx/schema/transfer.ts:85](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L85)

--- a/packages/types/docs/classes/BparamsOutputMsgValue.md
+++ b/packages/types/docs/classes/BparamsOutputMsgValue.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:69](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L69)
+[packages/types/src/tx/schema/transfer.ts:69](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L69)
 
 ## Properties
 
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:67](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L67)
+[packages/types/src/tx/schema/transfer.ts:67](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L67)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:64](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L64)
+[packages/types/src/tx/schema/transfer.ts:64](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L64)

--- a/packages/types/docs/classes/BparamsSpendMsgValue.md
+++ b/packages/types/docs/classes/BparamsSpendMsgValue.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:57](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L57)
+[packages/types/src/tx/schema/transfer.ts:57](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L57)
 
 ## Properties
 
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:55](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L55)
+[packages/types/src/tx/schema/transfer.ts:55](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L55)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:52](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L52)
+[packages/types/src/tx/schema/transfer.ts:52](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L52)

--- a/packages/types/docs/classes/BroadcastTxError.md
+++ b/packages/types/docs/classes/BroadcastTxError.md
@@ -1,0 +1,222 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / BroadcastTxError
+
+# Class: BroadcastTxError
+
+Custom error for Broadcast Tx
+
+## Hierarchy
+
+- `Error`
+
+  ↳ **`BroadcastTxError`**
+
+## Table of contents
+
+### Constructors
+
+- [constructor](BroadcastTxError.md#constructor)
+
+### Properties
+
+- [cause](BroadcastTxError.md#cause)
+- [message](BroadcastTxError.md#message)
+- [name](BroadcastTxError.md#name)
+- [stack](BroadcastTxError.md#stack)
+- [prepareStackTrace](BroadcastTxError.md#preparestacktrace)
+- [stackTraceLimit](BroadcastTxError.md#stacktracelimit)
+
+### Methods
+
+- [toProps](BroadcastTxError.md#toprops)
+- [toString](BroadcastTxError.md#tostring)
+- [captureStackTrace](BroadcastTxError.md#capturestacktrace)
+
+## Constructors
+
+### constructor
+
+• **new BroadcastTxError**(`message`): [`BroadcastTxError`](BroadcastTxError.md)
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `message` | `string` | string |
+
+#### Returns
+
+[`BroadcastTxError`](BroadcastTxError.md)
+
+BroadcastTxError
+
+#### Overrides
+
+Error.constructor
+
+#### Defined in
+
+[packages/types/src/errors.ts:11](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/errors.ts#L11)
+
+## Properties
+
+### cause
+
+• `Optional` **cause**: `unknown`
+
+#### Inherited from
+
+Error.cause
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es2022.error.d.ts:24
+
+___
+
+### message
+
+• **message**: `string`
+
+#### Inherited from
+
+Error.message
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1077
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Inherited from
+
+Error.name
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1076
+
+___
+
+### stack
+
+• `Optional` **stack**: `string`
+
+#### Inherited from
+
+Error.stack
+
+#### Defined in
+
+node_modules/typescript/lib/lib.es5.d.ts:1078
+
+___
+
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+Optional override for formatting stack traces
+
+**`See`**
+
+https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+Error.prepareStackTrace
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:143
+
+___
+
+### stackTraceLimit
+
+▪ `Static` **stackTraceLimit**: `number`
+
+#### Inherited from
+
+Error.stackTraceLimit
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:145
+
+## Methods
+
+### toProps
+
+▸ **toProps**(): [`TxResponseMsgValue`](TxResponseMsgValue.md)
+
+#### Returns
+
+[`TxResponseMsgValue`](TxResponseMsgValue.md)
+
+TxResponseProps
+
+#### Defined in
+
+[packages/types/src/errors.ts:35](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/errors.ts#L35)
+
+___
+
+### toString
+
+▸ **toString**(): `string`
+
+#### Returns
+
+`string`
+
+string
+
+#### Defined in
+
+[packages/types/src/errors.ts:19](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/errors.ts#L19)
+
+___
+
+### captureStackTrace
+
+▸ **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+
+Create .stack property on a target object
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `targetObject` | `object` |
+| `constructorOpt?` | `Function` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+Error.captureStackTrace
+
+#### Defined in
+
+node_modules/@types/node/globals.d.ts:136

--- a/packages/types/docs/classes/ClaimRewardsMsgValue.md
+++ b/packages/types/docs/classes/ClaimRewardsMsgValue.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[tx/schema/claimRewards.ts:12](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/claimRewards.ts#L12)
+[packages/types/src/tx/schema/claimRewards.ts:12](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/claimRewards.ts#L12)
 
 ## Properties
 
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[tx/schema/claimRewards.ts:10](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/claimRewards.ts#L10)
+[packages/types/src/tx/schema/claimRewards.ts:10](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/claimRewards.ts#L10)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[tx/schema/claimRewards.ts:7](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/claimRewards.ts#L7)
+[packages/types/src/tx/schema/claimRewards.ts:7](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/claimRewards.ts#L7)

--- a/packages/types/docs/classes/CommitmentMsgValue.md
+++ b/packages/types/docs/classes/CommitmentMsgValue.md
@@ -36,7 +36,7 @@
 
 #### Defined in
 
-[tx/schema/txDetails.ts:57](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txDetails.ts#L57)
+[packages/types/src/tx/schema/txDetails.ts:57](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txDetails.ts#L57)
 
 ## Properties
 
@@ -46,7 +46,7 @@
 
 #### Defined in
 
-[tx/schema/txDetails.ts:46](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txDetails.ts#L46)
+[packages/types/src/tx/schema/txDetails.ts:46](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txDetails.ts#L46)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:40](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txDetails.ts#L40)
+[packages/types/src/tx/schema/txDetails.ts:40](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txDetails.ts#L40)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:52](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txDetails.ts#L52)
+[packages/types/src/tx/schema/txDetails.ts:52](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txDetails.ts#L52)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:55](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txDetails.ts#L55)
+[packages/types/src/tx/schema/txDetails.ts:55](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txDetails.ts#L55)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:49](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txDetails.ts#L49)
+[packages/types/src/tx/schema/txDetails.ts:49](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txDetails.ts#L49)
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:43](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txDetails.ts#L43)
+[packages/types/src/tx/schema/txDetails.ts:43](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txDetails.ts#L43)
 
 ___
 
@@ -106,4 +106,4 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:37](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txDetails.ts#L37)
+[packages/types/src/tx/schema/txDetails.ts:37](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txDetails.ts#L37)

--- a/packages/types/docs/classes/EthBridgeTransferMsgValue.md
+++ b/packages/types/docs/classes/EthBridgeTransferMsgValue.md
@@ -37,7 +37,7 @@
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:32](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/ethBridgeTransfer.ts#L32)
+[packages/types/src/tx/schema/ethBridgeTransfer.ts:32](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/ethBridgeTransfer.ts#L32)
 
 ## Properties
 
@@ -47,7 +47,7 @@
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:21](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/ethBridgeTransfer.ts#L21)
+[packages/types/src/tx/schema/ethBridgeTransfer.ts:21](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/ethBridgeTransfer.ts#L21)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:12](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/ethBridgeTransfer.ts#L12)
+[packages/types/src/tx/schema/ethBridgeTransfer.ts:12](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/ethBridgeTransfer.ts#L12)
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:24](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/ethBridgeTransfer.ts#L24)
+[packages/types/src/tx/schema/ethBridgeTransfer.ts:24](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/ethBridgeTransfer.ts#L24)
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:27](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/ethBridgeTransfer.ts#L27)
+[packages/types/src/tx/schema/ethBridgeTransfer.ts:27](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/ethBridgeTransfer.ts#L27)
 
 ___
 
@@ -87,7 +87,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:30](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/ethBridgeTransfer.ts#L30)
+[packages/types/src/tx/schema/ethBridgeTransfer.ts:30](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/ethBridgeTransfer.ts#L30)
 
 ___
 
@@ -97,7 +97,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:9](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/ethBridgeTransfer.ts#L9)
+[packages/types/src/tx/schema/ethBridgeTransfer.ts:9](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/ethBridgeTransfer.ts#L9)
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:15](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/ethBridgeTransfer.ts#L15)
+[packages/types/src/tx/schema/ethBridgeTransfer.ts:15](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/ethBridgeTransfer.ts#L15)
 
 ___
 
@@ -117,4 +117,4 @@ ___
 
 #### Defined in
 
-[tx/schema/ethBridgeTransfer.ts:18](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/ethBridgeTransfer.ts#L18)
+[packages/types/src/tx/schema/ethBridgeTransfer.ts:18](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/ethBridgeTransfer.ts#L18)

--- a/packages/types/docs/classes/IbcTransferMsgValue.md
+++ b/packages/types/docs/classes/IbcTransferMsgValue.md
@@ -39,7 +39,7 @@
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:38](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/ibcTransfer.ts#L38)
+[packages/types/src/tx/schema/ibcTransfer.ts:38](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/ibcTransfer.ts#L38)
 
 ## Properties
 
@@ -49,7 +49,7 @@
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:18](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/ibcTransfer.ts#L18)
+[packages/types/src/tx/schema/ibcTransfer.ts:18](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/ibcTransfer.ts#L18)
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:24](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/ibcTransfer.ts#L24)
+[packages/types/src/tx/schema/ibcTransfer.ts:24](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/ibcTransfer.ts#L24)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:33](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/ibcTransfer.ts#L33)
+[packages/types/src/tx/schema/ibcTransfer.ts:33](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/ibcTransfer.ts#L33)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:21](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/ibcTransfer.ts#L21)
+[packages/types/src/tx/schema/ibcTransfer.ts:21](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/ibcTransfer.ts#L21)
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:12](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/ibcTransfer.ts#L12)
+[packages/types/src/tx/schema/ibcTransfer.ts:12](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/ibcTransfer.ts#L12)
 
 ___
 
@@ -99,7 +99,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:36](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/ibcTransfer.ts#L36)
+[packages/types/src/tx/schema/ibcTransfer.ts:36](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/ibcTransfer.ts#L36)
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:9](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/ibcTransfer.ts#L9)
+[packages/types/src/tx/schema/ibcTransfer.ts:9](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/ibcTransfer.ts#L9)
 
 ___
 
@@ -119,7 +119,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:27](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/ibcTransfer.ts#L27)
+[packages/types/src/tx/schema/ibcTransfer.ts:27](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/ibcTransfer.ts#L27)
 
 ___
 
@@ -129,7 +129,7 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:30](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/ibcTransfer.ts#L30)
+[packages/types/src/tx/schema/ibcTransfer.ts:30](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/ibcTransfer.ts#L30)
 
 ___
 
@@ -139,4 +139,4 @@ ___
 
 #### Defined in
 
-[tx/schema/ibcTransfer.ts:15](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/ibcTransfer.ts#L15)
+[packages/types/src/tx/schema/ibcTransfer.ts:15](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/ibcTransfer.ts#L15)

--- a/packages/types/docs/classes/MaspTxIn.md
+++ b/packages/types/docs/classes/MaspTxIn.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[tx/schema/txDetails.ts:15](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txDetails.ts#L15)
+[packages/types/src/tx/schema/txDetails.ts:15](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txDetails.ts#L15)
 
 ## Properties
 
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[tx/schema/txDetails.ts:13](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txDetails.ts#L13)
+[packages/types/src/tx/schema/txDetails.ts:13](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txDetails.ts#L13)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:7](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txDetails.ts#L7)
+[packages/types/src/tx/schema/txDetails.ts:7](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txDetails.ts#L7)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:10](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txDetails.ts#L10)
+[packages/types/src/tx/schema/txDetails.ts:10](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txDetails.ts#L10)

--- a/packages/types/docs/classes/MaspTxOut.md
+++ b/packages/types/docs/classes/MaspTxOut.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[tx/schema/txDetails.ts:30](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txDetails.ts#L30)
+[packages/types/src/tx/schema/txDetails.ts:30](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txDetails.ts#L30)
 
 ## Properties
 
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[tx/schema/txDetails.ts:28](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txDetails.ts#L28)
+[packages/types/src/tx/schema/txDetails.ts:28](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txDetails.ts#L28)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:22](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txDetails.ts#L22)
+[packages/types/src/tx/schema/txDetails.ts:22](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txDetails.ts#L22)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:25](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txDetails.ts#L25)
+[packages/types/src/tx/schema/txDetails.ts:25](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txDetails.ts#L25)

--- a/packages/types/docs/classes/Message.md
+++ b/packages/types/docs/classes/Message.md
@@ -61,7 +61,7 @@
 
 #### Defined in
 
-[tx/messages/index.ts:9](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/messages/index.ts#L9)
+[packages/types/src/tx/messages/index.ts:9](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/messages/index.ts#L9)
 
 ___
 
@@ -88,4 +88,4 @@ ___
 
 #### Defined in
 
-[tx/messages/index.ts:18](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/messages/index.ts#L18)
+[packages/types/src/tx/messages/index.ts:18](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/messages/index.ts#L18)

--- a/packages/types/docs/classes/RedelegateMsgValue.md
+++ b/packages/types/docs/classes/RedelegateMsgValue.md
@@ -33,7 +33,7 @@
 
 #### Defined in
 
-[tx/schema/redelegate.ts:19](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/redelegate.ts#L19)
+[packages/types/src/tx/schema/redelegate.ts:19](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/redelegate.ts#L19)
 
 ## Properties
 
@@ -43,7 +43,7 @@
 
 #### Defined in
 
-[tx/schema/redelegate.ts:17](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/redelegate.ts#L17)
+[packages/types/src/tx/schema/redelegate.ts:17](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/redelegate.ts#L17)
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 #### Defined in
 
-[tx/schema/redelegate.ts:14](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/redelegate.ts#L14)
+[packages/types/src/tx/schema/redelegate.ts:14](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/redelegate.ts#L14)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[tx/schema/redelegate.ts:8](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/redelegate.ts#L8)
+[packages/types/src/tx/schema/redelegate.ts:8](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/redelegate.ts#L8)
 
 ___
 
@@ -73,4 +73,4 @@ ___
 
 #### Defined in
 
-[tx/schema/redelegate.ts:11](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/redelegate.ts#L11)
+[packages/types/src/tx/schema/redelegate.ts:11](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/redelegate.ts#L11)

--- a/packages/types/docs/classes/RevealPkMsgValue.md
+++ b/packages/types/docs/classes/RevealPkMsgValue.md
@@ -30,7 +30,7 @@
 
 #### Defined in
 
-[tx/schema/revealPk.ts:8](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/revealPk.ts#L8)
+[packages/types/src/tx/schema/revealPk.ts:8](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/revealPk.ts#L8)
 
 ## Properties
 
@@ -40,4 +40,4 @@
 
 #### Defined in
 
-[tx/schema/revealPk.ts:6](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/revealPk.ts#L6)
+[packages/types/src/tx/schema/revealPk.ts:6](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/revealPk.ts#L6)

--- a/packages/types/docs/classes/ShieldedTransferDataMsgValue.md
+++ b/packages/types/docs/classes/ShieldedTransferDataMsgValue.md
@@ -35,7 +35,7 @@ Shielded Transfer schemas
 
 #### Defined in
 
-[tx/schema/transfer.ts:114](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L114)
+[packages/types/src/tx/schema/transfer.ts:114](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L114)
 
 ## Properties
 
@@ -45,7 +45,7 @@ Shielded Transfer schemas
 
 #### Defined in
 
-[tx/schema/transfer.ts:112](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L112)
+[packages/types/src/tx/schema/transfer.ts:112](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L112)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:103](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L103)
+[packages/types/src/tx/schema/transfer.ts:103](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L103)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:106](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L106)
+[packages/types/src/tx/schema/transfer.ts:106](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L106)
 
 ___
 
@@ -75,4 +75,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:109](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L109)
+[packages/types/src/tx/schema/transfer.ts:109](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L109)

--- a/packages/types/docs/classes/ShieldedTransferMsgValue.md
+++ b/packages/types/docs/classes/ShieldedTransferMsgValue.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:129](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L129)
+[packages/types/src/tx/schema/transfer.ts:129](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L129)
 
 ## Properties
 
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:127](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L127)
+[packages/types/src/tx/schema/transfer.ts:127](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L127)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:121](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L121)
+[packages/types/src/tx/schema/transfer.ts:121](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L121)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:124](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L124)
+[packages/types/src/tx/schema/transfer.ts:124](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L124)

--- a/packages/types/docs/classes/ShieldingTransferDataMsgValue.md
+++ b/packages/types/docs/classes/ShieldingTransferDataMsgValue.md
@@ -34,7 +34,7 @@ Shielding Transfer schemas
 
 #### Defined in
 
-[tx/schema/transfer.ts:161](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L161)
+[packages/types/src/tx/schema/transfer.ts:161](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L161)
 
 ## Properties
 
@@ -44,7 +44,7 @@ Shielding Transfer schemas
 
 #### Defined in
 
-[tx/schema/transfer.ts:159](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L159)
+[packages/types/src/tx/schema/transfer.ts:159](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L159)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:153](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L153)
+[packages/types/src/tx/schema/transfer.ts:153](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L153)
 
 ___
 
@@ -64,4 +64,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:156](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L156)
+[packages/types/src/tx/schema/transfer.ts:156](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L156)

--- a/packages/types/docs/classes/ShieldingTransferMsgValue.md
+++ b/packages/types/docs/classes/ShieldingTransferMsgValue.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:176](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L176)
+[packages/types/src/tx/schema/transfer.ts:176](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L176)
 
 ## Properties
 
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:174](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L174)
+[packages/types/src/tx/schema/transfer.ts:174](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L174)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:171](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L171)
+[packages/types/src/tx/schema/transfer.ts:171](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L171)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:168](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L168)
+[packages/types/src/tx/schema/transfer.ts:168](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L168)

--- a/packages/types/docs/classes/SignatureMsgValue.md
+++ b/packages/types/docs/classes/SignatureMsgValue.md
@@ -34,7 +34,7 @@
 
 #### Defined in
 
-[tx/schema/signature.ts:21](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/signature.ts#L21)
+[packages/types/src/tx/schema/signature.ts:21](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/signature.ts#L21)
 
 ## Properties
 
@@ -44,7 +44,7 @@
 
 #### Defined in
 
-[tx/schema/signature.ts:7](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/signature.ts#L7)
+[packages/types/src/tx/schema/signature.ts:7](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/signature.ts#L7)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[tx/schema/signature.ts:10](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/signature.ts#L10)
+[packages/types/src/tx/schema/signature.ts:10](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/signature.ts#L10)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[tx/schema/signature.ts:13](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/signature.ts#L13)
+[packages/types/src/tx/schema/signature.ts:13](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/signature.ts#L13)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[tx/schema/signature.ts:16](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/signature.ts#L16)
+[packages/types/src/tx/schema/signature.ts:16](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/signature.ts#L16)
 
 ___
 
@@ -84,4 +84,4 @@ ___
 
 #### Defined in
 
-[tx/schema/signature.ts:19](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/signature.ts#L19)
+[packages/types/src/tx/schema/signature.ts:19](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/signature.ts#L19)

--- a/packages/types/docs/classes/SigningDataMsgValue.md
+++ b/packages/types/docs/classes/SigningDataMsgValue.md
@@ -36,7 +36,7 @@
 
 #### Defined in
 
-[tx/schema/tx.ts:32](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/tx.ts#L32)
+[packages/types/src/tx/schema/tx.ts:32](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/tx.ts#L32)
 
 ## Properties
 
@@ -46,7 +46,7 @@
 
 #### Defined in
 
-[tx/schema/tx.ts:21](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/tx.ts#L21)
+[packages/types/src/tx/schema/tx.ts:21](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/tx.ts#L21)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[tx/schema/tx.ts:24](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/tx.ts#L24)
+[packages/types/src/tx/schema/tx.ts:24](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/tx.ts#L24)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[tx/schema/tx.ts:30](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/tx.ts#L30)
+[packages/types/src/tx/schema/tx.ts:30](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/tx.ts#L30)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[tx/schema/tx.ts:8](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/tx.ts#L8)
+[packages/types/src/tx/schema/tx.ts:8](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/tx.ts#L8)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[tx/schema/tx.ts:11](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/tx.ts#L11)
+[packages/types/src/tx/schema/tx.ts:11](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/tx.ts#L11)
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 #### Defined in
 
-[tx/schema/tx.ts:27](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/tx.ts#L27)
+[packages/types/src/tx/schema/tx.ts:27](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/tx.ts#L27)
 
 ___
 
@@ -106,4 +106,4 @@ ___
 
 #### Defined in
 
-[tx/schema/tx.ts:14](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/tx.ts#L14)
+[packages/types/src/tx/schema/tx.ts:14](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/tx.ts#L14)

--- a/packages/types/docs/classes/TransferDataMsgValue.md
+++ b/packages/types/docs/classes/TransferDataMsgValue.md
@@ -34,7 +34,7 @@ General Transfer schema used for displaying details
 
 #### Defined in
 
-[tx/schema/transfer.ts:253](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L253)
+[packages/types/src/tx/schema/transfer.ts:253](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L253)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:247](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L247)
+[packages/types/src/tx/schema/transfer.ts:247](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L247)
 
 ___
 
@@ -54,4 +54,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:250](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L250)
+[packages/types/src/tx/schema/transfer.ts:250](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L250)

--- a/packages/types/docs/classes/TransferDetailsMsgValue.md
+++ b/packages/types/docs/classes/TransferDetailsMsgValue.md
@@ -35,7 +35,7 @@ shieldedSectionHash encoded as hex instead of Uint8Array
 
 #### Defined in
 
-[tx/schema/transfer.ts:282](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L282)
+[packages/types/src/tx/schema/transfer.ts:282](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L282)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:276](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L276)
+[packages/types/src/tx/schema/transfer.ts:276](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L276)
 
 ___
 
@@ -55,4 +55,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:279](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L279)
+[packages/types/src/tx/schema/transfer.ts:279](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L279)

--- a/packages/types/docs/classes/TransferMsgValue.md
+++ b/packages/types/docs/classes/TransferMsgValue.md
@@ -34,7 +34,7 @@ Used only for serializing transfers during build
 
 #### Defined in
 
-[tx/schema/transfer.ts:267](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L267)
+[packages/types/src/tx/schema/transfer.ts:267](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L267)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:261](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L261)
+[packages/types/src/tx/schema/transfer.ts:261](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L261)
 
 ___
 
@@ -54,4 +54,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:264](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L264)
+[packages/types/src/tx/schema/transfer.ts:264](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L264)

--- a/packages/types/docs/classes/TransparentTransferDataMsgValue.md
+++ b/packages/types/docs/classes/TransparentTransferDataMsgValue.md
@@ -35,7 +35,7 @@ Transparent Transfer schemas
 
 #### Defined in
 
-[tx/schema/transfer.ts:32](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L32)
+[packages/types/src/tx/schema/transfer.ts:32](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L32)
 
 ## Properties
 
@@ -45,7 +45,7 @@ Transparent Transfer schemas
 
 #### Defined in
 
-[tx/schema/transfer.ts:30](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L30)
+[packages/types/src/tx/schema/transfer.ts:30](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L30)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:21](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L21)
+[packages/types/src/tx/schema/transfer.ts:21](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L21)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:24](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L24)
+[packages/types/src/tx/schema/transfer.ts:24](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L24)
 
 ___
 
@@ -75,4 +75,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:27](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L27)
+[packages/types/src/tx/schema/transfer.ts:27](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L27)

--- a/packages/types/docs/classes/TransparentTransferMsgValue.md
+++ b/packages/types/docs/classes/TransparentTransferMsgValue.md
@@ -30,7 +30,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:41](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L41)
+[packages/types/src/tx/schema/transfer.ts:41](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L41)
 
 ## Properties
 
@@ -40,4 +40,4 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:39](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L39)
+[packages/types/src/tx/schema/transfer.ts:39](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L39)

--- a/packages/types/docs/classes/TxDetailsMsgValue.md
+++ b/packages/types/docs/classes/TxDetailsMsgValue.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[tx/schema/txDetails.ts:80](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txDetails.ts#L80)
+[packages/types/src/tx/schema/txDetails.ts:80](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txDetails.ts#L80)
 
 ___
 
@@ -41,4 +41,4 @@ ___
 
 #### Defined in
 
-[tx/schema/txDetails.ts:77](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txDetails.ts#L77)
+[packages/types/src/tx/schema/txDetails.ts:77](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txDetails.ts#L77)

--- a/packages/types/docs/classes/TxMsgValue.md
+++ b/packages/types/docs/classes/TxMsgValue.md
@@ -33,7 +33,7 @@
 
 #### Defined in
 
-[tx/schema/tx.ts:50](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/tx.ts#L50)
+[packages/types/src/tx/schema/tx.ts:50](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/tx.ts#L50)
 
 ## Properties
 
@@ -43,7 +43,7 @@
 
 #### Defined in
 
-[tx/schema/tx.ts:39](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/tx.ts#L39)
+[packages/types/src/tx/schema/tx.ts:39](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/tx.ts#L39)
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 #### Defined in
 
-[tx/schema/tx.ts:45](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/tx.ts#L45)
+[packages/types/src/tx/schema/tx.ts:45](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/tx.ts#L45)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[tx/schema/tx.ts:42](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/tx.ts#L42)
+[packages/types/src/tx/schema/tx.ts:42](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/tx.ts#L42)
 
 ___
 
@@ -73,4 +73,4 @@ ___
 
 #### Defined in
 
-[tx/schema/tx.ts:48](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/tx.ts#L48)
+[packages/types/src/tx/schema/tx.ts:48](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/tx.ts#L48)

--- a/packages/types/docs/classes/TxResponseMsgValue.md
+++ b/packages/types/docs/classes/TxResponseMsgValue.md
@@ -36,17 +36,17 @@
 
 #### Defined in
 
-[tx/schema/txResponse.ts:28](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txResponse.ts#L28)
+[packages/types/src/tx/schema/txResponse.ts:28](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txResponse.ts#L28)
 
 ## Properties
 
 ### code
 
-• **code**: `string`
+• **code**: `number`
 
 #### Defined in
 
-[tx/schema/txResponse.ts:8](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txResponse.ts#L8)
+[packages/types/src/tx/schema/txResponse.ts:8](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txResponse.ts#L8)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:11](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txResponse.ts#L11)
+[packages/types/src/tx/schema/txResponse.ts:11](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txResponse.ts#L11)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:14](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txResponse.ts#L14)
+[packages/types/src/tx/schema/txResponse.ts:14](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txResponse.ts#L14)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:17](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txResponse.ts#L17)
+[packages/types/src/tx/schema/txResponse.ts:17](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txResponse.ts#L17)
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:20](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txResponse.ts#L20)
+[packages/types/src/tx/schema/txResponse.ts:20](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txResponse.ts#L20)
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:23](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txResponse.ts#L23)
+[packages/types/src/tx/schema/txResponse.ts:23](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txResponse.ts#L23)
 
 ___
 
@@ -106,4 +106,4 @@ ___
 
 #### Defined in
 
-[tx/schema/txResponse.ts:26](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/txResponse.ts#L26)
+[packages/types/src/tx/schema/txResponse.ts:26](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/txResponse.ts#L26)

--- a/packages/types/docs/classes/UnbondMsgValue.md
+++ b/packages/types/docs/classes/UnbondMsgValue.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[tx/schema/unbond.ts:17](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/unbond.ts#L17)
+[packages/types/src/tx/schema/unbond.ts:17](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/unbond.ts#L17)
 
 ## Properties
 
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[tx/schema/unbond.ts:15](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/unbond.ts#L15)
+[packages/types/src/tx/schema/unbond.ts:15](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/unbond.ts#L15)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[tx/schema/unbond.ts:9](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/unbond.ts#L9)
+[packages/types/src/tx/schema/unbond.ts:9](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/unbond.ts#L9)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[tx/schema/unbond.ts:12](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/unbond.ts#L12)
+[packages/types/src/tx/schema/unbond.ts:12](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/unbond.ts#L12)

--- a/packages/types/docs/classes/UnshieldingTransferDataMsgValue.md
+++ b/packages/types/docs/classes/UnshieldingTransferDataMsgValue.md
@@ -34,7 +34,7 @@ Unshielding Transfer schemas
 
 #### Defined in
 
-[tx/schema/transfer.ts:200](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L200)
+[packages/types/src/tx/schema/transfer.ts:200](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L200)
 
 ## Properties
 
@@ -44,7 +44,7 @@ Unshielding Transfer schemas
 
 #### Defined in
 
-[tx/schema/transfer.ts:198](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L198)
+[packages/types/src/tx/schema/transfer.ts:198](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L198)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:192](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L192)
+[packages/types/src/tx/schema/transfer.ts:192](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L192)
 
 ___
 
@@ -64,4 +64,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:195](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L195)
+[packages/types/src/tx/schema/transfer.ts:195](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L195)

--- a/packages/types/docs/classes/UnshieldingTransferMsgValue.md
+++ b/packages/types/docs/classes/UnshieldingTransferMsgValue.md
@@ -33,7 +33,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:218](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L218)
+[packages/types/src/tx/schema/transfer.ts:218](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L218)
 
 ## Properties
 
@@ -43,7 +43,7 @@
 
 #### Defined in
 
-[tx/schema/transfer.ts:216](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L216)
+[packages/types/src/tx/schema/transfer.ts:216](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L216)
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:210](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L210)
+[packages/types/src/tx/schema/transfer.ts:210](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L210)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:213](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L213)
+[packages/types/src/tx/schema/transfer.ts:213](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L213)
 
 ___
 
@@ -73,4 +73,4 @@ ___
 
 #### Defined in
 
-[tx/schema/transfer.ts:207](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/transfer.ts#L207)
+[packages/types/src/tx/schema/transfer.ts:207](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/transfer.ts#L207)

--- a/packages/types/docs/classes/VoteProposalMsgValue.md
+++ b/packages/types/docs/classes/VoteProposalMsgValue.md
@@ -32,7 +32,7 @@
 
 #### Defined in
 
-[tx/schema/voteProposal.ts:15](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/voteProposal.ts#L15)
+[packages/types/src/tx/schema/voteProposal.ts:15](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/voteProposal.ts#L15)
 
 ## Properties
 
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[tx/schema/voteProposal.ts:10](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/voteProposal.ts#L10)
+[packages/types/src/tx/schema/voteProposal.ts:10](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/voteProposal.ts#L10)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[tx/schema/voteProposal.ts:7](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/voteProposal.ts#L7)
+[packages/types/src/tx/schema/voteProposal.ts:7](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/voteProposal.ts#L7)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[tx/schema/voteProposal.ts:13](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/voteProposal.ts#L13)
+[packages/types/src/tx/schema/voteProposal.ts:13](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/voteProposal.ts#L13)

--- a/packages/types/docs/classes/WithdrawMsgValue.md
+++ b/packages/types/docs/classes/WithdrawMsgValue.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[tx/schema/withdraw.ts:12](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/withdraw.ts#L12)
+[packages/types/src/tx/schema/withdraw.ts:12](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/withdraw.ts#L12)
 
 ## Properties
 
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[tx/schema/withdraw.ts:7](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/withdraw.ts#L7)
+[packages/types/src/tx/schema/withdraw.ts:7](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/withdraw.ts#L7)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[tx/schema/withdraw.ts:10](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/withdraw.ts#L10)
+[packages/types/src/tx/schema/withdraw.ts:10](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/withdraw.ts#L10)

--- a/packages/types/docs/classes/WrapperTxMsgValue.md
+++ b/packages/types/docs/classes/WrapperTxMsgValue.md
@@ -38,7 +38,7 @@
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:35](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/wrapperTx.ts#L35)
+[packages/types/src/tx/schema/wrapperTx.ts:35](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/wrapperTx.ts#L35)
 
 ## Properties
 
@@ -48,7 +48,7 @@
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:18](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/wrapperTx.ts#L18)
+[packages/types/src/tx/schema/wrapperTx.ts:18](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/wrapperTx.ts#L18)
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:30](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/wrapperTx.ts#L30)
+[packages/types/src/tx/schema/wrapperTx.ts:30](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/wrapperTx.ts#L30)
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:12](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/wrapperTx.ts#L12)
+[packages/types/src/tx/schema/wrapperTx.ts:12](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/wrapperTx.ts#L12)
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:27](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/wrapperTx.ts#L27)
+[packages/types/src/tx/schema/wrapperTx.ts:27](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/wrapperTx.ts#L27)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:15](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/wrapperTx.ts#L15)
+[packages/types/src/tx/schema/wrapperTx.ts:15](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/wrapperTx.ts#L15)
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:24](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/wrapperTx.ts#L24)
+[packages/types/src/tx/schema/wrapperTx.ts:24](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/wrapperTx.ts#L24)
 
 ___
 
@@ -108,7 +108,7 @@ ___
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:21](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/wrapperTx.ts#L21)
+[packages/types/src/tx/schema/wrapperTx.ts:21](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/wrapperTx.ts#L21)
 
 ___
 
@@ -118,7 +118,7 @@ ___
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:9](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/wrapperTx.ts#L9)
+[packages/types/src/tx/schema/wrapperTx.ts:9](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/wrapperTx.ts#L9)
 
 ___
 
@@ -128,4 +128,4 @@ ___
 
 #### Defined in
 
-[tx/schema/wrapperTx.ts:33](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/wrapperTx.ts#L33)
+[packages/types/src/tx/schema/wrapperTx.ts:33](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/wrapperTx.ts#L33)

--- a/packages/types/docs/enums/AccountType.md
+++ b/packages/types/docs/enums/AccountType.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[account.ts:28](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/account.ts#L28)
+[packages/types/src/account.ts:28](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/account.ts#L28)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[account.ts:22](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/account.ts#L22)
+[packages/types/src/account.ts:22](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/account.ts#L22)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[account.ts:24](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/account.ts#L24)
+[packages/types/src/account.ts:24](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/account.ts#L24)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[account.ts:26](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/account.ts#L26)
+[packages/types/src/account.ts:26](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/account.ts#L26)

--- a/packages/types/docs/enums/BridgeType.md
+++ b/packages/types/docs/enums/BridgeType.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[chain.ts:14](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/chain.ts#L14)
+[packages/types/src/chain.ts:14](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/chain.ts#L14)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[chain.ts:13](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/chain.ts#L13)
+[packages/types/src/chain.ts:13](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/chain.ts#L13)

--- a/packages/types/docs/enums/Events.md
+++ b/packages/types/docs/enums/Events.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[events.ts:5](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/events.ts#L5)
+[packages/types/src/events.ts:5](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/events.ts#L5)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[events.ts:9](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/events.ts#L9)
+[packages/types/src/events.ts:9](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/events.ts#L9)
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 #### Defined in
 
-[events.ts:7](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/events.ts#L7)
+[packages/types/src/events.ts:7](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/events.ts#L7)
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 #### Defined in
 
-[events.ts:8](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/events.ts#L8)
+[packages/types/src/events.ts:8](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/events.ts#L8)
 
 ___
 
@@ -60,4 +60,4 @@ ___
 
 #### Defined in
 
-[events.ts:6](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/events.ts#L6)
+[packages/types/src/events.ts:6](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/events.ts#L6)

--- a/packages/types/docs/enums/KeplrEvents.md
+++ b/packages/types/docs/enums/KeplrEvents.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[events.ts:14](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/events.ts#L14)
+[packages/types/src/events.ts:14](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/events.ts#L14)

--- a/packages/types/docs/enums/MetamaskEvents.md
+++ b/packages/types/docs/enums/MetamaskEvents.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[events.ts:19](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/events.ts#L19)
+[packages/types/src/events.ts:19](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/events.ts#L19)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[events.ts:20](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/events.ts#L20)
+[packages/types/src/events.ts:20](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/events.ts#L20)

--- a/packages/types/docs/enums/ResultCode.md
+++ b/packages/types/docs/enums/ResultCode.md
@@ -1,0 +1,151 @@
+[@namada/types](../README.md) / [Exports](../modules.md) / ResultCode
+
+# Enumeration: ResultCode
+
+## Table of contents
+
+### Enumeration Members
+
+- [AllocationError](ResultCode.md#allocationerror)
+- [ExpiredTx](ResultCode.md#expiredtx)
+- [FeeError](ResultCode.md#feeerror)
+- [InvalidChainId](ResultCode.md#invalidchainid)
+- [InvalidSig](ResultCode.md#invalidsig)
+- [InvalidTx](ResultCode.md#invalidtx)
+- [InvalidVoteExtension](ResultCode.md#invalidvoteextension)
+- [Ok](ResultCode.md#ok)
+- [ReplayTx](ResultCode.md#replaytx)
+- [TooLarge](ResultCode.md#toolarge)
+- [TxGasLimit](ResultCode.md#txgaslimit)
+- [TxNotAllowlisted](ResultCode.md#txnotallowlisted)
+- [WasmRuntimeError](ResultCode.md#wasmruntimeerror)
+
+## Enumeration Members
+
+### AllocationError
+
+• **AllocationError** = ``4``
+
+#### Defined in
+
+[packages/types/src/tx/types.ts:91](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L91)
+
+___
+
+### ExpiredTx
+
+• **ExpiredTx** = ``7``
+
+#### Defined in
+
+[packages/types/src/tx/types.ts:94](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L94)
+
+___
+
+### FeeError
+
+• **FeeError** = ``9``
+
+#### Defined in
+
+[packages/types/src/tx/types.ts:96](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L96)
+
+___
+
+### InvalidChainId
+
+• **InvalidChainId** = ``6``
+
+#### Defined in
+
+[packages/types/src/tx/types.ts:93](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L93)
+
+___
+
+### InvalidSig
+
+• **InvalidSig** = ``3``
+
+#### Defined in
+
+[packages/types/src/tx/types.ts:90](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L90)
+
+___
+
+### InvalidTx
+
+• **InvalidTx** = ``2``
+
+#### Defined in
+
+[packages/types/src/tx/types.ts:89](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L89)
+
+___
+
+### InvalidVoteExtension
+
+• **InvalidVoteExtension** = ``10``
+
+#### Defined in
+
+[packages/types/src/tx/types.ts:97](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L97)
+
+___
+
+### Ok
+
+• **Ok** = ``0``
+
+#### Defined in
+
+[packages/types/src/tx/types.ts:87](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L87)
+
+___
+
+### ReplayTx
+
+• **ReplayTx** = ``5``
+
+#### Defined in
+
+[packages/types/src/tx/types.ts:92](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L92)
+
+___
+
+### TooLarge
+
+• **TooLarge** = ``11``
+
+#### Defined in
+
+[packages/types/src/tx/types.ts:98](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L98)
+
+___
+
+### TxGasLimit
+
+• **TxGasLimit** = ``8``
+
+#### Defined in
+
+[packages/types/src/tx/types.ts:95](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L95)
+
+___
+
+### TxNotAllowlisted
+
+• **TxNotAllowlisted** = ``12``
+
+#### Defined in
+
+[packages/types/src/tx/types.ts:99](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L99)
+
+___
+
+### WasmRuntimeError
+
+• **WasmRuntimeError** = ``1``
+
+#### Defined in
+
+[packages/types/src/tx/types.ts:88](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L88)

--- a/packages/types/docs/interfaces/IMessage.md
+++ b/packages/types/docs/interfaces/IMessage.md
@@ -36,4 +36,4 @@
 
 #### Defined in
 
-[tx/messages/index.ts:5](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/messages/index.ts#L5)
+[packages/types/src/tx/messages/index.ts:5](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/messages/index.ts#L5)

--- a/packages/types/docs/interfaces/Namada.md
+++ b/packages/types/docs/interfaces/Namada.md
@@ -37,7 +37,7 @@
 
 #### Defined in
 
-[namada.ts:44](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/namada.ts#L44)
+[packages/types/src/namada.ts:44](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/namada.ts#L44)
 
 ## Methods
 
@@ -51,7 +51,7 @@
 
 #### Defined in
 
-[namada.ts:32](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/namada.ts#L32)
+[packages/types/src/namada.ts:32](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/namada.ts#L32)
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 #### Defined in
 
-[namada.ts:33](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/namada.ts#L33)
+[packages/types/src/namada.ts:33](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/namada.ts#L33)
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 #### Defined in
 
-[namada.ts:36](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/namada.ts#L36)
+[packages/types/src/namada.ts:36](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/namada.ts#L36)
 
 ___
 
@@ -105,7 +105,7 @@ ___
 
 #### Defined in
 
-[namada.ts:34](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/namada.ts#L34)
+[packages/types/src/namada.ts:34](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/namada.ts#L34)
 
 ___
 
@@ -119,7 +119,7 @@ ___
 
 #### Defined in
 
-[namada.ts:43](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/namada.ts#L43)
+[packages/types/src/namada.ts:43](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/namada.ts#L43)
 
 ___
 
@@ -139,7 +139,7 @@ ___
 
 #### Defined in
 
-[namada.ts:35](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/namada.ts#L35)
+[packages/types/src/namada.ts:35](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/namada.ts#L35)
 
 ___
 
@@ -159,7 +159,7 @@ ___
 
 #### Defined in
 
-[namada.ts:38](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/namada.ts#L38)
+[packages/types/src/namada.ts:38](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/namada.ts#L38)
 
 ___
 
@@ -179,7 +179,7 @@ ___
 
 #### Defined in
 
-[namada.ts:39](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/namada.ts#L39)
+[packages/types/src/namada.ts:39](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/namada.ts#L39)
 
 ___
 
@@ -199,7 +199,7 @@ ___
 
 #### Defined in
 
-[namada.ts:37](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/namada.ts#L37)
+[packages/types/src/namada.ts:37](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/namada.ts#L37)
 
 ___
 
@@ -219,4 +219,4 @@ ___
 
 #### Defined in
 
-[namada.ts:42](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/namada.ts#L42)
+[packages/types/src/namada.ts:42](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/namada.ts#L42)

--- a/packages/types/docs/interfaces/Signer.md
+++ b/packages/types/docs/interfaces/Signer.md
@@ -27,7 +27,7 @@
 
 #### Defined in
 
-[signer.ts:24](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/signer.ts#L24)
+[packages/types/src/signer.ts:24](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/signer.ts#L24)
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 #### Defined in
 
-[signer.ts:14](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/signer.ts#L14)
+[packages/types/src/signer.ts:14](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/signer.ts#L14)
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 #### Defined in
 
-[signer.ts:19](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/signer.ts#L19)
+[packages/types/src/signer.ts:19](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/signer.ts#L19)
 
 ___
 
@@ -104,4 +104,4 @@ ___
 
 #### Defined in
 
-[signer.ts:23](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/signer.ts#L23)
+[packages/types/src/signer.ts:23](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/signer.ts#L23)

--- a/packages/types/docs/modules.md
+++ b/packages/types/docs/modules.md
@@ -11,6 +11,7 @@
 - [Events](enums/Events.md)
 - [KeplrEvents](enums/KeplrEvents.md)
 - [MetamaskEvents](enums/MetamaskEvents.md)
+- [ResultCode](enums/ResultCode.md)
 
 ### Classes
 
@@ -20,6 +21,7 @@
 - [BparamsMsgValue](classes/BparamsMsgValue.md)
 - [BparamsOutputMsgValue](classes/BparamsOutputMsgValue.md)
 - [BparamsSpendMsgValue](classes/BparamsSpendMsgValue.md)
+- [BroadcastTxError](classes/BroadcastTxError.md)
 - [ClaimRewardsMsgValue](classes/ClaimRewardsMsgValue.md)
 - [CommitmentMsgValue](classes/CommitmentMsgValue.md)
 - [EthBridgeTransferMsgValue](classes/EthBridgeTransferMsgValue.md)
@@ -141,6 +143,7 @@
 - [CosmosSymbols](modules.md#cosmossymbols)
 - [CosmosTokens](modules.md#cosmostokens)
 - [Extensions](modules.md#extensions)
+- [ResultCodes](modules.md#resultcodes)
 - [Symbols](modules.md#symbols)
 - [Tokens](modules.md#tokens)
 - [proposalStatuses](modules.md#proposalstatuses)
@@ -161,11 +164,11 @@
 
 ### Account
 
-Ƭ **Account**: `Pick`\<[`DerivedAccount`](modules.md#derivedaccount), ``"address"`` \| ``"alias"`` \| ``"type"`` \| ``"publicKey"`` \| ``"owner"`` \| ``"pseudoExtendedKey"`` \| ``"source"`` \| ``"timestamp"``\> & \{ `viewingKey?`: `string`  }
+Ƭ **Account**: `Pick`\<[`DerivedAccount`](modules.md#derivedaccount), ``"address"`` \| ``"alias"`` \| ``"type"`` \| ``"publicKey"`` \| ``"owner"`` \| ``"pseudoExtendedKey"`` \| ``"source"`` \| ``"timestamp"`` \| ``"diversifierIndex"``\> & \{ `viewingKey?`: `string`  }
 
 #### Defined in
 
-[account.ts:46](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/account.ts#L46)
+[packages/types/src/account.ts:47](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/account.ts#L47)
 
 ___
 
@@ -182,7 +185,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:34](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L34)
+[packages/types/src/proposals.ts:35](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L35)
 
 ___
 
@@ -199,7 +202,7 @@ ___
 
 #### Defined in
 
-[namada.ts:26](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/namada.ts#L26)
+[packages/types/src/namada.ts:26](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/namada.ts#L26)
 
 ___
 
@@ -209,7 +212,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:31](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L31)
+[packages/types/src/tx/types.ts:31](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L31)
 
 ___
 
@@ -227,7 +230,7 @@ ___
 
 #### Defined in
 
-[account.ts:1](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/account.ts#L1)
+[packages/types/src/account.ts:1](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/account.ts#L1)
 
 ___
 
@@ -237,7 +240,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:32](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L32)
+[packages/types/src/tx/types.ts:32](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L32)
 
 ___
 
@@ -264,7 +267,7 @@ ___
 
 #### Defined in
 
-[chain.ts:49](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/chain.ts#L49)
+[packages/types/src/chain.ts:49](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/chain.ts#L49)
 
 ___
 
@@ -274,7 +277,7 @@ ___
 
 #### Defined in
 
-[chain.ts:21](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/chain.ts#L21)
+[packages/types/src/chain.ts:21](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/chain.ts#L21)
 
 ___
 
@@ -284,7 +287,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:54](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L54)
+[packages/types/src/tx/types.ts:54](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L54)
 
 ___
 
@@ -294,7 +297,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:72](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L72)
+[packages/types/src/tx/types.ts:72](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L72)
 
 ___
 
@@ -304,7 +307,7 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:13](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tokens/Cosmos.ts#L13)
+[packages/types/src/tokens/Cosmos.ts:13](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tokens/Cosmos.ts#L13)
 
 ___
 
@@ -314,7 +317,7 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:6](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tokens/Cosmos.ts#L6)
+[packages/types/src/tokens/Cosmos.ts:6](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tokens/Cosmos.ts#L6)
 
 ___
 
@@ -336,7 +339,7 @@ ___
 
 #### Defined in
 
-[chain.ts:1](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/chain.ts#L1)
+[packages/types/src/chain.ts:1](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/chain.ts#L1)
 
 ___
 
@@ -355,7 +358,7 @@ ViewingKey with optional birthday
 
 #### Defined in
 
-[account.ts:68](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/account.ts#L68)
+[packages/types/src/account.ts:70](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/account.ts#L70)
 
 ___
 
@@ -371,7 +374,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:63](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L63)
+[packages/types/src/proposals.ts:64](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L64)
 
 ___
 
@@ -388,7 +391,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:64](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L64)
+[packages/types/src/proposals.ts:65](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L65)
 
 ___
 
@@ -398,7 +401,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:93](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L93)
+[packages/types/src/proposals.ts:94](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L94)
 
 ___
 
@@ -412,6 +415,7 @@ ___
 | :------ | :------ |
 | `address` | `string` |
 | `alias` | `string` |
+| `diversifierIndex?` | `number` |
 | `id` | `string` |
 | `modifiedZip32Path?` | `string` |
 | `owner?` | `string` |
@@ -425,7 +429,7 @@ ___
 
 #### Defined in
 
-[account.ts:31](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/account.ts#L31)
+[packages/types/src/account.ts:31](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/account.ts#L31)
 
 ___
 
@@ -435,7 +439,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:33](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L33)
+[packages/types/src/tx/types.ts:33](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L33)
 
 ___
 
@@ -453,7 +457,7 @@ ___
 
 #### Defined in
 
-[chain.ts:23](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/chain.ts#L23)
+[packages/types/src/chain.ts:23](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/chain.ts#L23)
 
 ___
 
@@ -463,7 +467,7 @@ ___
 
 #### Defined in
 
-[chain.ts:18](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/chain.ts#L18)
+[packages/types/src/chain.ts:18](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/chain.ts#L18)
 
 ___
 
@@ -480,7 +484,7 @@ ___
 
 #### Defined in
 
-[signer.ts:8](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/signer.ts#L8)
+[packages/types/src/signer.ts:8](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/signer.ts#L8)
 
 ___
 
@@ -490,7 +494,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:34](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L34)
+[packages/types/src/tx/types.ts:34](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L34)
 
 ___
 
@@ -500,7 +504,7 @@ ___
 
 #### Defined in
 
-[utils.ts:1](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/utils.ts#L1)
+[packages/types/src/utils.ts:1](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/utils.ts#L1)
 
 ___
 
@@ -514,7 +518,7 @@ ___
 
 #### Defined in
 
-[utils.ts:2](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/utils.ts#L2)
+[packages/types/src/utils.ts:2](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/utils.ts#L2)
 
 ___
 
@@ -524,7 +528,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:44](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L44)
+[packages/types/src/tx/types.ts:44](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L44)
 
 ___
 
@@ -534,7 +538,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:45](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L45)
+[packages/types/src/tx/types.ts:45](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L45)
 
 ___
 
@@ -544,7 +548,7 @@ ___
 
 #### Defined in
 
-[account.ts:60](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/account.ts#L60)
+[packages/types/src/account.ts:62](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/account.ts#L62)
 
 ___
 
@@ -562,7 +566,7 @@ ___
 
 #### Defined in
 
-[account.ts:13](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/account.ts#L13)
+[packages/types/src/account.ts:13](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/account.ts#L13)
 
 ___
 
@@ -581,7 +585,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:55](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L55)
+[packages/types/src/proposals.ts:56](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L56)
 
 ___
 
@@ -601,7 +605,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:46](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L46)
+[packages/types/src/proposals.ts:47](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L47)
 
 ___
 
@@ -618,7 +622,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:66](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L66)
+[packages/types/src/proposals.ts:67](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L67)
 
 ___
 
@@ -635,7 +639,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:65](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L65)
+[packages/types/src/proposals.ts:66](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L66)
 
 ___
 
@@ -653,7 +657,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:39](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L39)
+[packages/types/src/proposals.ts:40](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L40)
 
 ___
 
@@ -663,7 +667,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:15](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L15)
+[packages/types/src/proposals.ts:16](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L16)
 
 ___
 
@@ -673,7 +677,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:10](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L10)
+[packages/types/src/proposals.ts:11](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L11)
 
 ___
 
@@ -683,7 +687,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:67](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L67)
+[packages/types/src/proposals.ts:68](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L68)
 
 ___
 
@@ -693,7 +697,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:69](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L69)
+[packages/types/src/proposals.ts:70](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L70)
 
 ___
 
@@ -703,7 +707,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:35](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L35)
+[packages/types/src/tx/types.ts:35](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L35)
 
 ___
 
@@ -713,7 +717,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:57](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L57)
+[packages/types/src/tx/types.ts:57](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L57)
 
 ___
 
@@ -723,7 +727,7 @@ ___
 
 #### Defined in
 
-[tx/schema/index.ts:48](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/index.ts#L48)
+[packages/types/src/tx/schema/index.ts:48](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/index.ts#L48)
 
 ___
 
@@ -733,7 +737,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:38](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L38)
+[packages/types/src/tx/types.ts:38](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L38)
 
 ___
 
@@ -743,7 +747,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:37](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L37)
+[packages/types/src/tx/types.ts:37](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L37)
 
 ___
 
@@ -753,7 +757,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:40](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L40)
+[packages/types/src/tx/types.ts:40](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L40)
 
 ___
 
@@ -763,7 +767,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:39](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L39)
+[packages/types/src/tx/types.ts:39](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L39)
 
 ___
 
@@ -780,7 +784,7 @@ ___
 
 #### Defined in
 
-[namada.ts:9](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/namada.ts#L9)
+[packages/types/src/namada.ts:9](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/namada.ts#L9)
 
 ___
 
@@ -797,7 +801,7 @@ ___
 
 #### Defined in
 
-[signer.ts:3](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/signer.ts#L3)
+[packages/types/src/signer.ts:3](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/signer.ts#L3)
 
 ___
 
@@ -815,7 +819,7 @@ ___
 
 #### Defined in
 
-[namada.ts:14](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/namada.ts#L14)
+[packages/types/src/namada.ts:14](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/namada.ts#L14)
 
 ___
 
@@ -825,7 +829,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:36](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L36)
+[packages/types/src/tx/types.ts:36](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L36)
 
 ___
 
@@ -835,7 +839,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:51](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L51)
+[packages/types/src/tx/types.ts:51](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L51)
 
 ___
 
@@ -845,7 +849,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:59](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L59)
+[packages/types/src/tx/types.ts:59](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L59)
 
 ___
 
@@ -855,7 +859,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:109](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L109)
+[packages/types/src/proposals.ts:110](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L110)
 
 ___
 
@@ -871,7 +875,7 @@ ___
 
 #### Defined in
 
-[tokens/types.ts:19](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tokens/types.ts#L19)
+[packages/types/src/tokens/types.ts:19](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tokens/types.ts#L19)
 
 ___
 
@@ -903,7 +907,7 @@ ___
 
 #### Defined in
 
-[tokens/types.ts:5](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tokens/types.ts#L5)
+[packages/types/src/tokens/types.ts:5](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tokens/types.ts#L5)
 
 ___
 
@@ -913,7 +917,7 @@ ___
 
 #### Defined in
 
-[tokens/Namada.ts:21](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tokens/Namada.ts#L21)
+[packages/types/src/tokens/Namada.ts:21](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tokens/Namada.ts#L21)
 
 ___
 
@@ -923,7 +927,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:46](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L46)
+[packages/types/src/tx/types.ts:46](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L46)
 
 ___
 
@@ -933,7 +937,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:43](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L43)
+[packages/types/src/tx/types.ts:43](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L43)
 
 ___
 
@@ -943,7 +947,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:48](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L48)
+[packages/types/src/tx/types.ts:48](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L48)
 
 ___
 
@@ -953,7 +957,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:47](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L47)
+[packages/types/src/tx/types.ts:47](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L47)
 
 ___
 
@@ -963,7 +967,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:80](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L80)
+[packages/types/src/tx/types.ts:80](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L80)
 
 ___
 
@@ -973,7 +977,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:49](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L49)
+[packages/types/src/tx/types.ts:49](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L49)
 
 ___
 
@@ -983,7 +987,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:50](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L50)
+[packages/types/src/tx/types.ts:50](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L50)
 
 ___
 
@@ -993,7 +997,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:52](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L52)
+[packages/types/src/tx/types.ts:52](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L52)
 
 ___
 
@@ -1003,7 +1007,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:73](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L73)
+[packages/types/src/proposals.ts:74](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L74)
 
 ___
 
@@ -1013,7 +1017,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:41](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L41)
+[packages/types/src/tx/types.ts:41](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L41)
 
 ___
 
@@ -1023,7 +1027,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:42](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L42)
+[packages/types/src/tx/types.ts:42](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L42)
 
 ___
 
@@ -1033,7 +1037,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:85](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L85)
+[packages/types/src/proposals.ts:86](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L86)
 
 ___
 
@@ -1051,7 +1055,7 @@ ___
 
 #### Defined in
 
-[namada.ts:20](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/namada.ts#L20)
+[packages/types/src/namada.ts:20](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/namada.ts#L20)
 
 ___
 
@@ -1061,7 +1065,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:101](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L101)
+[packages/types/src/proposals.ts:102](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L102)
 
 ___
 
@@ -1071,7 +1075,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:53](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L53)
+[packages/types/src/tx/types.ts:53](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L53)
 
 ___
 
@@ -1081,7 +1085,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:72](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L72)
+[packages/types/src/proposals.ts:73](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L73)
 
 ___
 
@@ -1091,7 +1095,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:78](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L78)
+[packages/types/src/proposals.ts:79](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L79)
 
 ___
 
@@ -1101,7 +1105,7 @@ ___
 
 #### Defined in
 
-[namada.ts:47](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/namada.ts#L47)
+[packages/types/src/namada.ts:47](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/namada.ts#L47)
 
 ___
 
@@ -1111,7 +1115,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:55](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L55)
+[packages/types/src/tx/types.ts:55](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L55)
 
 ___
 
@@ -1121,7 +1125,7 @@ ___
 
 #### Defined in
 
-[tx/types.ts:56](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/types.ts#L56)
+[packages/types/src/tx/types.ts:56](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L56)
 
 ___
 
@@ -1138,7 +1142,7 @@ ___
 
 #### Defined in
 
-[account.ts:7](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/account.ts#L7)
+[packages/types/src/account.ts:7](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/account.ts#L7)
 
 ## Variables
 
@@ -1155,7 +1159,7 @@ ___
 
 #### Defined in
 
-[tx/schema/utils.ts:4](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tx/schema/utils.ts#L4)
+[packages/types/src/tx/schema/utils.ts:4](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/schema/utils.ts#L4)
 
 ___
 
@@ -1165,7 +1169,7 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:5](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tokens/Cosmos.ts#L5)
+[packages/types/src/tokens/Cosmos.ts:5](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tokens/Cosmos.ts#L5)
 
 ___
 
@@ -1175,7 +1179,7 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:22](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tokens/Cosmos.ts#L22)
+[packages/types/src/tokens/Cosmos.ts:22](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tokens/Cosmos.ts#L22)
 
 ___
 
@@ -1202,7 +1206,17 @@ ___
 
 #### Defined in
 
-[chain.ts:30](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/chain.ts#L30)
+[packages/types/src/chain.ts:30](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/chain.ts#L30)
+
+___
+
+### ResultCodes
+
+• `Const` **ResultCodes**: `Record`\<[`ResultCode`](enums/ResultCode.md), `string`\>
+
+#### Defined in
+
+[packages/types/src/tx/types.ts:102](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tx/types.ts#L102)
 
 ___
 
@@ -1212,7 +1226,7 @@ ___
 
 #### Defined in
 
-[tokens/Namada.ts:11](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tokens/Namada.ts#L11)
+[packages/types/src/tokens/Namada.ts:11](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tokens/Namada.ts#L11)
 
 ___
 
@@ -1222,17 +1236,17 @@ ___
 
 #### Defined in
 
-[tokens/Namada.ts:23](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tokens/Namada.ts#L23)
+[packages/types/src/tokens/Namada.ts:23](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tokens/Namada.ts#L23)
 
 ___
 
 ### proposalStatuses
 
-• `Const` **proposalStatuses**: readonly [``"pending"``, ``"ongoing"``, ``"passed"``, ``"rejected"``]
+• `Const` **proposalStatuses**: readonly [``"pending"``, ``"ongoing"``, ``"passed"``, ``"rejected"``, ``"executed"``]
 
 #### Defined in
 
-[proposals.ts:3](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L3)
+[packages/types/src/proposals.ts:3](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L3)
 
 ___
 
@@ -1242,7 +1256,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:103](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L103)
+[packages/types/src/proposals.ts:104](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L104)
 
 ___
 
@@ -1252,7 +1266,7 @@ ___
 
 #### Defined in
 
-[proposals.ts:71](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L71)
+[packages/types/src/proposals.ts:72](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L72)
 
 ## Functions
 
@@ -1272,13 +1286,13 @@ vote is DelegatorVote
 
 #### Defined in
 
-[proposals.ts:98](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L98)
+[packages/types/src/proposals.ts:99](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L99)
 
 ___
 
 ### isProposalStatus
 
-▸ **isProposalStatus**(`str`): str is "pending" \| "ongoing" \| "passed" \| "rejected"
+▸ **isProposalStatus**(`str`): str is "pending" \| "ongoing" \| "passed" \| "rejected" \| "executed"
 
 #### Parameters
 
@@ -1288,11 +1302,11 @@ ___
 
 #### Returns
 
-str is "pending" \| "ongoing" \| "passed" \| "rejected"
+str is "pending" \| "ongoing" \| "passed" \| "rejected" \| "executed"
 
 #### Defined in
 
-[proposals.ts:12](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L12)
+[packages/types/src/proposals.ts:13](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L13)
 
 ___
 
@@ -1312,7 +1326,7 @@ tallyType is "two-fifths" \| "one-half-over-one-third" \| "less-one-half-over-on
 
 #### Defined in
 
-[proposals.ts:111](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L111)
+[packages/types/src/proposals.ts:112](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L112)
 
 ___
 
@@ -1332,7 +1346,7 @@ vote is ValidatorVote
 
 #### Defined in
 
-[proposals.ts:90](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L90)
+[packages/types/src/proposals.ts:91](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L91)
 
 ___
 
@@ -1352,7 +1366,7 @@ str is "yay" \| "nay" \| "abstain"
 
 #### Defined in
 
-[proposals.ts:75](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/proposals.ts#L75)
+[packages/types/src/proposals.ts:76](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/proposals.ts#L76)
 
 ___
 
@@ -1372,7 +1386,7 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:66](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tokens/Cosmos.ts#L66)
+[packages/types/src/tokens/Cosmos.ts:66](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tokens/Cosmos.ts#L66)
 
 ___
 
@@ -1392,4 +1406,4 @@ ___
 
 #### Defined in
 
-[tokens/Cosmos.ts:48](https://github.com/anoma/namada-interface/blob/7edc5dea72f906ae6699549c1d9c128a2fd22eac/packages/types/src/tokens/Cosmos.ts#L48)
+[packages/types/src/tokens/Cosmos.ts:48](https://github.com/anoma/namada-interface/blob/789e785c74e4f6d9560d65f2f0f63787beddc028/packages/types/src/tokens/Cosmos.ts#L48)


### PR DESCRIPTION
Updating type-generated docs for SDK & types packages.

- Fixed example to support updated `broadcastTx()`

### View updated docs

- **@namada/sdk** - https://github.com/anoma/namada-interface/blob/f523734e10968fd344bd0258789fd1fd09fb6324/packages/sdk/docs/modules.md
- **@namada/types** - https://github.com/anoma/namada-interface/blob/f523734e10968fd344bd0258789fd1fd09fb6324/packages/types/docs/modules.md