### PR TITLE
fix: /masp/shield routes

### DIFF
--- a/apps/namadillo/src/App/AccountOverview/UnshieldedAssetsOverview.tsx
+++ b/apps/namadillo/src/App/AccountOverview/UnshieldedAssetsOverview.tsx
@@ -32,7 +32,7 @@ export const UnshieldedAssetsOverview = (): JSX.Element => {
             footerButtons={
               <>
                 <ActionButton
-                  onClick={() => navigate(routes.shield)}
+                  onClick={() => navigate(routes.maspShield)}
                   size="xs"
                   className="w-auto px-4"
                 >

--- a/apps/namadillo/src/App/Common/ShieldAssetsModal.tsx
+++ b/apps/namadillo/src/App/Common/ShieldAssetsModal.tsx
@@ -28,7 +28,7 @@ export const ShieldAssetsModal = (): JSX.Element => {
               <img src={getAssetImageUrl(namadaAsset())} className="w-full" />
             </span>
           ),
-          onClick: () => navigate(routes.shield),
+          onClick: () => navigate(routes.maspShield),
           children: "Shield Assets from your Namada transparent account",
         },
       ]}

--- a/apps/namadillo/src/App/Masp/ShieldedAssetTable.tsx
+++ b/apps/namadillo/src/App/Masp/ShieldedAssetTable.tsx
@@ -20,7 +20,7 @@ const ShieldAssetCta = (): JSX.Element => {
       <div className="flex-1 flex items-center justify-center">
         <ActionButton
           className="w-fit uppercase"
-          onClick={() => navigate(routes.shield)}
+          onClick={() => navigate(routes.maspShield)}
         >
           Shield your first assets
         </ActionButton>

--- a/apps/namadillo/src/App/Sidebars/ShieldAllBanner.tsx
+++ b/apps/namadillo/src/App/Sidebars/ShieldAllBanner.tsx
@@ -41,7 +41,7 @@ export const ShieldAllBanner = (): JSX.Element => {
           backgroundHoverColor="transparent"
           textColor="yellow"
           textHoverColor="black"
-          onClick={() => navigate(routes.shield)}
+          onClick={() => navigate(routes.maspShield)}
           onMouseEnter={() => setIsAnimating(true)}
           onMouseLeave={() => setIsAnimating(false)}
         >

--- a/apps/namadillo/src/App/routes.ts
+++ b/apps/namadillo/src/App/routes.ts
@@ -15,9 +15,6 @@ export const routes = {
   governanceSubmitVote: "/governance/submit-vote/:proposalId",
   governanceJson: "/governance/json/:proposalId",
 
-  // Shield
-  shield: "/shield",
-
   // Masp
   maspShield: "/masp/shield",
   maspUnshield: "/masp/unshield",


### PR DESCRIPTION
One of the two ways for fixing #2319.

- Removes all dangling `/shield` routes and changes it to to `/masp/shield`.

I personally would pick PR #2320 over this one (_if_ any of the two is working and gets merged of course lol).