### PR TITLE
fix: proposal statuses filters

### DIFF
--- a/apps/namadillo/src/App/Governance/AllProposalsTable.tsx
+++ b/apps/namadillo/src/App/Governance/AllProposalsTable.tsx
@@ -120,9 +120,8 @@ const statusFilters = [
   "all",
   "pending",
   "ongoing",
-  "passed",
-  "rejected",
-  "executed",
+  "executedPassed",
+  "executedRejected",
 ] as const;
 type StatusFilter = (typeof statusFilters)[number];
 

--- a/apps/namadillo/src/App/Governance/ProposalLabels.tsx
+++ b/apps/namadillo/src/App/Governance/ProposalLabels.tsx
@@ -19,9 +19,8 @@ export const StatusLabel: React.FC<
   const statusClassName =
     status === "pending" ? "text-upcoming"
     : status === "ongoing" ? "text-intermediate"
-    : status === "passed" ? "text-success"
-    : status === "rejected" ? "text-fail"
-    : status === "executed" ? "text-success"
+    : status === "executedPassed" ? "text-success"
+    : status === "executedRejected" ? "text-fail"
     : assertNever(status);
 
   return (

--- a/apps/namadillo/src/App/Governance/ProposalsSummary.tsx
+++ b/apps/namadillo/src/App/Governance/ProposalsSummary.tsx
@@ -19,13 +19,13 @@ export const ProposalsSummary: React.FC<{
     ({ status }) => status === "ongoing"
   ).length;
   const passed = allProposals.filter(
-    ({ status }) => status === "passed"
+    ({ status }) => status === "executedPassed"
   ).length;
   const rejected = allProposals.filter(
-    ({ status }) => status === "rejected"
+    ({ status }) => status === "executedRejected"
   ).length;
   const executed = allProposals.filter(
-    ({ status }) => status === "executed"
+    ({ status }) => status === "executedPassed" || status === "executedRejected"
   ).length;
 
   return (

--- a/apps/namadillo/src/atoms/proposals/functions.ts
+++ b/apps/namadillo/src/atoms/proposals/functions.ts
@@ -274,13 +274,12 @@ const fromIndexerStatus = (
       return "pending";
     case IndexerProposalStatusEnum.Voting:
       return "ongoing";
-    case IndexerProposalStatusEnum.Passed:
-      return "passed";
     case IndexerProposalStatusEnum.ExecutedRejected:
     case IndexerProposalStatusEnum.Rejected:
-      return "rejected";
+      return "executedRejected";
+    case IndexerProposalStatusEnum.Passed:
     case IndexerProposalStatusEnum.ExecutedPassed:
-      return "executed";
+      return "executedPassed";
     default:
       return assertNever(indexerProposalStatus);
   }
@@ -294,11 +293,9 @@ const toIndexerStatus = (
       return ApiIndexerProposalStatusEnum.Pending;
     case "ongoing":
       return ApiIndexerProposalStatusEnum.VotingPeriod;
-    case "passed":
-      return ApiIndexerProposalStatusEnum.Passed;
-    case "rejected":
-      return ApiIndexerProposalStatusEnum.Rejected;
-    case "executed":
+    case "executedRejected":
+      return ApiIndexerProposalStatusEnum.ExecutedRejected;
+    case "executedPassed":
       return ApiIndexerProposalStatusEnum.ExecutedPassed;
     default:
       return assertNever(proposalStatus);

--- a/apps/namadillo/src/utils/index.ts
+++ b/apps/namadillo/src/utils/index.ts
@@ -16,9 +16,8 @@ export const proposalStatusToString = (status: ProposalStatus): string => {
   const statusText: Record<ProposalStatus, string> = {
     pending: "Upcoming",
     ongoing: "Ongoing",
-    passed: "Passed",
-    rejected: "Rejected",
-    executed: "Executed",
+    executedRejected: "Rejected",
+    executedPassed: "Passed",
   };
 
   return statusText[status];

--- a/packages/types/src/proposals.ts
+++ b/packages/types/src/proposals.ts
@@ -3,9 +3,8 @@ import BigNumber from "bignumber.js";
 export const proposalStatuses = [
   "pending",
   "ongoing",
-  "passed",
-  "rejected",
-  "executed",
+  "executedRejected",
+  "executedPassed",
 ] as const;
 
 export type ProposalStatus = (typeof proposalStatuses)[number];


### PR DESCRIPTION
Resolves #2141 

"passed" and "rejected" were migrated to "executedPassed" and "executedRejected" in the indexer

How to test?
Try filtering in the governance view
Check if number of proposal in sidebar is correct


Indexer will be fixed by removing unused statuses from query