### PR TITLE
ci: removing stable branch integration

### DIFF
--- a/.github/actions/release-project/action.yml
+++ b/.github/actions/release-project/action.yml
@@ -30,13 +30,3 @@ runs:
         zip -r ${{ inputs.bundle_filename }} .
         gh release upload ${{ inputs.tag }} ${{ inputs.bundle_filename }}
       shell: bash
-
-    - name: Merge main branch into stable
-      run: |
-        git config --global user.name "github-actions[bot]"
-        git config --global user.email "github-actions[bot]@users.noreply.github.com"
-        git fetch
-        git checkout stable-interface
-        git merge origin/main --no-edit
-        git push origin stable-interface
-      shell: bash


### PR DESCRIPTION
We're removing the last part failing, cause we won't stable branch for now