### PR TITLE
SDK - fix missing type dependency in SDK

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -77,6 +77,7 @@
     "@babel/preset-typescript": "^7.23.3",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.4",
+    "@types/semver": "^7.5.8",
     "babel-jest": "^29.0.3",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3927,6 +3927,7 @@ __metadata:
     "@ledgerhq/hw-transport-webusb": "npm:^6.29.4"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.11.4"
+    "@types/semver": "npm:^7.5.8"
     "@zondax/ledger-namada": "npm:^2.0.0"
     babel-jest: "npm:^29.0.3"
     bignumber.js: "npm:^9.1.1"


### PR DESCRIPTION
Testing the packaged Firefox extension source, I found that it cannot build without Namadillo being in the repo (which provides this dependency). This explicitly includes it in the SDK package, and should be added before submitting the extension with source.

Context: For Firefox extension submissions only, we submit the source code related to the extension build, in the case that they choose to recreate the submitted extension (usually this is not needed). There are file-size limits on the submission, so we prune a bit of the repo as needed (mostly this is to remove Namadillo and `.git` which takes up the most space, along with any other unneeded files).

### Testing

- Clone repo, delete `apps/namadillo`
- Run `yarn` to install deps
- In `apps/extension`, `yarn wasm:build && yarn build:firefox` - this should succeed