### PR TITLE
fix: refund target signing and empty memo

### DIFF
--- a/apps/extension/src/background/keyring/keyring.ts
+++ b/apps/extension/src/background/keyring/keyring.ts
@@ -801,7 +801,11 @@ export class KeyRing {
 
     let privateKey: string;
 
-    if (account.public.type === AccountType.PrivateKey) {
+    if (
+      [AccountType.PrivateKey, AccountType.Disposable].includes(
+        account.public.type
+      )
+    ) {
       privateKey = secret;
     } else {
       const sdk = this.sdkService.getSdk();

--- a/apps/namadillo/src/App/Masp/MaspShield.tsx
+++ b/apps/namadillo/src/App/Masp/MaspShield.tsx
@@ -35,7 +35,7 @@ export const MaspShield = ({
   setAssetSelectorModalOpen,
 }: MaspShieldProps): JSX.Element => {
   //  COMPONENT STATE
-  const [memo, setMemo] = useState("");
+  const [memo, setMemo] = useState<string | undefined>();
   const [displayAmount, setDisplayAmount] = useAtom(transferAmountAtom);
   const [selectedAssetWithAmount, setSelectedAssetWithAmount] = useState<
     AssetWithAmountAndChain | undefined

--- a/apps/namadillo/src/App/Masp/MaspUnshield.tsx
+++ b/apps/namadillo/src/App/Masp/MaspUnshield.tsx
@@ -34,7 +34,7 @@ export const MaspUnshield = ({
   setAssetSelectorModalOpen,
 }: MaspUnshieldProps): JSX.Element => {
   //  COMPONENT STATE
-  const [memo, setMemo] = useState("");
+  const [memo, setMemo] = useState<string | undefined>();
   const [displayAmount, setDisplayAmount] = useAtom(transferAmountAtom);
   const [selectedAssetWithAmount, setSelectedAssetWithAmount] = useState<
     AssetWithAmountAndChain | undefined

--- a/apps/namadillo/src/App/NamadaTransfer/NamadaTransfer.tsx
+++ b/apps/namadillo/src/App/NamadaTransfer/NamadaTransfer.tsx
@@ -42,7 +42,7 @@ export const NamadaTransfer = ({
   //  COMPONENT STATE
   const [displayAmount, setDisplayAmount] = useAtom(transferAmountAtom);
   const [customAddress] = useState<string>("");
-  const [memo, setMemo] = useState<string>("");
+  const [memo, setMemo] = useState<string | undefined>();
   const [selectedAssetWithAmount, setSelectedAssetWithAmount] = useState<
     AssetWithAmountAndChain | undefined
   >();

--- a/apps/namadillo/src/App/Transfer/types.ts
+++ b/apps/namadillo/src/App/Transfer/types.ts
@@ -44,7 +44,7 @@ export type TransferModuleProps = {
     isShieldedAddress: boolean;
     memo?: string;
     onChangeAddress: (address?: string) => void;
-    onChangeMemo?: Dispatch<SetStateAction<string>>;
+    onChangeMemo?: Dispatch<SetStateAction<string | undefined>>;
   };
   requiresIbcChannels?: boolean;
   feeProps?: TransactionFeeProps;


### PR DESCRIPTION
- could not get proper signer from the vault if source was refund target
- if not specified we would add empty memo string in tx, should be undefined