### PR TITLE
feat: add unlimited storage to the manifest

### DIFF
--- a/apps/extension/src/manifest/v3/_base.json
+++ b/apps/extension/src/manifest/v3/_base.json
@@ -13,7 +13,7 @@
   "action": {
     "default_popup": "popup.html"
   },
-  "permissions": ["storage"],
+  "permissions": ["storage", "unlimitedStorage"],
   "content_security_policy": {
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
   },


### PR DESCRIPTION
Reason:
> By default, extensions are subject to the normal quota restrictions on storage, which can be checked by calling [navigator.storage.estimate()](https://developer.mozilla.org/docs/Web/API/StorageManager/estimate). Storage can also be evicted under heavy memory pressure, although this is rare. To avoid this:
> 
> - Request the "unlimitedStorage" permission, which affects both extension and web storage APIs and exempts extensions from both quota restrictions and eviction.

more [here](https://developer.chrome.com/docs/extensions/develop/concepts/storage-and-cookies#storage-persistence)