### PR TITLE
feat: Bump SDK for Namada libs v0.150.1

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -62,6 +62,7 @@
     "@dao-xyz/borsh": "^5.1.5",
     "@ledgerhq/hw-transport": "^6.31.4",
     "@ledgerhq/hw-transport-webusb": "^6.29.4",
+    "@namada/shared": "0.3.0",
     "@zondax/ledger-namada": "^2.0.0",
     "bignumber.js": "^9.1.1",
     "buffer": "^6.0.3",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@namada/shared",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Namada shared functionality",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3925,6 +3925,7 @@ __metadata:
     "@dao-xyz/borsh": "npm:^5.1.5"
     "@ledgerhq/hw-transport": "npm:^6.31.4"
     "@ledgerhq/hw-transport-webusb": "npm:^6.29.4"
+    "@namada/shared": "npm:0.3.0"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.11.4"
     "@types/semver": "npm:^7.5.8"
@@ -3960,7 +3961,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@namada/shared@workspace:packages/shared":
+"@namada/shared@npm:0.3.0, @namada/shared@workspace:packages/shared":
   version: 0.0.0-use.local
   resolution: "@namada/shared@workspace:packages/shared"
   dependencies:


### PR DESCRIPTION
- Bump `@namada/shared`
- Specify version in `@namada/sdk` dependencies
- Include changes for https://github.com/anoma/namada-interface/pull/2075