### PR TITLE
WIP: Namadillo - Return original error if it is not JSON parseable

### DIFF
--- a/apps/namadillo/src/utils/index.ts
+++ b/apps/namadillo/src/utils/index.ts
@@ -128,14 +128,17 @@ export const toErrorDetail = (
   tx: TxMsgValue[],
   error: BroadcastTxError
 ): string => {
-  const { gasLimit } = tx[0].args;
-  const { code } = error.toProps();
-
-  // TODO: Over time we may expand this to format errors for more result codes
-  switch (code) {
-    case ResultCode.TxGasLimit:
-      return `${error.toString()} Please raise the Gas Amount above the previously provided ${gasLimit} in the fee options for your transaction.`;
-    default:
-      return error.toString();
+  try {
+    const { code } = error.toProps();
+    // TODO: Over time we may expand this to format errors for more result codes
+    switch (code) {
+      case ResultCode.TxGasLimit:
+        const { gasLimit } = tx[0].args;
+        return `${error.toString()} Please raise the Gas Amount above the previously provided ${gasLimit} in the fee options for your transaction.`;
+      default:
+        return error.toString();
+    }
+  } catch (_e) {
+    return `${error.toString()}`;
   }
 };


### PR DESCRIPTION
Fixes an issue where the utility mapping custom errors attempts to parse JSON when there is no JSON.

### Screenshot
![image](https://github.com/user-attachments/assets/9378ac16-b3b9-4554-a7f6-11991ba22964)
