### PR TITLE
fix: Bump existing release please manifest for extension

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "apps/namadillo": "1.24.0",
-  "apps/extension": "0.5.0",
+  "apps/extension": "0.6.0",
   "packages/sdk": "0.19.0",
   "packages/types": "0.6.0"
 }


### PR DESCRIPTION
`0.5.0` -> `0.6.0`