### PR TITLE
chore: update namada chain registry

### DIFF
--- a/apps/namadillo/package.json
+++ b/apps/namadillo/package.json
@@ -10,7 +10,7 @@
     "@chain-registry/client": "^1.53.5",
     "@cosmjs/encoding": "^0.32.3",
     "@keplr-wallet/types": "^0.12.136",
-    "@namada/chain-registry": "^1.2.0",
+    "@namada/chain-registry": "^1.3.0",
     "@namada/indexer-client": "3.0.1",
     "@tailwindcss/container-queries": "^0.1.1",
     "@tanstack/query-core": "^5.40.0",

--- a/apps/namadillo/src/App/Ibc/IbcTransfer.tsx
+++ b/apps/namadillo/src/App/Ibc/IbcTransfer.tsx
@@ -10,7 +10,6 @@ import { allDefaultAccountsAtom } from "atoms/accounts";
 import {
   assetBalanceAtomFamily,
   availableChainsAtom,
-  enabledIbcAssetsDenomFamily,
   ibcChannelsFamily,
 } from "atoms/integrations";
 import BigNumber from "bignumber.js";
@@ -61,9 +60,6 @@ export const IbcTransfer = (): JSX.Element => {
     })
   );
 
-  const { data: enabledAssets, isLoading: isLoadingEnabledAssets } =
-    useAtomValue(enabledIbcAssetsDenomFamily(ibcChannels?.namadaChannel));
-
   const [shielded, setShielded] = useState<boolean>(true);
   const [selectedAssetAddress, setSelectedAssetAddress] = useUrlState(
     params.asset
@@ -85,15 +81,15 @@ export const IbcTransfer = (): JSX.Element => {
     selectedAssetAddress ? userAssets?.[selectedAssetAddress] : undefined;
 
   const availableAssets = useMemo(() => {
-    if (!enabledAssets || !userAssets) return undefined;
+    if (!userAssets) return undefined;
     const output: AddressWithAssetAndAmountMap = {};
     for (const key in userAssets) {
-      if (enabledAssets.includes(userAssets[key].asset.base)) {
+      if (registry?.assets.assets.find((a) => a.base === key)?.base) {
         output[key] = { ...userAssets[key] };
       }
     }
     return output;
-  }, [enabledAssets, userAssets]);
+  }, [userAssets]);
 
   // Manage the history of transactions
   const { storeTransaction } = useTransactionActions();
@@ -180,7 +176,7 @@ export const IbcTransfer = (): JSX.Element => {
       </header>
       <TransferModule
         source={{
-          isLoadingAssets: isLoadingBalances || isLoadingEnabledAssets,
+          isLoadingAssets: isLoadingBalances,
           availableAssets,
           selectedAssetAddress,
           availableAmount,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3557,10 +3557,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@namada/chain-registry@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@namada/chain-registry@npm:1.2.0"
-  checksum: 10c0/23f571f9d5358cad747024df262ac0ef3d8c6fd1fa3d3d6ef145801883173b7b48e6f25acf32a4876b682d7138afa6db71971100fe2a9fc6c73c53b2e1da9232
+"@namada/chain-registry@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@namada/chain-registry@npm:1.3.0"
+  checksum: 10c0/4cde05f35e9bbf94bfa18a43e17ba14e04d8517bd32b11918a4b58f9d5a6ed05b1901f4369617efd8adf8dc2647e91148ce53b16ff79206f7b06986a4a8f1bb8
   languageName: node
   linkType: hard
 
@@ -3826,7 +3826,7 @@ __metadata:
     "@cosmjs/encoding": "npm:^0.32.3"
     "@eslint/js": "npm:^9.9.1"
     "@keplr-wallet/types": "npm:^0.12.136"
-    "@namada/chain-registry": "npm:^1.2.0"
+    "@namada/chain-registry": "npm:^1.3.0"
     "@namada/indexer-client": "npm:3.0.1"
     "@playwright/test": "npm:^1.24.1"
     "@svgr/webpack": "npm:^6.5.1"


### PR DESCRIPTION
For new tia on housefire.

Also changed `availableAssets` because it would query indexer for tokens, but if there are no token indexed yet(like new TIA), then it's not possible to make first ibc transfer into namada.