### PR TITLE
fix: ignore nested node_modules in Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
-node_modules
+**/node_modules
 .git
 .gitignore


### PR DESCRIPTION
## Summary
- update `.dockerignore` to ignore `node_modules` directories at any depth
- keep the existing `.git` and `.gitignore` exclusions unchanged

## Why
Docker `.dockerignore` patterns are not identical to `.gitignore` patterns. The previous `node_modules` entry only matched the top-level directory, so nested workspace dependencies could still be included in the build context.

## Testing
- `git diff --check`

Closes #2301