### PR TITLE
fix: namada beeing installable

### DIFF
--- a/apps/namadillo/public/manifest.json
+++ b/apps/namadillo/public/manifest.json
@@ -13,8 +13,6 @@
       "type": "image/png"
     }
   ],
-  "start_url": ".",
-  "display": "standalone",
   "theme_color": "#000000",
   "background_color": "#ffffff"
 }


### PR DESCRIPTION
Removes this:
![image](https://github.com/user-attachments/assets/05234d9a-d792-4991-ac93-bdedfc0e9844)
