### PR TITLE
fix: /shield and /unshield routes

### DIFF
--- a/apps/namadillo/src/App/AccountOverview/TotalBalanceBanner.tsx
+++ b/apps/namadillo/src/App/AccountOverview/TotalBalanceBanner.tsx
@@ -86,7 +86,7 @@ export const TotalBalanceBanner = (): JSX.Element => {
         {/* <aside className="hidden lg:flex gap-4 items-center flex-wrap">
           <ActionButton
             onClick={() =>
-              navigate(routes.maspShield)
+              navigate(routes.shield)
             }
             size="sm"
             className="w-auto px-3 py-1.5"

--- a/apps/namadillo/src/App/AccountOverview/UnshieldedAssetTable.tsx
+++ b/apps/namadillo/src/App/AccountOverview/UnshieldedAssetTable.tsx
@@ -112,7 +112,7 @@ const TransparentTokensTable = ({
             <div className="relative group/tooltip">
               <ActionButton
                 size="xs"
-                href={`${routes.maspShield}?${params.asset}=${asset.symbol}&${params.source}=${destinationAddress}&${params.destination}=${shieldedAddress}`}
+                href={`${routes.shield}?${params.asset}=${asset.symbol}&${params.source}=${destinationAddress}&${params.destination}=${shieldedAddress}`}
               >
                 Shield
               </ActionButton>

--- a/apps/namadillo/src/App/AppRoutes.tsx
+++ b/apps/namadillo/src/App/AppRoutes.tsx
@@ -95,8 +95,8 @@ export const MainRoutes = (): JSX.Element => {
             <Route path={routes.transfer} element={<div />} />
             <Route path={routes.ibc} element={<div />} />
             <Route path={routes.ibcWithdraw} element={<div />} />
-            <Route path={routes.maspShield} element={<div />} />
-            <Route path={routes.maspUnshield} element={<div />} />
+            <Route path={routes.shield} element={<div />} />
+            <Route path={routes.unshield} element={<div />} />
           </Route>
 
           {/* Transaction History */}

--- a/apps/namadillo/src/App/Common/UnshieldAssetsModal.tsx
+++ b/apps/namadillo/src/App/Common/UnshieldAssetsModal.tsx
@@ -39,7 +39,7 @@ export const UnshieldAssetsModal = ({
               <img src={getAssetImageUrl(namadaAsset())} className="w-full" />
             </span>
           ),
-          onClick: () => goTo(routes.maspUnshield),
+          onClick: () => goTo(routes.unshield),
           children:
             "Unshield assets from your Namada shielded to transparent account",
         },

--- a/apps/namadillo/src/App/Layout/Navigation.tsx
+++ b/apps/namadillo/src/App/Layout/Navigation.tsx
@@ -36,7 +36,7 @@ export const Navigation = (): JSX.Element => {
     {
       label: "Shield",
       icon: <ShieldIcon />,
-      url: routes.maspShield,
+      url: routes.shield,
     },
     {
       label: "Transfer",

--- a/apps/namadillo/src/App/Transfer/AddressDropdown.tsx
+++ b/apps/namadillo/src/App/Transfer/AddressDropdown.tsx
@@ -54,8 +54,8 @@ export const AddressDropdown = ({
   const shieldedAccount = accounts?.find(
     (account) => account.type === AccountType.ShieldedKeys
   );
-  const isShieldingTxn = [routes.maspShield, routes.ibc].includes(
-    location.pathname as "/masp/shield" | "/ibc"
+  const isShieldingTxn = [routes.shield, routes.ibc].includes(
+    location.pathname as "/shield" | "/ibc"
   );
   const isIbcDestination = isIbcAddress(destinationAddress ?? "");
 

--- a/apps/namadillo/src/App/Transfer/TransferDestination.tsx
+++ b/apps/namadillo/src/App/Transfer/TransferDestination.tsx
@@ -110,7 +110,7 @@ export const TransferDestination = ({
   );
 
   const isShieldingTransaction =
-    routes.maspShield === location.pathname || routes.ibc === location.pathname;
+    routes.shield === location.pathname || routes.ibc === location.pathname;
 
   // Make sure destination address isnt ibc if keplr is not connected
   useEffect(() => {

--- a/apps/namadillo/src/App/routes.ts
+++ b/apps/namadillo/src/App/routes.ts
@@ -17,10 +17,9 @@ export const routes = {
 
   // Shield
   shield: "/shield",
+  unshield: "/unshield",
 
   // Masp
-  maspShield: "/masp/shield",
-  maspUnshield: "/masp/unshield",
   shieldAssets: "/shield-assets",
 
   // Ibc


### PR DESCRIPTION
One of the ways for fixing #2319.

- This goes the /shield /unshield route omitting /masp.

This keeps it in alignment with the rest of the routes. But if the preference goes to keeping /masp then there's #2321.