### PR TITLE
feat: Keychain - Display chain name for known chains

### DIFF
--- a/apps/extension/src/App/Settings/Network.tsx
+++ b/apps/extension/src/App/Settings/Network.tsx
@@ -7,6 +7,7 @@ import {
   Input,
   Stack,
 } from "@namada/components";
+import { NamadaChains } from "@namada/types";
 import { PageHeader } from "App/Common";
 import { GetChainMsg, UpdateChainMsg } from "background/chain";
 import { useRequester } from "hooks/useRequester";
@@ -27,6 +28,7 @@ export const Network = (): JSX.Element => {
   const [errorMessage, setErrorMessage] = useState("");
 
   const shouldDisableSubmit = status === Status.Pending || !chainId;
+  const chainIdentifier = NamadaChains.get(chainId);
 
   useEffect(() => {
     void (async () => {
@@ -88,6 +90,9 @@ export const Network = (): JSX.Element => {
           onChange={(e) => setChainId(e.target.value)}
           error={chainId.length === 0 ? "Chain ID required!" : ""}
         />
+        {chainIdentifier && (
+          <p className="text-white text-sm px-2">{chainIdentifier}</p>
+        )}
         {errorMessage && <Alert type="error">{errorMessage}</Alert>}
         {status === Status.Complete && (
           <Alert type="info">Successfully updated network!</Alert>

--- a/apps/extension/src/Approvals/Approvals.tsx
+++ b/apps/extension/src/Approvals/Approvals.tsx
@@ -29,6 +29,8 @@ export const ExtensionLockContext =
 export type ApprovalDetails = {
   signer: string;
   accountType: AccountType;
+  origin: string;
+  chainIds: string[];
   msgId: string;
   txDetails: TxDetails[];
   txType?: string;
@@ -38,6 +40,7 @@ export type SignArbitraryDetails = {
   msgId: string;
   signer: string;
   data: string;
+  origin: string;
 };
 
 export const Approvals: React.FC = () => {
@@ -75,7 +78,7 @@ export const Approvals: React.FC = () => {
       >
         <Routes>
           <Route
-            path={`${TopLevelRoute.ApproveSignTx}/:msgId/:accountType/:signer`}
+            path={`${TopLevelRoute.ApproveSignTx}/:msgId/:origin/:accountType/:signer`}
             element={
               <WithAuth>
                 <ApproveSignTx details={details} setDetails={setDetails} />
@@ -115,7 +118,7 @@ export const Approvals: React.FC = () => {
             }
           />
           <Route
-            path={`${TopLevelRoute.ApproveSignArbitrary}/:signer`}
+            path={`${TopLevelRoute.ApproveSignArbitrary}/:origin/:signer`}
             element={
               <WithAuth>
                 <ApproveSignArbitrary

--- a/apps/extension/src/Approvals/ApproveConnection.tsx
+++ b/apps/extension/src/Approvals/ApproveConnection.tsx
@@ -1,4 +1,5 @@
 import { ActionButton, Alert, GapPatterns, Stack } from "@namada/components";
+import { NamadaChains } from "@namada/types";
 import { PageHeader } from "App/Common";
 import {
   CheckIsApprovedSiteMsg,
@@ -18,6 +19,8 @@ export const ApproveConnection: React.FC = () => {
   const chainId = params.get("chainId")!;
   const { isUnlocked } = useContext(ExtensionLockContext);
   const [isApproved, setIsApproved] = useState<boolean>();
+
+  const chainIdentifier = NamadaChains.get(chainId);
 
   const checkIsApproved = async (): Promise<void> => {
     requester
@@ -67,7 +70,12 @@ export const ApproveConnection: React.FC = () => {
               {chainId && (
                 <>
                   {" "}
-                  and enable signing for <strong>{chainId}</strong>
+                  and enable signing for{" "}
+                  {chainIdentifier ?
+                    <>
+                      <strong>{chainIdentifier}</strong> ({chainId})
+                    </>
+                  : <strong>{chainId}</strong>}
                 </>
               )}
               ?

--- a/apps/extension/src/Approvals/ApproveSignArbitrary.tsx
+++ b/apps/extension/src/Approvals/ApproveSignArbitrary.tsx
@@ -31,6 +31,7 @@ export const ApproveSignArbitrary: React.FC<Props> = ({
   const navigate = useNavigate();
   const params = useSanitizedParams();
   const requester = useRequester();
+  const origin = params.origin!;
   const signer = params.signer!;
   const query = useQuery();
   const { msgId } = query.getAll();
@@ -46,11 +47,11 @@ export const ApproveSignArbitrary: React.FC<Props> = ({
   };
 
   useEffect(() => {
-    if (msgId && signer) {
+    if (msgId && signer && origin) {
       queryPendingSignArbitraryData(msgId)
         .then((data) => {
           setMessage(data);
-          setSignArbitraryDetails({ msgId, signer, data });
+          setSignArbitraryDetails({ msgId, signer, data, origin });
         })
         .catch((e) => {
           console.error(e);
@@ -112,11 +113,15 @@ export const ApproveSignArbitrary: React.FC<Props> = ({
           )}
         </main>
         <Stack gap={2}>
-          {signer && (
-            <p className="text-xs">
-              Signer: <strong>{shortenAddress(signer)}</strong>
-            </p>
-          )}
+          <p className="text-xs">
+            {signer && (
+              <>
+                Signer: <strong>{shortenAddress(signer)}</strong>
+              </>
+            )}
+            <br />
+            Origin: <strong>{origin}</strong>
+          </p>
           <Stack gap={2}>
             <ActionButton onClick={handleApproveClick}>Approve</ActionButton>
             <ActionButton

--- a/apps/extension/src/Approvals/ApproveSignTx.tsx
+++ b/apps/extension/src/Approvals/ApproveSignTx.tsx
@@ -1,7 +1,7 @@
 import { ActionButton, GapPatterns, Stack } from "@namada/components";
 import { useSanitizedParams } from "@namada/hooks";
 import { TxType, TxTypeLabel } from "@namada/sdk/web";
-import { AccountType, TransferProps } from "@namada/types";
+import { AccountType, NamadaChains, TransferProps } from "@namada/types";
 import { shortenAddress } from "@namada/utils";
 import { PageHeader } from "App/Common/PageHeader";
 import { ApprovalDetails } from "Approvals/Approvals";
@@ -28,12 +28,13 @@ export const ApproveSignTx: React.FC<Props> = ({ details, setDetails }) => {
   const accountType =
     (params?.accountType as AccountType) || AccountType.PrivateKey;
   const msgId = params?.msgId;
+  const origin = params?.origin;
   const signer = params?.signer;
   const [displayTransactionData, setDisplayTransactionData] = useState(false);
 
   useEffect(() => {
     const fetchDetails = async (): Promise<void> => {
-      if (signer && msgId) {
+      if (signer && msgId && origin) {
         const txDetails = await requester.sendMessage(
           Ports.Background,
           new QueryTxDetailsMsg(msgId)
@@ -64,6 +65,8 @@ export const ApproveSignTx: React.FC<Props> = ({ details, setDetails }) => {
           msgId,
           signer,
           accountType,
+          origin,
+          chainIds: txDetails.map((cmt) => cmt.chainId),
           txDetails,
           txType: txTypes[0],
         });
@@ -158,11 +161,25 @@ export const ApproveSignTx: React.FC<Props> = ({ details, setDetails }) => {
           )}
         </main>
         <Stack gap={2} as="form" onSubmit={handleApproveSubmit}>
-          {signer && (
-            <p className="text-xs">
-              Signer: <strong>{shortenAddress(signer)}</strong>
-            </p>
-          )}
+          <p className="text-xs">
+            {signer && (
+              <>
+                Signer: <strong>{shortenAddress(signer)}</strong>
+              </>
+            )}
+            <br />
+            Origin: <strong>{origin}</strong>
+            <br />
+            Chain:{" "}
+            <strong>
+              {details?.chainIds
+                // Get only unique chain IDs
+                .filter((chainId, i) => details.chainIds.indexOf(chainId) === i)
+                // Display chain alias for known networks, otherwise display chain ID
+                .map((chainId) => NamadaChains.get(chainId) || chainId)
+                .join(", ")}
+            </strong>
+          </p>
           <Stack gap={1.5} direction="vertical">
             <ActionButton>Approve</ActionButton>
             <ActionButton

--- a/apps/extension/src/background/approvals/handler.ts
+++ b/apps/extension/src/background/approvals/handler.ts
@@ -211,8 +211,8 @@ const handleSubmitUpdateDefaultAccountMsg: (
 const handleApproveSignTxMsg: (
   service: ApprovalsService
 ) => InternalHandler<ApproveSignTxMsg> = (service) => {
-  return async (_, { signer, tx, checksums }) => {
-    return await service.approveSignTx(signer, tx, checksums);
+  return async (_, { origin, signer, tx, checksums }) => {
+    return await service.approveSignTx(signer, tx, origin, checksums);
   };
 };
 
@@ -235,8 +235,8 @@ const handleSubmitApprovedSignTxMsg: (
 const handleApproveSignArbitraryMsg: (
   service: ApprovalsService
 ) => InternalHandler<ApproveSignArbitraryMsg> = (service) => {
-  return async (_, { signer, data }) => {
-    return await service.approveSignArbitrary(signer, data);
+  return async (_, { signer, data, origin }) => {
+    return await service.approveSignArbitrary(signer, data, origin);
   };
 };
 

--- a/apps/extension/src/background/approvals/service.test.ts
+++ b/apps/extension/src/background/approvals/service.test.ts
@@ -86,7 +86,11 @@ describe("approvals service", () => {
         signature: "sig",
       };
 
-      const signaturePromise = service.approveSignArbitrary("signer", "data");
+      const signaturePromise = service.approveSignArbitrary(
+        "signer",
+        "data",
+        "origin"
+      );
 
       await new Promise((resolve) =>
         setTimeout(() => {
@@ -106,7 +110,7 @@ describe("approvals service", () => {
       });
 
       await expect(
-        service.approveSignArbitrary("signer", "data")
+        service.approveSignArbitrary("signer", "data", "origin")
       ).rejects.toBeDefined();
     });
 
@@ -122,7 +126,7 @@ describe("approvals service", () => {
       (service as any).resolverMap[tabId] = sigResponse;
 
       await expect(
-        service.approveSignArbitrary("signer", "data")
+        service.approveSignArbitrary("signer", "data", "origin")
       ).rejects.toBeDefined();
     });
   });
@@ -143,7 +147,11 @@ describe("approvals service", () => {
         .spyOn(keyRingService, "signArbitrary")
         .mockResolvedValue(sigResponse);
       const signer = "signer";
-      const signaturePromise = service.approveSignArbitrary(signer, "data");
+      const signaturePromise = service.approveSignArbitrary(
+        signer,
+        "data",
+        "origin"
+      );
 
       await new Promise((resolve) =>
         setTimeout(() => {
@@ -218,19 +226,23 @@ describe("approvals service", () => {
 
       (keyRingService.queryAccountDetails as any).mockResolvedValue(() => ({}));
 
-      const signaturePromise = service.approveSignTx(signer, [
-        {
-          args: new WrapperTxMsgValue({
-            token: "",
-            feeAmount: BigNumber(0),
-            gasLimit: BigNumber(0),
-            chainId: "",
-          }),
-          hash: "",
-          bytes,
-          signingData: [],
-        },
-      ]);
+      const signaturePromise = service.approveSignTx(
+        signer,
+        [
+          {
+            args: new WrapperTxMsgValue({
+              token: "",
+              feeAmount: BigNumber(0),
+              gasLimit: BigNumber(0),
+              chainId: "",
+            }),
+            hash: "",
+            bytes,
+            signingData: [],
+          },
+        ],
+        "http://localhost:5173"
+      );
 
       jest.spyOn(service as any, "clearPendingTx");
 

--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -61,6 +61,7 @@ export class ApprovalsService {
   async approveSignTx(
     signer: string,
     txs: EncodedTxData[],
+    origin: string,
     checksums?: Record<string, string>
   ): Promise<Uint8Array[]> {
     if (await this.isLocked()) {
@@ -88,13 +89,14 @@ export class ApprovalsService {
     await this.txStore.set(msgId, pendingTx);
 
     return this.launchApprovalPopup(
-      `${TopLevelRoute.ApproveSignTx}/${msgId}/${details.type}/${signer}`
+      `${TopLevelRoute.ApproveSignTx}/${msgId}/${encodeURIComponent(origin)}/${details.type}/${signer}`
     );
   }
 
   async approveSignArbitrary(
     signer: string,
-    data: string
+    data: string,
+    origin: string
   ): Promise<SignArbitraryResponse> {
     if (await this.isLocked()) {
       throw new Error(ApprovalErrors.KeychainLocked());
@@ -104,7 +106,7 @@ export class ApprovalsService {
     await this.dataStore.set(msgId, data);
 
     return this.launchApprovalPopup(
-      `${TopLevelRoute.ApproveSignArbitrary}/${signer}`,
+      `${TopLevelRoute.ApproveSignArbitrary}/${encodeURIComponent(origin)}/${signer}`,
       { msgId }
     );
   }

--- a/packages/types/src/chain.ts
+++ b/packages/types/src/chain.ts
@@ -62,3 +62,12 @@ export type Chain = {
     portId: string;
   };
 };
+
+/**
+ * Chain name lookup for mainnet and known long-running testnets
+ */
+export const NamadaChains: Map<string, string> = new Map([
+  ["namada.5f5de2dd1b88cba30586420", "Namada Mainnet"],
+  ["housefire-alpaca.cc0d3e0c033be", "Housefire Testnet"],
+  ["campfire-square.ff09671d333707", "Campfire Testnet"],
+]);


### PR DESCRIPTION
Resolves #1923 

If `chainId` is known (mainnet or long-running testnet) display name, otherwise, just chain ID, and show origin (the origin that issues the call to the keychain) on signing approvals.

- [x] Add lookup for chain name based on chain ID
- [x] Add chain name / chain ID and origin to `ApproveConnection`
- [x] Add origin to `ApproveSignTx`
- [x] Add chain name to `Network` if a definition exists

**NOTE** The reason I added `chainIds` as as `string[]` to `ApproveSignTx` is because, in the case of Ledger, it is _possible_ to submit multiple Txs with different chain IDs, so this will display all of them (this should never really happen, but if say another interface attempts to submit it this way, we will display them). 

### Testing

- Approve Connection: With an unapproved chain/domain, connect to keychain - should see the chain name if it is one of the three known networks, otherwise, just the chain ID
- Submit transactions for signing - should see origin & chain ID
- Also test Ledger with multiple tx (such as bond), ensure that for Namadillo we only see one Chain ID.
- Check Network form, changing chain ID will either show the associated chain, or nothing if it is not a known change (users will likely never use this form, and it will go away with https://github.com/anoma/namada-interface/issues/1922 anyways)
- Submit Sign Arbitrary - should see origin in approval

### Screenshots

#### Approve Connection
_Unknown_ chain (this is a test, I made the campfire chain ID invalid)
![image](https://github.com/user-attachments/assets/01ad7061-be1a-4690-a5d4-f85a38321a2f)

_Known_ chain
![image](https://github.com/user-attachments/assets/95b52b84-a03c-47ad-b635-0c0a1dc78c27)

#### Approve Sign Tx

![image](https://github.com/user-attachments/assets/7e62c4e4-ae62-43d5-8ef3-2ee19aa1b4de)

### Network

![image](https://github.com/user-attachments/assets/cc60403f-096a-4dc6-91a5-5cd2da2c79ea)
