### PR TITLE
fix: fix new ibc tokens not showing

### DIFF
--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -10,7 +10,7 @@
     "@chain-registry/client": "^1.53.5",
     "@cosmjs/encoding": "^0.32.3",
     "@keplr-wallet/types": "^0.12.136",
-    "@namada/chain-registry": "^1.0.0",
+    "@namada/chain-registry": "github:anoma/namada-chain-registry#5a884bf6343f5130c4a419901a87ea86df53dd83",
     "@namada/indexer-client": "2.5.4",
     "@tailwindcss/container-queries": "^0.1.1",
     "@tanstack/query-core": "^5.40.0",

--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -10,7 +10,7 @@
     "@chain-registry/client": "^1.53.5",
     "@cosmjs/encoding": "^0.32.3",
     "@keplr-wallet/types": "^0.12.136",
-    "@namada/chain-registry": "github:anoma/namada-chain-registry#5a884bf6343f5130c4a419901a87ea86df53dd83",
+    "@namada/chain-registry": "^1.2.0",
     "@namada/indexer-client": "2.5.4",
     "@tailwindcss/container-queries": "^0.1.1",
     "@tanstack/query-core": "^5.40.0",

--- a/apps/namadillo/src/App/Transfer/TransferModule.tsx
+++ b/apps/namadillo/src/App/Transfer/TransferModule.tsx
@@ -22,7 +22,7 @@ import {
   LedgerAccountInfo,
   WalletProvider,
 } from "types";
