### PR TITLE
fix: Prepare build action should have correct rust toolchain

### DIFF
--- a/.github/actions/prepare-build/action.yml
+++ b/.github/actions/prepare-build/action.yml
@@ -11,6 +11,9 @@ runs:
       with:
         cache-name: build
 
+    - name: Setup Rust toolchain
+      run: rustup toolchain add nightly-2025-03-27
+
     - name: Install protoc
       run: sudo apt-get install -y protobuf-compiler
       shell: bash


### PR DESCRIPTION
This should fix the build issues when releasing via CI