### PR TITLE
feat: enable transfers between shielded and transparent addresses in the

### DIFF
--- a/apps/namadillo/src/App/Transfer/TransferModule.tsx
+++ b/apps/namadillo/src/App/Transfer/TransferModule.tsx
@@ -119,6 +119,7 @@ type ValidationResult =
   | "NotEnoughBalanceForFees"
   | "KeychainNotCompatibleWithMasp"
   | "CustomAddressNotMatchingChain"
+  | "TheSameAddress"
   | "NoLedgerConnected"
   | "Ok";
 
@@ -126,22 +127,15 @@ type ValidationResult =
 const isValidDestinationAddress = ({
   customAddress,
   chain,
-  shielded,
 }: {
   customAddress: string;
   chain: Chain | undefined;
-  shielded: boolean;
 }): boolean => {
   // Skip validation if no custom address or chain provided
   if (!customAddress || !chain) return true;
 
   // Check shielded/transparent address requirements for Namada
   if (chain.bech32_prefix === "nam") {
-    // If shielded is required but address is transparent, validation fails
-    if (shielded && isTransparentAddress(customAddress)) return false;
-    // If transparent is required but address is shielded, validation fails
-    if (!shielded && isShieldedAddress(customAddress)) return false;
-    // Valid Namada address that matches transaction type
     return (
       isTransparentAddress(customAddress) || isShieldedAddress(customAddress)
     );
@@ -229,11 +223,12 @@ export const TransferModule = ({
   const validationResult = useMemo((): ValidationResult => {
     if (!source.wallet) {
       return "NoSourceWallet";
+    } else if (source.walletAddress === destination.customAddress) {
+      return "TheSameAddress";
     } else if (
       !isValidDestinationAddress({
         customAddress: destination.customAddress ?? "",
         chain: destination.chain,
-        shielded: isShieldedTx,
       })
     ) {
       return "CustomAddressNotMatchingChain";
@@ -395,6 +390,8 @@ export const TransferModule = ({
     switch (validationResult) {
       case "NoSourceWallet":
         return getText("Select Wallet");
+      case "TheSameAddress":
+        return getText("Source and destination addresses are the same");
 
       case "NoSourceChain":
       case "NoDestinationChain":


### PR DESCRIPTION
Resolves #2107
- enabled `transparent<->shielded` to  custom addresses
- added validation for `target == destination`
![obraz](https://github.com/user-attachments/assets/0d0a5dcc-f479-436f-a2b9-ebf231ad0f89)
validation
![obraz](https://github.com/user-attachments/assets/a760624e-3d76-4fbd-8ff2-d49c5d6d599a)
