### PR TITLE
fix: use correct derivation path for masp signs using ledger AND sign all sapling inputs

### DIFF
--- a/apps/extension/src/Approvals/ConfirmSignLedgerTx.tsx
+++ b/apps/extension/src/Approvals/ConfirmSignLedgerTx.tsx
@@ -1,3 +1,5 @@
+import { getSdk } from "@namada/sdk/web";
+import sdkInit from "@namada/sdk/web-init";
 import clsx from "clsx";
 import { ReactNode, useCallback, useEffect, useState } from "react";
 
@@ -84,8 +86,9 @@ export const ConfirmSignLedgerTx: React.FC<Props> = ({ details }) => {
   const signMaspTx = async (
     ledger: Ledger,
     bytes: Uint8Array,
-    path: string
-  ): Promise<{ sbar: Uint8Array; rbar: Uint8Array }> => {
+    path: string,
+    shieldedHash?: string
+  ): Promise<{ sbar: Uint8Array; rbar: Uint8Array }[]> => {
     const signMaspSpendsResponse = await ledger.namadaApp.signMaspSpends(
       path,
       Buffer.from(bytes)
@@ -97,14 +100,36 @@ export const ConfirmSignLedgerTx: React.FC<Props> = ({ details }) => {
       );
     }
 
-    const spendSignatureResponse = await ledger.namadaApp.getSpendSignature();
-    if (spendSignatureResponse.returnCode !== LedgerError.NoErrors) {
-      throw new Error(
-        `Getting spends signature error encountered: ${signMaspSpendsResponse.errorMessage}`
-      );
+    if (!shieldedHash) {
+      throw new Error("Shielded hash is required for MASP transactions");
     }
 
-    return spendSignatureResponse;
+    const { cryptoMemory } = await sdkInit();
+    // TODO: Find a better way to init the sdk, token has to be any valid token
+    const sdk = getSdk(
+      cryptoMemory,
+      "",
+      "",
+      "",
+      "tnam1q9gr66cvu4hrzm0sd5kmlnjje82gs3xlfg3v6nu7"
+    );
+    const descriptors = await sdk
+      .getMasp()
+      .getDescriptorMap(bytes, fromBase64(shieldedHash));
+
+    const responses = [];
+    // TODO: this probably means that we do not really need descriptor map, but just to iterate over the sapling inputs
+    for (const _ of descriptors) {
+      const spendSignatureResponse = await ledger.namadaApp.getSpendSignature();
+      if (spendSignatureResponse.returnCode !== LedgerError.NoErrors) {
+        throw new Error(
+          `Getting spends signature error encountered: ${signMaspSpendsResponse.errorMessage}`
+        );
+      }
+      responses.push(spendSignatureResponse);
+    }
+
+    return responses;
   };
 
   const signLedgerTx = async (
@@ -130,15 +155,20 @@ export const ConfirmSignLedgerTx: React.FC<Props> = ({ details }) => {
       ledger: Ledger,
       tx: string,
       zip32Path: string,
-      signatures: string[]
+      signatures: string[],
+      shieldedHash?: string
     ) => {
-      const { sbar, rbar } = await signMaspTx(
+      const responses = await signMaspTx(
         ledger,
         fromBase64(tx),
-        zip32Path
+        zip32Path,
+        shieldedHash
       );
-      const signature = toBase64(new Uint8Array([...rbar, ...sbar]));
-      signatures.push(signature);
+
+      responses.forEach(({ sbar, rbar }) => {
+        const signature = toBase64(new Uint8Array([...rbar, ...sbar]));
+        signatures.push(signature);
+      });
     },
     []
   );
@@ -249,7 +279,7 @@ export const ConfirmSignLedgerTx: React.FC<Props> = ({ details }) => {
           transferTypes.includes("Unshielding") ||
           transferTypes.includes("IbcUnshieldTransfer");
 
-        for await (const tx of pendingTxs) {
+        for await (const { tx, shieldedHash } of pendingTxs) {
           if (txCount > 1) {
             setStepTwoDescription(
               <p>
@@ -270,7 +300,13 @@ export const ConfirmSignLedgerTx: React.FC<Props> = ({ details }) => {
               account: shieldedAccount.path.account,
             });
             // Adds new signature to the collection
-            await handleMaspSignTx(ledger, tx, zip32Path, maspSignatures);
+            await handleMaspSignTx(
+              ledger,
+              tx,
+              zip32Path,
+              maspSignatures,
+              shieldedHash
+            );
           } else {
             const bip44Path = makeBip44Path(chains.namada.bip44.coinType, path);
             // Adds new signature to the collection

--- a/apps/extension/src/Approvals/ConfirmSignLedgerTx.tsx
+++ b/apps/extension/src/Approvals/ConfirmSignLedgerTx.tsx
@@ -197,10 +197,12 @@ export const ConfirmSignLedgerTx: React.FC<Props> = ({ details }) => {
         if (!accountDetails) {
           throw new Error(`Failed to query account details for ${signer}`);
         }
+        const [transparentAccount, shieldedAccount] = accountDetails;
+
         const path = {
-          account: accountDetails.path.account,
-          change: accountDetails.path.change || 0,
-          index: accountDetails.path.index || 0,
+          account: transparentAccount.path.account,
+          change: transparentAccount.path.change || 0,
+          index: transparentAccount.path.index || 0,
         };
 
         const pendingTxs = await requester.sendMessage(
@@ -259,8 +261,13 @@ export const ConfirmSignLedgerTx: React.FC<Props> = ({ details }) => {
           }
 
           if (fromMasp) {
+            if (!shieldedAccount) {
+              throw new Error(
+                `Shielded account details for ${signer} not found!`
+              );
+            }
             const zip32Path = makeSaplingPath(chains.namada.bip44.coinType, {
-              account: path.account,
+              account: shieldedAccount.path.account,
             });
             // Adds new signature to the collection
             await handleMaspSignTx(ledger, tx, zip32Path, maspSignatures);

--- a/apps/extension/src/background/approvals/messages.ts
+++ b/apps/extension/src/background/approvals/messages.ts
@@ -311,7 +311,9 @@ export class QueryTxDetailsMsg extends Message<TxDetails[]> {
   }
 }
 
-export class QueryPendingTxBytesMsg extends Message<string[] | undefined> {
+export class QueryPendingTxBytesMsg extends Message<
+  { tx: string; shieldedHash?: string }[] | undefined
+> {
   public static type(): MessageType {
     return MessageType.QueryPendingTxBytes;
   }

--- a/apps/extension/src/background/approvals/service.test.ts
+++ b/apps/extension/src/background/approvals/service.test.ts
@@ -224,7 +224,7 @@ describe("approvals service", () => {
       // tx bytes expected to be base64-encoded
       const bytes = "dHhEYXRh"; // "txData"
 
-      (keyRingService.queryAccountDetails as any).mockResolvedValue(() => ({}));
+      (keyRingService.queryAccountDetails as any).mockResolvedValue([{}, {}]);
 
       const signaturePromise = service.approveSignTx(
         signer,

--- a/apps/extension/src/background/approvals/service.ts
+++ b/apps/extension/src/background/approvals/service.ts
@@ -79,6 +79,7 @@ export class ApprovalsService {
     if (!details) {
       throw new Error(ApprovalErrors.AccountNotFound(signer));
     }
+    const [account] = details;
 
     const pendingTx: PendingTx = {
       signer,
@@ -89,7 +90,7 @@ export class ApprovalsService {
     await this.txStore.set(msgId, pendingTx);
 
     return this.launchApprovalPopup(
-      `${TopLevelRoute.ApproveSignTx}/${msgId}/${encodeURIComponent(origin)}/${details.type}/${signer}`
+      `${TopLevelRoute.ApproveSignTx}/${msgId}/${encodeURIComponent(origin)}/${account.type}/${signer}`
     );
   }
 
@@ -406,11 +407,15 @@ export class ApprovalsService {
   }
 
   async approveUpdateDefaultAccount(address: string): Promise<void> {
-    const account = await this.keyRingService.queryAccountDetails(address);
+    const accounts = await this.keyRingService.queryAccountDetails(address);
+    if (!accounts) {
+      throw new Error(ApprovalErrors.AccountNotFound(address));
+    }
+    const [transactionAccount] = accounts;
 
     return this.launchApprovalPopup(TopLevelRoute.ApproveUpdateDefaultAccount, {
       address,
-      alias: account?.alias ?? "",
+      alias: transactionAccount.alias,
     });
   }
 

--- a/apps/extension/src/background/keyring/messages.ts
+++ b/apps/extension/src/background/keyring/messages.ts
@@ -394,7 +394,7 @@ export class DeleteAccountMsg extends Message<
 }
 
 export class QueryAccountDetailsMsg extends Message<
-  DerivedAccount | undefined
+  [DerivedAccount, DerivedAccount | undefined] | undefined
 > {
   public static type(): MessageType {
     return MessageType.QueryAccountDetails;

--- a/apps/extension/src/background/keyring/service.ts
+++ b/apps/extension/src/background/keyring/service.ts
@@ -254,7 +254,7 @@ export class KeyRingService {
 
   async queryAccountDetails(
     address: string
-  ): Promise<DerivedAccount | undefined> {
+  ): Promise<[DerivedAccount, DerivedAccount | undefined] | undefined> {
     if (await this.vaultService.isLocked()) {
       throw new Error(ApprovalErrors.KeychainLocked());
     }

--- a/packages/sdk/src/masp/masp.ts
+++ b/packages/sdk/src/masp/masp.ts
@@ -10,6 +10,20 @@ export class Masp {
   constructor(protected readonly sdk: SdkWasm) {}
 
   /**
+   * Get spend notes descriptor map
+   * @async
+   * @param tx - tx bytes
+   * @param shieldedHash - bytes of the shielded hash
+   * @returns - Promise resolving to an array of numbers representing the descriptor map
+   */
+  async getDescriptorMap(
+    tx: Uint8Array,
+    shieldedHash: Uint8Array
+  ): Promise<number[]> {
+    return await this.sdk.get_descriptor_map(tx, shieldedHash);
+  }
+
+  /**
    * Check if SDK has MASP parameters loaded
    * @async
    * @returns True if MASP parameters are loaded

--- a/packages/sdk/src/tx/tx.ts
+++ b/packages/sdk/src/tx/tx.ts
@@ -370,15 +370,15 @@ export class Tx {
    * Append signature for transactions signed by Ledger Hardware Wallet
    * @param txBytes - bytes of the transaction
    * @param signingData - signing data
-   * @param signature - masp signature
+   * @param signatures - masp signature
    * @returns transaction bytes with signature appended
    */
-  appendMaspSignature(
+  appendMaspSignatures(
     txBytes: Uint8Array,
     signingData: Uint8Array[],
-    signature: Uint8Array
+    signatures: Uint8Array[]
   ): Uint8Array {
-    return this.sdk.sign_masp_ledger(txBytes, signingData, signature);
+    return this.sdk.sign_masp_ledger(txBytes, signingData, signatures);
   }
 
   /**


### PR DESCRIPTION
How to test signing inputs:
- try to unshield some nam
- during confirmation click on details and see if `maspTxIn` array has more than one entry:
```
"maspTxIn": [
        {
          "token": "tnam1q9gr66cvu4hrzm0sd5kmlnjje82gs3xlfg3v6nu7",
          "value": "10",
          "owner": "zvknam1qve5s2ayqqqqpqph2fygt2qa35f0gjz2qcfmcw8wejugyr4vlgrgxd4d05yg3ugskh7vwuzsgelfkffg7y9fal39xxafknv8wted2r8zlaxpfs2gnvuazr4x5cjpngx2p047zjrtmk9fgs6v3uk8h03nf23jdqdpzjq7udphuefful5u3nm5yx5xnxc8n4rtm09kn9e2z7jpe42t0jvaljc8fj6ncufdy7eq2g4u3rxpax9wqh6ye9s7qc6vd44nhp6e4hgafads95csqxwzn"
        },
        {
          "token": "tnam1q9gr66cvu4hrzm0sd5kmlnjje82gs3xlfg3v6nu7",
          "value": "86.7463",
          "owner": "zvknam1qve5s2ayqqqqpqph2fygt2qa35f0gjz2qcfmcw8wejugyr4vlgrgxd4d05yg3ugskh7vwuzsgelfkffg7y9fal39xxafknv8wted2r8zlaxpfs2gnvuazr4x5cjpngx2p047zjrtmk9fgs6v3uk8h03nf23jdqdpzjq7udphuefful5u3nm5yx5xnxc8n4rtm09kn9e2z7jpe42t0jvaljc8fj6ncufdy7eq2g4u3rxpax9wqh6ye9s7qc6vd44nhp6e4hgafads95csqxwzn"
        }
      ],
```
- continue with signing and see if it works

**We also need to test non ledger signing!**

How to test derivation path:
- try to import ledger using default path(s)
- try to import ledger using custom paths
- try to send masp txs using ledger accounts
- try switching default account - from withing namadillo
- try to import normal account
- try to use normal account for masp txs

How to reproduce
- change:
```
account: shieldedAccount.path.account
```
to some bs like: `1337`
- try to unshield

I was testing using infra from https://housefire-interface.sproutstake.space/