### PR TITLE
fix: update maintenance branch indexer

### DIFF
--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -11,7 +11,7 @@
     "@cosmjs/encoding": "^0.32.3",
     "@keplr-wallet/types": "^0.12.136",
     "@namada/chain-registry": "^1.0.0",
-    "@namada/indexer-client": "2.5.2",
+    "@namada/indexer-client": "2.5.4",
     "@tailwindcss/container-queries": "^0.1.1",
     "@tanstack/query-core": "^5.40.0",
     "@tanstack/react-query": "^5.40.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3780,12 +3780,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@namada/indexer-client@npm:2.5.2":
-  version: 2.5.2
-  resolution: "@namada/indexer-client@npm:2.5.2"
+"@namada/indexer-client@npm:2.5.4":
+  version: 2.5.4
+  resolution: "@namada/indexer-client@npm:2.5.4"
   dependencies:
     axios: "npm:^1.6.1"
-  checksum: 10c0/2ef90e5456f819d1cee0517bc89ef1b07fd1d70ba1bf16db9fba2562068daaf5c88fb64efbcb987448c4bf91b1a3afd2a7de5497220ee32166dedade68e39ddf
+  checksum: 10c0/08128223b4657359f2d32762879d4195e4de20b9c69dc040f4eb1bbcef912a65590b1947191f16ad03cb193a4a5e59f8ac12b0f4b1e6d81d8fc64c2661565b31
   languageName: node
   linkType: hard
 
@@ -3827,7 +3827,7 @@ __metadata:
     "@eslint/js": "npm:^9.9.1"
     "@keplr-wallet/types": "npm:^0.12.136"
     "@namada/chain-registry": "npm:^1.0.0"
-    "@namada/indexer-client": "npm:2.5.2"
+    "@namada/indexer-client": "npm:2.5.4"
     "@playwright/test": "npm:^1.24.1"
     "@svgr/webpack": "npm:^6.5.1"
     "@tailwindcss/container-queries": "npm:^0.1.1"


### PR DESCRIPTION
<!--

Make sure you have read CONTRIBUTING.md before submitting a pull request!

-->

This updates the mainnet maintenance branch indexer to version 2.5.4. This version includes the deducting of claimed staking rewards to show a proper Unclaimed Staking Rewards balance. 