### PR TITLE
fix: extension sliced address

### DIFF
--- a/apps/extension/src/App/Accounts/ViewAccount.tsx
+++ b/apps/extension/src/App/Accounts/ViewAccount.tsx
@@ -128,7 +128,7 @@ export const ViewAccount = (): JSX.Element => {
               transparentAccountPath={transparentPath}
               shieldedAccountAddress={shieldedAccount?.address}
               shieldedAccountPath={shieldedPath}
-              trimCharacters={21}
+              trimCharacters={16}
             />
             {viewingKey && (
               <>


### PR DESCRIPTION
On extension, the account address is sliced by a few pixels

It's a bigger issue if the last character are thin, like `i` and `l`

The fix is only crop more character in the address start part

![Screenshot 2025-06-18 at 14 28 56](https://github.com/user-attachments/assets/b07dedc7-dd1b-46a8-b7fd-187a8deea69e)

![Screenshot 2025-06-18 at 14 56 39](https://github.com/user-attachments/assets/bc87eaa3-0aac-41e3-a806-77cc27fea2fe)

