### PR TITLE
fix: red toast for partially successful transfers

### DIFF
--- a/apps/namadillo/src/atoms/integrations/services.ts
+++ b/apps/namadillo/src/atoms/integrations/services.ts
@@ -296,7 +296,8 @@ export const handleStandardTransfer = async (
 
   try {
     const txResponse = await fetchTx(tx.hash ?? "");
-    const hasRejectedTx = txResponse.innerTransactions.some(
+    // We consider tx as rejected if every inner transaction has an exit code of Rejected
+    const hasRejectedTx = txResponse.innerTransactions.every(
       ({ exitCode }) => exitCode === WrapperTransactionExitCodeEnum.Rejected
     );
 


### PR DESCRIPTION
Resolves #2205

The easiest way to test this is:
- change `every` to `some` again
- change this code so we always revealPk.:
```ts
    if (!publicKeyRevealed) {
      const revealPkTx = await sdk.tx.buildRevealPk(wrapperTxProps);
      txs.push(revealPkTx);
    }
```
- then try to replicate by modifying gas, should be enough to make one of two tx pass(save the gas amount somewhere)
- then change `some` to `every` again
- use the same gas that was used to replicate the bug
- no error?