### PR TITLE
feat: change query tx status loop

### DIFF
--- a/apps/namadillo/src/App/Common/Toast.tsx
+++ b/apps/namadillo/src/App/Common/Toast.tsx
@@ -129,7 +129,9 @@ const Toast = ({ notification, onClose }: ToastProps): JSX.Element => {
           )}
         {notification.details &&
           (viewDetails || notification.type === "error") && (
-            <div className="w-full text-xs text-white block">
+            <div className="w-full text-xs text-white block whitespace-pre-wrap">
+              {/* We "prefix" the error message with a line break to make it more visible */}
+              {notification.type === "error" && <br />}
               {notification.details}
             </div>
           )}

--- a/apps/namadillo/src/utils/index.ts
+++ b/apps/namadillo/src/utils/index.ts
@@ -141,10 +141,10 @@ export const toErrorDetail = (
     // TODO: Over time we may expand this to format errors for more result codes
     switch (code) {
       case ResultCode.TxGasLimit:
-        return `${error.toString()} ${toGasMsg(args.gasLimit)}`;
+        return `${error.toString()}.\n${toGasMsg(args.gasLimit)}`;
       case ResultCode.WasmRuntimeError:
         // We can only check error type by reading the error message
-        return error.toString() + ` ${textToErrorDetail(info, tx[0])}`;
+        return `${error.toString()}.\n${textToErrorDetail(info, tx[0])}`;
 
       default:
         return error.toString() + ` ${info}`;

--- a/packages/shared/lib/src/sdk/io.rs
+++ b/packages/shared/lib/src/sdk/io.rs
@@ -9,12 +9,9 @@ fn read(question: Option<&str>) -> std::io::Result<String> {
                 .prompt_with_message(question)
                 .expect("Prompt to be defined");
 
-            input.ok_or(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "Input is null",
-            ))
+            input.ok_or(std::io::Error::other("Input is null"))
         }
-        None => Err(std::io::Error::new(std::io::ErrorKind::Other, "No window")),
+        None => Err(std::io::Error::other("No window")),
     }
 }
 

--- a/packages/shared/lib/src/sdk/masp/masp_web.rs
+++ b/packages/shared/lib/src/sdk/masp/masp_web.rs
@@ -77,7 +77,7 @@ impl WebShieldedUtils {
     }
 
     fn to_io_err(e: Error) -> std::io::Error {
-        std::io::Error::new(std::io::ErrorKind::Other, e.to_string())
+        std::io::Error::other(e.to_string())
     }
 
     pub async fn build_database(chain_id: &str) -> Result<Rexie, Error> {

--- a/packages/shared/lib/src/sdk/mod.rs
+++ b/packages/shared/lib/src/sdk/mod.rs
@@ -34,7 +34,7 @@ use namada_sdk::masp::ShieldedContext;
 use namada_sdk::masp_primitives::sapling::ViewingKey;
 use namada_sdk::masp_primitives::transaction::components::amount::I128Sum;
 use namada_sdk::masp_primitives::zip32::{ExtendedFullViewingKey, ExtendedKey};
-use namada_sdk::rpc::{self, query_denom, query_epoch, InnerTxResult, TxResponse};
+use namada_sdk::rpc::{self, query_denom, query_epoch, InnerTxResult, TxAppliedEvents, TxResponse};
 use namada_sdk::signing::SigningTxData;
 use namada_sdk::string_encoding::Format;
 use namada_sdk::tendermint_rpc::Url;
@@ -337,6 +337,48 @@ impl Sdk {
         to_js_result(borsh::to_vec(&namada_tx)?)
     }
 
+    // We query tx evcents in loop here as control flow in namada_sdk does not seem to work well in
+    // browsers
+    async fn query_tx_result(
+        &self,
+        deadline: u64,
+        tx_hash: &str,
+    ) -> Result<TxAppliedEvents, JsValue> {
+        let mut backoff = 0;
+        let deadline = time::Instant::now() + time::Duration::from_secs(deadline);
+        let tx_query = rpc::TxEventQuery::Applied(tx_hash);
+
+        let event = loop {
+            // We do linear backoff here to avoid hammering the RPC server
+            backoff += 1000;
+
+            if time::Instant::now() >= deadline {
+                break Err(JsValue::from("Timed out waiting for tx to be applied"));
+            }
+            let res = rpc::query_tx_events(self.namada.client(), tx_query).await;
+
+            let maybe_response = match res {
+                Ok(response) => response,
+                Err(_) => {
+                    crate::utils::sleep(backoff).await;
+                    continue;
+                }
+            };
+
+            match maybe_response {
+                Some(res) => {
+                    break Ok(res);
+                }
+                None => {
+                    crate::utils::sleep(backoff).await;
+                    continue;
+                }
+            }
+        }?;
+
+        Ok(event)
+    }
+
     pub async fn broadcast_tx(&self, tx_bytes: &[u8], deadline: u64) -> Result<JsValue, JsValue> {
         #[derive(serde::Serialize)]
         struct TxErrResponse {
@@ -363,11 +405,7 @@ impl Sdk {
                     ));
                 }
 
-                let deadline = time::Instant::now() + time::Duration::from_secs(deadline);
-                let tx_query = rpc::TxEventQuery::Applied(tx_hash.as_str());
-                let event = rpc::query_tx_status(&self.namada, tx_query, deadline)
-                    .await
-                    .map_err(|e| JsValue::from_str(&e.to_string()))?;
+                let event = self.query_tx_result(deadline, &tx_hash).await?;
                 let tx_response = TxResponse::from_events(event);
 
                 let mut batch_tx_results: Vec<tx::BatchTxResult> = vec![];

--- a/packages/shared/lib/src/sdk/tx.rs
+++ b/packages/shared/lib/src/sdk/tx.rs
@@ -450,7 +450,11 @@ pub struct BatchTxResult {
 
 impl BatchTxResult {
     pub fn new(hash: String, is_applied: bool, error: Option<String>) -> BatchTxResult {
-        BatchTxResult { hash, is_applied, error }
+        BatchTxResult {
+            hash,
+            is_applied,
+            error,
+        }
     }
 }
 

--- a/packages/shared/lib/src/utils.rs
+++ b/packages/shared/lib/src/utils.rs
@@ -1,8 +1,9 @@
 use gloo_utils::format::JsValueSerdeExt;
-use js_sys::Uint8Array;
+use js_sys::{Promise, Uint8Array};
 use serde::Serialize;
 use std::fmt::Debug;
 use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::JsFuture;
 
 #[wasm_bindgen]
 extern "C" {
@@ -43,4 +44,16 @@ where
 pub fn set_panic_hook() {
     web_sys::console::log_1(&"Set panic hook".into());
     console_error_panic_hook::set_once();
+}
+
+/// Sleep function using setTimeout wrapped in a JS Promise
+pub async fn sleep(ms: i32) {
+    let promise = Promise::new(&mut |resolve, _reject| {
+        web_sys::window()
+            .unwrap()
+            .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, ms)
+            .unwrap();
+    });
+
+    let _ = JsFuture::from(promise).await;
 }


### PR DESCRIPTION
Often tx time out without any specific reason. It looks like `ControlFlow` logic  from `namada_sdk` does not work well with wasm/browser target. I moved loop from namada_sdk to shared and used promise based sleep.

Ah, also fixed clippy errors and ran fmt that's why there are more files changed.