### PR TITLE
fix: missing shell in gh action

### DIFF
--- a/.github/actions/prepare-build/action.yml
+++ b/.github/actions/prepare-build/action.yml
@@ -13,6 +13,7 @@ runs:
 
     - name: Setup Rust toolchain
       run: rustup toolchain add nightly-2025-03-27
+      shell: bash
 
     - name: Install protoc
       run: sudo apt-get install -y protobuf-compiler


### PR DESCRIPTION
Cuz action is failing: https://github.com/anoma/namada-interface/actions/runs/15207513436/job/42773978172