### PR TITLE
fix: displaying housefire nam in mainnet osmosis assets

### DIFF
--- a/apps/namadillo/src/atoms/integrations/functions.ts
+++ b/apps/namadillo/src/atoms/integrations/functions.ts
@@ -162,7 +162,8 @@ const findCounterpartChainName = (
 const tryDenomToIbcAsset = async (
   denom: string,
   ibcAddressToDenomTrace: (address: string) => Promise<DenomTrace | undefined>,
-  chainName: string
+  chainName: string,
+  namadaChainName: string
 ): Promise<Asset | undefined> => {
   const denomTrace = await ibcAddressToDenomTrace(denom);
   if (typeof denomTrace === "undefined") {
@@ -171,10 +172,14 @@ const tryDenomToIbcAsset = async (
 
   const { path, baseDenom } = denomTrace;
 
-  const assetOnRegistry = tryDenomToRegistryAsset(
-    baseDenom,
-    registry.assets.map((assetListEl) => assetListEl.assets).flat()
-  );
+  // We only check assets for the selected chain i.e. osmosis and current namada chain,
+  // this prevents displaying housefire produced nam on mainnet namada
+  const assets = assetLookup(chainName) || [];
+  const namadaAssets = assetLookup(namadaChainName) || [];
+  const assetOnRegistry = tryDenomToRegistryAsset(baseDenom, [
+    ...assets,
+    ...namadaAssets,
+  ]);
 
   if (assetOnRegistry) {
     return assetOnRegistry;
@@ -220,6 +225,7 @@ const findOriginalAsset = async (
   coin: Coin,
   assets: Asset[],
   ibcAddressToDenomTrace: (address: string) => Promise<DenomTrace | undefined>,
+  namadaChainName: string,
   chainName?: string
 ): Promise<AddressWithAssetAndAmount> => {
   const { minDenomAmount, denom } = coin;
@@ -230,7 +236,12 @@ const findOriginalAsset = async (
   }
 
   if (!asset && chainName) {
-    asset = await tryDenomToIbcAsset(denom, ibcAddressToDenomTrace, chainName);
+    asset = await tryDenomToIbcAsset(
+      denom,
+      ibcAddressToDenomTrace,
+      chainName,
+      namadaChainName
+    );
   }
 
   if (!asset) {
@@ -257,9 +268,12 @@ export const findChainById = (chainId: string): Chain | undefined => {
 export const mapCoinsToAssets = async (
   coins: Coin[],
   chainId: string,
+  namadaChainId: string,
   ibcAddressToDenomTrace: (address: string) => Promise<DenomTrace | undefined>
 ): Promise<AddressWithAssetAndAmountMap> => {
   const chainName = findChainById(chainId)?.chain_name;
+  // Namada chain name should be always available
+  const namadaChainName = findChainById(namadaChainId)?.chain_name as string;
   const assets = mapUndefined(assetLookup, chainName);
   const results = await Promise.allSettled(
     coins.map(
@@ -268,6 +282,7 @@ export const mapCoinsToAssets = async (
           coin,
           assets || [],
           ibcAddressToDenomTrace,
+          namadaChainName,
           chainName
         )
     )


### PR DESCRIPTION
How to test:
- send some nam on housefire to osmosis
- go to ibc deposit and check if you can see nam(you should be able to)
- change providers to mainnet
- go to ibc deposit and check if you can see nam(you shouldnt be able to)