-import { filterAvailableAsssetsWithBalance } from "utils/assets";
+import { filterAvailableAssetsWithBalance } from "utils/assets";
 import { checkKeychainCompatibleWithMasp } from "utils/compatibility";
 import { getDisplayGasFee } from "utils/gas";
 import {
@@ -184,7 +184,7 @@ export const TransferModule = ({
   const [memo, setMemo] = useState<undefined | string>();
   const keychainVersion = useKeychainVersion();
   const chainAssetsMap = useAtomValue(chainAssetsMapAtom);
-  const allUsersAssets = Object.values(chainAssetsMap) ?? [];
+  const chainAssets = Object.values(chainAssetsMap) ?? [];
   const gasConfig = gasConfigProp ?? feeProps?.gasConfig;
 
   const displayGasFee = useMemo(() => {
@@ -192,7 +192,7 @@ export const TransferModule = ({
   }, [gasConfig]);
 
   const availableAssets: AddressWithAssetAndAmountMap = useMemo(() => {
-    return filterAvailableAsssetsWithBalance(source.availableAssets);
+    return filterAvailableAssetsWithBalance(source.availableAssets);
   }, [source.availableAssets]);
 
   const selectedAsset = mapUndefined(
@@ -348,24 +348,24 @@ export const TransferModule = ({
     return assetDisplayAmount.gt(feeDisplayAmount);
   }
 
-  const chainAcceptedAssets = useMemo(() => {
+  const filteredAvailableAssets = useMemo(() => {
     // Get available assets that are accepted by the chain
     return Object.values(availableAssets).filter(({ asset }) => {
       if (!source.chain) return true;
-      return allUsersAssets.some(
+      return chainAssets.some(
         (chainAsset) =>
           chainAsset?.symbol.toLowerCase() === asset?.symbol.toLowerCase()
       );
     });
-  }, [availableAssets, source.chain, allUsersAssets]);
+  }, [availableAssets, source.chain, chainAssets]);
 
   const sortedAssets = useMemo(() => {
-    if (!chainAcceptedAssets.length) {
+    if (!filteredAvailableAssets.length) {
       return [];
     }
 
     // Sort filtered assets by amount
-    return [...chainAcceptedAssets].sort(
+    return [...filteredAvailableAssets].sort(
       (
         asset1: AddressWithAssetAndAmount,
         asset2: AddressWithAssetAndAmount
@@ -373,7 +373,7 @@ export const TransferModule = ({
         return asset1.amount.gt(asset2.amount) ? -1 : 1;
       }
     );
-  }, [chainAcceptedAssets]);
+  }, [filteredAvailableAssets]);
 
   const getButtonTextError = (
     id: ValidationResult,

--- a/apps/namadillo/src/atoms/chain/atoms.ts
+++ b/apps/namadillo/src/atoms/chain/atoms.ts
@@ -86,7 +86,7 @@ export const chainAssetsMapAtom = atom<Record<Address, Asset | undefined>>(
     const chainTokensQuery = get(chainTokensAtom);
 
     // TODO we should get this dynamically from the Github like how we do for chains
-    const assets: Asset[] = namadaAssets.assets as Asset[];
+    const assets = namadaAssets.assets as Asset[];
 
     const chainAssetsMap: Record<Address, Asset> = {};
     if (nativeTokenAddress.data) {

--- a/apps/namadillo/src/atoms/chain/atoms.ts
+++ b/apps/namadillo/src/atoms/chain/atoms.ts
@@ -10,7 +10,6 @@ import {
 } from "atoms/settings";
 import { queryDependentFn } from "atoms/utils";
 import BigNumber from "bignumber.js";
-import * as osmosis from "chain-registry/mainnet/osmosis";
 import { atom } from "jotai";
 import { atomWithQuery } from "jotai-tanstack-query";
 import {
@@ -86,20 +85,16 @@ export const chainAssetsMapAtom = atom<Record<Address, Asset | undefined>>(
     const nativeTokenAddress = get(nativeTokenAddressAtom);
     const chainTokensQuery = get(chainTokensAtom);
 
+    // TODO we should get this dynamically from the Github like how we do for chains
+    const assets: Asset[] = namadaAssets.assets as Asset[];
+
     const chainAssetsMap: Record<Address, Asset> = {};
     if (nativeTokenAddress.data) {
       // the first asset is the native token asset
-      chainAssetsMap[nativeTokenAddress.data] = namadaAssets.assets[0];
+      chainAssetsMap[nativeTokenAddress.data] = assets[0];
     }
-    // TODO
-    // while we don't have all assets listed on namada-chain-registry,
-    // merge the osmosis assets to guarantee the most common ones to be available
-    const assetList: Asset[] = [
-      ...namadaAssets.assets,
-      ...osmosis.assets.assets,
-    ];
     chainTokensQuery.data?.forEach((token) => {
-      const asset = findAssetByToken(token, assetList);
+      const asset = findAssetByToken(token, assets);
       if (asset) {
         chainAssetsMap[token.address] = asset;
       }

--- a/apps/namadillo/src/atoms/integrations/atoms.ts
+++ b/apps/namadillo/src/atoms/integrations/atoms.ts
@@ -122,12 +122,6 @@ export const availableChainsAtom = atom((get) => {
   return getKnownChains(settings.advancedMode).map(({ chain }) => chain);
 });
 
-// Lists only the available assets list
-export const availableAssetsAtom = atom((get) => {
-  const settings = get(settingsAtom);
-  return getKnownChains(settings.advancedMode).map(({ assets }) => assets);
-});
-
 export const ibcRateLimitAtom = atomWithQuery((get) => {
   const chainTokens = get(chainTokensAtom);
   return {
@@ -159,7 +153,12 @@ export const enabledIbcAssetsDenomFamily = atomFamily((ibcChannel?: string) => {
           const ibcRateLimit = ibcRateLimits.data?.find(
             (rateLimit) => rateLimit.tokenAddress === token.address
           );
-          if (ibcRateLimit && BigNumber(ibcRateLimit.throughputLimit).gt(0)) {
+          if (
+            // if we don't have a rate limit defined on the indexer, believe that the sky is the limit
+            !ibcRateLimit ||
+            // otherwise, check if the limit is greater than zero
+            (ibcRateLimit && BigNumber(ibcRateLimit.throughputLimit).gt(0))
+          ) {
             if ("trace" in token) {
               availableTokens.push(getDenomFromIbcTrace(token.trace));
             }

--- a/apps/namadillo/src/atoms/integrations/functions.ts
+++ b/apps/namadillo/src/atoms/integrations/functions.ts
@@ -6,6 +6,9 @@ import { mapUndefined } from "@namada/utils";
 import BigNumber from "bignumber.js";
 import * as celestia from "chain-registry/mainnet/celestia";
 import * as cosmos from "chain-registry/mainnet/cosmoshub";
+import * as neutron from "chain-registry/mainnet/neutron";
+import * as noble from "chain-registry/mainnet/noble";
+import * as nyx from "chain-registry/mainnet/nyx";
 import * as osmosis from "chain-registry/mainnet/osmosis";
 import * as stride from "chain-registry/mainnet/stride";
 import * as celestiaTestnet from "chain-registry/testnet/celestiatestnet3";
@@ -56,7 +59,15 @@ registry.assets.push(
   namadaAssets
 );
 
-const mainnetChains: ChainRegistryEntry[] = [celestia, cosmos, osmosis, stride];
+const mainnetChains: ChainRegistryEntry[] = [
+  celestia,
+  cosmos,
+  osmosis,
+  stride,
+  neutron,
+  noble,
+  nyx,
+];
 const testnetChains: ChainRegistryEntry[] = [
   cosmosTestnet,
   celestiaTestnet,

--- a/apps/namadillo/src/atoms/integrations/functions.ts
+++ b/apps/namadillo/src/atoms/integrations/functions.ts
@@ -59,6 +59,7 @@ registry.assets.push(
   namadaAssets
 );
 
+// This is the array we must update to add new chains and assets
 const mainnetChains: ChainRegistryEntry[] = [
   celestia,
   cosmos,

--- a/apps/namadillo/src/utils/assets.ts
+++ b/apps/namadillo/src/utils/assets.ts
@@ -17,6 +17,13 @@ export const findAssetByToken = (
   token: NativeToken | IbcToken,
   assets: Asset[]
 ): Asset | undefined => {
+  // first, search by the address
+  const asset = assets.find((a) => a.address === token.address);
+  if (asset) {
+    return asset;
+  }
+
+  // then, search by trace
   if ("trace" in token) {
     const traceDenom = token.trace.split("/").at(-1);
     if (traceDenom) {
@@ -36,7 +43,7 @@ export const findAssetByToken = (
   return undefined;
 };
 
-export const filterAvailableAsssetsWithBalance = (
+export const filterAvailableAssetsWithBalance = (
   availableAssets?: AddressWithAssetAndAmountMap
 ): AddressWithAssetAndAmountMap => {
   if (!availableAssets) return {};

--- a/apps/namadillo/src/utils/index.ts
+++ b/apps/namadillo/src/utils/index.ts
@@ -83,7 +83,10 @@ export const namadaAsset = (): Asset => {
   const config = store.get(localnetConfigAtom);
 
   const configTokenAddress = config.data?.tokenAddress;
-  const registryAsset = namadaAssets.assets[0];
+
+  // TODO we should get this dynamically from the Github like how we do for chains
+  const assets = namadaAssets.assets as Asset[];
+  const registryAsset = assets[0];
   const asset =
     configTokenAddress ?
       {
@@ -92,7 +95,7 @@ export const namadaAsset = (): Asset => {
       }
     : registryAsset;
 
-  return asset satisfies Asset;
+  return asset;
 };
 
 export const isNamadaAsset = (asset?: Asset): boolean =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3557,10 +3557,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@namada/chain-registry@npm:^1.0.0":
+"@namada/chain-registry@github:anoma/namada-chain-registry#5a884bf6343f5130c4a419901a87ea86df53dd83":
   version: 1.1.0
-  resolution: "@namada/chain-registry@npm:1.1.0"
-  checksum: 10c0/5a9d94c1963cf6d9269281fba77a13fa2b3e3a1d8181b02ce628bae14e004a4ebb0ecf6fa901597d7f3e16b7136303d71447fa11ce19d1583d9208e43afd1ed4
+  resolution: "@namada/chain-registry@https://github.com/anoma/namada-chain-registry.git#commit=5a884bf6343f5130c4a419901a87ea86df53dd83"
+  checksum: 10c0/419160814963c71a9b867f34cc86593b6eac6f670788494b43a8a61ac7afe3f2da36581b60a4fb920933cd9c23e343c0916991aa97c37d2808d2d7bf92accb74
   languageName: node
   linkType: hard
 
@@ -3826,7 +3826,7 @@ __metadata:
     "@cosmjs/encoding": "npm:^0.32.3"
     "@eslint/js": "npm:^9.9.1"
     "@keplr-wallet/types": "npm:^0.12.136"
-    "@namada/chain-registry": "npm:^1.0.0"
+    "@namada/chain-registry": "github:anoma/namada-chain-registry#5a884bf6343f5130c4a419901a87ea86df53dd83"
     "@namada/indexer-client": "npm:2.5.4"
     "@playwright/test": "npm:^1.24.1"
     "@svgr/webpack": "npm:^6.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3557,10 +3557,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@namada/chain-registry@github:anoma/namada-chain-registry#5a884bf6343f5130c4a419901a87ea86df53dd83":
-  version: 1.1.0
-  resolution: "@namada/chain-registry@https://github.com/anoma/namada-chain-registry.git#commit=5a884bf6343f5130c4a419901a87ea86df53dd83"
-  checksum: 10c0/419160814963c71a9b867f34cc86593b6eac6f670788494b43a8a61ac7afe3f2da36581b60a4fb920933cd9c23e343c0916991aa97c37d2808d2d7bf92accb74
+"@namada/chain-registry@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@namada/chain-registry@npm:1.2.0"
+  checksum: 10c0/23f571f9d5358cad747024df262ac0ef3d8c6fd1fa3d3d6ef145801883173b7b48e6f25acf32a4876b682d7138afa6db71971100fe2a9fc6c73c53b2e1da9232
   languageName: node
   linkType: hard
 
@@ -3826,7 +3826,7 @@ __metadata:
     "@cosmjs/encoding": "npm:^0.32.3"
     "@eslint/js": "npm:^9.9.1"
     "@keplr-wallet/types": "npm:^0.12.136"
-    "@namada/chain-registry": "github:anoma/namada-chain-registry#5a884bf6343f5130c4a419901a87ea86df53dd83"
+    "@namada/chain-registry": "npm:^1.2.0"
     "@namada/indexer-client": "npm:2.5.4"
     "@playwright/test": "npm:^1.24.1"
     "@svgr/webpack": "npm:^6.5.1"


### PR DESCRIPTION
Fix the new tokens missing from the chain/asset selector when executing a transfer.

- Add the missing chains
- Update the `namada-chain-registry` to pull the new assets from there, instead of merging with the osmosis one
- Rename some variables to help to understand the code
- Penumbra is out of this PR because they have another issue. They are listed as `non-cosmos` chain and they don't have a `chain.json` file. We need to handle this differently. https://github.com/cosmos/chain-registry/tree/master/_non-cosmos/penumbra


https://github.com/user-attachments/assets/5c8750f6-7dc6-4937-9a67-3afbe00a36cc

