### PR TITLE
fix: missing nam on mainnet ibc deposit

### DIFF
--- a/apps/namadillo/src/atoms/integrations/atoms.ts
+++ b/apps/namadillo/src/atoms/integrations/atoms.ts
@@ -2,7 +2,7 @@ import { AssetList, Chain } from "@chain-registry/types";
 import { DeliverTxResponse, SigningStargateClient } from "@cosmjs/stargate";
 import { ExtensionKey } from "@namada/types";
 import { defaultAccountAtom } from "atoms/accounts";
-import { chainAtom, chainParametersAtom, chainTokensAtom } from "atoms/chain";
+import { chainAtom, chainTokensAtom } from "atoms/chain";
 import { defaultServerConfigAtom, settingsAtom } from "atoms/settings";
 import { queryDependentFn } from "atoms/utils";
 import BigNumber from "bignumber.js";
@@ -79,28 +79,19 @@ export const broadcastIbcTransactionAtom = atomWithMutation(() => {
 
 export const assetBalanceAtomFamily = atomFamily(
   ({ chain, walletAddress, assets }: AssetBalanceAtomParams) => {
-    return atomWithQuery<AddressWithAssetAndAmountMap>((get) => {
-      const chainParametersQuery = get(chainParametersAtom);
-
-      return {
-        queryKey: ["assets", walletAddress, chain?.chain_id, assets],
-        ...queryDependentFn(async () => {
-          return await queryAndStoreRpc(chain!, async (rpc: string) => {
-            const assetsBalances = await queryAssetBalances(
-              walletAddress!,
-              rpc
-            );
-
-            return await mapCoinsToAssets(
-              assetsBalances,
-              chain!.chain_id,
-              chainParametersQuery.data!.chainId,
-              ibcAddressToDenomTrace(rpc)
-            );
-          });
-        }, [!!walletAddress, !!chain, chainParametersQuery.isSuccess]),
-      };
-    });
+    return atomWithQuery<AddressWithAssetAndAmountMap>(() => ({
+      queryKey: ["assets", walletAddress, chain?.chain_id, assets],
+      ...queryDependentFn(async () => {
+        return await queryAndStoreRpc(chain!, async (rpc: string) => {
+          const assetsBalances = await queryAssetBalances(walletAddress!, rpc);
+          return await mapCoinsToAssets(
+            assetsBalances,
+            chain!.chain_id,
+            ibcAddressToDenomTrace(rpc)
+          );
+        });
+      }, [!!walletAddress, !!chain]),
+    }));
   },
   (prev, current) => {
     return Boolean(

--- a/apps/namadillo/src/atoms/integrations/functions.ts
+++ b/apps/namadillo/src/atoms/integrations/functions.ts
@@ -42,6 +42,7 @@ import internalDevnetCosmosTestnetIbc from "@namada/chain-registry/_testnets/_IB
 // TODO: this causes a big increase on bundle size. See #1224.
 import registry from "chain-registry";
 import { searchNamadaTestnetByChainId } from "lib/chain";
+import { mainnetNamAssetOnOsmosis } from "./temp-assets";
 
 export const namadaTestnetChainList = [
   internalDevnetChain,
@@ -76,6 +77,15 @@ const testnetChains: ChainRegistryEntry[] = [
 ];
 
 const mainnetAndTestnetChains = [...mainnetChains, ...testnetChains];
+
+// Terrible hack to inject nam asset in osmosis so we can show them as a token for ibc.
+// We should update the chain-registry and later remove this hack!
+// Please note that this is only a fix for mainnet nam, not housefire
+registry.assets
+  .find((chain) => chain.chain_name === "osmosis")
+  ?.assets.push(mainnetNamAssetOnOsmosis);
+osmosis.assets.assets.push(mainnetNamAssetOnOsmosis);
+// End of the hack
 
 export const getKnownChains = (
   includeTestnets?: boolean

--- a/apps/namadillo/src/atoms/integrations/temp-assets.ts
+++ b/apps/namadillo/src/atoms/integrations/temp-assets.ts
@@ -1,0 +1,93 @@
+export const mainnetNamAssetOnOsmosis = {
+  description: "The native token of Namada.",
+  denom_units: [
+    {
+      denom:
+        "ibc/C7110DEC66869DAE9BE9C3C60F4B5313B16A2204AE020C3B0527DD6B322386A3",
+      exponent: 0,
+      aliases: ["unam"],
+    },
+    {
+      denom: "nam",
+      exponent: 6,
+    },
+  ],
+  type_asset: "ics20",
+  base: "ibc/C7110DEC66869DAE9BE9C3C60F4B5313B16A2204AE020C3B0527DD6B322386A3",
+  name: "Namada",
+  display: "nam",
+  symbol: "NAM",
+  traces: [
+    {
+      type: "ibc",
+      counterparty: {
+        chain_name: "namada",
+        base_denom: "unam",
+        channel_id: "channel-1",
+      },
+      chain: {
+        channel_id: "channel-98451",
+        path: "transfer/channel-98451/unam",
+      },
+    },
+  ],
+  logo_URIs: {
+    svg: "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/namada/images/namada.svg",
+  },
+  images: [
+    {
+      image_sync: {
+        chain_name: "namada",
+        base_denom: "unam",
+      },
+      svg: "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/namada/images/namada.svg",
+    },
+  ],
+};
+
+export const housefireNamAssetOnOsmosis = {
+  description: "The native token of Namada.",
+  denom_units: [
+    {
+      denom:
+        "ibc/48473B990DD70EC30F270727C4FEBA5D49C7D74949498CDE99113B13F9EA5522",
+      exponent: 0,
+      aliases: ["unam"],
+    },
+    {
+      denom: "nam",
+      exponent: 6,
+    },
+  ],
+  type_asset: "ics20",
+  base: "ibc/48473B990DD70EC30F270727C4FEBA5D49C7D74949498CDE99113B13F9EA5522",
+  name: "Namada",
+  display: "nam",
+  symbol: "NAM",
+  traces: [
+    {
+      type: "ibc",
+      counterparty: {
+        chain_name: "namada",
+        base_denom: "unam",
+        channel_id: "channel-1",
+      },
+      chain: {
+        channel_id: "channel-98451",
+        path: "transfer/channel-98451/unam",
+      },
+    },
+  ],
+  logo_URIs: {
+    svg: "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/namada/images/namada.svg",
+  },
+  images: [
+    {
+      image_sync: {
+        chain_name: "namada",
+        base_denom: "unam",
+      },
+      svg: "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/namada/images/namada.svg",
+    },
+  ],
+};


### PR DESCRIPTION
Fix missing nam on mainnet ibc deposit

This PR rolls back https://github.com/anoma/namada-interface/pull/2182 and add the hardcoded asset nam

This is a hack, we should fix asap on chain-registry package

Also, notice this will only show mainnet NAMs, not housefire ones

![Screenshot 2025-06-20 at 17 05 30](https://github.com/user-attachments/assets/38e8492c-eebf-4996-8ec4-54920b79ef4e)
