### PR TITLE
fix: shielded balance comma separator

### DIFF
--- a/apps/namadillo/src/App/Masp/ShieldedFungibleTable.tsx
+++ b/apps/namadillo/src/App/Masp/ShieldedFungibleTable.tsx
@@ -60,7 +60,7 @@ export const ShieldedFungibleTable = ({
           key={`balance-${originalAddress}`}
           className="flex flex-col text-right leading-tight"
         >
-          {amount.toString()}
+          <TokenCurrency symbol={asset.symbol} amount={amount} />
           {dollar && (
             <FiatCurrency
               className="text-neutral-600 text-sm"


### PR DESCRIPTION
On home, show the comma separator for Shielded balance

Before

![Screenshot 2025-06-18 at 15 15 00](https://github.com/user-attachments/assets/dfbd5c17-baa0-42c2-b865-f3967949979c)

After 

![Screenshot 2025-06-18 at 15 14 29](https://github.com/user-attachments/assets/b16088ec-a034-4f36-ab5f-70bdb78970f4)
