### PR TITLE
feat: Mark Ledger accounts missing shielded account as outdated

### DIFF
--- a/apps/extension/src/App/Accounts/ParentAccounts.tsx
+++ b/apps/extension/src/App/Accounts/ParentAccounts.tsx
@@ -53,6 +53,20 @@ export const ParentAccounts = (): JSX.Element => {
       }
     });
 
+  // We check whether a Ledger parent has an associated shielded account
+  allAccounts
+    .filter(
+      (account) => !account.parentId && account.type === AccountType.Ledger
+    )
+    .forEach(({ id }) => {
+      const shieldedAccount = allAccounts.find(
+        ({ parentId }) => parentId === id
+      );
+      if (!shieldedAccount) {
+        allParentAccounts[id]["outdated"] = true;
+      }
+    });
+
   const accounts = Object.values(allParentAccounts);
 
   useEffect(() => {

--- a/apps/extension/src/App/Accounts/UpdateRequired.tsx
+++ b/apps/extension/src/App/Accounts/UpdateRequired.tsx
@@ -71,7 +71,8 @@ export const UpdateRequired = (): JSX.Element => {
                 </li>
                 <li>Delete the marked account from  the keychain</li>
                 <li>
-                  Re-Import the account using your seed phrase / private key
+                  Re-Import the account using your seed phrase / private key /
+                  Ledger HW wallet
                 </li>
               </ol>
             </Stack>


### PR DESCRIPTION
Imported Ledger accounts which are outdated (i.e., missing shielded keys) should display a warning similar to the warning we use to re-import pre-modified zip32 shielded keys.

### Testing

If you don't have an outdated Ledger to test with:

- In https://github.com/anoma/namada-interface/blob/1b3f4b9cc12034ffdc20de9908d3bc1367fcb019/apps/extension/src/Setup/Ledger/LedgerConnect.tsx#L62 set `const isMaspSupported = false;`
- Import from Ledger - it will not import shielded keys, then opening the app, the check will nag you about re-importing
- Revert changes to `LedgerConnect.tsx`, delete the account, then re-import. You will not see the warning.

If you do have an oudated Ledger:
- Import Ledger (if you haven't already) - you should see the banner and warning icon
- Update Ledger firmware & Namada app to latest
- Delete account and re-import - If you are _not_ on Nano S, the warning should go away!

**NOTE** A known consequence of this is that Nano S users will _always_ see the banner & warning icon - we do not track device model so we can't avoid this. Re-importing will not remove the error since Nano S will never support shielded keys!

### Screenshots

Outdated keys banner:
![image](https://github.com/user-attachments/assets/3e546049-f800-4b22-8edb-8a24d0f63032)

Ledger account missing shielded keys warning:
![image](https://github.com/user-attachments/assets/015dd851-326c-46c8-bdf4-163ecaec713b)

Showing it indeed does not have shielded keys:
![image](https://github.com/user-attachments/assets/1023767b-678f-4151-888b-061f021df6e8)

Re-imported Ledger keys (with shielded) - No banner or warning:
![image](https://github.com/user-attachments/assets/650fc536-844a-4cf5-9dfa-9f5b6712a8ff)
