### PR TITLE
fix: hide masp rewards box until phase 4

### DIFF
--- a/apps/namadillo/src/App/AccountOverview/ShieldedAssetsOverview.tsx
+++ b/apps/namadillo/src/App/AccountOverview/ShieldedAssetsOverview.tsx
@@ -2,13 +2,16 @@ import { ActionButton, Panel } from "@namada/components";
 import { MaspSyncCover } from "App/Common/MaspSyncCover";
 import { ShieldedAssetTable } from "App/Masp/ShieldedAssetTable";
 import { routes } from "App/routes";
+import { applicationFeaturesAtom } from "atoms/settings";
 import clsx from "clsx";
 import { useAmountsInFiat } from "hooks/useAmountsInFiat";
 import { useRequiresNewShieldedSync } from "hooks/useRequiresNewShieldedSync";
+import { useAtomValue } from "jotai";
 import { EstimateShieldingRewardsCard } from "./EstimateShieldingRewardsCard";
 import { TotalBalanceCard } from "./TotalBalanceCard";
 
 export const ShieldedAssetsOverview = (): JSX.Element => {
+  const { shieldingRewardsEnabled } = useAtomValue(applicationFeaturesAtom);
   const { shieldedAmountInFiat } = useAmountsInFiat();
   const textContainerClassList = `flex h-full gap-1 items-center justify-center`;
   const requiresNewShieldedSync = useRequiresNewShieldedSync();
@@ -34,7 +37,7 @@ export const ShieldedAssetsOverview = (): JSX.Element => {
             </>
           }
         />
-        <EstimateShieldingRewardsCard />
+        {shieldingRewardsEnabled && <EstimateShieldingRewardsCard />}
       </div>
       <div className="mt-10">
         <ShieldedAssetTable />


### PR DESCRIPTION
Hide masp rewards box until phase 4

Before
![Screenshot 2025-06-18 at 17 34 09](https://github.com/user-attachments/assets/c56d025b-557d-4118-bda9-6fd39de17646)


After
![Screenshot 2025-06-18 at 17 33 44](https://github.com/user-attachments/assets/1f3e5db7-4b8c-4348-be83-5e62511912a7)
