### PR TITLE
fix: images on AssetsModalCard not appearing on Firefox

### DIFF
--- a/apps/namadillo/src/App/Common/AssetsModalCard.tsx
+++ b/apps/namadillo/src/App/Common/AssetsModalCard.tsx
@@ -23,7 +23,7 @@ export const AssetsModalCard = ({
       )}
     >
       <h3 className="text-xl font-medium">{title}</h3>
-      <aside className="max-w-[78px]">{icon}</aside>
+      <aside className="w-full max-w-[78px]">{icon}</aside>
       <div className="text-base/tight">{children}</div>
     </Stack>
   );


### PR DESCRIPTION
This PR fixes this error on Firefox: 
<img width="684" alt="image" src="https://github.com/user-attachments/assets/ebc647be-e49b-4956-9f64-3d712a3c4def" />
