### PR TITLE
fix: Add missing Ledger dependency

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -78,6 +78,7 @@
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.4",
     "@types/semver": "^7.5.8",
+    "@types/w3c-web-usb": "^1.0.10",
     "babel-jest": "^29.0.3",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3928,6 +3928,7 @@ __metadata:
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.11.4"
     "@types/semver": "npm:^7.5.8"
+    "@types/w3c-web-usb": "npm:^1.0.10"
     "@zondax/ledger-namada": "npm:^2.0.0"
     babel-jest: "npm:^29.0.3"
     bignumber.js: "npm:^9.1.1"


### PR DESCRIPTION
SDK build fails due to a missing type for `USBDevice` - this previously wasn't a problem, but is breaking the build now.