### PR TITLE
fix: change link title from 'View pending transactions' to 'Unshield'

### DIFF
--- a/apps/namadillo/src/App/Transfer/TransferModule.tsx
+++ b/apps/namadillo/src/App/Transfer/TransferModule.tsx
@@ -354,7 +354,7 @@ export const TransferModule = ({
           <Link
             className="text-yellow underline"
             to={`${routes.transfer}?${params.source}=${shieldedAccount?.address || ""}&${params.destination}=${transparentAccount?.address || ""}`}
-            title={`View pending transactions`}
+            title={`Unshield`}
           >
             Click here.
           </Link>


### PR DESCRIPTION
Update the title of the "Click here" link

<img width="1254" height="340" alt="Screenshot 2025-11-26 at 10 13 45" src="https://github.com/user-attachments/assets/3cbd6fa4-93ed-4d28-9818-43a865b4a267" />
